### PR TITLE
fix: scrolling dropdown items into view

### DIFF
--- a/core/field_dropdown.ts
+++ b/core/field_dropdown.ts
@@ -20,6 +20,7 @@ import {Field, FieldConfig, FieldValidator, UnattachedFieldError} from './field.
 import * as fieldRegistry from './field_registry.js';
 import {Menu} from './menu.js';
 import {MenuItem} from './menuitem.js';
+import * as style from './utils/style.js';
 import * as aria from './utils/aria.js';
 import {Coordinate} from './utils/coordinate.js';
 import * as dom from './utils/dom.js';
@@ -283,6 +284,10 @@ export class FieldDropdown extends Field<string> {
 
     if (this.selectedMenuItem_) {
       this.menu_!.setHighlighted(this.selectedMenuItem_);
+      style.scrollIntoContainerView(
+          this.selectedMenuItem_.getElement()!,
+          dropDownDiv.getContentDiv(),
+          true);
     }
 
     this.applyColour();

--- a/core/field_dropdown.ts
+++ b/core/field_dropdown.ts
@@ -285,8 +285,7 @@ export class FieldDropdown extends Field<string> {
     if (this.selectedMenuItem_) {
       this.menu_!.setHighlighted(this.selectedMenuItem_);
       style.scrollIntoContainerView(
-          this.selectedMenuItem_.getElement()!,
-          dropDownDiv.getContentDiv(),
+          this.selectedMenuItem_.getElement()!, dropDownDiv.getContentDiv(),
           true);
     }
 


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [X] I ran `npm run format` and `npm run lint`

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #4465 

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
Makes it so that dropdowns actually scroll to the selected element.

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
Setting the highlight would normally scroll the menu. However, when a menu is in the dropdown div, it isn't actually scrollable. The dropdown div /content/ is scrollable. So we need to trigger a scroll of that separately.

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->
Just manual testing.

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->
N/A

### Additional Information

<!-- Anything else we should know? -->
N/A