### PR TITLE
feat: updated flyout button to set border radius via static variable

### DIFF
--- a/core/flyout_button.ts
+++ b/core/flyout_button.ts
@@ -32,6 +32,10 @@ export class FlyoutButton {
 
   /** The vertical margin around the text in the button. */
   static TEXT_MARGIN_Y = 2;
+
+  /** The radius of the flyout button's borders. */
+  static BORDER_RADIUS = 4;
+
   private readonly text_: string;
   private readonly position_: Coordinate;
   private readonly callbackKey_: string;
@@ -102,8 +106,8 @@ export class FlyoutButton {
       shadow = dom.createSvgElement(
           Svg.RECT, {
             'class': 'blocklyFlyoutButtonShadow',
-            'rx': 4,
-            'ry': 4,
+            'rx': FlyoutButton.BORDER_RADIUS,
+            'ry': FlyoutButton.BORDER_RADIUS,
             'x': 1,
             'y': 1,
           },
@@ -114,8 +118,8 @@ export class FlyoutButton {
         Svg.RECT, {
           'class': this.isLabel_ ? 'blocklyFlyoutLabelBackground' :
                                    'blocklyFlyoutButtonBackground',
-          'rx': 4,
-          'ry': 4,
+          'rx': FlyoutButton.BORDER_RADIUS,
+          'ry': FlyoutButton.BORDER_RADIUS,
         },
         this.svgGroup_!);
 


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [x] I ran `npm run format` and `npm run lint`

## The details
### Resolves

In response to https://groups.google.com/g/blockly/c/sMG41uE-WG0, this enables setting the border radius via overwriting the newly added static variable.

### Proposed Changes

Add static variable for the button's border radius.

#### Behavior Before Change

No static variable for Flyout Button's border radius.

#### Behavior After Change

Added static variable for Flyout Button's border radius.
