### PR TITLE
fix: improve performance of connecting blocks

### DIFF
--- a/core/block_svg.ts
+++ b/core/block_svg.ts
@@ -123,6 +123,7 @@ export class BlockSvg extends Block implements IASTNodeLocationSvg,
   /** @internal */
   pathObject: IPathObject;
   override rendered = false;
+  private visuallyDisabled = false;
 
   /**
    * Is this block currently rendering? Used to stop recursive render calls
@@ -889,15 +890,12 @@ export class BlockSvg extends Block implements IASTNodeLocationSvg,
    * @internal
    */
   updateDisabled() {
-    const children = (this.getChildren(false));
+    const disabled = !this.isEnabled() || this.getInheritedDisabled();
+    if (this.visuallyDisabled === disabled) return;
     this.applyColour();
-    if (this.isCollapsed()) {
-      return;
-    }
-    for (let i = 0, child; child = children[i]; i++) {
-      if (child.rendered) {
-        child.updateDisabled();
-      }
+    this.visuallyDisabled = disabled;
+    for (const child of this.getChildren(false)) {
+      child.updateDisabled();
     }
   }
 

--- a/core/connection.ts
+++ b/core/connection.ts
@@ -93,7 +93,7 @@ export class Connection implements IASTNodeLocationWithBlock {
 
     // Make sure the childConnection is available.
     if (childConnection.isConnected()) {
-      childConnection.disconnect(false);
+      childConnection.disconnectInternal(false);
     }
 
     // Make sure the parentConnection is available.
@@ -104,7 +104,7 @@ export class Connection implements IASTNodeLocationWithBlock {
       if (target!.isShadow()) {
         target!.dispose(false);
       } else {
-        this.disconnect();
+        this.disconnectInternal();
         orphan = target;
       }
       this.applyShadowState_(shadowState);
@@ -245,11 +245,20 @@ export class Connection implements IASTNodeLocationWithBlock {
 
   /**
    * Disconnect this connection.
+   */
+  disconnect() {
+    this.disconnectInternal();
+  }
+
+  /**
+   * Disconnect two blocks that are connected by this connection.
    *
    * @param setParent Whether to set the parent of the disconnected block or
    *     not, defaults to true.
+   *     If you do not set the parent, ensure that a subsequent action does,
+   *     otherwise the view and model will be out of sync.
    */
-  disconnect(setParent = true) {
+  protected disconnectInternal(setParent = true) {
     const {parentConnection, childConnection} =
         this.getParentAndChildConnections();
     if (!parentConnection || !childConnection) {

--- a/core/connection.ts
+++ b/core/connection.ts
@@ -93,7 +93,7 @@ export class Connection implements IASTNodeLocationWithBlock {
 
     // Make sure the childConnection is available.
     if (childConnection.isConnected()) {
-      childConnection.disconnect();
+      childConnection.disconnect(false);
     }
 
     // Make sure the parentConnection is available.
@@ -244,7 +244,7 @@ export class Connection implements IASTNodeLocationWithBlock {
   }
 
   /** Disconnect this connection. */
-  disconnect() {
+  disconnect(setParent = true) {
     const {parentConnection, childConnection} =
         this.getParentAndChildConnections();
     if (!parentConnection || !childConnection) {
@@ -264,7 +264,7 @@ export class Connection implements IASTNodeLocationWithBlock {
       otherConnection.targetConnection = null;
     }
     this.targetConnection = null;
-    childConnection.getSourceBlock().setParent(null);
+    if (setParent) childConnection.getSourceBlock().setParent(null);
     if (event) {
       event.recordNew();
       eventUtils.fire(event);

--- a/core/connection.ts
+++ b/core/connection.ts
@@ -293,6 +293,9 @@ export class Connection implements IASTNodeLocationWithBlock {
   }
 
   /**
+   * Returns the parent connection (superior) and child connection (inferior)
+   * given this connection and the connection it is connected to.
+   *
    * @returns The parent connection and child connection, given this connection
    *     and the connection it is connected to.
    */

--- a/core/connection.ts
+++ b/core/connection.ts
@@ -243,7 +243,12 @@ export class Connection implements IASTNodeLocationWithBlock {
     return this.isConnected();
   }
 
-  /** Disconnect this connection. */
+  /**
+   * Disconnect this connection.
+   *
+   * @param setParent Whether to set the parent of the disconnected block or
+   *     not, defaults to true.
+   */
   disconnect(setParent = true) {
     const {parentConnection, childConnection} =
         this.getParentAndChildConnections();
@@ -278,6 +283,10 @@ export class Connection implements IASTNodeLocationWithBlock {
     if (!eventGroup) eventUtils.setGroup(false);
   }
 
+  /**
+   * @returns The parent connection and child connection, given this connection
+   *     and the connection it is connected to.
+   */
   protected getParentAndChildConnections():
       {parentConnection?: Connection, childConnection?: Connection} {
     if (!this.targetConnection) return {};

--- a/core/contextmenu.ts
+++ b/core/contextmenu.ts
@@ -117,11 +117,15 @@ function populate_(
     if (option.enabled) {
       const actionHandler = function() {
         hide();
-        // If .scope does not exist on the option, then the callback will not
-        // be expecting a scope parameter, so there should be no problems. Just
-        // assume it is a ContextMenuOption and we'll pass undefined if it's
-        // not.
-        option.callback((option as ContextMenuOption).scope);
+        requestAnimationFrame(() => {
+          setTimeout(() => {
+            // If .scope does not exist on the option, then the callback
+            // will not be expecting a scope parameter, so there should be
+            // no problems. Just assume it is a ContextMenuOption and we'll
+            // pass undefined if it's not.
+            option.callback((option as ContextMenuOption).scope);
+          }, 0);
+        });
       };
       menuItem.onAction(actionHandler, {});
     }

--- a/core/insertion_marker_manager.ts
+++ b/core/insertion_marker_manager.ts
@@ -180,19 +180,14 @@ export class InsertionMarkerManager {
    */
   applyConnections() {
     if (!this.activeCandidate) return;
-    // Don't fire events for insertion markers.
+    const {local, closest} = this.activeCandidate;
+    local.connect(closest);
     eventUtils.disable();
     this.hidePreview();
     eventUtils.enable();
-    const {local, closest} = this.activeCandidate;
-    // Connect two blocks together.
-    local.connect(closest);
     if (this.topBlock.rendered) {
-      // Trigger a connection animation.
-      // Determine which connection is inferior (lower in the source stack).
       const inferiorConnection = local.isSuperior() ? closest : local;
       blockAnimations.connectionUiEffect(inferiorConnection.getSourceBlock());
-      // Bring the just-edited stack to the front.
       const rootBlock = this.topBlock.getRootBlock();
       setTimeout(() => {
         rootBlock.bringToFront();

--- a/core/rendered_connection.ts
+++ b/core/rendered_connection.ts
@@ -481,14 +481,16 @@ export class RenderedConnection extends Connection {
    *
    * @param setParent Whether to set the parent of the disconnected block or
    *     not, defaults to true.
+   *     If you do not set the parent, ensure that a subsequent action does,
+   *     otherwise the view and model will be out of sync.
    */
-  override disconnect(setParent = true) {
+  override disconnectInternal(setParent = true) {
     const {parentConnection, childConnection} =
         this.getParentAndChildConnections();
     if (!parentConnection || !childConnection) return;
     const parent = parentConnection.getSourceBlock() as BlockSvg;
     const child = childConnection.getSourceBlock() as BlockSvg;
-    super.disconnect(setParent);
+    super.disconnectInternal(setParent);
     // Rerender the parent so that it may reflow.
     if (parent.rendered) {
       parent.queueRender();

--- a/core/rendered_connection.ts
+++ b/core/rendered_connection.ts
@@ -482,7 +482,7 @@ export class RenderedConnection extends Connection {
    * @param parentBlock The superior block.
    * @param childBlock The inferior block.
    */
-  override disconnect() {
+  override disconnect(setParent = true) {
     const {parentConnection, childConnection} =
         this.getParentAndChildConnections();
     if (!parentConnection || !childConnection) return;
@@ -498,7 +498,7 @@ export class RenderedConnection extends Connection {
       // Reset visibility, since the child is now a top block.
       child.getSvgRoot().style.display = 'block';
     }
-    super.disconnect();
+    super.disconnect(setParent);
   }
 
   /**

--- a/core/rendered_connection.ts
+++ b/core/rendered_connection.ts
@@ -488,6 +488,7 @@ export class RenderedConnection extends Connection {
     if (!parentConnection || !childConnection) return;
     const parent = parentConnection.getSourceBlock() as BlockSvg;
     const child = childConnection.getSourceBlock() as BlockSvg;
+    super.disconnect(setParent);
     // Rerender the parent so that it may reflow.
     if (parent.rendered) {
       parent.queueRender();
@@ -498,7 +499,6 @@ export class RenderedConnection extends Connection {
       // Reset visibility, since the child is now a top block.
       child.getSvgRoot().style.display = 'block';
     }
-    super.disconnect(setParent);
   }
 
   /**

--- a/core/rendered_connection.ts
+++ b/core/rendered_connection.ts
@@ -479,8 +479,8 @@ export class RenderedConnection extends Connection {
   /**
    * Disconnect two blocks that are connected by this connection.
    *
-   * @param parentBlock The superior block.
-   * @param childBlock The inferior block.
+   * @param setParent Whether to set the parent of the disconnected block or
+   *     not, defaults to true.
    */
   override disconnect(setParent = true) {
     const {parentConnection, childConnection} =

--- a/core/rendered_connection.ts
+++ b/core/rendered_connection.ts
@@ -482,21 +482,23 @@ export class RenderedConnection extends Connection {
    * @param parentBlock The superior block.
    * @param childBlock The inferior block.
    */
-  protected override disconnectInternal_(
-      parentBlock: Block, childBlock: Block) {
-    super.disconnectInternal_(parentBlock, childBlock);
-    const renderedParent = parentBlock as BlockSvg;
-    const renderedChild = childBlock as BlockSvg;
+  override disconnect() {
+    const {parentConnection, childConnection} =
+        this.getParentAndChildConnections();
+    if (!parentConnection || !childConnection) return;
+    const parent = parentConnection.getSourceBlock() as BlockSvg;
+    const child = childConnection.getSourceBlock() as BlockSvg;
     // Rerender the parent so that it may reflow.
-    if (renderedParent.rendered) {
-      renderedParent.queueRender();
+    if (parent.rendered) {
+      parent.queueRender();
     }
-    if (renderedChild.rendered) {
-      renderedChild.updateDisabled();
-      renderedChild.queueRender();
+    if (child.rendered) {
+      child.updateDisabled();
+      child.queueRender();
       // Reset visibility, since the child is now a top block.
-      renderedChild.getSvgRoot().style.display = 'block';
+      child.getSvgRoot().style.display = 'block';
     }
+    super.disconnect();
   }
 
   /**

--- a/tests/mocha/block_test.js
+++ b/tests/mocha/block_test.js
@@ -1825,25 +1825,6 @@ suite('Blocks', function() {
         chai.assert.isFalse(blockB.disabled);
         chai.assert.isFalse(blockB.getSvgRoot().classList.contains('blocklyDisabled'));
       });
-      test('Children of Collapsed Block Should Not Update', function() {
-        const blockA = createRenderedBlock(this.workspace, 'statement_block');
-        const blockB = createRenderedBlock(this.workspace, 'stack_block');
-        blockA.getInput('STATEMENT').connection
-            .connect(blockB.previousConnection);
-
-        // Disable the block and collapse it.
-        blockA.setEnabled(false);
-        blockA.setCollapsed(true);
-
-        const blockUpdateDisabled = sinon.stub(blockB, 'updateDisabled');
-
-        // Enable the block before expanding it.
-        blockA.setEnabled(true);
-
-        // For performance reasons updateDisabled should not be called
-        // on children of collapsed blocks.
-        sinon.assert.notCalled(blockUpdateDisabled);
-      });
       test('Disabled Children of Collapsed Blocks Should Stay Disabled', function() {
         const blockA = createRenderedBlock(this.workspace, 'statement_block');
         const blockB = createRenderedBlock(this.workspace, 'stack_block');


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [x] I ran `npm run format` and `npm run lint`

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Related to #6130 

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
Optimizes the performance of connecting blocks by:
  * Removing unnessary calls to `updateDisabled`
  * Only setting the parent once (when connecting) instead of twice (when connecting and disconnecting)

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
Cuts off ~100ms from wrapping an if block around the spaghetti code test blocks.

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->
Only manual testing :/

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->
N/A

### Additional Information

<!-- Anything else we should know? -->

Dependent on #6860 
