### PR TITLE
fix: Always draw dragged blocks atop others in the workspace.

### DIFF
--- a/core/block_dragger.ts
+++ b/core/block_dragger.ts
@@ -105,13 +105,10 @@ export class BlockDragger implements IBlockDragger {
     }
     this.fireDragStartEvent_();
 
-    // Mutators don't have the same type of z-ordering as the normal workspace
-    // during a drag.  They have to rely on the order of the blocks in the SVG.
-    // For performance reasons that usually happens at the end of a drag,
-    // but do it at the beginning for mutators.
-    if (this.workspace_.isMutator) {
-      this.draggingBlock_.bringToFront();
-    }
+    // The z-order of blocks depends on their order in the SVG, so move the
+    // block being dragged to the front so that it will appear atop other blocks
+    // in the workspace.
+    this.draggingBlock_.bringToFront(true);
 
     // During a drag there may be a lot of rerenders, but not field changes.
     // Turn the cache on so we don't do spurious remeasures during the drag.

--- a/core/block_svg.ts
+++ b/core/block_svg.ts
@@ -328,8 +328,9 @@ export class BlockSvg
     } else if (oldParent) {
       // If we are losing a parent, we want to move our DOM element to the
       // root of the workspace.
-      const draggingBlock =
-          this.workspace.getCanvas().querySelector('.blocklyDragging');
+      const draggingBlock = this.workspace
+        .getCanvas()
+        .querySelector('.blocklyDragging');
       if (draggingBlock) {
         this.workspace.getCanvas().insertBefore(svgRoot, draggingBlock);
       } else {

--- a/core/block_svg.ts
+++ b/core/block_svg.ts
@@ -328,7 +328,13 @@ export class BlockSvg
     } else if (oldParent) {
       // If we are losing a parent, we want to move our DOM element to the
       // root of the workspace.
-      this.workspace.getCanvas().appendChild(svgRoot);
+      const draggingBlock =
+          this.workspace.getCanvas().querySelector('.blocklyDragging');
+      if (draggingBlock) {
+        this.workspace.getCanvas().insertBefore(svgRoot, draggingBlock);
+      } else {
+        this.workspace.getCanvas().appendChild(svgRoot);
+      }
       this.translate(oldXY.x, oldXY.y);
     }
 
@@ -1146,9 +1152,11 @@ export class BlockSvg
    * order that they are in the DOM.  By placing this block first within the
    * block group's <g>, it will render on top of any other blocks.
    *
+   * @param blockOnly: True to only move this block to the front without
+   *     adjusting its parents.
    * @internal
    */
-  bringToFront() {
+  bringToFront(blockOnly = false) {
     /* eslint-disable-next-line @typescript-eslint/no-this-alias */
     let block: this | null = this;
     do {
@@ -1159,6 +1167,7 @@ export class BlockSvg
       if (childNodes[childNodes.length - 1] !== root) {
         parent!.appendChild(root);
       }
+      if (blockOnly) break;
       block = block.getParent();
     } while (block);
   }


### PR DESCRIPTION
## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [x] I ran `npm run format` and `npm run lint`

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #6852

### Proposed Changes
When blocks are dragged, bring them to the front, and update `setParent` to insert blocks before the block being dragged, if any, when removing it from its parent.

#### Behavior Before Change
Blocks would occassionally appear behind other blocks when being dragged.

#### Behavior After Change
Blocks being dragged appear atop all other blocks.

### Reason for Changes
Fixes a regression introduced in #6758.