### PR TITLE
fix: dispose performance

### DIFF
--- a/core/block.ts
+++ b/core/block.ts
@@ -316,7 +316,10 @@ export class Block implements IASTNodeLocation, IDeletable {
     if (this.isDeadOrDying()) return;
 
     this.unplug(healStack);
-    eventUtils.fire(new (eventUtils.get(eventUtils.BLOCK_DELETE))(this));
+    if (Blockly.Events.isEnabled()) {
+      // Constructing the delete event is costly. Only perform if necessary.
+      eventUtils.fire(new (eventUtils.get(eventUtils.BLOCK_DELETE))(this));
+    }
     this.workspace.removeTopBlock(this);
     this.disposeInternal();
   }

--- a/core/block.ts
+++ b/core/block.ts
@@ -336,7 +336,7 @@ export class Block implements IASTNodeLocation, IDeletable {
       this.workspace.removeTypedBlock(this);
       this.workspace.removeBlockById(this.id);
       this.disposing = true;
-  
+
       [...this.childBlocks_].forEach((c) => c.disposeInternal());
       this.inputList.forEach((i) => i.dispose());
       this.inputList.length = 0;

--- a/core/block.ts
+++ b/core/block.ts
@@ -313,10 +313,8 @@ export class Block implements IASTNodeLocation, IDeletable {
    * @suppress {checkTypes}
    */
   dispose(healStack: boolean) {
-    if (this.isDeadOrDying()) {
-      return;
-    }
-    // Terminate onchange event calls.
+    if (this.isDeadOrDying()) return;
+
     if (this.onchangeWrapper_) {
       this.workspace.removeChangeListener(this.onchangeWrapper_);
     }
@@ -328,29 +326,15 @@ export class Block implements IASTNodeLocation, IDeletable {
     eventUtils.disable();
 
     try {
-      // This block is now at the top of the workspace.
-      // Remove this block from the workspace's list of top-most blocks.
       this.workspace.removeTopBlock(this);
       this.workspace.removeTypedBlock(this);
-      // Remove from block database.
       this.workspace.removeBlockById(this.id);
       this.disposing = true;
 
-      // First, dispose of all my children.
-      for (let i = this.childBlocks_.length - 1; i >= 0; i--) {
-        this.childBlocks_[i].dispose(false);
-      }
-      // Then dispose of myself.
-      // Dispose of all inputs and their fields.
-      for (let i = 0, input; input = this.inputList[i]; i++) {
-        input.dispose();
-      }
+      [...this.childBlocks_].forEach((c) => c.dispose(false));
+      this.inputList.forEach((i) => i.dispose());
       this.inputList.length = 0;
-      // Dispose of any remaining connections (next/previous/output).
-      const connections = this.getConnections_(true);
-      for (let i = 0, connection; connection = connections[i]; i++) {
-        connection.dispose();
-      }
+      this.getConnections_(true).forEach((c) => c.dispose());
     } finally {
       eventUtils.enable();
       if (typeof this.destroy === 'function') {

--- a/core/block.ts
+++ b/core/block.ts
@@ -315,6 +315,13 @@ export class Block implements IASTNodeLocation, IDeletable {
   dispose(healStack: boolean) {
     if (this.isDeadOrDying()) return;
 
+    // Dispose of this change listener before unplugging.
+    // Technically not necessary due to the event firing delay.
+    // But future-proofing.
+    if (this.onchangeWrapper_) {
+      this.workspace.removeChangeListener(this.onchangeWrapper_);
+    }
+
     this.unplug(healStack);
     if (eventUtils.isEnabled()) {
       // Constructing the delete event is costly. Only perform if necessary.
@@ -324,6 +331,10 @@ export class Block implements IASTNodeLocation, IDeletable {
     this.disposeInternal();
   }
 
+  /**
+   * Disposes of this block without doing things required by the top block.
+   * E.g. does not fire events, unplug the block, etc.
+   */
   protected disposeInternal() {
     if (this.isDeadOrDying()) return;
 
@@ -337,7 +348,7 @@ export class Block implements IASTNodeLocation, IDeletable {
       this.workspace.removeBlockById(this.id);
       this.disposing = true;
 
-      [...this.childBlocks_].forEach((c) => c.disposeInternal());
+      this.childBlocks_.forEach((c) => c.disposeInternal());
       this.inputList.forEach((i) => i.dispose());
       this.inputList.length = 0;
       this.getConnections_(true).forEach((c) => c.dispose());

--- a/core/block.ts
+++ b/core/block.ts
@@ -316,7 +316,7 @@ export class Block implements IASTNodeLocation, IDeletable {
     if (this.isDeadOrDying()) return;
 
     this.unplug(healStack);
-    if (Blockly.Events.isEnabled()) {
+    if (eventUtils.isEnabled()) {
       // Constructing the delete event is costly. Only perform if necessary.
       eventUtils.fire(new (eventUtils.get(eventUtils.BLOCK_DELETE))(this));
     }

--- a/core/block_animations.ts
+++ b/core/block_animations.ts
@@ -39,6 +39,9 @@ let wobblingBlock: BlockSvg|null = null;
  * @internal
  */
 export function disposeUiEffect(block: BlockSvg) {
+  // Disposing is going to take so long the animation won't playanyway.
+  if (block.getDescendants(false).length > 100) return;
+
   const workspace = block.workspace;
   const svgGroup = block.getSvgRoot();
   workspace.getAudioManager().play('delete');

--- a/core/block_animations.ts
+++ b/core/block_animations.ts
@@ -39,7 +39,7 @@ let wobblingBlock: BlockSvg|null = null;
  * @internal
  */
 export function disposeUiEffect(block: BlockSvg) {
-  // Disposing is going to take so long the animation won't playanyway.
+  // Disposing is going to take so long the animation won't play anyway.
   if (block.getDescendants(false).length > 100) return;
 
   const workspace = block.workspace;

--- a/core/block_svg.ts
+++ b/core/block_svg.ts
@@ -779,10 +779,12 @@ export class BlockSvg extends Block implements IASTNodeLocationSvg,
     }
 
     super.dispose(!!healStack);
+    dom.removeNode(this.svgGroup_);
   }
 
   override disposeInternal() {
     if (this.isDeadOrDying()) return;
+    super.disposeInternal();
 
     this.rendered = false;
 
@@ -797,9 +799,6 @@ export class BlockSvg extends Block implements IASTNodeLocationSvg,
     this.warningTextDb.clear();
 
     this.getIcons().forEach((i) => i.dispose());
-
-    super.disposeInternal();
-    dom.removeNode(this.svgGroup_);
   }
 
   /**

--- a/core/block_svg.ts
+++ b/core/block_svg.ts
@@ -771,6 +771,21 @@ export class BlockSvg extends Block implements IASTNodeLocationSvg,
     if (this.isDeadOrDying()) return;
 
     Tooltip.dispose();
+    ContextMenu.hide();
+
+    if (animate && this.rendered) {
+      this.unplug(healStack);
+      blockAnimations.disposeUiEffect(this);
+    }
+
+    super.dispose(!!healStack);
+  }
+
+  override disposeInternal() {
+    if (this.isDeadOrDying()) return;
+
+    this.rendered = false;
+
     Tooltip.unbindMouseEvents(this.pathObject.svgPath);
 
     if (common.getSelected() === this) {
@@ -778,20 +793,12 @@ export class BlockSvg extends Block implements IASTNodeLocationSvg,
       this.workspace.cancelCurrentGesture();
     }
 
-    ContextMenu.hide();
-
-    if (animate && this.rendered) {
-      this.unplug(healStack);
-      blockAnimations.disposeUiEffect(this);
-    }
-    this.rendered = false;
-
     [...this.warningTextDb.values()].forEach((n) => clearTimeout(n));
     this.warningTextDb.clear();
 
     this.getIcons().forEach((i) => i.dispose());
 
-    super.dispose(!!healStack);
+    super.disposeInternal();
     dom.removeNode(this.svgGroup_);
   }
 

--- a/core/block_svg.ts
+++ b/core/block_svg.ts
@@ -788,8 +788,6 @@ export class BlockSvg extends Block implements IASTNodeLocationSvg,
 
     this.rendered = false;
 
-    Tooltip.unbindMouseEvents(this.pathObject.svgPath);
-
     if (common.getSelected() === this) {
       this.unselect();
       this.workspace.cancelCurrentGesture();

--- a/core/block_svg.ts
+++ b/core/block_svg.ts
@@ -768,54 +768,31 @@ export class BlockSvg extends Block implements IASTNodeLocationSvg,
    * @suppress {checkTypes}
    */
   override dispose(healStack?: boolean, animate?: boolean) {
-    if (this.isDeadOrDying()) {
-      return;
-    }
+    if (this.isDeadOrDying()) return;
+
     Tooltip.dispose();
     Tooltip.unbindMouseEvents(this.pathObject.svgPath);
-    dom.startTextWidthCache();
-    // Save the block's workspace temporarily so we can resize the
-    // contents once the block is disposed.
-    const blockWorkspace = this.workspace;
-    // If this block is being dragged, unlink the mouse events.
+
     if (common.getSelected() === this) {
       this.unselect();
       this.workspace.cancelCurrentGesture();
     }
-    // If this block has a context menu open, close it.
-    if (ContextMenu.getCurrentBlock() === this) {
-      ContextMenu.hide();
-    }
+
+    ContextMenu.hide();
 
     if (animate && this.rendered) {
       this.unplug(healStack);
       blockAnimations.disposeUiEffect(this);
     }
-    // Stop rerendering.
     this.rendered = false;
 
-    // Clear pending warnings.
-    for (const n of this.warningTextDb.values()) {
-      clearTimeout(n);
-    }
+    [...this.warningTextDb.values()].forEach((n) => clearTimeout(n));
     this.warningTextDb.clear();
 
-    const icons = this.getIcons();
-    for (let i = 0; i < icons.length; i++) {
-      icons[i].dispose();
-    }
-
-    // Just deleting this block from the DOM would result in a memory leak as
-    // well as corruption of the connection database.  Therefore we must
-    // methodically step through the blocks and carefully disassemble them.
-    if (common.getSelected() === this) {
-      common.setSelected(null);
-    }
+    this.getIcons().forEach((i) => i.dispose());
 
     super.dispose(!!healStack);
-
     dom.removeNode(this.svgGroup_);
-    dom.stopTextWidthCache();
   }
 
   /**

--- a/core/block_svg.ts
+++ b/core/block_svg.ts
@@ -782,6 +782,10 @@ export class BlockSvg extends Block implements IASTNodeLocationSvg,
     dom.removeNode(this.svgGroup_);
   }
 
+  /**
+   * Disposes of this block without doing things required by the top block.
+   * E.g. does trigger UI effects, remove nodes, etc.
+   */
   override disposeInternal() {
     if (this.isDeadOrDying()) return;
     super.disposeInternal();

--- a/core/block_svg.ts
+++ b/core/block_svg.ts
@@ -815,7 +815,6 @@ export class BlockSvg extends Block implements IASTNodeLocationSvg,
     super.dispose(!!healStack);
 
     dom.removeNode(this.svgGroup_);
-    blockWorkspace.resizeContents();
     dom.stopTextWidthCache();
   }
 

--- a/core/connection.ts
+++ b/core/connection.ts
@@ -150,7 +150,7 @@ export class Connection implements IASTNodeLocationWithBlock {
       this.setShadowStateInternal_();
 
       const targetBlock = this.targetBlock();
-      if (targetBlock) {
+      if (targetBlock && !targetBlock.isDeadOrDying()) {
         // Disconnect the attached normal block.
         targetBlock.unplug();
       }

--- a/core/connection.ts
+++ b/core/connection.ts
@@ -544,6 +544,7 @@ export class Connection implements IASTNodeLocationWithBlock {
       }
     } else if (target.isShadow()) {
       target.dispose(false);
+      if (this.getSourceBlock().isDeadOrDying()) return;
       this.respawnShadow_();
       if (this.targetBlock() && this.targetBlock()!.isShadow()) {
         this.serializeShadow_(this.targetBlock());

--- a/core/field.ts
+++ b/core/field.ts
@@ -495,7 +495,9 @@ export abstract class Field<T = any> implements IASTNodeLocationSvg,
       browserEvents.unbind(this.mouseDownWrapper_);
     }
 
-    dom.removeNode(this.fieldGroup_);
+    if (!this.getSourceBlock()?.isDeadOrDying()) {
+      dom.removeNode(this.fieldGroup_);
+    }
 
     this.disposed = true;
   }

--- a/core/field.ts
+++ b/core/field.ts
@@ -489,11 +489,6 @@ export abstract class Field<T = any> implements IASTNodeLocationSvg,
   dispose() {
     dropDownDiv.hideIfOwner(this);
     WidgetDiv.hideIfOwner(this);
-    Tooltip.unbindMouseEvents(this.getClickTarget_());
-
-    if (this.mouseDownWrapper_) {
-      browserEvents.unbind(this.mouseDownWrapper_);
-    }
 
     if (!this.getSourceBlock()?.isDeadOrDying()) {
       dom.removeNode(this.fieldGroup_);

--- a/core/icon.ts
+++ b/core/icon.ts
@@ -83,7 +83,7 @@ export abstract class Icon {
       dom.removeNode(this.iconGroup_);
     }
     // TODO: Check if this is necessary.
-    this.setVisible(false); // Dispose of and unlink the bubble.
+    this.setVisible(false);  // Dispose of and unlink the bubble.
   }
 
   /** Add or remove the UI indicating if this icon may be clicked or not. */

--- a/core/icon.ts
+++ b/core/icon.ts
@@ -79,8 +79,11 @@ export abstract class Icon {
 
   /** Dispose of this icon. */
   dispose() {
-    dom.removeNode(this.iconGroup_);  // Dispose of and unlink the icon.
-    this.setVisible(false);           // Dispose of and unlink the bubble.
+    if (!this.getBlock().isDeadOrDying()) {
+      dom.removeNode(this.iconGroup_);
+    }
+    // TODO: Check if this is necessary.
+    this.setVisible(false); // Dispose of and unlink the bubble.
   }
 
   /** Add or remove the UI indicating if this icon may be clicked or not. */

--- a/core/icon.ts
+++ b/core/icon.ts
@@ -82,7 +82,6 @@ export abstract class Icon {
     if (!this.getBlock().isDeadOrDying()) {
       dom.removeNode(this.iconGroup_);
     }
-    // TODO: Check if this is necessary.
     this.setVisible(false);  // Dispose of and unlink the bubble.
   }
 

--- a/core/tooltip.ts
+++ b/core/tooltip.ts
@@ -276,6 +276,7 @@ function onMouseOut(_e: PointerEvent) {
     hide();
   }, 1);
   clearTimeout(showPid);
+  showPid = 0;
 }
 
 /**
@@ -342,6 +343,7 @@ export function hide() {
   }
   if (showPid) {
     clearTimeout(showPid);
+    showPid = 0;
   }
 }
 

--- a/tests/mocha/connection_checker_test.js
+++ b/tests/mocha/connection_checker_test.js
@@ -386,7 +386,7 @@ suite('Connection checker', function() {
       });
 
       test('Connect to unconnected unmovable block', function() {
-        // Delete blockA.
+        this.blockB.previousConnection.disconnect();
         this.blockA.dispose();
 
         // Try to connect blockC above blockB.
@@ -436,7 +436,7 @@ suite('Connection checker', function() {
       });
 
       test('Connect to unconnected unmovable block', function() {
-        // Delete blockA
+        this.blockB.outputConnection.disconnect();
         this.blockA.dispose();
 
         // Try to connect C's input to B's output. Allowed because B is now unconnected.

--- a/tests/mocha/event_block_delete_test.js
+++ b/tests/mocha/event_block_delete_test.js
@@ -6,19 +6,35 @@
 
 goog.declareModuleId('Blockly.test.eventBlockDelete');
 
-import * as eventUtils from '../../build/src/core/events/utils.js';
 import {defineRowBlock} from './test_helpers/block_definitions.js';
 import {sharedTestSetup, sharedTestTeardown} from './test_helpers/setup_teardown.js';
 
 suite('Block Delete Event', function() {
   setup(function() {
-    sharedTestSetup.call(this);
+    this.clock = sharedTestSetup.call(this, {fireEventsNow: false}).clock;
     defineRowBlock();
     this.workspace = new Blockly.Workspace();
   });
 
   teardown(function() {
     sharedTestTeardown.call(this);
+  });
+
+  suite('Receiving', function() {
+    test('blocks do not receive their own delete events', function() {
+      Blockly.Blocks['test'] = {
+        onchange: function(e) { },
+      };
+      // Need to stub the definition, because the property on the definition is
+      // what gets registered as an event listener.
+      const spy = sinon.spy(Blockly.Blocks['test'], 'onchange');
+      const testBlock = this.workspace.newBlock('test');
+
+      testBlock.dispose();
+      this.clock.runAll();
+
+      chai.assert.isFalse(spy.called);
+    });
   });
 
   suite('Serialization', function() {

--- a/tests/mocha/serializer_test.js
+++ b/tests/mocha/serializer_test.js
@@ -1866,7 +1866,7 @@ const runSerializerTestSuite = (serializer, deserializer, testSuite) => {
 
   suiteCall(testSuite.title, function() {
     setup(function() {
-      sharedTestSetup.call(this);
+      sharedTestSetup.call(this, {fireEventsNow: false});
       this.workspace = new Blockly.Workspace();
     });
 


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [X] I ran `npm run format` and `npm run lint`

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #6890 

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
Improves performance of deleting blocks.

See #6890 for previous performance. The new performance is ~300ms total, and ~100ms for `checkAndDelete`.

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
Speeeed

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->
Manual testing + fixing failing tests.

Added one test to check that blocks do not receive their own delete events.

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->
N/A

### Additional Information

<!-- Anything else we should know? -->
We save an extra 20ms after #6876 is merged.

Best to review this commit-wise since there is some code reorganization.
