### PR TITLE
feat: add basic render queueing

### DIFF
--- a/core/block_dragger.ts
+++ b/core/block_dragger.ts
@@ -283,9 +283,6 @@ export class BlockDragger implements IBlockDragger {
 
   /**
    * Updates the necessary information to place a block at a certain location.
-   *
-   * @param delta The change in location from where the block started the drag
-   *     to where it ended the drag.
    */
   protected updateBlockAfterMove_() {
     this.fireMoveEvent_();

--- a/core/block_dragger.ts
+++ b/core/block_dragger.ts
@@ -288,13 +288,12 @@ export class BlockDragger implements IBlockDragger {
    *     to where it ended the drag.
    */
   protected updateBlockAfterMove_(delta: Coordinate) {
-    this.draggingBlock_.moveConnections(delta.x, delta.y);
     this.fireMoveEvent_();
     if (this.draggedConnectionManager_.wouldConnectBlock()) {
       // Applying connections also rerenders the relevant blocks.
       this.draggedConnectionManager_.applyConnections();
     } else {
-      this.draggingBlock_.render();
+      this.draggingBlock_.queueRender();
     }
     this.draggingBlock_.scheduleSnapAndBump();
   }

--- a/core/block_dragger.ts
+++ b/core/block_dragger.ts
@@ -230,7 +230,7 @@ export class BlockDragger implements IBlockDragger {
       // These are expensive and don't need to be done if we're deleting.
       this.draggingBlock_.setDragging(false);
       if (delta) {  // !preventMove
-        this.updateBlockAfterMove_(delta);
+        this.updateBlockAfterMove_();
       } else {
         // Blocks dragged directly from a flyout may need to be bumped into
         // bounds.
@@ -287,7 +287,7 @@ export class BlockDragger implements IBlockDragger {
    * @param delta The change in location from where the block started the drag
    *     to where it ended the drag.
    */
-  protected updateBlockAfterMove_(delta: Coordinate) {
+  protected updateBlockAfterMove_() {
     this.fireMoveEvent_();
     if (this.draggedConnectionManager_.wouldConnectBlock()) {
       // Applying connections also rerenders the relevant blocks.

--- a/core/block_svg.ts
+++ b/core/block_svg.ts
@@ -56,6 +56,7 @@ import * as svgMath from './utils/svg_math.js';
 import {Warning} from './warning.js';
 import type {Workspace} from './workspace.js';
 import type {WorkspaceSvg} from './workspace_svg.js';
+import {queueRender} from './render_management.js';
 
 
 /**
@@ -1579,7 +1580,17 @@ export class BlockSvg extends Block implements IASTNodeLocationSvg,
   }
 
   /**
-   * Lays out and reflows a block based on its contents and settings.
+   * Triggers a rerender after a delay to allow for batching.
+   *
+   * @internal
+   */
+  queueRender() {
+    queueRender(this);
+  }
+
+  /**
+   * Immediately lays out and reflows a block based on its contents and
+   * settings.
    *
    * @param opt_bubble If false, just render this block.
    *   If true, also render block's parent, grandparent, etc.  Defaults to true.
@@ -1597,7 +1608,7 @@ export class BlockSvg extends Block implements IASTNodeLocationSvg,
         this.updateCollapsed_();
       }
       this.workspace.getRenderer().render(this);
-      this.updateConnectionLocations_();
+      this.updateConnectionLocations();
 
       if (opt_bubble !== false) {
         const parentBlock = this.getParent();
@@ -1631,8 +1642,10 @@ export class BlockSvg extends Block implements IASTNodeLocationSvg,
    * Update all of the connections on this block with the new locations
    * calculated during rendering.  Also move all of the connected blocks based
    * on the new connection locations.
+   * 
+   * @internal
    */
-  private updateConnectionLocations_() {
+  updateConnectionLocations() {
     const blockTL = this.getRelativeToSurfaceXY();
     // Don't tighten previous or output connections because they are inferior
     // connections.

--- a/core/block_svg.ts
+++ b/core/block_svg.ts
@@ -1642,7 +1642,7 @@ export class BlockSvg extends Block implements IASTNodeLocationSvg,
    * Update all of the connections on this block with the new locations
    * calculated during rendering.  Also move all of the connected blocks based
    * on the new connection locations.
-   * 
+   *
    * @internal
    */
   updateConnectionLocations() {

--- a/core/block_svg.ts
+++ b/core/block_svg.ts
@@ -341,9 +341,6 @@ export class BlockSvg extends Block implements IASTNodeLocationSvg,
     const oldXY = this.getRelativeToSurfaceXY();
     if (newParent) {
       (newParent as BlockSvg).getSvgRoot().appendChild(svgRoot);
-      const newXY = this.getRelativeToSurfaceXY();
-      // Move the connections to match the child's new position.
-      this.moveConnections(newXY.x - oldXY.x, newXY.y - oldXY.y);
     } else if (oldParent) {
       // If we are losing a parent, we want to move our DOM element to the
       // root of the workspace.

--- a/core/insertion_marker_manager.ts
+++ b/core/insertion_marker_manager.ts
@@ -199,7 +199,9 @@ export class InsertionMarkerManager {
       blockAnimations.connectionUiEffect(inferiorConnection.getSourceBlock());
       // Bring the just-edited stack to the front.
       const rootBlock = this.topBlock.getRootBlock();
-      rootBlock.bringToFront();
+      setTimeout(() => {
+        rootBlock.bringToFront();
+      }, 0);
     }
   }
 

--- a/core/render_management.ts
+++ b/core/render_management.ts
@@ -1,0 +1,71 @@
+/**
+ * @license
+ * Copyright 2023 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {BlockSvg} from './block_svg';
+
+
+const rootBlocks = new Set<BlockSvg>();
+const dirtyBlocks = new WeakSet<BlockSvg>();
+let pid = 0;
+
+/**
+ * Registers that the given block and all of its parents need to be rerendered,
+ * and registers a callback to do so after a delay, to allowf or batching.
+ *
+ * @param block The block to rerender.
+ * @internal
+ */
+export function queueRender(block: BlockSvg) {
+  queueBlock(block);
+  if (!pid) pid = window.requestAnimationFrame(doRenders);
+}
+
+/**
+ * Adds the given block and its parents to the render queue. Adds the root block
+ * to the list of root blocks.
+ *
+ * @param block The block to queue.
+ */
+function queueBlock(block: BlockSvg) {
+  dirtyBlocks.add(block);
+  const parent = block.getParent();
+  if (parent) {
+    queueBlock(parent);
+  } else {
+    rootBlocks.add(block);
+  }
+}
+
+/**
+ * Rerenders all of the blocks in the queue.
+ */
+function doRenders() {
+  for (const block of rootBlocks) {
+    if (block.isDisposed()) continue;
+    renderBlock(block);
+  }
+
+  pid = 0;
+}
+
+/**
+ * Recursively renders all of the children of the given block, and then renders
+ * the block.
+ *
+ * @param block The block to rerender.
+ */
+function renderBlock(block: BlockSvg) {
+  for (const child of block.getChildren(false)) {
+    renderBlock(child);
+  }
+  if (dirtyBlocks.has(block)) {
+    dirtyBlocks.delete(block);
+    rootBlocks.delete(block);
+    block.render(false);
+  } else {
+    block.updateConnectionLocations();
+  }
+}

--- a/core/rendered_connection.ts
+++ b/core/rendered_connection.ts
@@ -308,14 +308,12 @@ export class RenderedConnection extends Connection {
           (shape as unknown as PathLeftShape).pathLeft +
           svgPaths.lineOnAxis('h', xLen);
     }
-    const xy = this.sourceBlock_.getRelativeToSurfaceXY();
-    const x = this.x - xy.x;
-    const y = this.y - xy.y;
+    const offset = this.offsetInBlock_;
     this.highlightPath = dom.createSvgElement(
         Svg.PATH, {
           'class': 'blocklyHighlightedConnectionPath',
           'd': steps,
-          'transform': 'translate(' + x + ',' + y + ')' +
+          'transform': `translate(${offset.x}, ${offset.y})` +
               (this.sourceBlock_.RTL ? ' scale(-1 1)' : ''),
         },
         this.sourceBlock_.getSvgRoot());

--- a/core/rendered_connection.ts
+++ b/core/rendered_connection.ts
@@ -185,13 +185,19 @@ export class RenderedConnection extends Connection {
    * @param y New absolute y coordinate, in workspace coordinates.
    */
   moveTo(x: number, y: number) {
+    const dx = this.x - x;
+    const dy = this.y - y;
+
     if (this.trackedState_ === RenderedConnection.TrackedState.WILL_TRACK) {
       this.db_.addConnection(this, y);
       this.trackedState_ = RenderedConnection.TrackedState.TRACKED;
-    } else if (this.trackedState_ === RenderedConnection.TrackedState.TRACKED) {
+    } else if (
+        this.trackedState_ === RenderedConnection.TrackedState.TRACKED &&
+        (dx !== 0 || dy !== 0)) {
       this.db_.removeConnection(this, this.y);
       this.db_.addConnection(this, y);
     }
+
     this.x = x;
     this.y = y;
   }

--- a/core/rendered_connection.ts
+++ b/core/rendered_connection.ts
@@ -465,11 +465,11 @@ export class RenderedConnection extends Connection {
     const renderedChild = childBlock as BlockSvg;
     // Rerender the parent so that it may reflow.
     if (renderedParent.rendered) {
-      renderedParent.render();
+      renderedParent.queueRender();
     }
     if (renderedChild.rendered) {
       renderedChild.updateDisabled();
-      renderedChild.render();
+      renderedChild.queueRender();
       // Reset visibility, since the child is now a top block.
       renderedChild.getSvgRoot().style.display = 'block';
     }
@@ -490,7 +490,7 @@ export class RenderedConnection extends Connection {
 
     const parentBlock = this.getSourceBlock();
     if (parentBlock.rendered) {
-      parentBlock.render();
+      parentBlock.queueRender();
     }
   }
 
@@ -534,11 +534,11 @@ export class RenderedConnection extends Connection {
           this.type === ConnectionType.PREVIOUS_STATEMENT) {
         // Child block may need to square off its corners if it is in a stack.
         // Rendering a child will render its parent.
-        childBlock.render();
+        childBlock.queueRender();
       } else {
         // Child block does not change shape.  Rendering the parent node will
         // move its connected children into position.
-        parentBlock.render();
+        parentBlock.queueRender();
       }
     }
 


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [X] I ran `npm run format` and `npm run lint`

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #6130 
Work on #6786 

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
Adds a render queue that is used to delay / batch block rerendering.

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
5x performance improvement!

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->

Only manual testing.

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->
N/A

### Additional Information

<!-- Anything else we should know? -->

There are some things in core that need blocks to be rendered immediately. E.g. flyouts need blocks to render immediately so that they can then be positioned. So I only converted dragging / connecting / disconnecting to use the queue, and we can convert other things over time.

This did run into some problems with the connection database, because rendering blocks after a delay means their connections have moved a bit before the normal call to `tighten` happens. Which is why we need to `updateConnectionLocations` on all blocks, even the ones that haven't been rendered. So we might need to pull this change out if it causes other unfound problems related to that.

On the other hand, I think our connection tracking is badly understood and overly complex. So I might look into cleaning this up a bit. E.g. why does `tighten` look at the `relativeXY` of the block when it can just calculate the offset based on the `offsetInBlock_` of it and its parent connection?

On the other other hand, touching the connection stuff is scary :P
