### PR TITLE
fix: updating connections in the db multiple times

### DIFF
--- a/core/rendered_connection.ts
+++ b/core/rendered_connection.ts
@@ -279,8 +279,8 @@ export class RenderedConnection extends Connection {
   }
 
   /**
-   * Moves the block son either side of this connection right next to eachother,
-   * based on their local offsets, not global positions.
+   * Moves the blocks on either side of this connection right next to
+   * each other, based on their local offsets, not global positions.
    *
    * @internal
    */

--- a/core/rendered_connection.ts
+++ b/core/rendered_connection.ts
@@ -183,23 +183,31 @@ export class RenderedConnection extends Connection {
    *
    * @param x New absolute x coordinate, in workspace coordinates.
    * @param y New absolute y coordinate, in workspace coordinates.
+   * @return True if the position of the connection in the connection db
+   *     was updated.
    */
-  moveTo(x: number, y: number) {
+  moveTo(x: number, y: number): boolean {
     const dx = this.x - x;
     const dy = this.y - y;
+
+    let moved = false;
 
     if (this.trackedState_ === RenderedConnection.TrackedState.WILL_TRACK) {
       this.db_.addConnection(this, y);
       this.trackedState_ = RenderedConnection.TrackedState.TRACKED;
+      moved = true;
     } else if (
         this.trackedState_ === RenderedConnection.TrackedState.TRACKED &&
         (dx !== 0 || dy !== 0)) {
       this.db_.removeConnection(this, this.y);
       this.db_.addConnection(this, y);
+      moved = true;
     }
 
     this.x = x;
     this.y = y;
+
+    return moved;
   }
 
   /**
@@ -207,9 +215,11 @@ export class RenderedConnection extends Connection {
    *
    * @param dx Change to x coordinate, in workspace units.
    * @param dy Change to y coordinate, in workspace units.
+   * @return True if the position of the connection in the connection db
+   *     was updated.
    */
-  moveBy(dx: number, dy: number) {
-    this.moveTo(this.x + dx, this.y + dy);
+  moveBy(dx: number, dy: number): boolean {
+    return this.moveTo(this.x + dx, this.y + dy);
   }
 
   /**
@@ -218,9 +228,11 @@ export class RenderedConnection extends Connection {
    *
    * @param blockTL The location of the top left corner of the block, in
    *     workspace coordinates.
+   * @return True if the position of the connection in the connection db
+   *     was updated.
    */
-  moveToOffset(blockTL: Coordinate) {
-    this.moveTo(
+  moveToOffset(blockTL: Coordinate): boolean {
+    return this.moveTo(
         blockTL.x + this.offsetInBlock_.x, blockTL.y + this.offsetInBlock_.y);
   }
 
@@ -261,10 +273,24 @@ export class RenderedConnection extends Connection {
       }
       // Workspace coordinates.
       const xy = svgMath.getRelativeXY(svgRoot);
-      block!.getSvgRoot().setAttribute(
-          'transform', 'translate(' + (xy.x - dx) + ',' + (xy.y - dy) + ')');
+      block!.translate(xy.x - dx, xy.y - dy);
       block!.moveConnections(-dx, -dy);
     }
+  }
+
+  /**
+   * Moves the block son either side of this connection right next to eachother,
+   * based on their local offsets, not global positions.
+   *
+   * @internal
+   */
+  tightenEfficiently() {
+    const target = this.targetConnection;
+    const block = this.targetBlock();
+    if (!target || !block) return;
+    const offset =
+        Coordinate.difference(this.offsetInBlock_, target.offsetInBlock_);
+    block.translate(offset.x, offset.y);
   }
 
   /**


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [X] I ran `npm run format` and `npm run lint`

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Works on #6786 as a follow up to #6851 

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
Separates out updating connection locations into a separate pass, specifically when using the render queue (normal immediate rendering is unaffected).


### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
This means that we are no longer recursively moving all of the child blocks every time we tighten a parent block (which was causing us to do a lot of duplicate work adding and removing things from the connection db). It also eliminates a heck-ton of calls to `getRelativeToSurfaceXY`, which is a pretty expensive function.

This makes rerendering ~ 2.5x faster when you're moving a bunch of connections. E.g. when you're wrapping a new if-block around the spaghetti stress test blocks.

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->
Just manual testing =(

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->
N/A

### Additional Information

<!-- Anything else we should know? -->
Dependent on #6851 