### PR TITLE
chore(build,tests): Remove obsolete kludges / config options

### DIFF
--- a/tests/bootstrap_helper.js
+++ b/tests/bootstrap_helper.js
@@ -21,20 +21,6 @@
     // Force debug module loader to finish loading all modules.
     for (const require of info.requires) {
       goog.require(require);
-
-      // This is a kludge to work around an issue where attempting to
-      // load Blockly.libraryBlocks (blocks/blocks.js) fails if the
-      // Blockly global variable is not defined.
-      //
-      // This is apparently because the debug module loader fails to
-      // load Blockly.libraryBlocks.lists (blocks/lists.js) and
-      // .procedures (blocks/procedures.js) first, despite they both
-      // being required from blocks.js, and that is apparently because
-      // they both depend on Blockly.Xml which the debug loader seems
-      // to think has not been loaded yet even though it has.
-      if (require === 'Blockly') {
-        window.Blockly = goog.module.get('Blockly');
-      }
     }
   }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,9 +3,6 @@
     "core/**/*",  // N.B.: also pulls in closure/goog/goog.js if needed.
     "closure/**/*",  // Just for ouptut directory structure.
   ],
-  "exclude": [
-    "core/blockly.js"
-  ],
   "compilerOptions": {
     // Tells TypeScript to read JS files, as
     // normally they are ignored as source files


### PR DESCRIPTION
## The basics

- [X] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [X] I ran `npm run format` and `npm run lint`

## The details

### Proposed Changes

#### Remove circular import loading issue kludge

Prior to PR #6818, circular imports resulted in the debug module loader (in `closure/goog/base.js`) failing to record the
`goog.module` ID of most modules that were involved in any cycle, and in particular of the `Blockly.Xml` module.  This had secondary fallout that resulted in library blocks modules being loaded in the wrong order.

A kludge was introduced in PR #6703 that worked around this problem by making sure that `window.Blockly` was set, allowing the modules loaded out-of-order to still work.

Now that we have removed all remaining circular dependencies there is no need for the kludge, since all module IDs are properly recorded and modules are loaded in the correct order.

#### Remove exclude for non-existent `core/blockly.js` from `tsconfig.js`

There was a transitional period where we had both `core/blockly.ts` and `core/blockly.js`, and wished to exclude
the latter from `tsc`'s input, but that file was deleted (and inadvertently restored, then re-deleted) some time ago.

### Reason for Changes

Cleanup.

### Test Coverage

Passes `npm test`; playground loads correctly.  No manual test changes anticipated.

