### PR TITLE
fix: serializing disabled interactions

### DIFF
--- a/core/block.ts
+++ b/core/block.ts
@@ -796,6 +796,15 @@ export class Block implements IASTNodeLocation, IDeletable {
   }
 
   /**
+   * Return whether this block's own deletable property is true or false.
+   *
+   * @returns True if the block's deletable property is true, false otherwise.
+   */
+  isOwnDeletable(): boolean {
+    return this.deletable_;
+  }
+
+  /**
    * Set whether this block is deletable or not.
    *
    * @param deletable True if deletable.
@@ -808,10 +817,21 @@ export class Block implements IASTNodeLocation, IDeletable {
    * Get whether this block is movable or not.
    *
    * @returns True if movable.
+   * @internal
    */
   isMovable(): boolean {
     return this.movable_ && !this.isShadow_ && !this.isDeadOrDying() &&
         !this.workspace.options.readOnly;
+  }
+
+  /**
+   * Return whether this block's own movable property is true or false.
+   *
+   * @returns True if the block's movable property is true, false otherwise.
+   * @internal
+   */
+  isOwnMovable(): boolean {
+    return this.movable_;
   }
 
   /**
@@ -882,10 +902,20 @@ export class Block implements IASTNodeLocation, IDeletable {
    * Get whether this block is editable or not.
    *
    * @returns True if editable.
+   * @internal
    */
   isEditable(): boolean {
     return this.editable_ && !this.isDeadOrDying() &&
         !this.workspace.options.readOnly;
+  }
+
+  /**
+   * Return whether this block's own editable property is true or false.
+   *
+   * @returns True if the block's editable property is true, false otherwise.
+   */
+  isOwnEditable(): boolean {
+    return this.editable_;
   }
 
   /**

--- a/core/serialization/blocks.ts
+++ b/core/serialization/blocks.ts
@@ -48,6 +48,9 @@ export interface State {
   x?: number;
   y?: number;
   collapsed?: boolean;
+  deletable?: boolean;
+  movable?: boolean;
+  editable?: boolean;
   enabled?: boolean;
   inline?: boolean;
   data?: string;
@@ -141,6 +144,15 @@ function saveAttributes(block: Block, state: State) {
   }
   if (!block.isEnabled()) {
     state['enabled'] = false;
+  }
+  if (!block.isOwnDeletable()) {
+    state['deletable'] = false;
+  }
+  if (!block.isOwnMovable()) {
+    state['movable'] = false;
+  }
+  if (!block.isOwnEditable()) {
+    state['editable'] = false;
   }
   if (block.inputsInline !== undefined &&
       block.inputsInline !== block.inputsInlineDefault) {
@@ -436,6 +448,15 @@ function loadCoords(block: Block, state: State) {
 function loadAttributes(block: Block, state: State) {
   if (state['collapsed']) {
     block.setCollapsed(true);
+  }
+  if (state['deletable'] === false) {
+    block.setDeletable(false);
+  }
+  if (state['movable'] === false) {
+    block.setMovable(false);
+  }
+  if (state['editable'] === false) {
+    block.setEditable(false);
   }
   if (state['enabled'] === false) {
     block.setEnabled(false);

--- a/tests/mocha/serializer_test.js
+++ b/tests/mocha/serializer_test.js
@@ -73,10 +73,25 @@ Serializer.Attributes.Disabled = new SerializerTestCase('Disabled',
     '<xml xmlns="https://developers.google.com/blockly/xml">' +
     '<block type="logic_negate" id="id******************" disabled="true" x="42" y="42"></block>' +
     '</xml>');
+Serializer.Attributes.NotDeletable = new SerializerTestCase('Deletable',
+    '<xml xmlns="https://developers.google.com/blockly/xml">' +
+    '<block type="logic_negate" id="id******************" deletable="false" x="42" y="42"></block>' +
+    '</xml>');
+Serializer.Attributes.NotMovable = new SerializerTestCase('Movable',
+    '<xml xmlns="https://developers.google.com/blockly/xml">' +
+    '<block type="logic_negate" id="id******************" movable="false" x="42" y="42"></block>' +
+    '</xml>');
+Serializer.Attributes.NotEditable = new SerializerTestCase('Editable',
+    '<xml xmlns="https://developers.google.com/blockly/xml">' +
+    '<block type="logic_negate" id="id******************" editable="false" x="42" y="42"></block>' +
+    '</xml>');
 Serializer.Attributes.testCases = [
   Serializer.Attributes.Basic,
   Serializer.Attributes.Collapsed,
   Serializer.Attributes.Disabled,
+  Serializer.Attributes.NotDeletable,
+  Serializer.Attributes.NotMovable,
+  Serializer.Attributes.NotEditable,
 ];
 
 Serializer.Attributes.Inline = new SerializerTestSuite('Inline');


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [X] I ran `npm run format` and `npm run lint`

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Work on #6807

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
Serializes disabled interactions in the built-in JSON serializer.

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
This fixes undo and redo for deleting immovable and ineditable blocks.

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->
Added tests for round-tripping the disabled properties from XML -> Workspace -> JSON -> Workspace -> XML

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->
N/A

### Additional Information

<!-- Anything else we should know? -->
Next step is to work on deprecating the plugin.
