### PR TITLE
fix: Fix scrolling of menus on mobile.

### DIFF
--- a/core/menu.ts
+++ b/core/menu.ts
@@ -104,7 +104,7 @@ export class Menu {
     this.mouseOverHandler = browserEvents.conditionalBind(
         element, 'pointerover', this, this.handleMouseOver, true);
     this.clickHandler = browserEvents.conditionalBind(
-        element, 'pointerdown', this, this.handleClick, true);
+        element, 'pointerup', this, this.handleClick, true);
     this.mouseEnterHandler = browserEvents.conditionalBind(
         element, 'pointerenter', this, this.handleMouseEnter, true);
     this.mouseLeaveHandler = browserEvents.conditionalBind(


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [x] I ran `npm run format` and `npm run lint`

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #6759

### Proposed Changes
The menu item selection handler is triggered on pointerup vs down.

#### Behavior Before Change
Attempting to scroll a menu on mobile would select the item that was tapped to initiate the scroll.

#### Behavior After Change
Menus can be scrolled as expected, and tapping an item selects it.