### PR TITLE
docs: Fix a few typos

### DIFF
--- a/closure/goog/base.js
+++ b/closure/goog/base.js
@@ -727,7 +727,7 @@ if (!COMPILED) {
 
   // NOTE: We add goog.module as an implicit namespace as goog.module is defined
   // here and because the existing module package has not been moved yet out of
-  // the goog.module namespace. This satisifies both the debug loader and
+  // the goog.module namespace. This satisfies both the debug loader and
   // ahead-of-time dependency management.
 }
 

--- a/demos/minimap/minimap.js
+++ b/demos/minimap/minimap.js
@@ -198,7 +198,7 @@ Minimap.scaleMinimap = function() {
   var workspaceMetrics = Minimap.workspace.getMetrics();
   var minimapMetrics = Minimap.minimap.getMetrics();
 
-  // Scaling the mimimap such that all the blocks can be seen in the viewport.
+  // Scaling the minimap such that all the blocks can be seen in the viewport.
   // This padding is default because this is how to scrollbar(in main workspace)
   // is implemented.
   var topPadding = (workspaceMetrics.viewHeight) * Minimap.minimap.scale /

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -40,7 +40,7 @@ module.exports = {
   deployDemosBeta: appengineTasks.deployDemosBeta,
   gitUpdateGithubPages: gitTasks.updateGithubPages,
 
-  // Manually-invokable targets, with prequisites where required.
+  // Manually-invokable targets, with prerequisites where required.
   format: buildTasks.format,
   messages: buildTasks.messages,  // Generate msg/json/en.json et al.
   sortRequires: cleanupTasks.sortRequires,

--- a/scripts/gulpfiles/build_tasks.js
+++ b/scripts/gulpfiles/build_tasks.js
@@ -254,7 +254,7 @@ const JSCOMP_OFF = [
    * When adding additional items to this list it may be helpful to
    * search the compiler source code
    * (https://github.com/google/closure-compiler/) for the JSC_*
-   * disagnostic name (omitting the JSC_ prefix) to find the corresponding
+   * diagnostic name (omitting the JSC_ prefix) to find the corresponding
    * DiagnosticGroup.
    */
   'checkTypes',
@@ -376,7 +376,7 @@ error message above, try running:
 }
 
 /**
- * This task regenrates msg/json/en.js and msg/json/qqq.js from
+ * This task regenerates msg/json/en.js and msg/json/qqq.js from
  * msg/messages.js.
  */
 function generateMessages(done) {
@@ -738,7 +738,7 @@ exports.deps = gulp.series(exports.tsc, buildDeps);
 exports.minify = gulp.series(exports.deps, buildCompiled);
 exports.build = gulp.parallel(exports.minify, exports.langfiles);
 
-// Manually-invokable targets, with prequisites where required.
+// Manually-invokable targets, with prerequisites where required.
 exports.format = format;
 exports.messages = generateMessages;  // Generate msg/json/en.json et al.
 exports.buildAdvancedCompilationTest =

--- a/scripts/gulpfiles/cleanup_tasks.js
+++ b/scripts/gulpfiles/cleanup_tasks.js
@@ -81,6 +81,6 @@ function sortRequires() {
 };
 
 module.exports = {
-  // Manually-invokable targets, with prequisites where required.
+  // Manually-invokable targets, with prerequisites where required.
   sortRequires: sortRequires
 };

--- a/scripts/gulpfiles/license_tasks.js
+++ b/scripts/gulpfiles/license_tasks.js
@@ -17,6 +17,6 @@ function checkLicenses() {
 };
 
 module.exports = {
-  // Manually-invokable targets, with prequisites where required.
+  // Manually-invokable targets, with prerequisites where required.
   checkLicenses: checkLicenses
 };


### PR DESCRIPTION
There are small typos in:
- closure/goog/base.js
- demos/minimap/minimap.js
- gulpfile.js
- scripts/gulpfiles/build_tasks.js
- scripts/gulpfiles/cleanup_tasks.js
- scripts/gulpfiles/license_tasks.js

Fixes:
- Should read `prerequisites` rather than `prequisites`.
- Should read `satisfies` rather than `satisifies`.
- Should read `regenerates` rather than `regenrates`.
- Should read `minimap` rather than `mimimap`.
- Should read `diagnostic` rather than `disagnostic`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md