### PR TITLE
fix(tests): Use `build/msg/en.js` instead of `msg/messages.js`

### DIFF
--- a/tests/bootstrap_helper.js
+++ b/tests/bootstrap_helper.js
@@ -10,7 +10,7 @@
  * This is loaded, via goog.bootstrap(), after the other top-level
  * Blockly modules.  It simply calls goog.require() for each of them,
  * to force the debug module loader to finish loading them before any
- * non-module scripts (like msg/messages.js) that might have
+ * non-module scripts (like msg/en.js) that might have
  * undeclared dependencies on them.
  */
 

--- a/tests/playgrounds/shared_procedures.html
+++ b/tests/playgrounds/shared_procedures.html
@@ -9,7 +9,7 @@
 <script>
   var BLOCKLY_BOOTSTRAP_OPTIONS = {
     additionalScripts: [
-      'msg/messages.js',
+      'build/msg/en.js',
       'node_modules/@blockly/dev-tools/dist/index.js',
     ],
   }


### PR DESCRIPTION
## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [X] I ran `npm run format` and `npm run lint`

## The details
### Resolves

Fixes #6824.

### Proposed Changes

Use `en.js` instead of `messages.js` in tests.

### Reason for Changes

`messages.js` is not intended to be used this way.  Also: we want to test build output.

### Additional Information

This change had already been made (by PR #6475 amongst other) to most of the tests, but there were a couple of stragglers that still mentioned `messages.js`.
