### PR TITLE
feat(build): Run `tsc` on `blocks/` and `generators/`

### DIFF
--- a/scripts/gulpfiles/build_tasks.js
+++ b/scripts/gulpfiles/build_tasks.js
@@ -35,11 +35,6 @@ const {posixPath} = require('../helpers');
 ////////////////////////////////////////////////////////////
 
 /**
- * Directory in which core/ can be found after passing through tsc.
- */
-const CORE_DIR = path.join(TSC_OUTPUT_DIR, 'core');
-
-/**
  * Suffix to add to compiled output files.
  */
 const COMPILED_SUFFIX = '_compressed';
@@ -104,49 +99,47 @@ const NAMESPACE_PROPERTY = '__namespace__';
 const chunks = [
   {
     name: 'blockly',
-    entry: posixPath((argv.compileTs) ?
-      path.join(TSC_OUTPUT_DIR, CORE_DIR, 'main.js') :
-      path.join(CORE_DIR, 'main.js')),
+    entry: path.join(TSC_OUTPUT_DIR, 'core', 'main.js'),
     exports: 'module$build$src$core$blockly',
     reexport: 'Blockly',
   },
   {
     name: 'blocks',
-    entry: 'blocks/blocks.js',
+    entry: path.join(TSC_OUTPUT_DIR, 'blocks', 'blocks.js'),
     exports: 'module$exports$Blockly$libraryBlocks',
     reexport: 'Blockly.libraryBlocks',
   },
   {
     name: 'javascript',
-    entry: 'generators/javascript/all.js',
+    entry: path.join(TSC_OUTPUT_DIR, 'generators', 'javascript', 'all.js'),
     exports: 'module$exports$Blockly$JavaScript',
     reexport: 'Blockly.JavaScript',
     reexportOnly: 'javascriptGenerator',
   },
   {
     name: 'python',
-    entry: 'generators/python/all.js',
+    entry: path.join(TSC_OUTPUT_DIR, 'generators', 'python', 'all.js'),
     exports: 'module$exports$Blockly$Python',
     reexport: 'Blockly.Python',
     reexportOnly: 'pythonGenerator',
   },
   {
     name: 'php',
-    entry: 'generators/php/all.js',
+    entry: path.join(TSC_OUTPUT_DIR, 'generators', 'php', 'all.js'),
     exports: 'module$exports$Blockly$PHP',
     reexport: 'Blockly.PHP',
     reexportOnly: 'phpGenerator',
   },
   {
     name: 'lua',
-    entry: 'generators/lua/all.js',
+    entry: path.join(TSC_OUTPUT_DIR, 'generators', 'lua', 'all.js'),
     exports: 'module$exports$Blockly$Lua',
     reexport: 'Blockly.Lua',
     reexportOnly: 'luaGenerator',
   },
   {
     name: 'dart',
-    entry: 'generators/dart/all.js',
+    entry: path.join(TSC_OUTPUT_DIR, 'generators', 'dart', 'all.js'),
     exports: 'module$exports$Blockly$Dart',
     reexport: 'Blockly.Dart',
     reexportOnly: 'dartGenerator',
@@ -313,8 +306,6 @@ function buildDeps() {
   const roots = [
     path.join(TSC_OUTPUT_DIR, 'closure', 'goog', 'base.js'),
     TSC_OUTPUT_DIR,
-    'blocks',
-    'generators',
     'tests/mocha',
   ];
 
@@ -691,13 +682,12 @@ function buildAdvancedCompilationTest() {
   }
 
   const srcs = [
-    TSC_OUTPUT_DIR + '/closure/goog/base_minimal.js',
-    TSC_OUTPUT_DIR + '/closure/goog/goog.js',
-    TSC_OUTPUT_DIR + '/core/**/*.js',
-    'blocks/**/*.js',
-    'generators/**/*.js',
+    TSC_OUTPUT_DIR + '/**/*.js',
     'tests/compile/main.js',
     'tests/compile/test_blocks.js',
+  ];
+  const ignore = [
+    TSC_OUTPUT_DIR + '/closure/goog/base.js',  // Use base_minimal.js only.
   ];
 
   // Closure Compiler options.
@@ -707,7 +697,7 @@ function buildAdvancedCompilationTest() {
     entry_point: './tests/compile/main.js',
     js_output_file: 'main_compressed.js',
   };
-  return gulp.src(srcs, {base: './'})
+  return gulp.src(srcs, {base: './', ignore})
       .pipe(stripApacheLicense())
       .pipe(gulp.sourcemaps.init())
       .pipe(compile(options))

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,9 @@
 {
   "include": [
     "core/**/*",  // N.B.: also pulls in closure/goog/goog.js if needed.
-    "closure/**/*",  // Just for ouptut directory structure.
+    "closure/goog/*",  // For base.js and base_minimal.js.
+    "blocks/**/*",
+    "generators/**/*",
   ],
   "compilerOptions": {
     // Tells TypeScript to read JS files, as
@@ -36,5 +38,5 @@
     // PR #6564: https://github.com/google/blockly/pull/6564), so
     // disable it except for the explicitly-specified types.
     "types": [],
-  }
+  },
 }


### PR DESCRIPTION
## The basics

- [X] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [X] I ran `npm run format` and `npm run lint`

## The details
### Resolves

Part of #6828

### Proposed Changes

Modify `build_tasks.js` so that `blocks/` and `generators/` are passed through `tsc` before being fed to `closure-make-deps`, Closure Compiler, etc.

#### Behaviour Before Change

Closure Compiler and debug module loader read from `blocks/` and `generators/` directly.

#### Behaviour After Change

`blocks/` and `generators/` are included in `tsc`'s input, and Closure Compiler and debug module loader read from `build/src/blocks/` and `build/src/generators/`.

### Reason for Changes

Allow conversion of blocks and generators to TypeScript.

### Test Coverage

Changes untested so far; leaving this PR as a draft until I've verified that everything actually works as expected.

### Additional Information

<!-- Anything else we should know? -->
