### PR TITLE
refactor: Remove last remaining circular `import` in `core/`

### DIFF
--- a/appengine/storage.js
+++ b/appengine/storage.js
@@ -44,7 +44,7 @@ BlocklyStorage.restoreBlocks = function(opt_workspace) {
   var url = window.location.href.split('#')[0];
   if ('localStorage' in window && window.localStorage[url]) {
     var workspace = opt_workspace || Blockly.getMainWorkspace();
-    var xml = Blockly.Xml.textToDom(window.localStorage[url]);
+    var xml = Blockly.utils.xml.textToDom(window.localStorage[url]);
     Blockly.Xml.domToWorkspace(xml, workspace);
   }
 };
@@ -168,7 +168,7 @@ BlocklyStorage.monitorChanges_ = function(workspace) {
  */
 BlocklyStorage.loadXml_ = function(xml, workspace) {
   try {
-    xml = Blockly.Xml.textToDom(xml);
+    xml = Blockly.utils.xml.textToDom(xml);
   } catch (e) {
     BlocklyStorage.alert(BlocklyStorage.XML_ERROR + '\nXML: ' + xml);
     return;

--- a/blocks/lists.js
+++ b/blocks/lists.js
@@ -13,7 +13,6 @@
 goog.module('Blockly.libraryBlocks.lists');
 
 const xmlUtils = goog.require('Blockly.utils.xml');
-const Xml = goog.require('Blockly.Xml');
 const {Align} = goog.require('Blockly.Input');
 /* eslint-disable-next-line no-unused-vars */
 const {Block} = goog.requireType('Blockly.Block');
@@ -480,7 +479,7 @@ blocks['lists_getIndex'] = {
       this.updateStatement_(true);
     } else if (typeof state === 'string') {
       // backward compatible for json serialised mutations
-      this.domToMutation(Xml.textToDom(state));
+      this.domToMutation(xmlUtils.textToDom(state));
     }
   },
 

--- a/closure/goog/base.js
+++ b/closure/goog/base.js
@@ -617,8 +617,10 @@ goog.declareModuleId = function(namespace) {
           'within an ES6 module');
     }
     if (goog.moduleLoaderState_ && goog.moduleLoaderState_.moduleName) {
-      // throw new Error(
-      //     'goog.declareModuleId may only be called once per module.');
+      throw new Error(
+          'goog.declareModuleId may only be called once per module.' +
+          'This error can also be caused by circular imports, which ' +
+          'are not supported by debug module loader.');
     }
     if (namespace in goog.loadedModules_) {
       throw new Error(

--- a/core/events/events_block_change.ts
+++ b/core/events/events_block_change.ts
@@ -16,6 +16,7 @@ import type {Block} from '../block.js';
 import type {BlockSvg} from '../block_svg.js';
 import * as deprecation from '../utils/deprecation.js';
 import * as registry from '../registry.js';
+import * as utilsXml from '../utils/xml.js';
 import {Workspace} from '../workspace.js';
 import * as Xml from '../xml.js';
 
@@ -184,7 +185,8 @@ export class BlockChange extends BlockBase {
         if (block.loadExtraState) {
           block.loadExtraState(JSON.parse(value as string || '{}'));
         } else if (block.domToMutation) {
-          block.domToMutation(Xml.textToDom(value as string || '<mutation/>'));
+          block.domToMutation(
+              utilsXml.textToDom(value as string || '<mutation/>'));
         }
         eventUtils.fire(
             new BlockChange(block, 'mutation', null, oldState, value));

--- a/core/events/events_block_create.ts
+++ b/core/events/events_block_create.ts
@@ -16,6 +16,7 @@ import type {Block} from '../block.js';
 import * as deprecation from '../utils/deprecation.js';
 import * as registry from '../registry.js';
 import * as blocks from '../serialization/blocks.js';
+import * as utilsXml from '../utils/xml.js';
 import * as Xml from '../xml.js';
 
 import {BlockBase, BlockBaseJson} from './events_block_base.js';
@@ -101,7 +102,7 @@ export class BlockCreate extends BlockBase {
         'Blockly.Events.BlockCreate.prototype.fromJson', 'version 9',
         'version 10', 'Blockly.Events.fromJson');
     super.fromJson(json);
-    this.xml = Xml.textToDom(json['xml']);
+    this.xml = utilsXml.textToDom(json['xml']);
     this.ids = json['ids'];
     this.json = json['json'] as blocks.State;
     if (json['recordUndo'] !== undefined) {
@@ -123,7 +124,7 @@ export class BlockCreate extends BlockBase {
     const newEvent =
         super.fromJson(json, workspace, event ?? new BlockCreate()) as
         BlockCreate;
-    newEvent.xml = Xml.textToDom(json['xml']);
+    newEvent.xml = utilsXml.textToDom(json['xml']);
     newEvent.ids = json['ids'];
     newEvent.json = json['json'] as blocks.State;
     if (json['recordUndo'] !== undefined) {

--- a/core/events/events_block_delete.ts
+++ b/core/events/events_block_delete.ts
@@ -16,6 +16,7 @@ import type {Block} from '../block.js';
 import * as deprecation from '../utils/deprecation.js';
 import * as registry from '../registry.js';
 import * as blocks from '../serialization/blocks.js';
+import * as utilsXml from '../utils/xml.js';
 import * as Xml from '../xml.js';
 
 import {BlockBase, BlockBaseJson} from './events_block_base.js';
@@ -114,7 +115,7 @@ export class BlockDelete extends BlockBase {
         'Blockly.Events.BlockDelete.prototype.fromJson', 'version 9',
         'version 10', 'Blockly.Events.fromJson');
     super.fromJson(json);
-    this.oldXml = Xml.textToDom(json['oldXml']);
+    this.oldXml = utilsXml.textToDom(json['oldXml']);
     this.ids = json['ids'];
     this.wasShadow =
         json['wasShadow'] || this.oldXml.tagName.toLowerCase() === 'shadow';
@@ -138,7 +139,7 @@ export class BlockDelete extends BlockBase {
     const newEvent =
         super.fromJson(json, workspace, event ?? new BlockDelete()) as
         BlockDelete;
-    newEvent.oldXml = Xml.textToDom(json['oldXml']);
+    newEvent.oldXml = utilsXml.textToDom(json['oldXml']);
     newEvent.ids = json['ids'];
     newEvent.wasShadow =
         json['wasShadow'] || newEvent.oldXml.tagName.toLowerCase() === 'shadow';

--- a/core/events/events_comment_create.ts
+++ b/core/events/events_comment_create.ts
@@ -15,6 +15,7 @@ goog.declareModuleId('Blockly.Events.CommentCreate');
 import * as deprecation from '../utils/deprecation.js';
 import * as registry from '../registry.js';
 import type {WorkspaceComment} from '../workspace_comment.js';
+import * as utilsXml from '../utils/xml.js';
 import * as Xml from '../xml.js';
 
 import {CommentBase, CommentBaseJson} from './events_comment_base.js';
@@ -74,7 +75,7 @@ export class CommentCreate extends CommentBase {
         'Blockly.Events.CommentCreate.prototype.fromJson', 'version 9',
         'version 10', 'Blockly.Events.fromJson');
     super.fromJson(json);
-    this.xml = Xml.textToDom(json['xml']);
+    this.xml = utilsXml.textToDom(json['xml']);
   }
 
   /**
@@ -91,7 +92,7 @@ export class CommentCreate extends CommentBase {
     const newEvent =
         super.fromJson(json, workspace, event ?? new CommentCreate()) as
         CommentCreate;
-    newEvent.xml = Xml.textToDom(json['xml']);
+    newEvent.xml = utilsXml.textToDom(json['xml']);
     return newEvent;
   }
 

--- a/core/events/events_comment_delete.ts
+++ b/core/events/events_comment_delete.ts
@@ -17,6 +17,7 @@ import type {WorkspaceComment} from '../workspace_comment.js';
 
 import {CommentBase, CommentBaseJson} from './events_comment_base.js';
 import * as eventUtils from './utils.js';
+import * as utilsXml from '../utils/xml.js';
 import * as Xml from '../xml.js';
 import type {Workspace} from '../workspace.js';
 
@@ -85,7 +86,7 @@ export class CommentDelete extends CommentBase {
     const newEvent =
         super.fromJson(json, workspace, event ?? new CommentDelete()) as
         CommentDelete;
-    newEvent.xml = Xml.textToDom(json['xml']);
+    newEvent.xml = utilsXml.textToDom(json['xml']);
     return newEvent;
   }
 }

--- a/core/field.ts
+++ b/core/field.ts
@@ -43,7 +43,6 @@ import * as userAgent from './utils/useragent.js';
 import * as utilsXml from './utils/xml.js';
 import * as WidgetDiv from './widgetdiv.js';
 import type {WorkspaceSvg} from './workspace_svg.js';
-import * as Xml from './xml.js';
 
 /**
  * A function that is called to validate changes to the field's value before
@@ -455,7 +454,7 @@ export abstract class Field<T = any> implements IASTNodeLocationSvg,
         callingClass.prototype.toXml !== this.toXml) {
       const elem = utilsXml.createElement('field');
       elem.setAttribute('name', this.name || '');
-      const text = Xml.domToText(this.toXml(elem));
+      const text = utilsXml.domToText(this.toXml(elem));
       return text.replace(
           ' xmlns="https://developers.google.com/blockly/xml"', '');
     }
@@ -477,7 +476,7 @@ export abstract class Field<T = any> implements IASTNodeLocationSvg,
       boolean {
     if (callingClass.prototype.loadState === this.loadState &&
         callingClass.prototype.fromXml !== this.fromXml) {
-      this.fromXml(Xml.textToDom(state as string));
+      this.fromXml(utilsXml.textToDom(state as string));
       return true;
     }
     // Either they called this on purpose from their loadState, or they have

--- a/core/flyout_base.ts
+++ b/core/flyout_base.ts
@@ -33,6 +33,7 @@ import {Svg} from './utils/svg.js';
 import * as toolbox from './utils/toolbox.js';
 import * as Variables from './variables.js';
 import {WorkspaceSvg} from './workspace_svg.js';
+import * as utilsXml from './utils/xml.js';
 import * as Xml from './xml.js';
 
 
@@ -744,7 +745,7 @@ export abstract class Flyout extends DeleteArea implements IFlyout {
     let block;
     if (blockInfo['blockxml']) {
       const xml = (typeof blockInfo['blockxml'] === 'string' ?
-                       Xml.textToDom(blockInfo['blockxml']) :
+                       utilsXml.textToDom(blockInfo['blockxml']) :
                        blockInfo['blockxml']) as Element;
       block = this.getRecycledBlock_(xml.getAttribute('type')!);
       if (!block) {
@@ -803,7 +804,7 @@ export abstract class Flyout extends DeleteArea implements IFlyout {
       gap = parseInt(blockInfo['gap'].toString());
     } else if (blockInfo['blockxml']) {
       const xml = (typeof blockInfo['blockxml'] === 'string' ?
-                       Xml.textToDom(blockInfo['blockxml']) :
+                       utilsXml.textToDom(blockInfo['blockxml']) :
                        blockInfo['blockxml']) as Element;
       gap = parseInt(xml.getAttribute('gap')!);
     }

--- a/core/procedures.ts
+++ b/core/procedures.ts
@@ -454,12 +454,12 @@ export function mutateCallers(defBlock: Block) {
   const callers = getCallers(name, defBlock.workspace);
   for (let i = 0, caller; caller = callers[i]; i++) {
     const oldMutationDom = caller.mutationToDom!();
-    const oldMutation = oldMutationDom && Xml.domToText(oldMutationDom);
+    const oldMutation = oldMutationDom && utilsXml.domToText(oldMutationDom);
     if (caller.domToMutation) {
       caller.domToMutation(xmlElement);
     }
     const newMutationDom = caller.mutationToDom!();
-    const newMutation = newMutationDom && Xml.domToText(newMutationDom);
+    const newMutation = newMutationDom && utilsXml.domToText(newMutationDom);
     if (oldMutation !== newMutation) {
       // Fire a mutation on every caller block.  But don't record this as an
       // undo action since it is deterministically tied to the procedure's

--- a/core/procedures.ts
+++ b/core/procedures.ts
@@ -34,7 +34,6 @@ import * as utilsXml from './utils/xml.js';
 import * as Variables from './variables.js';
 import type {Workspace} from './workspace.js';
 import type {WorkspaceSvg} from './workspace_svg.js';
-import * as Xml from './xml.js';
 
 
 /**

--- a/core/serialization/blocks.ts
+++ b/core/serialization/blocks.ts
@@ -19,6 +19,7 @@ import * as eventUtils from '../events/utils.js';
 import {inputTypes} from '../input_types.js';
 import type {ISerializer} from '../interfaces/i_serializer.js';
 import {Size} from '../utils/size.js';
+import * as utilsXml from '../utils/xml.js';
 import type {Workspace} from '../workspace.js';
 import * as Xml from '../xml.js';
 
@@ -468,7 +469,7 @@ function loadExtraState(block: Block, state: State) {
   if (block.loadExtraState) {
     block.loadExtraState(state['extraState']);
   } else if (block.domToMutation) {
-    block.domToMutation(Xml.textToDom(state['extraState']));
+    block.domToMutation(utilsXml.textToDom(state['extraState']));
   }
 }
 

--- a/core/utils/toolbox.ts
+++ b/core/utils/toolbox.ts
@@ -15,7 +15,7 @@ goog.declareModuleId('Blockly.utils.toolbox');
 import type {ConnectionState} from '../serialization/blocks.js';
 import type {CssConfig as CategoryCssConfig} from '../toolbox/category.js';
 import type {CssConfig as SeparatorCssConfig} from '../toolbox/separator.js';
-import * as Xml from '../xml.js';
+import * as utilsXml from './xml.js';
 
 
 /**
@@ -422,7 +422,7 @@ export function parseToolboxTree(toolboxDef: Element|null|string): Element|
   let parsedToolboxDef: Element|null = null;
   if (toolboxDef) {
     if (typeof toolboxDef === 'string') {
-      parsedToolboxDef = Xml.textToDom(toolboxDef);
+      parsedToolboxDef = utilsXml.textToDom(toolboxDef);
       if (parsedToolboxDef.nodeName.toLowerCase() !== 'xml') {
         throw TypeError('Toolbox should be an <xml> document.');
       }

--- a/core/utils/xml.ts
+++ b/core/utils/xml.ts
@@ -119,7 +119,6 @@ export function createTextNode(text: string): Text {
  * @returns A DOM object representing the singular child of the document
  *     element.
  * @throws if the text doesn't parse.
- * @alias Blockly.utils.xml.textToDom
  */
 export function textToDom(text: string): Element {
   const doc = textToDomDocument(text);

--- a/core/utils/xml.ts
+++ b/core/utils/xml.ts
@@ -113,6 +113,24 @@ export function createTextNode(text: string): Text {
 }
 
 /**
+ * Converts an XML string into a DOM structure.
+ *
+ * @param text An XML string.
+ * @returns A DOM object representing the singular child of the document
+ *     element.
+ * @throws if the text doesn't parse.
+ * @alias Blockly.utils.xml.textToDom
+ */
+export function textToDom(text: string): Element {
+  const doc = textToDomDocument(text);
+  if (!doc || !doc.documentElement ||
+      doc.getElementsByTagName('parsererror').length) {
+    throw Error('textToDom was unable to parse: ' + text);
+  }
+  return doc.documentElement;
+}
+
+/**
  * Converts an XML string into a DOM tree.
  *
  * @param text XML string.

--- a/core/variables.ts
+++ b/core/variables.ts
@@ -19,7 +19,6 @@ import * as utilsXml from './utils/xml.js';
 import {VariableModel} from './variable_model.js';
 import type {Workspace} from './workspace.js';
 import type {WorkspaceSvg} from './workspace_svg.js';
-import * as Xml from './xml.js';
 
 
 /**
@@ -142,7 +141,7 @@ export function flyoutCategoryBlocks(workspace: Workspace): Element[] {
       block.setAttribute('type', 'math_change');
       block.setAttribute('gap', Blocks['variables_get'] ? '20' : '8');
       block.appendChild(generateVariableFieldDom(mostRecentVariable));
-      const value = Xml.textToDom(
+      const value = utilsXml.textToDom(
           '<value name="DELTA">' +
           '<shadow type="math_number">' +
           '<field name="NUM">1</field>' +

--- a/core/xml.ts
+++ b/core/xml.ts
@@ -15,6 +15,7 @@ goog.declareModuleId('Blockly.Xml');
 import type {Block} from './block.js';
 import type {BlockSvg} from './block_svg.js';
 import type {Connection} from './connection.js';
+import * as deprecation from './utils/deprecation.js';
 import * as eventUtils from './events/utils.js';
 import type {Field} from './field.js';
 import {inputTypes} from './input_types.js';
@@ -386,15 +387,14 @@ export function domToPrettyText(dom: Node): string {
  * @returns A DOM object representing the singular child of the document
  *     element.
  * @throws if the text doesn't parse.
+ * @deprecated Moved to core/utils/xml.js.
  * @alias Blockly.Xml.textToDom
  */
 export function textToDom(text: string): Element {
-  const doc = utilsXml.textToDomDocument(text);
-  if (!doc || !doc.documentElement ||
-      doc.getElementsByTagName('parsererror').length) {
-    throw Error('textToDom was unable to parse: ' + text);
-  }
-  return doc.documentElement;
+  deprecation.warn(
+      'Blockly.Xml.textToDom', 'version 9', 'version 10',
+      'Use Blockly.utils.xml.textToDom instead');
+  return utilsXml.textToDom(text);
 }
 
 /**

--- a/demos/blockfactory/app_controller.js
+++ b/demos/blockfactory/app_controller.js
@@ -138,7 +138,7 @@ AppController.prototype.formatBlockLibraryForExport_ = function(blockXmlMap) {
 
   // Append each block node to XML DOM.
   for (var blockType in blockXmlMap) {
-    var blockXmlDom = Blockly.Xml.textToDom(blockXmlMap[blockType]);
+    var blockXmlDom = Blockly.utils.xml.textToDom(blockXmlMap[blockType]);
     var blockNode = blockXmlDom.firstElementChild;
     xmlDom.appendChild(blockNode);
   }
@@ -155,7 +155,7 @@ AppController.prototype.formatBlockLibraryForExport_ = function(blockXmlMap) {
  * @private
  */
 AppController.prototype.formatBlockLibraryForImport_ = function(xmlText) {
-  var inputXml = Blockly.Xml.textToDom(xmlText);
+  var inputXml = Blockly.utils.xml.textToDom(xmlText);
   // Convert the live HTMLCollection of child Elements into a static array,
   // since the addition to editorWorkspaceXml below removes it from inputXml.
   var inputChildren = Array.from(inputXml.children);
@@ -192,7 +192,7 @@ AppController.prototype.formatBlockLibraryForImport_ = function(xmlText) {
  * @private
  */
 AppController.prototype.getBlockTypeFromXml_ = function(xmlText) {
-  var xmlDom = Blockly.Xml.textToDom(xmlText);
+  var xmlDom = Blockly.utils.xml.textToDom(xmlText);
   // Find factory base block.
   var factoryBaseBlockXml = xmlDom.getElementsByTagName('block')[0];
   // Get field elements from factory base.

--- a/demos/blockfactory/block_library_storage.js
+++ b/demos/blockfactory/block_library_storage.js
@@ -90,7 +90,7 @@ BlockLibraryStorage.prototype.removeBlock = function(blockType) {
 BlockLibraryStorage.prototype.getBlockXml = function(blockType) {
   var xml = this.blocks[blockType] || null;
   if (xml) {
-    var xml = Blockly.Xml.textToDom(xml);
+    var xml = Blockly.utils.xml.textToDom(xml);
   }
   return xml;
 };

--- a/demos/blockfactory/factory.js
+++ b/demos/blockfactory/factory.js
@@ -305,7 +305,7 @@ BlockFactory.disableEnableLink = function() {
  */
 BlockFactory.showStarterBlock = function() {
   BlockFactory.mainWorkspace.clear();
-  var xml = Blockly.Xml.textToDom(BlockFactory.STARTER_BLOCK_XML_TEXT);
+  var xml = Blockly.utils.xml.textToDom(BlockFactory.STARTER_BLOCK_XML_TEXT);
   Blockly.Xml.domToWorkspace(xml, BlockFactory.mainWorkspace);
 };
 

--- a/demos/blockfactory/standard_categories.js
+++ b/demos/blockfactory/standard_categories.js
@@ -27,7 +27,7 @@ StandardCategories.categoryMap = Object.create(null);
 StandardCategories.categoryMap['logic'] =
     new ListElement(ListElement.TYPE_CATEGORY, 'Logic');
 StandardCategories.categoryMap['logic'].xml =
-    Blockly.Xml.textToDom(
+    Blockly.utils.xml.textToDom(
     '<xml xmlns="https://developers.google.com/blockly/xml">' +
       '<block type="controls_if"></block>' +
       '<block type="logic_compare"></block>' +
@@ -42,7 +42,7 @@ StandardCategories.categoryMap['logic'].hue = 210;
 StandardCategories.categoryMap['loops'] =
     new ListElement(ListElement.TYPE_CATEGORY, 'Loops');
 StandardCategories.categoryMap['loops'].xml =
-    Blockly.Xml.textToDom(
+    Blockly.utils.xml.textToDom(
     '<xml xmlns="https://developers.google.com/blockly/xml">' +
       '<block type="controls_repeat_ext">' +
         '<value name="TIMES">' +
@@ -77,7 +77,7 @@ StandardCategories.categoryMap['loops'].hue = 120;
 StandardCategories.categoryMap['math'] =
     new ListElement(ListElement.TYPE_CATEGORY, 'Math');
 StandardCategories.categoryMap['math'].xml =
-    Blockly.Xml.textToDom(
+    Blockly.utils.xml.textToDom(
     '<xml xmlns="https://developers.google.com/blockly/xml">' +
       '<block type="math_number"></block>' +
       '<block type="math_arithmetic">' +
@@ -170,7 +170,7 @@ StandardCategories.categoryMap['math'].hue = 230;
 StandardCategories.categoryMap['text'] =
     new ListElement(ListElement.TYPE_CATEGORY, 'Text');
 StandardCategories.categoryMap['text'].xml =
-    Blockly.Xml.textToDom(
+    Blockly.utils.xml.textToDom(
     '<xml xmlns="https://developers.google.com/blockly/xml">' +
       '<block type="text"></block>' +
       '<block type="text_join"></block>' +
@@ -253,7 +253,7 @@ StandardCategories.categoryMap['text'].hue = 160;
 StandardCategories.categoryMap['lists'] =
     new ListElement(ListElement.TYPE_CATEGORY, 'Lists');
 StandardCategories.categoryMap['lists'].xml =
-    Blockly.Xml.textToDom(
+    Blockly.utils.xml.textToDom(
     '<xml xmlns="https://developers.google.com/blockly/xml">' +
       '<block type="lists_create_with">' +
         '<mutation items="0"></mutation>' +
@@ -310,7 +310,7 @@ StandardCategories.categoryMap['lists'].hue = 260;
 StandardCategories.categoryMap['colour'] =
     new ListElement(ListElement.TYPE_CATEGORY, 'Colour');
 StandardCategories.categoryMap['colour'].xml =
-    Blockly.Xml.textToDom(
+    Blockly.utils.xml.textToDom(
     '<xml xmlns="https://developers.google.com/blockly/xml">' +
       '<block type="colour_picker"></block>' +
       '<block type="colour_random"></block>' +

--- a/demos/blockfactory/workspacefactory/wfactory_controller.js
+++ b/demos/blockfactory/workspacefactory/wfactory_controller.js
@@ -702,7 +702,7 @@ WorkspaceFactoryController.prototype.importFile = function(file, importMode) {
     // Try to parse XML from file and load it into toolbox editing area.
     // Print error message if fail.
     try {
-      var tree = Blockly.Xml.textToDom(reader.result);
+      var tree = Blockly.utils.xml.textToDom(reader.result);
       if (importMode === WorkspaceFactoryController.MODE_TOOLBOX) {
         // Switch mode.
         controller.setMode(WorkspaceFactoryController.MODE_TOOLBOX);

--- a/demos/blockfactory_old/factory.js
+++ b/demos/blockfactory_old/factory.js
@@ -799,7 +799,7 @@ function init() {
                                mainWorkspace);
   } else {
     var xml = '<xml xmlns="https://developers.google.com/blockly/xml"><block type="factory_base" deletable="false" movable="false"></block></xml>';
-    Blockly.Xml.domToWorkspace(Blockly.Xml.textToDom(xml), mainWorkspace);
+    Blockly.Xml.domToWorkspace(Blockly.utils.xml.textToDom(xml), mainWorkspace);
   }
   mainWorkspace.clearUndo();
 

--- a/demos/code/code.js
+++ b/demos/code/code.js
@@ -127,11 +127,11 @@ Code.loadBlocks = function(defaultXml) {
   } else if (loadOnce) {
     // Language switching stores the blocks during the reload.
     delete window.sessionStorage.loadOnceBlocks;
-    var xml = Blockly.Xml.textToDom(loadOnce);
+    var xml = Blockly.utils.xml.textToDom(loadOnce);
     Blockly.Xml.domToWorkspace(xml, Code.workspace);
   } else if (defaultXml) {
     // Load the editor with default starting blocks.
-    var xml = Blockly.Xml.textToDom(defaultXml);
+    var xml = Blockly.utils.xml.textToDom(defaultXml);
     Blockly.Xml.domToWorkspace(xml, Code.workspace);
   } else if ('BlocklyStorage' in window) {
     // Restore saved blocks in a separate thread so that subsequent
@@ -264,7 +264,7 @@ Code.tabClick = function(clickedName) {
     var xmlText = xmlTextarea.value;
     var xmlDom = null;
     try {
-      xmlDom = Blockly.Xml.textToDom(xmlText);
+      xmlDom = Blockly.utils.xml.textToDom(xmlText);
     } catch (e) {
       var q = window.confirm(
           MSG['parseError'].replace(/%1/g, 'XML').replace('%2', e));
@@ -459,7 +459,7 @@ Code.init = function() {
   var toolboxText = document.getElementById('toolbox').outerHTML;
   toolboxText = toolboxText.replace(/(^|[^%]){(\w+)}/g,
       function(m, p1, p2) {return p1 + MSG[p2];});
-  var toolboxXml = Blockly.Xml.textToDom(toolboxText);
+  var toolboxXml = Blockly.utils.xml.textToDom(toolboxText);
 
   Code.workspace = Blockly.inject('content_blocks',
       {grid:

--- a/scripts/migration/renamings.json5
+++ b/scripts/migration/renamings.json5
@@ -1427,6 +1427,14 @@
     {
       oldName: 'Blockly.TouchGesture',
       newName: 'Blockly.Gesture',
-    },    
-  ]
+    },
+    {
+      oldName: 'Blockly.Xml',
+      exports: {
+        textToDom: {
+          newModule: 'Blockly.utils.xml',
+        },
+      },
+    }
+  ],
 }

--- a/tests/generators/index.html
+++ b/tests/generators/index.html
@@ -121,7 +121,7 @@ function fromXml(filename, xmlText, opt_append) {
     demoWorkspace.clear();
   }
   try {
-    var xmlDoc = Blockly.Xml.textToDom(xmlText);
+    var xmlDoc = Blockly.utils.xml.textToDom(xmlText);
     if (opt_append) {
       Blockly.Xml.appendDomToWorkspace(xmlDoc, demoWorkspace);
     } else {

--- a/tests/mocha/block_test.js
+++ b/tests/mocha/block_test.js
@@ -506,7 +506,7 @@ suite('Blocks', function() {
     suite('Deserialization', function() {
       setup(function() {
         this.deserializationHelper = function(text) {
-          const dom = Blockly.Xml.textToDom(text);
+          const dom = Blockly.utils.xml.textToDom(text);
           Blockly.Xml.appendDomToWorkspace(dom, this.workspace);
           this.assertConnectionsEmpty();
           this.clock.runAll();
@@ -616,7 +616,7 @@ suite('Blocks', function() {
         chai.assert.equal(this.getInputs().length, 0);
       });
       test('Collapsed Multi-Row Middle', function() {
-        Blockly.Xml.appendDomToWorkspace(Blockly.Xml.textToDom(
+        Blockly.Xml.appendDomToWorkspace(Blockly.utils.xml.textToDom(
             '<xml>' +
             '  <block type="row_block">' +
             '    <value name="INPUT">' +
@@ -735,7 +735,7 @@ suite('Blocks', function() {
     });
     suite('setCollapsed', function() {
       test('Stack', function() {
-        const block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
+        const block = Blockly.Xml.domToBlock(Blockly.utils.xml.textToDom(
             '<block type="stack_block"/>'
         ), this.workspace);
         this.clock.runAll();
@@ -751,7 +751,7 @@ suite('Blocks', function() {
         chai.assert.equal(this.getNext().length, 1);
       });
       test('Multi-Stack', function() {
-        const block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
+        const block = Blockly.Xml.domToBlock(Blockly.utils.xml.textToDom(
             '<block type="stack_block">' +
             '  <next>' +
             '    <block type="stack_block">' +
@@ -776,7 +776,7 @@ suite('Blocks', function() {
         chai.assert.equal(this.getNext().length, 3);
       });
       test('Row', function() {
-        const block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
+        const block = Blockly.Xml.domToBlock(Blockly.utils.xml.textToDom(
             '<block type="row_block"/>'
         ), this.workspace);
         this.clock.runAll();
@@ -792,7 +792,7 @@ suite('Blocks', function() {
         chai.assert.equal(this.getInputs().length, 1);
       });
       test('Multi-Row', function() {
-        const block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
+        const block = Blockly.Xml.domToBlock(Blockly.utils.xml.textToDom(
             '<block type="row_block">' +
             '  <value name="INPUT">' +
             '    <block type="row_block">' +
@@ -816,7 +816,7 @@ suite('Blocks', function() {
         chai.assert.equal(this.getInputs().length, 3);
       });
       test('Multi-Row Middle', function() {
-        let block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
+        let block = Blockly.Xml.domToBlock(Blockly.utils.xml.textToDom(
             '<block type="row_block">' +
             '  <value name="INPUT">' +
             '    <block type="row_block">' +
@@ -843,7 +843,7 @@ suite('Blocks', function() {
       test('Multi-Row Double Collapse', function() {
         // Collapse middle -> Collapse top ->
         // Uncollapse top -> Uncollapse middle
-        const block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
+        const block = Blockly.Xml.domToBlock(Blockly.utils.xml.textToDom(
             '<block type="row_block">' +
             '  <value name="INPUT">' +
             '    <block type="row_block">' +
@@ -876,7 +876,7 @@ suite('Blocks', function() {
         chai.assert.equal(this.getInputs().length, 3);
       });
       test('Statement', function() {
-        const block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
+        const block = Blockly.Xml.domToBlock(Blockly.utils.xml.textToDom(
             '<block type="statement_block"/>'
         ), this.workspace);
         this.clock.runAll();
@@ -892,7 +892,7 @@ suite('Blocks', function() {
         chai.assert.equal(this.getNext().length, 2);
       });
       test('Multi-Statement', function() {
-        const block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
+        const block = Blockly.Xml.domToBlock(Blockly.utils.xml.textToDom(
             '<block type="statement_block">' +
             '  <statement name="STATEMENT">' +
             '    <block type="statement_block">' +
@@ -917,7 +917,7 @@ suite('Blocks', function() {
         chai.assert.equal(this.getNext().length, 6);
       });
       test('Multi-Statement Middle', function() {
-        let block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
+        let block = Blockly.Xml.domToBlock(Blockly.utils.xml.textToDom(
             '<block type="statement_block">' +
             '  <statement name="STATEMENT">' +
             '    <block type="statement_block">' +
@@ -943,7 +943,7 @@ suite('Blocks', function() {
         chai.assert.equal(this.getNext().length, 6);
       });
       test('Multi-Statement Double Collapse', function() {
-        const block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
+        const block = Blockly.Xml.domToBlock(Blockly.utils.xml.textToDom(
             '<block type="statement_block">' +
             '  <statement name="STATEMENT">' +
             '    <block type="statement_block">' +
@@ -979,7 +979,7 @@ suite('Blocks', function() {
     });
     suite('Setting Parent Block', function() {
       setup(function() {
-        this.printBlock = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
+        this.printBlock = Blockly.Xml.domToBlock(Blockly.utils.xml.textToDom(
             '<block type="text_print">' +
             '  <value name="TEXT">' +
             '    <block type="text_join">' +
@@ -1181,7 +1181,7 @@ suite('Blocks', function() {
       });
       suite('Headless', function() {
         setup(function() {
-          this.block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
+          this.block = Blockly.Xml.domToBlock(Blockly.utils.xml.textToDom(
               '<block type="empty_block"/>'
           ), this.workspace);
         });
@@ -1214,7 +1214,7 @@ suite('Blocks', function() {
             comments: true,
             scrollbars: true,
           });
-          this.block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
+          this.block = Blockly.Xml.domToBlock(Blockly.utils.xml.textToDom(
               '<block type="empty_block"/>'
           ), this.workspace);
         });
@@ -1281,7 +1281,7 @@ suite('Blocks', function() {
   suite('Getting/Setting Field (Values)', function() {
     setup(function() {
       this.workspace = Blockly.inject('blocklyDiv');
-      this.block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
+      this.block = Blockly.Xml.domToBlock(Blockly.utils.xml.textToDom(
           '<block type="text"><field name = "TEXT">test</field></block>'
       ), this.workspace);
     });
@@ -1349,7 +1349,7 @@ suite('Blocks', function() {
       });
 
       test('Has Icon', function() {
-        const block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
+        const block = Blockly.Xml.domToBlock(Blockly.utils.xml.textToDom(
             '<block type="statement_block"/>'
         ), this.workspace);
         block.setCommentText('test text');
@@ -1359,7 +1359,7 @@ suite('Blocks', function() {
         chai.assert.isFalse(block.comment.isVisible());
       });
       test('Child Has Icon', function() {
-        const block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
+        const block = Blockly.Xml.domToBlock(Blockly.utils.xml.textToDom(
             '<block type="statement_block">' +
             '  <statement name="STATEMENT">' +
             '    <block type="statement_block"/>' +
@@ -1374,7 +1374,7 @@ suite('Blocks', function() {
         chai.assert.isFalse(childBlock.comment.isVisible());
       });
       test('Next Block Has Icon', function() {
-        const block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
+        const block = Blockly.Xml.domToBlock(Blockly.utils.xml.textToDom(
             '<block type="statement_block">' +
             '  <next>' +
             '    <block type="statement_block"/>' +
@@ -1873,7 +1873,7 @@ suite('Blocks', function() {
   suite('Style', function() {
     suite('Headless', function() {
       setup(function() {
-        this.block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
+        this.block = Blockly.Xml.domToBlock(Blockly.utils.xml.textToDom(
             '<block type="empty_block"/>'
         ), this.workspace);
       });
@@ -1894,7 +1894,7 @@ suite('Blocks', function() {
     suite('Rendered', function() {
       setup(function() {
         this.workspace = Blockly.inject('blocklyDiv', {});
-        this.block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
+        this.block = Blockly.Xml.domToBlock(Blockly.utils.xml.textToDom(
             '<block type="empty_block"/>'
         ), this.workspace);
         this.workspace.setTheme(new Blockly.Theme('test', {
@@ -2046,7 +2046,7 @@ suite('Blocks', function() {
     // Create mocha test cases for each toString test.
     toStringTests.forEach(function(t) {
       test(t.name, function() {
-        const block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(t.xml),
+        const block = Blockly.Xml.domToBlock(Blockly.utils.xml.textToDom(t.xml),
             this.workspace);
         chai.assert.equal(block.toString(), t.toString);
       });

--- a/tests/mocha/blocks/procedures_test.js
+++ b/tests/mocha/blocks/procedures_test.js
@@ -771,7 +771,7 @@ suite('Procedures', function() {
 
     suite('xml', function() {
       test('callers without defs create new defs', function() {
-        const callBlock = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(`
+        const callBlock = Blockly.Xml.domToBlock(Blockly.utils.xml.textToDom(`
             <block type="procedures_callreturn">
               <mutation name="do something"/>
             </block>`
@@ -783,7 +783,7 @@ suite('Procedures', function() {
       });
 
       test('callers without mutations create unnamed defs', function() {
-        const callBlock = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
+        const callBlock = Blockly.Xml.domToBlock(Blockly.utils.xml.textToDom(
             '<block type="procedures_callreturn"></block>'
         ), this.workspace);
         this.clock.runAll();
@@ -793,7 +793,7 @@ suite('Procedures', function() {
       });
 
       test('callers with missing args create new defs', function() {
-        const defBlock = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(`
+        const defBlock = Blockly.Xml.domToBlock(Blockly.utils.xml.textToDom(`
             <block type="procedures_defreturn">
               <field name="NAME">do something</field>
               <mutation>
@@ -801,7 +801,7 @@ suite('Procedures', function() {
               </mutation>
             </block>
         `), this.workspace);
-        const callBlock = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
+        const callBlock = Blockly.Xml.domToBlock(Blockly.utils.xml.textToDom(
             '<block type="procedures_callreturn">' +
             '  <mutation name="do something"/>' +
             '</block>'
@@ -812,7 +812,7 @@ suite('Procedures', function() {
       });
 
       test('callers with mismatched args create new defs', function() {
-        const defBlock = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(`
+        const defBlock = Blockly.Xml.domToBlock(Blockly.utils.xml.textToDom(`
             <block type="procedures_defreturn">
               <field name="NAME">do something</field>
               <mutation>
@@ -820,7 +820,7 @@ suite('Procedures', function() {
               </mutation>
             </block>
         `), this.workspace);
-        const callBlock = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(`
+        const callBlock = Blockly.Xml.domToBlock(Blockly.utils.xml.textToDom(`
             <block type="procedures_callreturn">
               <mutation name="do something">
                 <arg name="y"></arg>
@@ -836,7 +836,7 @@ suite('Procedures', function() {
       test.skip(
           'callers whose defs are deserialized later do not create defs',
           function() {
-            Blockly.Xml.domToWorkspace(Blockly.Xml.textToDom(`
+            Blockly.Xml.domToWorkspace(Blockly.utils.xml.textToDom(`
                 <xml>
                   <block type="procedures_callreturn">
                     <mutation name="do something">
@@ -1139,7 +1139,7 @@ suite('Procedures', function() {
 
     suite('no name renamed to unnamed', function() {
       test('defnoreturn and defreturn', function() {
-        const xml = Blockly.Xml.textToDom(`
+        const xml = Blockly.utils.xml.textToDom(`
               <xml xmlns="https://developers.google.com/blockly/xml">
                 <block type="procedures_defnoreturn"/>
                 <block type="procedures_defreturn"/>
@@ -1152,7 +1152,7 @@ suite('Procedures', function() {
       });
 
       test('defreturn and defnoreturn', function() {
-        const xml = Blockly.Xml.textToDom(`
+        const xml = Blockly.utils.xml.textToDom(`
               <xml xmlns="https://developers.google.com/blockly/xml">
                 <block type="procedures_defreturn"/>
                 <block type="procedures_defnoreturn"/>
@@ -1165,7 +1165,7 @@ suite('Procedures', function() {
       });
 
       test('callreturn (no def in xml)', function() {
-        const xml = Blockly.Xml.textToDom(`
+        const xml = Blockly.utils.xml.textToDom(`
               <xml xmlns="https://developers.google.com/blockly/xml">
                 <block type="procedures_callreturn"/>
               </xml>`);
@@ -1176,7 +1176,7 @@ suite('Procedures', function() {
       });
 
       test('callnoreturn and callreturn (no def in xml)', function() {
-        const xml = Blockly.Xml.textToDom(`
+        const xml = Blockly.utils.xml.textToDom(`
               <xml xmlns="https://developers.google.com/blockly/xml">
                 <block type="procedures_callnoreturn" id="first"/>
                 <block type="procedures_callreturn" id="second"/>
@@ -1188,7 +1188,7 @@ suite('Procedures', function() {
       });
 
       test('callreturn and callnoreturn (no def in xml)', function() {
-        const xml = Blockly.Xml.textToDom(`
+        const xml = Blockly.utils.xml.textToDom(`
               <xml xmlns="https://developers.google.com/blockly/xml">
                 <block type="procedures_callreturn"/>
                 <block type="procedures_callnoreturn"/>
@@ -1579,7 +1579,7 @@ suite('Procedures', function() {
                 chai.assert.isFalse(this.defBlock.hasStatements_);
               });
               test('Saving Statements', function() {
-                const blockXml = Blockly.Xml.textToDom(
+                const blockXml = Blockly.utils.xml.textToDom(
                     '<block type="procedures_defreturn">' +
                     '  <statement name="STACK">' +
                     '    <block type="procedures_ifreturn" id="test"></block>' +

--- a/tests/mocha/comment_deserialization_test.js
+++ b/tests/mocha/comment_deserialization_test.js
@@ -34,7 +34,7 @@ suite('Comment Deserialization', function() {
       scrollbars: true,
       trashcan: true,
       maxTrashcanContents: Infinity,
-      toolbox: Blockly.Xml.textToDom(toolboxXml),
+      toolbox: Blockly.utils.xml.textToDom(toolboxXml),
     });
   });
   teardown(function() {
@@ -46,7 +46,7 @@ suite('Comment Deserialization', function() {
       this.workspace.clear();
     });
     function createBlock(workspace) {
-      const block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
+      const block = Blockly.Xml.domToBlock(Blockly.utils.xml.textToDom(
         '<block type="empty_block"/>'
       ), workspace);
       block.setCommentText('test text');

--- a/tests/mocha/comment_test.js
+++ b/tests/mocha/comment_test.js
@@ -25,7 +25,7 @@ suite('Comments', function() {
       comments: true,
       scrollbars: true,
     });
-    this.block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
+    this.block = Blockly.Xml.domToBlock(Blockly.utils.xml.textToDom(
         '<block type="empty_block"/>'
     ), this.workspace);
     this.comment = new Blockly.Comment(this.block);

--- a/tests/mocha/connection_checker_test.js
+++ b/tests/mocha/connection_checker_test.js
@@ -346,7 +346,7 @@ suite('Connection checker', function() {
       setup(function() {
         this.workspace = Blockly.inject('blocklyDiv');
         // Load in three blocks: A and B are connected (next/prev); B is unmovable.
-        Blockly.Xml.domToWorkspace(Blockly.Xml.textToDom(`<xml xmlns="https://developers.google.com/blockly/xml">
+        Blockly.Xml.domToWorkspace(Blockly.utils.xml.textToDom(`<xml xmlns="https://developers.google.com/blockly/xml">
         <block type="text_print" id="A" x="-76" y="-112">
           <next>
             <block type="text_print" id="B" movable="false">
@@ -402,7 +402,7 @@ suite('Connection checker', function() {
       setup(function() {
         this.workspace = Blockly.inject('blocklyDiv');
         // Load 3 blocks: A and B are connected (input/output); B is unmovable.
-        Blockly.Xml.domToWorkspace(Blockly.Xml.textToDom(`<xml xmlns="https://developers.google.com/blockly/xml">
+        Blockly.Xml.domToWorkspace(Blockly.utils.xml.textToDom(`<xml xmlns="https://developers.google.com/blockly/xml">
         <block type="test_basic_row" id="A" x="38" y="37">
           <value name="INPUT">
             <block type="test_basic_row" id="B" movable="false"></block>

--- a/tests/mocha/connection_test.js
+++ b/tests/mocha/connection_test.js
@@ -109,21 +109,21 @@ suite('Connection', function() {
           suite('Add - No Block Connected', function() {
             // These are defined separately in each suite.
             function createRowBlock(workspace) {
-              const block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
+              const block = Blockly.Xml.domToBlock(Blockly.utils.xml.textToDom(
                   '<block type="row_block" id="id0"/>'
               ), workspace);
               return block;
             }
 
             function createStatementBlock(workspace) {
-              const block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
+              const block = Blockly.Xml.domToBlock(Blockly.utils.xml.textToDom(
                   '<block type="statement_block" id="id0"/>'
               ), workspace);
               return block;
             }
 
             function createStackBlock(workspace) {
-              const block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
+              const block = Blockly.Xml.domToBlock(Blockly.utils.xml.textToDom(
                   '<block type="stack_block" id="id0"/>'
               ), workspace);
               return block;
@@ -131,7 +131,7 @@ suite('Connection', function() {
 
             test('Value', function() {
               const parent = createRowBlock(this.workspace);
-              const xml = Blockly.Xml.textToDom(
+              const xml = Blockly.utils.xml.textToDom(
                   '<shadow type="row_block" id="id1"/>'
               );
               parent.getInput('INPUT').connection.setShadowDom(xml);
@@ -161,7 +161,7 @@ suite('Connection', function() {
 
             test('Multiple Value', function() {
               const parent = createRowBlock(this.workspace);
-              const xml = Blockly.Xml.textToDom(
+              const xml = Blockly.utils.xml.textToDom(
                   '<shadow type="row_block" id="id1">' +
                   '  <value name="INPUT">' +
                   '    <shadow type="row_block" id="id2"/>' +
@@ -209,7 +209,7 @@ suite('Connection', function() {
 
             test('Statement', function() {
               const parent = createStatementBlock(this.workspace);
-              const xml = Blockly.Xml.textToDom(
+              const xml = Blockly.utils.xml.textToDom(
                   '<shadow type="statement_block" id="id1"/>'
               );
               parent.getInput('NAME').connection.setShadowDom(xml);
@@ -239,7 +239,7 @@ suite('Connection', function() {
 
             test('Multiple Statement', function() {
               const parent = createStatementBlock(this.workspace);
-              const xml = Blockly.Xml.textToDom(
+              const xml = Blockly.utils.xml.textToDom(
                   '<shadow type="statement_block" id="id1">' +
                   '  <statement name="NAME">' +
                   '    <shadow type="statement_block" id="id2"/>' +
@@ -287,7 +287,7 @@ suite('Connection', function() {
 
             test('Next', function() {
               const parent = createStackBlock(this.workspace);
-              const xml = Blockly.Xml.textToDom(
+              const xml = Blockly.utils.xml.textToDom(
                   '<shadow type="stack_block" id="id1"/>'
               );
               parent.nextConnection.setShadowDom(xml);
@@ -315,7 +315,7 @@ suite('Connection', function() {
 
             test('Multiple Next', function() {
               const parent = createStackBlock(this.workspace);
-              const xml = Blockly.Xml.textToDom(
+              const xml = Blockly.utils.xml.textToDom(
                   '<shadow type="stack_block" id="id1">' +
                   '  <next>' +
                   '    <shadow type="stack_block" id="id2"/>' +
@@ -360,7 +360,7 @@ suite('Connection', function() {
           suite('Add - With Block Connected', function() {
             // These are defined separately in each suite.
             function createRowBlocks(workspace) {
-              const block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
+              const block = Blockly.Xml.domToBlock(Blockly.utils.xml.textToDom(
                   '<block type="row_block" id="id0">' +
                   '  <value name="INPUT">' +
                   '    <block type="row_block" id="idA"/>' +
@@ -371,7 +371,7 @@ suite('Connection', function() {
             }
 
             function createStatementBlocks(workspace) {
-              const block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
+              const block = Blockly.Xml.domToBlock(Blockly.utils.xml.textToDom(
                   '<block type="statement_block" id="id0">' +
                   '  <statement name="NAME">' +
                   '    <block type="statement_block" id="idA"/>' +
@@ -382,7 +382,7 @@ suite('Connection', function() {
             }
 
             function createStackBlocks(workspace) {
-              const block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
+              const block = Blockly.Xml.domToBlock(Blockly.utils.xml.textToDom(
                   '<block type="stack_block" id="id0">' +
                   '  <next>' +
                   '    <block type="stack_block" id="idA"/>' +
@@ -394,7 +394,7 @@ suite('Connection', function() {
 
             test('Value', function() {
               const parent = createRowBlocks(this.workspace);
-              const xml = Blockly.Xml.textToDom(
+              const xml = Blockly.utils.xml.textToDom(
                   '<shadow type="row_block" id="id1"/>'
               );
               parent.getInput('INPUT').connection.setShadowDom(xml);
@@ -426,7 +426,7 @@ suite('Connection', function() {
 
             test('Multiple Value', function() {
               const parent = createRowBlocks(this.workspace);
-              const xml = Blockly.Xml.textToDom(
+              const xml = Blockly.utils.xml.textToDom(
                   '<shadow type="row_block" id="id1">' +
                   '  <value name="INPUT">' +
                   '    <shadow type="row_block" id="id2"/>' +
@@ -477,7 +477,7 @@ suite('Connection', function() {
 
             test('Statement', function() {
               const parent = createStatementBlocks(this.workspace);
-              const xml = Blockly.Xml.textToDom(
+              const xml = Blockly.utils.xml.textToDom(
                   '<shadow type="statement_block" id="id1"/>'
               );
               parent.getInput('NAME').connection.setShadowDom(xml);
@@ -509,7 +509,7 @@ suite('Connection', function() {
 
             test('Multiple Statement', function() {
               const parent = createStatementBlocks(this.workspace);
-              const xml = Blockly.Xml.textToDom(
+              const xml = Blockly.utils.xml.textToDom(
                   '<shadow type="statement_block" id="id1">' +
                   '  <statement name="NAME">' +
                   '    <shadow type="statement_block" id="id2"/>' +
@@ -561,7 +561,7 @@ suite('Connection', function() {
 
             test('Next', function() {
               const parent = createStackBlocks(this.workspace);
-              const xml = Blockly.Xml.textToDom(
+              const xml = Blockly.utils.xml.textToDom(
                   '<shadow type="stack_block" id="id1"/>'
               );
               parent.nextConnection.setShadowDom(xml);
@@ -591,7 +591,7 @@ suite('Connection', function() {
 
             test('Multiple Next', function() {
               const parent = createStackBlocks(this.workspace);
-              const xml = Blockly.Xml.textToDom(
+              const xml = Blockly.utils.xml.textToDom(
                   '<shadow type="stack_block" id="id1">' +
                   '  <next>' +
                   '    <shadow type="stack_block" id="id2"/>' +
@@ -639,21 +639,21 @@ suite('Connection', function() {
           suite('Add - With Shadow Connected', function() {
             // These are defined separately in each suite.
             function createRowBlock(workspace) {
-              const block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
+              const block = Blockly.Xml.domToBlock(Blockly.utils.xml.textToDom(
                   '<block type="row_block" id="id0"/>'
               ), workspace);
               return block;
             }
 
             function createStatementBlock(workspace) {
-              const block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
+              const block = Blockly.Xml.domToBlock(Blockly.utils.xml.textToDom(
                   '<block type="statement_block" id="id0"/>'
               ), workspace);
               return block;
             }
 
             function createStackBlock(workspace) {
-              const block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
+              const block = Blockly.Xml.domToBlock(Blockly.utils.xml.textToDom(
                   '<block type="stack_block" id="id0"/>'
               ), workspace);
               return block;
@@ -661,13 +661,13 @@ suite('Connection', function() {
 
             test('Value', function() {
               const parent = createRowBlock(this.workspace);
-              const xml1 = Blockly.Xml.textToDom(
+              const xml1 = Blockly.utils.xml.textToDom(
                   '<shadow type="row_block" id="1"/>'
               );
               parent.getInput('INPUT').connection.setShadowDom(xml1);
               assertInputHasBlock(parent, 'INPUT', true, '1');
               const xml2 =
-                  Blockly.Xml.textToDom('<shadow type="row_block" id="2"/>');
+                  Blockly.utils.xml.textToDom('<shadow type="row_block" id="2"/>');
               parent.getInput('INPUT').connection.setShadowDom(xml2);
               assertInputHasBlock(parent, 'INPUT', true, '2');
               assertSerialization(
@@ -695,7 +695,7 @@ suite('Connection', function() {
 
             test('Multiple Value', function() {
               const parent = createRowBlock(this.workspace);
-              const xml1 = Blockly.Xml.textToDom(
+              const xml1 = Blockly.utils.xml.textToDom(
                   '<shadow type="row_block" id="1">' +
                   '  <value name="INPUT">' +
                   '    <shadow type="row_block" id="a"/>' +
@@ -705,7 +705,7 @@ suite('Connection', function() {
               assertInputHasBlock(parent, 'INPUT', true, '1');
               assertInputHasBlock(
                   parent.getInputTargetBlock('INPUT'), 'INPUT', true, 'a');
-              const xml2 = Blockly.Xml.textToDom(
+              const xml2 = Blockly.utils.xml.textToDom(
                   '<shadow type="row_block" id="2">' +
                   '  <value name="INPUT">' +
                   '    <shadow type="row_block" id="b"/>' +
@@ -752,11 +752,11 @@ suite('Connection', function() {
 
             test('Statement', function() {
               const parent = createStatementBlock(this.workspace);
-              const xml1 = Blockly.Xml.textToDom(
+              const xml1 = Blockly.utils.xml.textToDom(
                   '<shadow type="statement_block" id="1"/>');
               parent.getInput('NAME').connection.setShadowDom(xml1);
               assertInputHasBlock(parent, 'NAME', true, '1');
-              const xml2 = Blockly.Xml.textToDom(
+              const xml2 = Blockly.utils.xml.textToDom(
                   '<shadow type="statement_block" id="2"/>');
               parent.getInput('NAME').connection.setShadowDom(xml2);
               assertInputHasBlock(parent, 'NAME', true, '2');
@@ -785,7 +785,7 @@ suite('Connection', function() {
 
             test('Multiple Statement', function() {
               const parent = createStatementBlock(this.workspace);
-              const xml1 = Blockly.Xml.textToDom(
+              const xml1 = Blockly.utils.xml.textToDom(
                   '<shadow type="statement_block" id="1">' +
                   '  <statement name="NAME">' +
                   '    <shadow type="statement_block" id="a"/>' +
@@ -795,7 +795,7 @@ suite('Connection', function() {
               assertInputHasBlock(parent, 'NAME', true, '1');
               assertInputHasBlock(
                   parent.getInputTargetBlock('NAME'), 'NAME', true, 'a');
-              const xml2 = Blockly.Xml.textToDom(
+              const xml2 = Blockly.utils.xml.textToDom(
                   '<shadow type="statement_block" id="2">' +
                   '  <statement name="NAME">' +
                   '    <shadow type="statement_block" id="b"/>' +
@@ -843,11 +843,11 @@ suite('Connection', function() {
             test('Next', function() {
               const parent = createStackBlock(this.workspace);
               const xml1 =
-                  Blockly.Xml.textToDom('<shadow type="stack_block" id="1"/>');
+                  Blockly.utils.xml.textToDom('<shadow type="stack_block" id="1"/>');
               parent.nextConnection.setShadowDom(xml1);
               assertNextHasBlock(parent, true, '1');
               const xml2 =
-                  Blockly.Xml.textToDom('<shadow type="stack_block" id="2"/>');
+                  Blockly.utils.xml.textToDom('<shadow type="stack_block" id="2"/>');
               parent.nextConnection.setShadowDom(xml2);
               assertNextHasBlock(parent, true, '2');
               assertSerialization(
@@ -873,7 +873,7 @@ suite('Connection', function() {
 
             test('Multiple Next', function() {
               const parent = createStackBlock(this.workspace);
-              const xml1 = Blockly.Xml.textToDom(
+              const xml1 = Blockly.utils.xml.textToDom(
                   '<shadow type="stack_block" id="1">' +
                   '  <next>' +
                   '    <shadow type="stack_block" id="a"/>' +
@@ -882,7 +882,7 @@ suite('Connection', function() {
               parent.nextConnection.setShadowDom(xml1);
               assertNextHasBlock(parent, true, '1');
               assertNextHasBlock(parent.getNextBlock(), true, 'a');
-              const xml2 = Blockly.Xml.textToDom(
+              const xml2 = Blockly.utils.xml.textToDom(
                   '<shadow type="stack_block" id="2">' +
                   '  <next>' +
                   '    <shadow type="stack_block" id="b"/>' +
@@ -926,7 +926,7 @@ suite('Connection', function() {
           suite('Remove - No Block Connected', function() {
             // These are defined separately in each suite.
             function createRowBlock(workspace) {
-              const block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
+              const block = Blockly.Xml.domToBlock(Blockly.utils.xml.textToDom(
                   '<block type="row_block" id="id0">' +
                   '  <value name="INPUT">' +
                   '    <shadow type="row_block" id="idA"/>' +
@@ -937,7 +937,7 @@ suite('Connection', function() {
             }
 
             function createStatementBlock(workspace) {
-              const block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
+              const block = Blockly.Xml.domToBlock(Blockly.utils.xml.textToDom(
                   '<block type="statement_block" id="id0">' +
                   '  <statement name="NAME">' +
                   '    <shadow type="statement_block" id="idA"/>' +
@@ -948,7 +948,7 @@ suite('Connection', function() {
             }
 
             function createStackBlock(workspace) {
-              const block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
+              const block = Blockly.Xml.domToBlock(Blockly.utils.xml.textToDom(
                   '<block type="stack_block" id="id0">' +
                   '  <next>' +
                   '    <shadow type="stack_block" id="idA"/>' +
@@ -1010,7 +1010,7 @@ suite('Connection', function() {
           suite('Remove - Block Connected', function() {
             // These are defined separately in each suite.
             function createRowBlock(workspace) {
-              const block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
+              const block = Blockly.Xml.domToBlock(Blockly.utils.xml.textToDom(
                   '<block type="row_block" id="id0">' +
                   '  <value name="INPUT">' +
                   '    <shadow type="row_block" id="idA"/>' +
@@ -1022,7 +1022,7 @@ suite('Connection', function() {
             }
 
             function createStatementBlock(workspace) {
-              const block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
+              const block = Blockly.Xml.domToBlock(Blockly.utils.xml.textToDom(
                   '<block type="statement_block" id="id0">' +
                   '  <statement name="NAME">' +
                   '    <shadow type="statement_block" id="idA"/>' +
@@ -1034,7 +1034,7 @@ suite('Connection', function() {
             }
 
             function createStackBlock(workspace) {
-              const block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
+              const block = Blockly.Xml.domToBlock(Blockly.utils.xml.textToDom(
                   '<block type="stack_block" id="id0">' +
                   '  <next>' +
                   '    <shadow type="stack_block" id="idA"/>' +
@@ -1103,21 +1103,21 @@ suite('Connection', function() {
           suite('Add - Connect & Disconnect - Remove', function() {
             // These are defined separately in each suite.
             function createRowBlock(workspace) {
-              const block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
+              const block = Blockly.Xml.domToBlock(Blockly.utils.xml.textToDom(
                   '<block type="row_block"/>'
               ), workspace);
               return block;
             }
 
             function createStatementBlock(workspace) {
-              const block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
+              const block = Blockly.Xml.domToBlock(Blockly.utils.xml.textToDom(
                   '<block type="statement_block"/>'
               ), workspace);
               return block;
             }
 
             function createStackBlock(workspace) {
-              const block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
+              const block = Blockly.Xml.domToBlock(Blockly.utils.xml.textToDom(
                   '<block type="stack_block"/>'
               ), workspace);
               return block;
@@ -1125,7 +1125,7 @@ suite('Connection', function() {
 
             test('Value', function() {
               const parent = createRowBlock(this.workspace);
-              const xml = Blockly.Xml.textToDom(
+              const xml = Blockly.utils.xml.textToDom(
                   '<shadow type="row_block"/>'
               );
               parent.getInput('INPUT').connection.setShadowDom(xml);
@@ -1141,7 +1141,7 @@ suite('Connection', function() {
 
             test('Multiple Value', function() {
               const parent = createRowBlock(this.workspace);
-              const xml = Blockly.Xml.textToDom(
+              const xml = Blockly.utils.xml.textToDom(
                   '<shadow type="row_block">' +
                   '  <value name="INPUT">' +
                   '    <shadow type="row_block"/>' +
@@ -1165,7 +1165,7 @@ suite('Connection', function() {
 
             test('Statement', function() {
               const parent = createStatementBlock(this.workspace);
-              const xml = Blockly.Xml.textToDom(
+              const xml = Blockly.utils.xml.textToDom(
                   '<shadow type="statement_block"/>'
               );
               parent.getInput('NAME').connection.setShadowDom(xml);
@@ -1182,7 +1182,7 @@ suite('Connection', function() {
 
             test('Multiple Statement', function() {
               const parent = createStatementBlock(this.workspace);
-              const xml = Blockly.Xml.textToDom(
+              const xml = Blockly.utils.xml.textToDom(
                   '<shadow type="statement_block">' +
                   '  <statement name="NAME">' +
                   '    <shadow type="statement_block"/>' +
@@ -1207,7 +1207,7 @@ suite('Connection', function() {
 
             test('Next', function() {
               const parent = createStackBlock(this.workspace);
-              const xml = Blockly.Xml.textToDom(
+              const xml = Blockly.utils.xml.textToDom(
                   '<shadow type="stack_block"/>'
               );
               parent.nextConnection.setShadowDom(xml);
@@ -1223,7 +1223,7 @@ suite('Connection', function() {
 
             test('Multiple Next', function() {
               const parent = createStackBlock(this.workspace);
-              const xml = Blockly.Xml.textToDom(
+              const xml = Blockly.utils.xml.textToDom(
                   '<shadow type="stack_block" id="parent">' +
                   '  <next>' +
                   '    <shadow type="stack_block" id="child"/>' +
@@ -1248,28 +1248,28 @@ suite('Connection', function() {
             test('Attach to output', function() {
               const block = this.workspace.newBlock('row_block');
               chai.assert.throws(() =>
-                block.outputConnection.setShadowDom(Blockly.Xml.textToDom(
+                block.outputConnection.setShadowDom(Blockly.utils.xml.textToDom(
                     '<block type="row_block">')));
             });
 
             test('Attach to previous', function() {
               const block = this.workspace.newBlock('stack_block');
               chai.assert.throws(() =>
-                block.previousConnection.setShadowDom(Blockly.Xml.textToDom(
+                block.previousConnection.setShadowDom(Blockly.utils.xml.textToDom(
                     '<block type="stack_block">')));
             });
 
             test('Missing output', function() {
               const block = this.workspace.newBlock('row_block');
               chai.assert.throws(() =>
-                block.outputConnection.setShadowDom(Blockly.Xml.textToDom(
+                block.outputConnection.setShadowDom(Blockly.utils.xml.textToDom(
                     '<block type="stack_block">')));
             });
 
             test('Missing previous', function() {
               const block = this.workspace.newBlock('stack_block');
               chai.assert.throws(() =>
-                block.previousConnection.setShadowDom(Blockly.Xml.textToDom(
+                block.previousConnection.setShadowDom(Blockly.utils.xml.textToDom(
                     '<block type="row_block">')));
             });
 
@@ -1277,7 +1277,7 @@ suite('Connection', function() {
               const block = this.workspace.newBlock('logic_operation');
               chai.assert.throws(() =>
                 block.getInput('A').connection.setShadowDom(
-                    Blockly.Xml.textToDom('<block type="stack_block">')));
+                    Blockly.utils.xml.textToDom('<block type="stack_block">')));
             });
 
             test('Invalid connection checks, previous', function() {
@@ -1289,7 +1289,7 @@ suite('Connection', function() {
               }]);
               const block = this.workspace.newBlock('stack_checks_block');
               chai.assert.throws(() =>
-                block.nextConnection.setShadowDom(Blockly.Xml.textToDom(
+                block.nextConnection.setShadowDom(Blockly.utils.xml.textToDom(
                     '<block type="stack_checks_block">')));
             });
           });
@@ -2788,7 +2788,7 @@ suite('Connection', function() {
       test('Value', function() {
         const newParent = this.workspace.newBlock('row_block');
         const child = this.workspace.newBlock('row_block');
-        const xml = Blockly.Xml.textToDom(
+        const xml = Blockly.utils.xml.textToDom(
             '<shadow type="row_block"/>'
         );
         newParent.getInput('INPUT').connection.setShadowDom(xml);
@@ -2803,7 +2803,7 @@ suite('Connection', function() {
       test('Statement', function() {
         const newParent = this.workspace.newBlock('statement_block');
         const child = this.workspace.newBlock('stack_block');
-        const xml = Blockly.Xml.textToDom(
+        const xml = Blockly.utils.xml.textToDom(
             '<shadow type="stack_block"/>'
         );
         newParent.getInput('NAME').connection.setShadowDom(xml);
@@ -2821,7 +2821,7 @@ suite('Connection', function() {
       test('Next', function() {
         const newParent = this.workspace.newBlock('stack_block');
         const child = this.workspace.newBlock('stack_block');
-        const xml = Blockly.Xml.textToDom(
+        const xml = Blockly.utils.xml.textToDom(
             '<shadow type="stack_block"/>'
         );
         newParent.nextConnection.setShadowDom(xml);
@@ -2838,7 +2838,7 @@ suite('Connection', function() {
       test('Value', function() {
         const newParent = this.workspace.newBlock('row_block');
         const child = this.workspace.newBlock('row_block');
-        const xml = Blockly.Xml.textToDom(
+        const xml = Blockly.utils.xml.textToDom(
             '<shadow type="row_block"/>'
         );
         newParent.getInput('INPUT').connection.setShadowDom(xml);
@@ -2856,7 +2856,7 @@ suite('Connection', function() {
       test('Statement', function() {
         const newParent = this.workspace.newBlock('statement_block');
         const child = this.workspace.newBlock('stack_block');
-        const xml = Blockly.Xml.textToDom(
+        const xml = Blockly.utils.xml.textToDom(
             '<shadow type="stack_block"/>'
         );
         newParent.getInput('NAME').connection.setShadowDom(xml);
@@ -2876,7 +2876,7 @@ suite('Connection', function() {
       test('Next', function() {
         const newParent = this.workspace.newBlock('stack_block');
         const child = this.workspace.newBlock('stack_block');
-        const xml = Blockly.Xml.textToDom(
+        const xml = Blockly.utils.xml.textToDom(
             '<shadow type="stack_block"/>'
         );
         newParent.nextConnection.setShadowDom(xml);
@@ -3054,10 +3054,10 @@ suite('Connection', function() {
               parent.getInput('INPUT').connection
                   .connect(oldChild.outputConnection);
               newChild.getInput('INPUT').connection.setShadowDom(
-                  Blockly.Xml.textToDom('<xml><shadow type="row_block"/></xml>')
+                  Blockly.utils.xml.textToDom('<xml><shadow type="row_block"/></xml>')
                       .firstChild);
               newChild.getInput('INPUT2').connection.setShadowDom(
-                  Blockly.Xml.textToDom('<xml><shadow type="row_block"/></xml>')
+                  Blockly.utils.xml.textToDom('<xml><shadow type="row_block"/></xml>')
                       .firstChild);
 
               parent.getInput('INPUT').connection
@@ -3086,10 +3086,10 @@ suite('Connection', function() {
               newChild.getInput('INPUT2').connection
                   .connect(childY.outputConnection);
               childX.getInput('INPUT').connection.setShadowDom(
-                  Blockly.Xml.textToDom('<xml><shadow type="row_block"/></xml>')
+                  Blockly.utils.xml.textToDom('<xml><shadow type="row_block"/></xml>')
                       .firstChild);
               childY.getInput('INPUT').connection.setShadowDom(
-                  Blockly.Xml.textToDom('<xml><shadow type="row_block"/></xml>')
+                  Blockly.utils.xml.textToDom('<xml><shadow type="row_block"/></xml>')
                       .firstChild);
 
               parent.getInput('INPUT').connection
@@ -3115,7 +3115,7 @@ suite('Connection', function() {
               newChild.getInput('INPUT').connection
                   .connect(otherChild.outputConnection);
               newChild.getInput('INPUT2').connection.setShadowDom(
-                  Blockly.Xml.textToDom('<xml><shadow type="row_block"/></xml>')
+                  Blockly.utils.xml.textToDom('<xml><shadow type="row_block"/></xml>')
                       .firstChild);
 
               parent.getInput('INPUT').connection
@@ -3161,7 +3161,7 @@ suite('Connection', function() {
             parent.getInput('INPUT').connection
                 .connect(oldChild.outputConnection);
             newChild.getInput('INPUT').connection.setShadowDom(
-                Blockly.Xml.textToDom('<xml><shadow type="row_block"/></xml>')
+                Blockly.utils.xml.textToDom('<xml><shadow type="row_block"/></xml>')
                     .firstChild);
 
             parent.getInput('INPUT').connection
@@ -3268,7 +3268,7 @@ suite('Connection', function() {
             const newChild = this.workspace.newBlock('stack_block');
             parent.getInput('NAME').connection
                 .connect(oldChild.previousConnection);
-            const xml = Blockly.Xml.textToDom(
+            const xml = Blockly.utils.xml.textToDom(
                 '<shadow type="stack_block"/>'
             );
             newChild.nextConnection.setShadowDom(xml);
@@ -3293,7 +3293,7 @@ suite('Connection', function() {
             parent.getInput('NAME').connection
                 .connect(oldChild.previousConnection);
             newChild1.nextConnection.connect(newChild2.previousConnection);
-            const xml = Blockly.Xml.textToDom(
+            const xml = Blockly.utils.xml.textToDom(
                 '<shadow type="stack_block"/>'
             );
             newChild2.nextConnection.setShadowDom(xml);
@@ -3316,7 +3316,7 @@ suite('Connection', function() {
             const newChild = this.workspace.newBlock('stack_block_1to2');
             parent.getInput('NAME').connection
                 .connect(oldChild.previousConnection);
-            const xml = Blockly.Xml.textToDom(
+            const xml = Blockly.utils.xml.textToDom(
                 '<shadow type="stack_block_2to1"/>'
             );
             newChild.nextConnection.setShadowDom(xml);
@@ -3409,7 +3409,7 @@ suite('Connection', function() {
             const oldChild = this.workspace.newBlock('stack_block');
             const newChild = this.workspace.newBlock('stack_block');
             parent.nextConnection.connect(oldChild.previousConnection);
-            const xml = Blockly.Xml.textToDom(
+            const xml = Blockly.utils.xml.textToDom(
                 '<shadow type="stack_block"/>'
             );
             newChild.nextConnection.setShadowDom(xml);
@@ -3430,7 +3430,7 @@ suite('Connection', function() {
             const newChild2 = this.workspace.newBlock('stack_block_2to1');
             parent.nextConnection.connect(oldChild.previousConnection);
             newChild1.nextConnection.connect(newChild2.previousConnection);
-            const xml = Blockly.Xml.textToDom(
+            const xml = Blockly.utils.xml.textToDom(
                 '<shadow type="stack_block"/>'
             );
             newChild2.nextConnection.setShadowDom(xml);
@@ -3449,7 +3449,7 @@ suite('Connection', function() {
             const oldChild = this.workspace.newBlock('stack_block');
             const newChild = this.workspace.newBlock('stack_block_1to2');
             parent.nextConnection.connect(oldChild.previousConnection);
-            const xml = Blockly.Xml.textToDom(
+            const xml = Blockly.utils.xml.textToDom(
                 '<shadow type="stack_block_2to1"/>'
             );
             newChild.nextConnection.setShadowDom(xml);

--- a/tests/mocha/event_block_change_test.js
+++ b/tests/mocha/event_block_change_test.js
@@ -35,7 +35,7 @@ suite('Block Change Event', function() {
         test('Undo', function() {
           const block = this.workspace.newBlock('xml_block', 'block_id');
           block.domToMutation(
-              Blockly.Xml.textToDom('<mutation hasInput="true"/>'));
+              Blockly.utils.xml.textToDom('<mutation hasInput="true"/>'));
           const blockChange = new Blockly.Events.BlockChange(
               block, 'mutation', null, '', '<mutation hasInput="true"/>');
           blockChange.run(false);
@@ -85,7 +85,7 @@ suite('Block Change Event', function() {
     test('events round-trip through JSON', function() {
       const block = this.workspace.newBlock('xml_block', 'block_id');
       block.domToMutation(
-          Blockly.Xml.textToDom('<mutation hasInput="true"/>'));
+          Blockly.utils.xml.textToDom('<mutation hasInput="true"/>'));
       const origEvent = new Blockly.Events.BlockChange(
           block, 'mutation', null, '', '<mutation hasInput="true"/>');
 

--- a/tests/mocha/event_test.js
+++ b/tests/mocha/event_test.js
@@ -1047,7 +1047,7 @@ suite('Events', function() {
     test('New block new var xml', function() {
       const TEST_GROUP_ID = 'test_group_id';
       const genUidStub = createGenUidStubWithReturns(TEST_GROUP_ID);
-      const dom = Blockly.Xml.textToDom(
+      const dom = Blockly.utils.xml.textToDom(
           '<xml xmlns="https://developers.google.com/blockly/xml">' +
           '  <block type="field_variable_test_block" id="test_block_id">' +
           '    <field name="VAR" id="test_var_id">name1</field>' +

--- a/tests/mocha/field_test.js
+++ b/tests/mocha/field_test.js
@@ -315,21 +315,21 @@ suite('Abstract Fields', function() {
         test('No implementations', function() {
           const field = new DefaultSerializationField('');
           field.fromXml(
-              Blockly.Xml.textToDom('<field name="">test value</field>'));
+              Blockly.utils.xml.textToDom('<field name="">test value</field>'));
           chai.assert.equal(field.getValue(), 'test value');
         });
 
         test('Xml implementations', function() {
           const field = new CustomXmlField('');
           field.fromXml(
-              Blockly.Xml.textToDom('<field name="">custom value</field>'));
+              Blockly.utils.xml.textToDom('<field name="">custom value</field>'));
           chai.assert.equal(field.someProperty, 'custom value');
         });
 
         test('Xml super implementation', function() {
           const field = new CustomXmlCallSuperField('');
           field.fromXml(
-              Blockly.Xml.textToDom(
+              Blockly.utils.xml.textToDom(
                   '<field attribute="custom value" name="">test value</field>'
               )
           );
@@ -340,7 +340,7 @@ suite('Abstract Fields', function() {
         test('XML andd JSO implementations', function() {
           const field = new CustomXmlAndJsoField('');
           field.fromXml(
-              Blockly.Xml.textToDom('<field name="">custom value</field>'));
+              Blockly.utils.xml.textToDom('<field name="">custom value</field>'));
           chai.assert.equal(field.someProperty, 'custom value');
         });
       });
@@ -666,7 +666,7 @@ suite('Abstract Fields', function() {
                   .appendField(field, 'TOOLTIP');
             },
           };
-          const block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
+          const block = Blockly.Xml.domToBlock(Blockly.utils.xml.textToDom(
               '<xml xmlns="https://developers.google.com/blockly/xml">' +
               '  <block type="tooltip"></block>' +
               '</xml>'
@@ -684,7 +684,7 @@ suite('Abstract Fields', function() {
               field.setTooltip('tooltip');
             },
           };
-          const block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
+          const block = Blockly.Xml.domToBlock(Blockly.utils.xml.textToDom(
               '<xml xmlns="https://developers.google.com/blockly/xml">' +
               '  <block type="tooltip"></block>' +
               '</xml>'
@@ -701,7 +701,7 @@ suite('Abstract Fields', function() {
                   .appendField(field, 'TOOLTIP');
             },
           };
-          const block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
+          const block = Blockly.Xml.domToBlock(Blockly.utils.xml.textToDom(
               '<xml xmlns="https://developers.google.com/blockly/xml">' +
               '  <block type="tooltip"></block>' +
               '</xml>'
@@ -724,7 +724,7 @@ suite('Abstract Fields', function() {
               return this.getFieldValue('TOOLTIP');
             },
           };
-          const block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
+          const block = Blockly.Xml.domToBlock(Blockly.utils.xml.textToDom(
               '<xml xmlns="https://developers.google.com/blockly/xml">' +
               '  <block type="tooltip"></block>' +
               '</xml>'
@@ -745,7 +745,7 @@ suite('Abstract Fields', function() {
               tooltip: 'tooltip',
             },
           };
-          const block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
+          const block = Blockly.Xml.domToBlock(Blockly.utils.xml.textToDom(
               '<xml xmlns="https://developers.google.com/blockly/xml">' +
               '  <block type="tooltip"></block>' +
               '</xml>'
@@ -763,7 +763,7 @@ suite('Abstract Fields', function() {
                   .appendField(field, 'TOOLTIP');
             },
           };
-          const block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
+          const block = Blockly.Xml.domToBlock(Blockly.utils.xml.textToDom(
               '<xml xmlns="https://developers.google.com/blockly/xml">' +
               '  <block type="tooltip"></block>' +
               '</xml>'
@@ -780,7 +780,7 @@ suite('Abstract Fields', function() {
                   .appendField(field, 'TOOLTIP');
             },
           };
-          const block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
+          const block = Blockly.Xml.domToBlock(Blockly.utils.xml.textToDom(
               '<xml xmlns="https://developers.google.com/blockly/xml">' +
               '  <block type="tooltip"></block>' +
               '</xml>'

--- a/tests/mocha/flyout_test.js
+++ b/tests/mocha/flyout_test.js
@@ -360,7 +360,7 @@ suite('Flyout', function() {
 
       suite('XML', function() {
         test('True string', function() {
-          const xml = Blockly.Xml.textToDom(
+          const xml = Blockly.utils.xml.textToDom(
               '<xml>' +
               '<block type="text_print" disabled="true"></block>' +
               '</xml>'
@@ -370,7 +370,7 @@ suite('Flyout', function() {
         });
 
         test('False string', function() {
-          const xml = Blockly.Xml.textToDom(
+          const xml = Blockly.utils.xml.textToDom(
               '<xml>' +
               '<block type="text_print" disabled="false"></block>' +
               '</xml>'
@@ -381,7 +381,7 @@ suite('Flyout', function() {
 
         test('Disabled string', function() {
           // The XML system supports this for some reason!?
-          const xml = Blockly.Xml.textToDom(
+          const xml = Blockly.utils.xml.textToDom(
               '<xml>' +
               '<block type="text_print" disabled="disabled"></block>' +
               '</xml>'
@@ -391,7 +391,7 @@ suite('Flyout', function() {
         });
 
         test('Different string', function() {
-          const xml = Blockly.Xml.textToDom(
+          const xml = Blockly.utils.xml.textToDom(
               '<xml>' +
               '<block type="text_print" disabled="random"></block>' +
               '</xml>'

--- a/tests/mocha/input_test.js
+++ b/tests/mocha/input_test.js
@@ -19,7 +19,7 @@ suite('Inputs', function() {
     }]);
 
     this.workspace = Blockly.inject('blocklyDiv');
-    this.block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
+    this.block = Blockly.Xml.domToBlock(Blockly.utils.xml.textToDom(
         '<block type="empty_block"/>'
     ), this.workspace);
 

--- a/tests/mocha/insertion_marker_test.js
+++ b/tests/mocha/insertion_marker_test.js
@@ -77,7 +77,7 @@ suite('InsertionMarkers', function() {
       delete javascriptGenerator['statement_block'];
     });
     test('Marker Surrounds', function() {
-      const xml = Blockly.Xml.textToDom(
+      const xml = Blockly.utils.xml.textToDom(
           '<xml xmlns="https://developers.google.com/blockly/xml">' +
           '  <block type="statement_block" id="insertion">' +
           '    <statement name="STATEMENT">' +
@@ -88,7 +88,7 @@ suite('InsertionMarkers', function() {
       this.assertGen(xml, 'statement[a]{\n};\n');
     });
     test('Marker Enclosed', function() {
-      const xml = Blockly.Xml.textToDom(
+      const xml = Blockly.utils.xml.textToDom(
           '<xml xmlns="https://developers.google.com/blockly/xml">' +
           '  <block type="statement_block" id="a">' +
           '    <statement name="STATEMENT">' +
@@ -99,7 +99,7 @@ suite('InsertionMarkers', function() {
       this.assertGen(xml, 'statement[a]{\n};\n');
     });
     test('Marker Enclosed and Surrounds', function() {
-      const xml = Blockly.Xml.textToDom(
+      const xml = Blockly.utils.xml.textToDom(
           '<xml xmlns="https://developers.google.com/blockly/xml">' +
           '  <block type="statement_block" id="a">' +
           '    <statement name="STATEMENT">' +
@@ -118,7 +118,7 @@ suite('InsertionMarkers', function() {
           '};\n');
     });
     test('Marker Prev', function() {
-      const xml = Blockly.Xml.textToDom(
+      const xml = Blockly.utils.xml.textToDom(
           '<xml xmlns="https://developers.google.com/blockly/xml">' +
           '  <block type="stack_block" id="insertion">' +
           '    <next>' +
@@ -129,7 +129,7 @@ suite('InsertionMarkers', function() {
       this.assertGen(xml, 'stack[a];\n');
     });
     test('Marker Next', function() {
-      const xml = Blockly.Xml.textToDom(
+      const xml = Blockly.utils.xml.textToDom(
           '<xml xmlns="https://developers.google.com/blockly/xml">' +
           '  <block type="stack_block" id="a">' +
           '    <next>' +
@@ -140,7 +140,7 @@ suite('InsertionMarkers', function() {
       this.assertGen(xml, 'stack[a];\n');
     });
     test('Marker Middle of Stack', function() {
-      const xml = Blockly.Xml.textToDom(
+      const xml = Blockly.utils.xml.textToDom(
           '<xml xmlns="https://developers.google.com/blockly/xml">' +
           '  <block type="stack_block" id="a">' +
           '    <next>' +
@@ -157,7 +157,7 @@ suite('InsertionMarkers', function() {
           'stack[b];\n');
     });
     test('Marker On Output', function() {
-      const xml = Blockly.Xml.textToDom(
+      const xml = Blockly.utils.xml.textToDom(
           '<xml xmlns="https://developers.google.com/blockly/xml">' +
           '  <block type="row_block" id="insertion">' +
           '    <value name="INPUT">' +
@@ -168,7 +168,7 @@ suite('InsertionMarkers', function() {
       this.assertGen(xml, 'row[a]();\n');
     });
     test('Marker On Input', function() {
-      const xml = Blockly.Xml.textToDom(
+      const xml = Blockly.utils.xml.textToDom(
           '<xml xmlns="https://developers.google.com/blockly/xml">' +
           '  <block type="row_block" id="a">' +
           '    <value name="INPUT">' +
@@ -179,7 +179,7 @@ suite('InsertionMarkers', function() {
       this.assertGen(xml, 'row[a]();\n');
     });
     test('Marker Middle of Row', function() {
-      const xml = Blockly.Xml.textToDom(
+      const xml = Blockly.utils.xml.textToDom(
           '<xml xmlns="https://developers.google.com/blockly/xml">' +
           '  <block type="row_block" id="a">' +
           '    <value name="INPUT">' +
@@ -194,7 +194,7 @@ suite('InsertionMarkers', function() {
       this.assertGen(xml, 'row[a](row[b]());\n');
     });
     test('Marker Detatched', function() {
-      const xml = Blockly.Xml.textToDom(
+      const xml = Blockly.utils.xml.textToDom(
           '<xml xmlns="https://developers.google.com/blockly/xml">' +
           '  <block type="stack_block" id="insertion"/>' +
           '  <block type="stack_block" id="a"/>' +
@@ -215,7 +215,7 @@ suite('InsertionMarkers', function() {
       };
     });
     test('Marker Surrounds', function() {
-      const xml = Blockly.Xml.textToDom(
+      const xml = Blockly.utils.xml.textToDom(
           '<xml xmlns="https://developers.google.com/blockly/xml">' +
           '  <block type="statement_block" id="insertion" x="20" y="20">' +
           '    <statement name="STATEMENT">' +
@@ -231,7 +231,7 @@ suite('InsertionMarkers', function() {
           '</xml>');
     });
     test('Marker Enclosed', function() {
-      const xml = Blockly.Xml.textToDom(
+      const xml = Blockly.utils.xml.textToDom(
           '<xml xmlns="https://developers.google.com/blockly/xml">' +
           '  <block type="statement_block" id="a" x="20" y="20">' +
           '    <statement name="STATEMENT">' +
@@ -245,7 +245,7 @@ suite('InsertionMarkers', function() {
           '</xml>');
     });
     test('Marker Enclosed and Surrounds', function() {
-      const xml = Blockly.Xml.textToDom(
+      const xml = Blockly.utils.xml.textToDom(
           '<xml xmlns="https://developers.google.com/blockly/xml">' +
           '  <block type="statement_block" id="a" x="20" y="20">' +
           '    <statement name="STATEMENT">' +
@@ -267,7 +267,7 @@ suite('InsertionMarkers', function() {
           '</xml>');
     });
     test('Marker Prev', function() {
-      const xml = Blockly.Xml.textToDom(
+      const xml = Blockly.utils.xml.textToDom(
           '<xml xmlns="https://developers.google.com/blockly/xml">' +
           '  <block type="stack_block" id="insertion" x="20" y="20">' +
           '    <next>' +
@@ -283,7 +283,7 @@ suite('InsertionMarkers', function() {
           '</xml>');
     });
     test('Marker Next', function() {
-      const xml = Blockly.Xml.textToDom(
+      const xml = Blockly.utils.xml.textToDom(
           '<xml xmlns="https://developers.google.com/blockly/xml">' +
           '  <block type="stack_block" id="a" x="20" y="20">' +
           '    <next>' +
@@ -297,7 +297,7 @@ suite('InsertionMarkers', function() {
           '</xml>');
     });
     test('Marker Middle of Stack', function() {
-      const xml = Blockly.Xml.textToDom(
+      const xml = Blockly.utils.xml.textToDom(
           '<xml xmlns="https://developers.google.com/blockly/xml">' +
           '  <block type="stack_block" id="a" x="20" y="20">' +
           '    <next>' +
@@ -319,7 +319,7 @@ suite('InsertionMarkers', function() {
           '</xml>');
     });
     test('Marker On Output', function() {
-      const xml = Blockly.Xml.textToDom(
+      const xml = Blockly.utils.xml.textToDom(
           '<xml xmlns="https://developers.google.com/blockly/xml">' +
           '  <block type="row_block" id="insertion" x="20" y="20">' +
           '    <value name="INPUT">' +
@@ -335,7 +335,7 @@ suite('InsertionMarkers', function() {
           '</xml>');
     });
     test('Marker On Input', function() {
-      const xml = Blockly.Xml.textToDom(
+      const xml = Blockly.utils.xml.textToDom(
           '<xml xmlns="https://developers.google.com/blockly/xml">' +
           '  <block type="row_block" id="a" x="20" y="20">' +
           '    <value name="INPUT">' +
@@ -349,7 +349,7 @@ suite('InsertionMarkers', function() {
           '</xml>');
     });
     test('Marker Middle of Row', function() {
-      const xml = Blockly.Xml.textToDom(
+      const xml = Blockly.utils.xml.textToDom(
           '<xml xmlns="https://developers.google.com/blockly/xml">' +
           '  <block type="row_block" id="a" x="20" y="20">' +
           '    <value name="INPUT">' +
@@ -371,7 +371,7 @@ suite('InsertionMarkers', function() {
           '</xml>');
     });
     test('Marker Detatched', function() {
-      const xml = Blockly.Xml.textToDom(
+      const xml = Blockly.utils.xml.textToDom(
           '<xml xmlns="https://developers.google.com/blockly/xml">' +
           '  <block type="stack_block" id="insertion"/>' +
           '  <block type="stack_block" id="a" x="20" y="20"/>' +

--- a/tests/mocha/jso_serialization_test.js
+++ b/tests/mocha/jso_serialization_test.js
@@ -374,7 +374,7 @@ suite('JSO Serialization', function() {
         this.createBlockWithShadow = function(blockType, inputName) {
           const block = this.workspace.newBlock(blockType);
           block.getInput(inputName).connection.setShadowDom(
-              Blockly.Xml.textToDom(
+              Blockly.utils.xml.textToDom(
                   '<shadow type="' + blockType + '" id="test"></shadow>'));
           return block;
         };
@@ -385,7 +385,7 @@ suite('JSO Serialization', function() {
           block.getInput(inputName).connection.connect(
               childBlock.outputConnection || childBlock.previousConnection);
           block.getInput(inputName).connection.setShadowDom(
-              Blockly.Xml.textToDom(
+              Blockly.utils.xml.textToDom(
                   '<shadow type="' + blockType + '" id="test"></shadow>'));
           return block;
         };
@@ -601,7 +601,7 @@ suite('JSO Serialization', function() {
           this.createNextWithShadow = function() {
             const block = this.workspace.newBlock('stack_block');
             block.nextConnection.setShadowDom(
-                Blockly.Xml.textToDom(
+                Blockly.utils.xml.textToDom(
                     '<shadow type="stack_block" id="test"></shadow>'));
             return block;
           };
@@ -611,7 +611,7 @@ suite('JSO Serialization', function() {
             const childBlock = this.workspace.newBlock('stack_block');
             block.nextConnection.connect(childBlock.previousConnection);
             block.nextConnection.setShadowDom(
-                Blockly.Xml.textToDom(
+                Blockly.utils.xml.textToDom(
                     '<shadow type="stack_block" id="test"></shadow>'));
             return block;
           };

--- a/tests/mocha/serializer_test.js
+++ b/tests/mocha/serializer_test.js
@@ -1830,7 +1830,7 @@ const runSerializerTestSuite = (serializer, deserializer, testSuite) => {
   const createTestFunction = function(test) {
     return function() {
       Blockly.Xml.domToWorkspace(
-          Blockly.Xml.textToDom(test.xml), this.workspace);
+          Blockly.utils.xml.textToDom(test.xml), this.workspace);
       if (serializer && deserializer) {
         const save = serializer(workspaces.save(this.workspace));
         this.workspace.clear();

--- a/tests/mocha/test_helpers/procedures.js
+++ b/tests/mocha/test_helpers/procedures.js
@@ -127,7 +127,7 @@ export function createProcDefBlock(
   xml +=
       `  <field name="NAME">${name}</field>` +
       '</block>';
-  return Blockly.Xml.domToBlock(Blockly.Xml.textToDom(xml), workspace);
+  return Blockly.Xml.domToBlock(Blockly.utils.xml.textToDom(xml), workspace);
 }
 
 /**
@@ -142,7 +142,7 @@ export function createProcCallBlock(
     workspace, hasReturn = false, name = 'proc name') {
   const type = hasReturn ?
       'procedures_callreturn' : 'procedures_callnoreturn';
-  return Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
+  return Blockly.Xml.domToBlock(Blockly.utils.xml.textToDom(
       `<block type="${type}">` +
       `  <mutation name="${name}"/>` +
       `</block>`

--- a/tests/mocha/test_helpers/serialization.js
+++ b/tests/mocha/test_helpers/serialization.js
@@ -63,7 +63,7 @@ export const runSerializationTestSuite = (testCases) => {
         block = Blockly.serialization.blocks.append(
             testCase.json, this.workspace, {recordUndo: true});
       } else {
-        block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
+        block = Blockly.Xml.domToBlock(Blockly.utils.xml.textToDom(
             testCase.xml), this.workspace);
       }
       this.clock.runAll();
@@ -85,7 +85,7 @@ export const runSerializationTestSuite = (testCases) => {
         const expectedJson = testCase.expectedJson || testCase.json;
         chai.assert.deepEqual(generatedJson, expectedJson);
       } else {
-        const block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
+        const block = Blockly.Xml.domToBlock(Blockly.utils.xml.textToDom(
             testCase.xml), this.workspace);
         this.clock.runAll();
         const generatedXml =

--- a/tests/mocha/test_helpers/toolbox_definitions.js
+++ b/tests/mocha/test_helpers/toolbox_definitions.js
@@ -176,7 +176,7 @@ export function getDeeplyNestedJSON() {
  * @return {Array<Node>} Array holding xml elements for a toolbox.
  */
 export function getXmlArray() {
-  const block = Blockly.Xml.textToDom(
+  const block = Blockly.utils.xml.textToDom(
       `<block type="logic_compare">
         <field name="OP">NEQ</field>
         <value name="A">
@@ -190,9 +190,9 @@ export function getXmlArray() {
           </block>
         </value>
       </block>`);
-  const separator = Blockly.Xml.textToDom('<sep gap="20"></sep>');
-  const button = Blockly.Xml.textToDom('<button text="insert" callbackkey="insertConnectionRows"></button>');
-  const label = Blockly.Xml.textToDom('<label text="tooltips"></label>');
+  const separator = Blockly.utils.xml.textToDom('<sep gap="20"></sep>');
+  const button = Blockly.utils.xml.textToDom('<button text="insert" callbackkey="insertConnectionRows"></button>');
+  const label = Blockly.utils.xml.textToDom('<label text="tooltips"></label>');
   return [block, separator, button, label];
 }
 

--- a/tests/mocha/test_helpers/workspace.js
+++ b/tests/mocha/test_helpers/workspace.js
@@ -697,7 +697,7 @@ export function testAWorkspace() {
       });
 
       function testUndoDelete(xmlText) {
-        const xml = Blockly.Xml.textToDom(xmlText);
+        const xml = Blockly.utils.xml.textToDom(xmlText);
         Blockly.Xml.domToBlock(xml, this.workspace);
         this.workspace.getTopBlocks()[0].dispose(false);
         this.workspace.undo();
@@ -819,7 +819,7 @@ export function testAWorkspace() {
       });
 
       function testUndoConnect(xmlText, parentId, childId, func) {
-        const xml = Blockly.Xml.textToDom(xmlText);
+        const xml = Blockly.utils.xml.textToDom(xmlText);
         Blockly.Xml.domToWorkspace(xml, this.workspace);
 
         const parent = this.workspace.getBlockById(parentId);
@@ -1008,7 +1008,7 @@ export function testAWorkspace() {
       });
 
       function testUndoDisconnect(xmlText, childId) {
-        const xml = Blockly.Xml.textToDom(xmlText);
+        const xml = Blockly.utils.xml.textToDom(xmlText);
         Blockly.Xml.domToWorkspace(xml, this.workspace);
 
         const child = this.workspace.getBlockById(childId);

--- a/tests/mocha/trashcan_test.js
+++ b/tests/mocha/trashcan_test.js
@@ -15,7 +15,7 @@ import {simulateClick} from './test_helpers/user_input.js';
 
 suite("Trashcan", function() {
   function fireDeleteEvent(workspace, xmlString) {
-    let xml = Blockly.Xml.textToDom(
+    let xml = Blockly.utils.xml.textToDom(
         '<xml xmlns="https://developers.google.com/blockly/xml">' +
         xmlString + '</xml>');
     xml = xml.children[0];
@@ -63,7 +63,7 @@ suite("Trashcan", function() {
       chai.assert.equal(this.trashcan.contents_.length, 0);
     });
     test("Non-Delete w/ oldXml", function() {
-      let xml = Blockly.Xml.textToDom(
+      let xml = Blockly.utils.xml.textToDom(
           '<xml xmlns="https://developers.google.com/blockly/xml">' +
           '  <block type="test_field_block"/>' +
           '</xml>'

--- a/tests/mocha/workspace_svg_test.js
+++ b/tests/mocha/workspace_svg_test.js
@@ -46,7 +46,7 @@ suite('WorkspaceSvg', function() {
   });
 
   test('appendDomToWorkspace alignment', function() {
-    const dom = Blockly.Xml.textToDom(
+    const dom = Blockly.utils.xml.textToDom(
         '<xml xmlns="https://developers.google.com/blockly/xml">' +
         '  <block type="math_random_float" inline="true" x="21" y="23">' +
         '  </block>' +
@@ -71,7 +71,7 @@ suite('WorkspaceSvg', function() {
   });
 
   test('Replacing shadow disposes svg', function() {
-    const dom = Blockly.Xml.textToDom(
+    const dom = Blockly.utils.xml.textToDom(
         '<xml xmlns="https://developers.google.com/blockly/xml">' +
         '<block type="test_val_in">' +
         '<value name="NAME">' +
@@ -240,7 +240,7 @@ suite('WorkspaceSvg', function() {
       test('domToWorkspace that doesn\'t trigger scroll', function() {
         // 4 blocks with space in center.
         Blockly.Xml.domToWorkspace(
-            Blockly.Xml.textToDom(
+            Blockly.utils.xml.textToDom(
                 '<xml xmlns="https://developers.google.com/blockly/xml">' +
                 '<block type="controls_if" x="88" y="88"></block>' +
                 '<block type="controls_if" x="288" y="88"></block>' +
@@ -248,12 +248,12 @@ suite('WorkspaceSvg', function() {
                 '<block type="controls_if" x="288" y="238"></block>' +
                 '</xml>'),
             this.workspace);
-        const xmlDom = Blockly.Xml.textToDom(
+        const xmlDom = Blockly.utils.xml.textToDom(
             '<block type="controls_if" x="188" y="163"></block>');
         this.clock.runAll();
         resetEventHistory(this.eventsFireStub, this.changeListenerSpy);
         // Add block in center of other blocks, not triggering scroll.
-        Blockly.Xml.domToWorkspace(Blockly.Xml.textToDom(
+        Blockly.Xml.domToWorkspace(Blockly.utils.xml.textToDom(
             '<block type="controls_if" x="188" y="163"></block>'), this.workspace);
         this.clock.runAll();
         assertEventNotFired(
@@ -265,7 +265,7 @@ suite('WorkspaceSvg', function() {
       test('domToWorkspace at 0,0 that doesn\'t trigger scroll', function() {
         // 4 blocks with space in center.
         Blockly.Xml.domToWorkspace(
-            Blockly.Xml.textToDom(
+            Blockly.utils.xml.textToDom(
                 '<xml xmlns="https://developers.google.com/blockly/xml">' +
                 '<block type="controls_if" x="-75" y="-72"></block>' +
                 '<block type="controls_if" x="75" y="-72"></block>' +
@@ -273,7 +273,7 @@ suite('WorkspaceSvg', function() {
                 '<block type="controls_if" x="75" y="75"></block>' +
                 '</xml>'),
             this.workspace);
-        const xmlDom = Blockly.Xml.textToDom(
+        const xmlDom = Blockly.utils.xml.textToDom(
             '<block type="controls_if" x="0" y="0"></block>');
         this.clock.runAll();
         resetEventHistory(this.eventsFireStub, this.changeListenerSpy);
@@ -291,7 +291,7 @@ suite('WorkspaceSvg', function() {
         // TODO: Un-skip after adding filtering for consecutive viewport events.
         const addingMultipleBlocks = () => {
           Blockly.Xml.domToWorkspace(
-              Blockly.Xml.textToDom(
+              Blockly.utils.xml.textToDom(
                   '<xml xmlns="https://developers.google.com/blockly/xml">' +
                   '<block type="controls_if" x="88" y="88"></block>' +
                   '<block type="controls_if" x="288" y="88"></block>' +

--- a/tests/mocha/xml_test.js
+++ b/tests/mocha/xml_test.js
@@ -75,7 +75,7 @@ suite('XML', function() {
   });
   suite('textToDom', function() {
     test('Basic', function() {
-      const dom = Blockly.Xml.textToDom(this.complexXmlText);
+      const dom = Blockly.utils.xml.textToDom(this.complexXmlText);
       chai.assert.equal(dom.nodeName, 'xml', 'XML tag');
       chai.assert.equal(dom.getElementsByTagName('block').length, 6, 'Block tags');
     });
@@ -306,7 +306,7 @@ suite('XML', function() {
     suite('Comments', function() {
       suite('Headless', function() {
         setup(function() {
-          this.block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
+          this.block = Blockly.Xml.domToBlock(Blockly.utils.xml.textToDom(
               '<block type="empty_block"/>'
           ), this.workspace);
         });
@@ -331,7 +331,7 @@ suite('XML', function() {
         setup(function() {
           // Let the parent teardown dispose of it.
           this.workspace = Blockly.inject('blocklyDiv', {comments: true});
-          this.block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
+          this.block = Blockly.Xml.domToBlock(Blockly.utils.xml.textToDom(
               '<block type="empty_block"/>'
           ), this.workspace);
         });
@@ -435,7 +435,7 @@ suite('XML', function() {
   });
   suite('domToText', function() {
     test('Round tripping', function() {
-      const dom = Blockly.Xml.textToDom(this.complexXmlText);
+      const dom = Blockly.utils.xml.textToDom(this.complexXmlText);
       const text = Blockly.Xml.domToText(dom);
       chai.assert.equal(text.replace(/\s+/g, ''),
           this.complexXmlText.replace(/\s+/g, ''), 'Round trip');
@@ -443,7 +443,7 @@ suite('XML', function() {
   });
   suite('domToPrettyText', function() {
     test('Round tripping', function() {
-      const dom = Blockly.Xml.textToDom(this.complexXmlText);
+      const dom = Blockly.utils.xml.textToDom(this.complexXmlText);
       const text = Blockly.Xml.domToPrettyText(dom);
       chai.assert.equal(text.replace(/\s+/g, ''),
           this.complexXmlText.replace(/\s+/g, ''), 'Round trip');
@@ -479,7 +479,7 @@ suite('XML', function() {
     suite('Comments', function() {
       suite('Headless', function() {
         test('Text', function() {
-          const block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
+          const block = Blockly.Xml.domToBlock(Blockly.utils.xml.textToDom(
               '<block type="empty_block">' +
               '  <comment>test text</comment>' +
               '</block>'
@@ -487,7 +487,7 @@ suite('XML', function() {
           chai.assert.equal(block.getCommentText(), 'test text');
         });
         test('No Text', function() {
-          const block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
+          const block = Blockly.Xml.domToBlock(Blockly.utils.xml.textToDom(
               '<block type="empty_block">' +
               '  <comment></comment>' +
               '</block>'
@@ -495,7 +495,7 @@ suite('XML', function() {
           chai.assert.equal(block.getCommentText(), '');
         });
         test('Size', function() {
-          const block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
+          const block = Blockly.Xml.domToBlock(Blockly.utils.xml.textToDom(
               '<block type="empty_block">' +
               '  <comment w="100" h="200">test text</comment>' +
               '</block>'
@@ -504,7 +504,7 @@ suite('XML', function() {
               {width: 100, height: 200});
         });
         test('Pinned True', function() {
-          const block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
+          const block = Blockly.Xml.domToBlock(Blockly.utils.xml.textToDom(
               '<block type="empty_block">' +
               '  <comment pinned="true">test text</comment>' +
               '</block>'
@@ -512,7 +512,7 @@ suite('XML', function() {
           chai.assert.isTrue(block.commentModel.pinned);
         });
         test('Pinned False', function() {
-          const block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
+          const block = Blockly.Xml.domToBlock(Blockly.utils.xml.textToDom(
               '<block type="empty_block">' +
               '  <comment pinned="false">test text</comment>' +
               '</block>'
@@ -520,7 +520,7 @@ suite('XML', function() {
           chai.assert.isFalse(block.commentModel.pinned);
         });
         test('Pinned Undefined', function() {
-          const block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
+          const block = Blockly.Xml.domToBlock(Blockly.utils.xml.textToDom(
               '<block type="empty_block">' +
               '  <comment>test text</comment>' +
               '</block>'
@@ -537,7 +537,7 @@ suite('XML', function() {
         });
 
         test('Text', function() {
-          const block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
+          const block = Blockly.Xml.domToBlock(Blockly.utils.xml.textToDom(
               '<block type="empty_block">' +
               '  <comment>test text</comment>' +
               '</block>'
@@ -546,7 +546,7 @@ suite('XML', function() {
           chai.assert.isNotNull(block.getCommentIcon());
         });
         test('No Text', function() {
-          const block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
+          const block = Blockly.Xml.domToBlock(Blockly.utils.xml.textToDom(
               '<block type="empty_block">' +
               '  <comment></comment>' +
               '</block>'
@@ -555,7 +555,7 @@ suite('XML', function() {
           chai.assert.isNotNull(block.getCommentIcon());
         });
         test('Size', function() {
-          const block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
+          const block = Blockly.Xml.domToBlock(Blockly.utils.xml.textToDom(
               '<block type="empty_block">' +
               '  <comment w="100" h="200">test text</comment>' +
               '</block>'
@@ -568,7 +568,7 @@ suite('XML', function() {
         });
         suite('Pinned', function() {
           test('Pinned True', function() {
-            const block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
+            const block = Blockly.Xml.domToBlock(Blockly.utils.xml.textToDom(
                 '<block type="empty_block">' +
                 '  <comment pinned="true">test text</comment>' +
                 '</block>'
@@ -579,7 +579,7 @@ suite('XML', function() {
             chai.assert.isTrue(block.getCommentIcon().isVisible());
           });
           test('Pinned False', function() {
-            const block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
+            const block = Blockly.Xml.domToBlock(Blockly.utils.xml.textToDom(
                 '<block type="empty_block">' +
                 '  <comment pinned="false">test text</comment>' +
                 '</block>'
@@ -590,7 +590,7 @@ suite('XML', function() {
             chai.assert.isFalse(block.getCommentIcon().isVisible());
           });
           test('Pinned Undefined', function() {
-            const block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
+            const block = Blockly.Xml.domToBlock(Blockly.utils.xml.textToDom(
                 '<block type="empty_block">' +
                 '  <comment>test text</comment>' +
                 '</block>'
@@ -624,7 +624,7 @@ suite('XML', function() {
     });
     test('Backwards compatibility', function() {
       createGenUidStubWithReturns('1');
-      const dom = Blockly.Xml.textToDom(
+      const dom = Blockly.utils.xml.textToDom(
           '<xml xmlns="https://developers.google.com/blockly/xml">' +
           '  <block type="field_variable_test_block" id="block_id">' +
           '    <field name="VAR">name1</field>' +
@@ -635,7 +635,7 @@ suite('XML', function() {
       assertVariableValues(this.workspace, 'name1', '', '1');
     });
     test('Variables at top', function() {
-      const dom = Blockly.Xml.textToDom(
+      const dom = Blockly.utils.xml.textToDom(
           '<xml xmlns="https://developers.google.com/blockly/xml">' +
           '  <variables>' +
           '    <variable type="type1" id="id1">name1</variable>' +
@@ -653,7 +653,7 @@ suite('XML', function() {
       assertVariableValues(this.workspace, 'name3', '', 'id3');
     });
     test('Variables at top duplicated variables tag', function() {
-      const dom = Blockly.Xml.textToDom(
+      const dom = Blockly.utils.xml.textToDom(
           '<xml xmlns="https://developers.google.com/blockly/xml">' +
           '  <variables>' +
           '  </variables>' +
@@ -665,7 +665,7 @@ suite('XML', function() {
       });
     });
     test('Variables at top missing type', function() {
-      const dom = Blockly.Xml.textToDom(
+      const dom = Blockly.utils.xml.textToDom(
           '<xml xmlns="https://developers.google.com/blockly/xml">' +
           '  <variables>' +
           '    <variable id="id1">name1</variable>' +
@@ -679,7 +679,7 @@ suite('XML', function() {
       });
     });
     test('Variables at top mismatch block type', function() {
-      const dom = Blockly.Xml.textToDom(
+      const dom = Blockly.utils.xml.textToDom(
           '<xml xmlns="https://developers.google.com/blockly/xml">' +
           '  <variables>' +
           '    <variable type="type1" id="id1">name1</variable>' +
@@ -709,7 +709,7 @@ suite('XML', function() {
       workspaceTeardown.call(this, this.workspace);
     });
     test('Headless', function() {
-      const dom = Blockly.Xml.textToDom(
+      const dom = Blockly.utils.xml.textToDom(
           '<xml xmlns="https://developers.google.com/blockly/xml">' +
           '  <block type="test_block" inline="true" x="21" y="23">' +
           '  </block>' +
@@ -746,7 +746,7 @@ suite('XML', function() {
     };
     suite('Rendered -> XML -> Headless -> XML', function() {
       test('Comment', function() {
-        const block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
+        const block = Blockly.Xml.domToBlock(Blockly.utils.xml.textToDom(
             '<block type="empty_block"/>'
         ), this.renderedWorkspace);
         block.setCommentText('test text');
@@ -757,7 +757,7 @@ suite('XML', function() {
     });
     suite('Headless -> XML -> Rendered -> XML', function() {
       test('Comment', function() {
-        const block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
+        const block = Blockly.Xml.domToBlock(Blockly.utils.xml.textToDom(
             '<block type="empty_block"/>'
         ), this.headlessWorkspace);
         block.setCommentText('test text');

--- a/tests/node/run_node_test.js
+++ b/tests/node/run_node_test.js
@@ -24,14 +24,14 @@ const xmlText = '<xml xmlns="https://developers.google.com/blockly/xml">\n' +
 
 suite('Test Node.js', function() {
   test('Import XML', function() {
-    const xml = Blockly.Xml.textToDom(xmlText);
+    const xml = Blockly.utils.xml.textToDom(xmlText);
 
     // Create workspace and import the XML
     const workspace = new Blockly.Workspace();
     Blockly.Xml.domToWorkspace(xml, workspace);
   });
   test('Roundtrip XML', function() {
-    const xml = Blockly.Xml.textToDom(xmlText);
+    const xml = Blockly.utils.xml.textToDom(xmlText);
 
     const workspace = new Blockly.Workspace();
     Blockly.Xml.domToWorkspace(xml, workspace);
@@ -42,7 +42,7 @@ suite('Test Node.js', function() {
     assert.equal(headlessText, xmlText, 'equal');
   });
   test('Generate Code', function() {
-    const xml = Blockly.Xml.textToDom(xmlText);
+    const xml = Blockly.utils.xml.textToDom(xmlText);
 
     // Create workspace and import the XML
     const workspace = new Blockly.Workspace();

--- a/tests/playground.html
+++ b/tests/playground.html
@@ -177,7 +177,7 @@ function load() {
     var state = JSON.parse(input.value);
     Blockly.serialization.workspaces.load(state, workspace);
   } else if (valid.xml) {
-    var xml = Blockly.Xml.textToDom(input.value);
+    var xml = Blockly.utils.xml.textToDom(input.value);
     Blockly.Xml.domToWorkspace(xml, workspace);
   }
   taChange();
@@ -216,7 +216,7 @@ function saveIsValid(save) {
   }
   var validXml = true
   try {
-    Blockly.Xml.textToDom(save);
+    Blockly.utils.xml.textToDom(save);
   } catch (e) {
     validXml = false;
   }
@@ -296,7 +296,7 @@ function spaghetti(n) {
         '$1' + spaghettiXml + '</');
   }
   xml = '<xml xmlns="https://developers.google.com/blockly/xml">' + xml + '</xml>';
-  var dom = Blockly.Xml.textToDom(xml);
+  var dom = Blockly.utils.xml.textToDom(xml);
   console.time('Spaghetti domToWorkspace');
   Blockly.Xml.domToWorkspace(dom, workspace);
   console.timeEnd('Spaghetti domToWorkspace');


### PR DESCRIPTION
## The basics

- [X] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [X] I ran `npm run format` and `npm run lint`

## The details
### Resolves

Fixes #6817.

### Proposed Changes

* Move `textToDom` from `core/xml.ts` to `core/utils/xml.ts`.
* Re-enable `goog.declareModuleId` multiple-call check in `closure/goog/base.js`.

### Reason for Changes

The `textToDom` function being in `core/xml.ts` is the cause for the last remaining circular `import` in `core/` (between `variables.ts` and `xml.ts`).  Moving it to `core/utils/xml.ts` makes sense anyway, since there is nothing Blockly-specific about this function.

Reenabling the assertion which checks to make sure that `goog.declareModuleId` is not called more than once in a module will also catch circular `import`s amongst ES modules, which are not detected by `closure-make-deps`).

### Test Coverage

Passes `npm test`.

No manual test changes expected.
