### PR TITLE
chore: fix isNameUsed not fully respecting the procedure map

### DIFF
--- a/core/procedures.ts
+++ b/core/procedures.ts
@@ -194,14 +194,18 @@ export function isNameUsed(
   for (const block of workspace.getAllBlocks(false)) {
     if (block === opt_exclude) continue;
 
-    if (isProcedureBlock(block) && block.isProcedureDef() &&
-        Names.equals(block.getProcedureModel().getName(), name)) {
-      return true;
-    }
     if (isLegacyProcedureDefBlock(block) &&
         Names.equals(block.getProcedureDef()[0], name)) {
       return true;
     }
+  }
+
+  const excludeModel = opt_exclude && isProcedureBlock(opt_exclude) ?
+      opt_exclude?.getProcedureModel() :
+      undefined;
+  for (const model of workspace.getProcedureMap().getProcedures()) {
+    if (model === excludeModel) continue;
+    if (Names.equals(model.getName(), name)) return true;
   }
   return false;
 }

--- a/tests/mocha/blocks/procedures_test.js
+++ b/tests/mocha/blocks/procedures_test.js
@@ -7,7 +7,7 @@
 goog.declareModuleId('Blockly.test.procedures');
 
 import * as Blockly from '../../../build/src/core/blockly.js';
-import {assertCallBlockStructure, assertDefBlockStructure, createProcDefBlock, createProcCallBlock} from '../test_helpers/procedures.js';
+import {assertCallBlockStructure, assertDefBlockStructure, createProcDefBlock, createProcCallBlock, MockProcedureModel} from '../test_helpers/procedures.js';
 import {runSerializationTestSuite} from '../test_helpers/serialization.js';
 import {createGenUidStubWithReturns, sharedTestSetup, sharedTestTeardown, workspaceTeardown} from '../test_helpers/setup_teardown.js';
 import {defineRowBlock} from '../test_helpers/block_definitions.js';
@@ -1083,10 +1083,35 @@ suite('Procedures', function() {
   });
 
   suite('isNameUsed', function() {
-    test('No Blocks', function() {
+    test('returns false if no blocks or models exists', function() {
       chai.assert.isFalse(
-          Blockly.Procedures.isNameUsed('name1', this.workspace)
-      );
+          Blockly.Procedures.isNameUsed('proc name', this.workspace));
+    });
+
+    test('returns true if an associated block exists', function() {
+      createProcDefBlock(this.workspace, false, [], 'proc name');
+      chai.assert.isTrue(
+          Blockly.Procedures.isNameUsed('proc name', this.workspace));
+    });
+
+    test('return false if an associated block does not exist', function() {
+      createProcDefBlock(this.workspace, false, [], 'proc name');
+      chai.assert.isFalse(
+          Blockly.Procedures.isNameUsed('other proc name', this.workspace));
+    });
+
+    test('returns true if an associated procedure model exists', function() {
+      this.workspace.getProcedureMap()
+          .add(new MockProcedureModel().setName('proc name'));
+      chai.assert.isTrue(
+          Blockly.Procedures.isNameUsed('proc name', this.workspace));
+    });
+
+    test('returns false if an associated procedure model exists', function() {
+      this.workspace.getProcedureMap()
+          .add(new MockProcedureModel().setName('proc name'));
+      chai.assert.isFalse(
+          Blockly.Procedures.isNameUsed('other proc name', this.workspace));
     });
   });
 
@@ -1271,22 +1296,6 @@ suite('Procedures', function() {
           this.callBlock.setFieldValue('proc name', 'NAME');
           this.clock.runAll();
           assertCallBlockStructure(this.callBlock);
-        });
-      });
-      suite('isNameUsed', function() {
-        setup(function() {
-          this.defBlock = this.workspace.newBlock(testSuite.defType);
-          this.defBlock.setFieldValue('proc name', 'NAME');
-          this.callBlock = this.workspace.newBlock(testSuite.callType);
-          this.callBlock.setFieldValue('proc name', 'NAME');
-        });
-        test('True', function() {
-          chai.assert.isTrue(
-              Blockly.Procedures.isNameUsed('proc name', this.workspace));
-        });
-        test('False', function() {
-          chai.assert.isFalse(
-              Blockly.Procedures.isNameUsed('unused proc name', this.workspace));
         });
       });
       suite('rename', function() {


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [X] I ran `npm run format` and `npm run lint`

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
N/A

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
isNameUsed was not fully respecting the procedure map, so it was possible when sharing procedures between workspaces for two procedure definition blocks (in different workspaces) to have the same name. This makes it so that that is no longer possible.

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->

Add tests that `isNameUsed` respects the procedure map.

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->
N/A

### Additional Information

<!-- Anything else we should know? -->
N/A
