### PR TITLE
fix: Don't repeatedly recreate the last marker block during a drag.

### DIFF
--- a/core/insertion_marker_manager.ts
+++ b/core/insertion_marker_manager.ts
@@ -303,15 +303,9 @@ export class InsertionMarkerManager {
     if (lastOnStack && lastOnStack !== this.topBlock.nextConnection) {
       available.push(lastOnStack);
       this.lastOnStack = lastOnStack;
-      if (this.lastMarker) {
-        eventUtils.disable();
-        try {
-          this.lastMarker.dispose();
-        } finally {
-          eventUtils.enable();
-        }
+      if (!this.lastMarker) {
+        this.lastMarker = this.createMarkerBlock(lastOnStack.getSourceBlock());
       }
-      this.lastMarker = this.createMarkerBlock(lastOnStack.getSourceBlock());
     }
     return available;
   }
@@ -561,8 +555,31 @@ export class InsertionMarkerManager {
       // probably recreate the marker block (e.g. in getCandidate_), which is
       // called more often during the drag, but creating a block that often
       // might be too slow, so we only do it if necessary.
-      this.firstMarker = this.createMarkerBlock(this.topBlock);
-      insertionMarker = isLastInStack ? this.lastMarker : this.firstMarker;
+      if (isLastInStack && this.lastOnStack) {
+        if (this.lastMarker) {
+          eventUtils.disable();
+          try {
+            this.lastMarker.dispose();
+          } finally {
+            eventUtils.enable();
+          }
+        }
+        this.lastMarker =
+            this.createMarkerBlock(this.lastOnStack.getSourceBlock());
+        insertionMarker = this.lastMarker;
+      } else {
+        if (this.firstMarker) {
+          eventUtils.disable();
+          try {
+            this.firstMarker.dispose();
+          } finally {
+            eventUtils.enable();
+          }
+        }
+        this.firstMarker = this.createMarkerBlock(this.topBlock);
+        insertionMarker = this.firstMarker;
+      }
+
       if (!insertionMarker) {
         throw new Error(
             'Cannot show the insertion marker because there is no insertion ' +


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [x] I ran `npm run format` and `npm run lint`

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes  #6839

### Proposed Changes
#5722 introduced logic to update the available connections (and marker block) for a block being dragged as it was being dragged in order to make the marker block reflect changes to the connections of the block being dragged that happened during the drag. The insertion marker corresponding the first block in the stack being dragged was only regenerated when (a) it was shown and (b) its connections were inconsistent with those on the corresponding insertion marker block. However, the insertion marker corresponding to the last block in the stack was recreated every time the drag moved. This PR updates the insertion marker manager to only create the insertion marker block corresponding to the last block in the stack being dragged (a) at the beginning of the drag and (b) in the event of the same sort of mismatch during showing that would cause the insertion marker block corresponding to the first block in the stack being dragged to be regenerated.

#### Behavior Before Change
Numerous useless block creations.

#### Behavior After Change
Insertion marker blocks are only created on an as-needed basis.