### PR TITLE
fix: remove update disabled calls

### DIFF
--- a/core/block_svg.ts
+++ b/core/block_svg.ts
@@ -511,7 +511,7 @@ export class BlockSvg extends Block implements IASTNodeLocationSvg,
     if (!collapsed) {
       this.updateCollapsed_();
     } else if (this.rendered) {
-      this.render();
+      this.queueRender();
       // Don't bump neighbours. Users like to store collapsed functions together
       // and bumping makes them go out of alignment.
     }
@@ -1255,7 +1255,7 @@ export class BlockSvg extends Block implements IASTNodeLocationSvg,
     const removed = super.removeInput(name, opt_quiet);
 
     if (this.rendered) {
-      this.render();
+      this.queueRender();
       // Removing an input will cause the block to change shape.
       this.bumpNeighbours();
     }
@@ -1291,7 +1291,7 @@ export class BlockSvg extends Block implements IASTNodeLocationSvg,
     const input = super.appendInput_(type, name);
 
     if (this.rendered) {
-      this.render();
+      this.queueRender();
       // Adding an input will cause the block to change shape.
       this.bumpNeighbours();
     }

--- a/core/block_svg.ts
+++ b/core/block_svg.ts
@@ -515,13 +515,7 @@ export class BlockSvg extends Block implements IASTNodeLocationSvg,
       return;
     }
     super.setCollapsed(collapsed);
-    if (!collapsed) {
-      this.updateCollapsed_();
-    } else if (this.rendered) {
-      this.queueRender();
-      // Don't bump neighbours. Users like to store collapsed functions together
-      // and bumping makes them go out of alignment.
-    }
+    this.updateCollapsed_();
   }
 
   /**
@@ -1452,9 +1446,10 @@ export class BlockSvg extends Block implements IASTNodeLocationSvg,
     const group = eventUtils.getGroup();
 
     this.bumpNeighboursPid = setTimeout(() => {
+      const oldGroup = eventUtils.getGroup();
       eventUtils.setGroup(group);
       this.getRootBlock().bumpNeighboursInternal();
-      eventUtils.setGroup(false);
+      eventUtils.setGroup(oldGroup);
       this.bumpNeighboursPid = 0;
     }, config.bumpDelay);
   }
@@ -1652,6 +1647,11 @@ export class BlockSvg extends Block implements IASTNodeLocationSvg,
     if (this.workspace.keyboardAccessibilityMode && this.pathObject.markerSvg) {
       // TODO(#4592): Update all markers on the block.
       this.workspace.getMarker(MarkerManager.LOCAL_MARKER)!.draw();
+    }
+    for (const input of this.inputList) {
+      for (const field of input.fieldRow) {
+        field.updateMarkers_();
+      }
     }
   }
 

--- a/core/block_svg.ts
+++ b/core/block_svg.ts
@@ -334,8 +334,6 @@ export class BlockSvg extends Block implements IASTNodeLocationSvg,
       this.workspace.getCanvas().appendChild(svgRoot);
       this.translate(oldXY.x, oldXY.y);
     }
-
-    this.applyColour();
   }
 
   /**
@@ -534,7 +532,6 @@ export class BlockSvg extends Block implements IASTNodeLocationSvg,
     }
 
     if (!collapsed) {
-      this.updateDisabled();
       this.removeInput(collapsedInputName);
       return;
     }
@@ -1616,6 +1613,7 @@ export class BlockSvg extends Block implements IASTNodeLocationSvg,
       this.updateCollapsed_();
     }
     this.workspace.getRenderer().render(this);
+    this.applyColour();
     this.tightenChildrenEfficiently();
 
     dom.stopTextWidthCache();

--- a/core/field.ts
+++ b/core/field.ts
@@ -962,9 +962,8 @@ export abstract class Field<T = any> implements IASTNodeLocationSvg,
   forceRerender() {
     this.isDirty_ = true;
     if (this.sourceBlock_ && this.sourceBlock_.rendered) {
-      (this.sourceBlock_ as BlockSvg).render();
+      (this.sourceBlock_ as BlockSvg).queueRender();
       (this.sourceBlock_ as BlockSvg).bumpNeighbours();
-      this.updateMarkers_();
     }
   }
 
@@ -1288,8 +1287,12 @@ export abstract class Field<T = any> implements IASTNodeLocationSvg,
     this.markerSvg_ = markerSvg;
   }
 
-  /** Redraw any attached marker or cursor svgs if needed. */
-  protected updateMarkers_() {
+  /**
+   * Redraw any attached marker or cursor svgs if needed.
+   *
+   * @internal
+   */
+  updateMarkers_() {
     const block = this.getSourceBlock();
     if (!block) {
       throw new UnattachedFieldError();

--- a/core/input.ts
+++ b/core/input.ts
@@ -126,7 +126,7 @@ export class Input {
     }
 
     if (this.sourceBlock.rendered) {
-      (this.sourceBlock as BlockSvg).render();
+      (this.sourceBlock as BlockSvg).queueRender();
       // Adding a field will cause the block to change shape.
       this.sourceBlock.bumpNeighbours();
     }

--- a/core/input.ts
+++ b/core/input.ts
@@ -148,7 +148,7 @@ export class Input {
         field.dispose();
         this.fieldRow.splice(i, 1);
         if (this.sourceBlock.rendered) {
-          (this.sourceBlock as BlockSvg).render();
+          (this.sourceBlock as BlockSvg).queueRender();
           // Removing a field will cause the block to change shape.
           this.sourceBlock.bumpNeighbours();
         }

--- a/core/render_management.ts
+++ b/core/render_management.ts
@@ -72,11 +72,14 @@ function doRenders() {
  * @param block The block to rerender.
  */
 function renderBlock(block: BlockSvg) {
-  if (!dirtyBlocks.has(block)) return;
   for (const child of block.getChildren(false)) {
     renderBlock(child);
   }
-  block.renderEfficiently();
+  if (dirtyBlocks.has(block)) {
+    block.renderEfficiently();
+  } else {
+    block.applyColour();
+  }
 }
 
 /**

--- a/core/rendered_connection.ts
+++ b/core/rendered_connection.ts
@@ -492,7 +492,6 @@ export class RenderedConnection extends Connection {
       renderedParent.queueRender();
     }
     if (renderedChild.rendered) {
-      renderedChild.updateDisabled();
       renderedChild.queueRender();
       // Reset visibility, since the child is now a top block.
       renderedChild.getSvgRoot().style.display = 'block';
@@ -547,12 +546,6 @@ export class RenderedConnection extends Connection {
     const parentRendered = parentBlock.rendered;
     const childRendered = childBlock.rendered;
 
-    if (parentRendered) {
-      parentBlock.updateDisabled();
-    }
-    if (childRendered) {
-      childBlock.updateDisabled();
-    }
     if (parentRendered && childRendered) {
       if (this.type === ConnectionType.NEXT_STATEMENT ||
           this.type === ConnectionType.PREVIOUS_STATEMENT) {

--- a/core/xml.ts
+++ b/core/xml.ts
@@ -565,7 +565,6 @@ export function domToBlock(xmlBlock: Element, workspace: Workspace): Block {
           topBlockSvg.setConnectionTracking(true);
         }
       }, 1);
-      topBlockSvg.updateDisabled();
       // Allow the scrollbars to resize and move based on the new contents.
       // TODO(@picklesrus): #387. Remove when domToBlock avoids resizing.
       (workspace as WorkspaceSvg).resizeContents();

--- a/tests/mocha/block_test.js
+++ b/tests/mocha/block_test.js
@@ -1112,48 +1112,42 @@ suite('Blocks', function() {
     suite('Add Connections Programmatically', function() {
       test('Output', function() {
         const block = createRenderedBlock(this.workspace, 'empty_block');
-        // this.workspace.newBlock('empty_block');
-        // block.initSvg();
-        // block.render();
 
         block.setOutput(true);
 
+        this.clock.runAll();
         chai.assert.equal(this.getOutputs().length, 1);
       });
       test('Value', function() {
-        const block = this.workspace.newBlock('empty_block');
-        block.initSvg();
-        block.render();
+        const block = createRenderedBlock(this.workspace, 'empty_block');
 
         block.appendValueInput('INPUT');
 
+        this.clock.runAll();
         chai.assert.equal(this.getInputs().length, 1);
       });
       test('Previous', function() {
-        const block = this.workspace.newBlock('empty_block');
-        block.initSvg();
-        block.render();
+        const block = createRenderedBlock(this.workspace, 'empty_block');
 
         block.setPreviousStatement(true);
 
+        this.clock.runAll();
         chai.assert.equal(this.getPrevious().length, 1);
       });
       test('Next', function() {
-        const block = this.workspace.newBlock('empty_block');
-        block.initSvg();
-        block.render();
+        const block = createRenderedBlock(this.workspace, 'empty_block');
 
         block.setNextStatement(true);
 
+        this.clock.runAll();
         chai.assert.equal(this.getNext().length, 1);
       });
       test('Statement', function() {
-        const block = this.workspace.newBlock('empty_block');
-        block.initSvg();
-        block.render();
+        const block = createRenderedBlock(this.workspace, 'empty_block');
 
         block.appendStatementInput('STATEMENT');
 
+        this.clock.runAll();
         chai.assert.equal(this.getNext().length, 1);
       });
     });
@@ -1719,8 +1713,10 @@ suite('Blocks', function() {
       test('Add Input', function() {
         const blockA = createRenderedBlock(this.workspace, 'empty_block');
         blockA.setCollapsed(true);
-        assertCollapsed(blockA);
+
         blockA.appendDummyInput('NAME');
+
+        this.clock.runAll();
         assertCollapsed(blockA);
         chai.assert.isNotNull(blockA.getInput('NAME'));
       });
@@ -1794,20 +1790,20 @@ suite('Blocks', function() {
         const blockA = createRenderedBlock(this.workspace, 'variable_block');
 
         blockA.setCollapsed(true);
-        assertCollapsed(blockA, 'x');
-
         const variable = this.workspace.getVariable('x', '');
         this.workspace.renameVariableById(variable.getId(), 'y');
+
+        this.clock.runAll();
         assertCollapsed(blockA, 'y');
       });
       test('Coalesce, Different Case', function() {
         const blockA = createRenderedBlock(this.workspace, 'variable_block');
 
         blockA.setCollapsed(true);
-        assertCollapsed(blockA, 'x');
-
         const variable = this.workspace.createVariable('y');
         this.workspace.renameVariableById(variable.getId(), 'X');
+
+        this.clock.runAll();
         assertCollapsed(blockA, 'X');
       });
     });

--- a/tests/mocha/block_test.js
+++ b/tests/mocha/block_test.js
@@ -1822,6 +1822,7 @@ suite('Blocks', function() {
         blockA.setCollapsed(false);
 
         // The child blocks should be enabled.
+        this.clock.runAll();
         chai.assert.isFalse(blockB.disabled);
         chai.assert.isFalse(blockB.getSvgRoot().classList.contains('blocklyDisabled'));
       });

--- a/tests/mocha/blocks/procedures_test.js
+++ b/tests/mocha/blocks/procedures_test.js
@@ -541,6 +541,7 @@ suite('Procedures', function() {
           Blockly.Events.setGroup(false);
 
           this.workspace.undo();
+          this.clock.runAll();
 
           chai.assert.isTrue(
             defBlock.getFieldValue('PARAMS').includes('param1'),

--- a/tests/mocha/field_checkbox_test.js
+++ b/tests/mocha/field_checkbox_test.js
@@ -152,7 +152,7 @@ suite('Checkbox Fields', function() {
           workspace: {
             keyboardAccessibilityMode: false,
           },
-          render: function() {field.render_();},
+          queueRender: function() {field.render_();},
           bumpNeighbours: function() {},
         };
         field.constants_ = {

--- a/tests/mocha/input_test.js
+++ b/tests/mocha/input_test.js
@@ -23,7 +23,7 @@ suite('Inputs', function() {
         '<block type="empty_block"/>'
     ), this.workspace);
 
-    this.renderStub = sinon.stub(this.block, 'render');
+    this.renderStub = sinon.stub(this.block, 'queueRender');
     this.bumpNeighboursStub = sinon.stub(this.block, 'bumpNeighbours');
 
     this.dummy = this.block.appendDummyInput('DUMMY');

--- a/tests/playground.html
+++ b/tests/playground.html
@@ -505,8 +505,8 @@ start();
       <option value="rtl">RTL</option>
     </select>
     <select name="toolbox" onchange="document.forms.options.submit()">
-      <option value="categories">Categories (untyped variables)</option>
-      <option value="categories-typed-variables">Categories (typed variables)</option>
+      <option value="categories">Categories (untyped)</option>
+      <option value="categories-typed-variables">Categories (typed)</option>
       <option value="simple">Simple</option>
       <option value="test-blocks">Test Blocks</option>
     </select>


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [X] I ran `npm run format` and `npm run lint`

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes N/A

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->\
Removes some unnecessary calls to `updateDisabled` and `applyColour`.

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
`updateDisabled` is a very expensive operation because it recursively walks the block tree and applies styles to it. This moves color application to be triggered by `renderEfficiently` so we only have to do one walk of the block tree.

Everywhere where calls to `updateDisabled` were removed, there is a later call to `queueRender`. This means there is no change in behavior.

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->

Onlymanual testing :/

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->
N/A

### Additional Information

<!-- Anything else we should know? -->
Dependent on #6860
