### PR TITLE
fix: overwriting flyout def with dynamic categories

### DIFF
--- a/core/flyout_base.ts
+++ b/core/flyout_base.ts
@@ -570,9 +570,9 @@ export abstract class Flyout extends DeleteArea implements IFlyout {
       this.workspace_.removeChangeListener(this.reflowWrapper_);
       this.reflowWrapper_ = null;
     }
+    // Do NOT delete the blocks here.  Wait until Flyout.show.
+    // https://neil.fraser.name/news/2014/08/09/
   }
-  // Do NOT delete the blocks here.  Wait until Flyout.show.
-  // https://neil.fraser.name/news/2014/08/09/
 
   /**
    * Show and populate the flyout.
@@ -630,34 +630,32 @@ export abstract class Flyout extends DeleteArea implements IFlyout {
     const gaps: number[] = [];
     this.permanentlyDisabled_.length = 0;
     const defaultGap = this.horizontalLayout ? this.GAP_X : this.GAP_Y;
-    for (let i = 0, contentInfo; contentInfo = parsedContent[i]; i++) {
-      if ('custom' in contentInfo) {
-        const customInfo = (contentInfo as toolbox.DynamicCategoryInfo);
+    const createItem = (info: toolbox.FlyoutItemInfo) => {
+      if ('custom' in info) {
+        const customInfo = (info as toolbox.DynamicCategoryInfo);
         const categoryName = customInfo['custom'];
         const flyoutDef = this.getDynamicCategoryContents_(categoryName);
         const parsedDynamicContent =
             toolbox.convertFlyoutDefToJsonArray(flyoutDef);
-        // Replace the element at i with the dynamic content it represents.
-        parsedContent.splice.apply(
-            parsedContent, [i, 1, ...parsedDynamicContent]);
-        contentInfo = parsedContent[i];
+        parsedDynamicContent.forEach(createItem);
+        return;
       }
 
-      switch (contentInfo['kind'].toUpperCase()) {
+      switch (info['kind'].toUpperCase()) {
         case 'BLOCK': {
-          const blockInfo = (contentInfo as toolbox.BlockInfo);
+          const blockInfo = (info as toolbox.BlockInfo);
           const block = this.createFlyoutBlock_(blockInfo);
           contents.push({type: FlyoutItemType.BLOCK, block: block});
           this.addBlockGap_(blockInfo, gaps, defaultGap);
           break;
         }
         case 'SEP': {
-          const sepInfo = (contentInfo as toolbox.SeparatorInfo);
+          const sepInfo = (info as toolbox.SeparatorInfo);
           this.addSeparatorGap_(sepInfo, gaps, defaultGap);
           break;
         }
         case 'LABEL': {
-          const labelInfo = (contentInfo as toolbox.LabelInfo);
+          const labelInfo = (info as toolbox.LabelInfo);
           // A label is a button with different styling.
           const label = this.createButton_(labelInfo, /** isLabel */ true);
           contents.push({type: FlyoutItemType.BUTTON, button: label});
@@ -665,14 +663,16 @@ export abstract class Flyout extends DeleteArea implements IFlyout {
           break;
         }
         case 'BUTTON': {
-          const buttonInfo = (contentInfo as toolbox.ButtonInfo);
+          const buttonInfo = (info as toolbox.ButtonInfo);
           const button = this.createButton_(buttonInfo, /** isLabel */ false);
           contents.push({type: FlyoutItemType.BUTTON, button: button});
           gaps.push(defaultGap);
           break;
         }
       }
-    }
+    };
+    parsedContent.forEach(createItem);
+
     return {contents: contents, gaps: gaps};
   }
 

--- a/core/flyout_base.ts
+++ b/core/flyout_base.ts
@@ -630,15 +630,17 @@ export abstract class Flyout extends DeleteArea implements IFlyout {
     const gaps: number[] = [];
     this.permanentlyDisabled_.length = 0;
     const defaultGap = this.horizontalLayout ? this.GAP_X : this.GAP_Y;
-    const createItem = (info: toolbox.FlyoutItemInfo) => {
+    for (const info of parsedContent) {
       if ('custom' in info) {
         const customInfo = (info as toolbox.DynamicCategoryInfo);
         const categoryName = customInfo['custom'];
         const flyoutDef = this.getDynamicCategoryContents_(categoryName);
         const parsedDynamicContent =
             toolbox.convertFlyoutDefToJsonArray(flyoutDef);
-        parsedDynamicContent.forEach(createItem);
-        return;
+        const {contents: dynamicContents, gaps: dynamicGaps} =
+            this.createFlyoutInfo_(parsedDynamicContent);
+        contents.push(...dynamicContents);
+        gaps.push(...dynamicGaps);
       }
 
       switch (info['kind'].toUpperCase()) {
@@ -670,8 +672,7 @@ export abstract class Flyout extends DeleteArea implements IFlyout {
           break;
         }
       }
-    };
-    parsedContent.forEach(createItem);
+    }
 
     return {contents: contents, gaps: gaps};
   }

--- a/tests/playground.html
+++ b/tests/playground.html
@@ -115,18 +115,31 @@ function getToolboxSuffix() {
 }
 
 function getToolboxElement() {
-  var toolboxSuffix = getToolboxSuffix();
-  if (toolboxSuffix == 'test-blocks') {
-    if (typeof window.toolboxTestBlocks !== 'undefined') {
-      return toolboxTestBlocks;
-    } else {
-      alert('You need to run \'npm install\' in order to use the test blocks.');
-      toolboxSuffix = 'categories';
-    }
-  }
-  // The three possible values are: "simple", "categories",
-  // "categories-typed-variables".
-  return document.getElementById('toolbox-' + toolboxSuffix);
+  return {
+    "kind": "flyoutToolbox",
+    "contents": [
+      {
+        "kind": "block",
+        "type": "controls_if"
+      },
+      {
+        "kind": "category",
+        "custom": "VARIABLE"
+      }
+    ]
+  };
+  // var toolboxSuffix = getToolboxSuffix();
+  // if (toolboxSuffix == 'test-blocks') {
+  //   if (typeof window.toolboxTestBlocks !== 'undefined') {
+  //     return toolboxTestBlocks;
+  //   } else {
+  //     alert('You need to run \'npm install\' in order to use the test blocks.');
+  //     toolboxSuffix = 'categories';
+  //   }
+  // }
+  // // The three possible values are: "simple", "categories",
+  // // "categories-typed-variables".
+  // return document.getElementById('toolbox-' + toolboxSuffix);
 }
 
 function setToolboxDropdown() {

--- a/tests/playground.html
+++ b/tests/playground.html
@@ -115,31 +115,18 @@ function getToolboxSuffix() {
 }
 
 function getToolboxElement() {
-  return {
-    "kind": "flyoutToolbox",
-    "contents": [
-      {
-        "kind": "block",
-        "type": "controls_if"
-      },
-      {
-        "kind": "category",
-        "custom": "VARIABLE"
-      }
-    ]
-  };
-  // var toolboxSuffix = getToolboxSuffix();
-  // if (toolboxSuffix == 'test-blocks') {
-  //   if (typeof window.toolboxTestBlocks !== 'undefined') {
-  //     return toolboxTestBlocks;
-  //   } else {
-  //     alert('You need to run \'npm install\' in order to use the test blocks.');
-  //     toolboxSuffix = 'categories';
-  //   }
-  // }
-  // // The three possible values are: "simple", "categories",
-  // // "categories-typed-variables".
-  // return document.getElementById('toolbox-' + toolboxSuffix);
+  var toolboxSuffix = getToolboxSuffix();
+  if (toolboxSuffix == 'test-blocks') {
+    if (typeof window.toolboxTestBlocks !== 'undefined') {
+      return toolboxTestBlocks;
+    } else {
+      alert('You need to run \'npm install\' in order to use the test blocks.');
+      toolboxSuffix = 'categories';
+    }
+  }
+  // The three possible values are: "simple", "categories",
+  // "categories-typed-variables".
+  return document.getElementById('toolbox-' + toolboxSuffix);
 }
 
 function setToolboxDropdown() {


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [X] I ran `npm run format` and `npm run lint`

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #4443

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
Stops mutating the toolbox definition when parsing dynamic categories.

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
See explanation in #4443 

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->
Manual testing.

Can add unit testing after we confirm this is the behavior we actually want.

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->
N/A

### Additional Information

<!-- Anything else we should know? -->
Do we actually want flyout toolboxes to parse the dynamic categories? I kind of understand it in that you might want to embed variables / procedures in your flyout toolbox. But it also just seems.... weird?

Just want to confirm this before adding unit tests / merging.