### PR TITLE
fix: flyouts resizing for blocks

### DIFF
--- a/core/events/utils.ts
+++ b/core/events/utils.ts
@@ -220,14 +220,15 @@ function fireInternal(event: Abstract) {
   }
   if (!FIRE_QUEUE.length) {
     // First event added; schedule a firing of the event queue.
-    if (requestAnimationFrame) {
+    try {
       // If we are in a browser context, we want to make sure that the event
       // fires after blocks have been rerendered this frame.
       requestAnimationFrame(() => {
         setTimeout(fireNow, 0);
       });
-    } else {
+    } catch (e) {
       // Otherwise we just want to delay so events can be coallesced.
+      // requestAnimationFrame will error triggering this.
       setTimeout(fireNow, 0);
     }
   }

--- a/core/events/utils.ts
+++ b/core/events/utils.ts
@@ -220,9 +220,16 @@ function fireInternal(event: Abstract) {
   }
   if (!FIRE_QUEUE.length) {
     // First event added; schedule a firing of the event queue.
-    requestAnimationFrame(() => {
+    if (requestAnimationFrame) {
+      // If we are in a browser context, we want to make sure that the event
+      // fires after blocks have been rerendered this frame.
+      requestAnimationFrame(() => {
+        setTimeout(fireNow, 0);
+      });
+    } else {
+      // Otherwise we just want to delay so events can be coallesced.
       setTimeout(fireNow, 0);
-    });
+    }
   }
   FIRE_QUEUE.push(event);
 }

--- a/core/events/utils.ts
+++ b/core/events/utils.ts
@@ -220,7 +220,9 @@ function fireInternal(event: Abstract) {
   }
   if (!FIRE_QUEUE.length) {
     // First event added; schedule a firing of the event queue.
-    setTimeout(fireNow, 0);
+    requestAnimationFrame(() => {
+      setTimeout(fireNow, 0);
+    });
   }
   FIRE_QUEUE.push(event);
 }


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [X] I ran `npm run format` and `npm run lint`

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Discovered that flyouts were not being resized when blocks changed size (e.g. changing field values) during investigation of #4086 This was caused by #6860 

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
Makes it so that events are always fired after the current frame finishes drawing. This ensures that all blocks have been rendered and their dimensions, positions, connection positions, etc are all updated before event listeners are triggered.

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
Event listeners would be working with info that wasn't up to date because they were triggered too early.

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->

Just manual testing.

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->
N/A

### Additional Information

<!-- Anything else we should know? -->
This fixes a regression and should go in before the release.