### PR TITLE
chore: Make dropdownDispose available for plugins.

### DIFF
--- a/core/field_dropdown.ts
+++ b/core/field_dropdown.ts
@@ -332,7 +332,7 @@ export class FieldDropdown extends Field<string> {
   /**
    * Disposes of events and DOM-references belonging to the dropdown editor.
    */
-  private dropdownDispose_() {
+  protected dropdownDispose_() {
     if (this.menu_) {
       this.menu_.dispose();
     }

--- a/core/field_dropdown.ts
+++ b/core/field_dropdown.ts
@@ -587,8 +587,8 @@ export class FieldDropdown extends Field<string> {
 
   /**
    * Use the `getText_` developer hook to override the field's text
-   * representation.  Get the selected option text. If the selected option is an
-   * image we return the image alt text.
+   * representation.  Get the selected option text.  If the selected option is
+   * an image we return the image alt text.
    *
    * @returns Selected option text.
    */


### PR DESCRIPTION
Specifically in Blockly Samples the field-grid-dropdown wants to call this inherited function.
