### PR TITLE
fix: empty procedure arrays in serialization

### DIFF
--- a/core/serialization/procedures.ts
+++ b/core/serialization/procedures.ts
@@ -138,8 +138,9 @@ export class ProcedureSerializer<ProcedureModel extends IProcedureModel,
 
   /** Serializes the procedure models of the given workspace. */
   save(workspace: Workspace): State[]|null {
-    return workspace.getProcedureMap().getProcedures().map(
+    const save = workspace.getProcedureMap().getProcedures().map(
         (proc) => saveProcedure(proc));
+    return save.length ? save : null;
   }
 
   /**


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [X] I ran `npm run format` and `npm run lint`

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes N/A

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
Makes it so that ifthere are no procedure models in the workspace the procedure serializer returns null.

#### Behavior Before Change

<!--TODO: Image, gif or explanation of behavior before this pull request. -->

Workspaces without procedure models would be serialized as:
```
{
  'procedures': [],
}
```

#### Behavior After Change

Workspaces without procedure models are serialized as:
```
{ }
```

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
The tiniest amount of space saving.

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->
N/A

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->
N/A

### Additional Information

<!-- Anything else we should know? -->
N/A
