### PR TITLE
chore: force add the build files when updating gh-pages

### DIFF
--- a/scripts/gulpfiles/git_tasks.js
+++ b/scripts/gulpfiles/git_tasks.js
@@ -112,7 +112,8 @@ const updateGithubPages = gulp.series(
   packageTasks.cleanReleaseDir,
   buildTasks.build,
   function(done) {
-    execSync('git add build/msg/* dist/*_compressed.js*', {stdio: 'inherit'});
+    // The build and dist directories are normally gitignored, so we have to force add.
+    execSync('git add -f build/msg/* dist/*_compressed.js*', {stdio: 'inherit'});
     execSync('git commit -am "Rebuild"', {stdio: 'inherit'});
     execSync('git push ' + upstream_url + ' gh-pages --force',
         {stdio: 'inherit'});


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [x] I ran `npm run format` and `npm run lint`

## The details
### Resolves

Fixes a problem when running `npm run updateGithubPages`

One of the steps adds the built messages files and dist compressed files, but those files are gitignored by default. So I got an error:

```
The following paths are ignored by one of your .gitignore files:
build
dist
hint: Use -f if you really want to add them.
hint: Turn this message off by running
hint: "git config advice.addIgnoredFile false"
[11:33:42] '<anonymous>' errored after 161 ms
```

and the script quit executing.

I took its advice and added the `-f` flag and was able to update the site.

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->

#### Behavior Before Change

<!--TODO: Image, gif or explanation of behavior before this pull request. -->

#### Behavior After Change

<!--TODO: Image, gif or explanation of behavior after this pull request. -->

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
