### PR TITLE
refactor: Use input type=number for field_number.ts

### DIFF
--- a/core/css.ts
+++ b/core/css.ts
@@ -340,6 +340,17 @@ let content = `
   display: none;
 }
 
+/* Remove the increase and decrease arrows on the field number editor */
+input.blocklyHtmlInput[type=number]::-webkit-inner-spin-button,
+input.blocklyHtmlInput[type=number]::-webkit-outer-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
+}
+
+input[type=number] {
+  -moz-appearance: textfield;
+}
+
 .blocklyMainBackground {
   stroke-width: 1;
   stroke: #c6c6c6;  /* Equates to #ddd due to border being off-pixel. */

--- a/core/field_number.ts
+++ b/core/field_number.ts
@@ -291,14 +291,17 @@ export class FieldNumber extends FieldInput<number> {
    *
    * @returns The newly created number input editor.
    */
-  protected override widgetCreate_(): HTMLElement {
-    const htmlInput = super.widgetCreate_();
+  protected override widgetCreate_(): HTMLInputElement {
+    const htmlInput = super.widgetCreate_() as HTMLInputElement;
+    htmlInput.type = 'number';
 
     // Set the accessibility state
     if (this.min_ > -Infinity) {
+      htmlInput.min = `${this.min_}`;
       aria.setState(htmlInput, aria.State.VALUEMIN, this.min_);
     }
     if (this.max_ < Infinity) {
+      htmlInput.max = `${this.max_}`;
       aria.setState(htmlInput, aria.State.VALUEMAX, this.max_);
     }
     return htmlInput;


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [x] I ran `npm run format` and `npm run lint`

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #1595

### Proposed Changes
Sets the `type` of the input field for field_number.ts to `number`.

#### Behavior Before Change
field_number.ts didn't specify a type for its input field.

### Test Coverage
Verified that tests pass and field behaves normally on Chrome, Firefox, Safari and Mobile Safari.