### PR TITLE
fix: do not hide chaff when resizing

### DIFF
--- a/core/bump_objects.ts
+++ b/core/bump_objects.ts
@@ -26,22 +26,24 @@ import type {WorkspaceSvg} from './workspace_svg.js';
  * Bumps the given object that has passed out of bounds.
  *
  * @param workspace The workspace containing the object.
- * @param scrollMetrics Scroll metrics
- *    in workspace coordinates.
+ * @param bounds The region to bump an object into. For example, pass
+ *     ScrollMetrics to bump a block into the scrollable region of the
+ *     workspace, or pass ViewMetrics to bump a block into the visible region of
+ *     the workspace. This should be specified in workspace coordinates.
  * @param object The object to bump.
- * @returns True if block was bumped.
+ * @returns True if object was bumped.
  */
 function bumpObjectIntoBounds(
-    workspace: WorkspaceSvg, scrollMetrics: ContainerRegion,
+    workspace: WorkspaceSvg, bounds: ContainerRegion,
     object: IBoundedElement): boolean {
   // Compute new top/left position for object.
   const objectMetrics = object.getBoundingRectangle();
   const height = objectMetrics.bottom - objectMetrics.top;
   const width = objectMetrics.right - objectMetrics.left;
 
-  const topClamp = scrollMetrics.top;
-  const scrollMetricsBottom = scrollMetrics.top + scrollMetrics.height;
-  const bottomClamp = scrollMetricsBottom - height;
+  const topClamp = bounds.top;
+  const boundsBottom = bounds.top + bounds.height;
+  const bottomClamp = boundsBottom - height;
   // If the object is taller than the workspace we want to
   // top-align the block
   const newYPosition =
@@ -50,9 +52,9 @@ function bumpObjectIntoBounds(
 
   // Note: Even in RTL mode the "anchor" of the object is the
   // top-left corner of the object.
-  let leftClamp = scrollMetrics.left;
-  const scrollMetricsRight = scrollMetrics.left + scrollMetrics.width;
-  let rightClamp = scrollMetricsRight - width;
+  let leftClamp = bounds.left;
+  const boundsRight = bounds.left + bounds.width;
+  let rightClamp = boundsRight - width;
   if (workspace.RTL) {
     // If the object is wider than the workspace and we're in RTL
     // mode we want to right-align the block, which means setting

--- a/core/field.ts
+++ b/core/field.ts
@@ -730,6 +730,28 @@ export abstract class Field<T = any> implements IASTNodeLocationSvg,
   // NOP
 
   /**
+   * A developer hook to reposition the WidgetDiv during a window resize. You
+   * need to define this hook if your field has a WidgetDiv that needs to
+   * reposition itself when the window is resized. For example, text input
+   * fields define this hook so that the input WidgetDiv can reposition itself
+   * on a window resize event. This is especially important when modal inputs
+   * have been disabled, as Android devices will fire a window resize event when
+   * the soft keyboard opens.
+   *
+   * If you want the WidgetDiv to hide itself instead of repositioning, return
+   * false. This is the default behavior.
+   *
+   * DropdownDivs already handle their own positioning logic, so you do not need
+   * to override this function if your field only has a DropdownDiv.
+   *
+   * @returns True if the field should be repositioned,
+   *    false if the WidgetDiv should hide itself instead.
+   */
+  repositionForWindowResize(): boolean {
+    return false;
+  }
+
+  /**
    * Updates the size of the field based on the text.
    *
    * @param margin margin to use when positioning the text element.

--- a/core/field_input.ts
+++ b/core/field_input.ts
@@ -15,7 +15,8 @@ goog.declareModuleId('Blockly.FieldInput');
 // Unused import preserved for side-effects. Remove if unneeded.
 import './events/events_block_change.js';
 
-import type {BlockSvg} from './block_svg.js';
+import {BlockSvg} from './block_svg.js';
+import * as bumpObjects from './bump_objects.js';
 import * as browserEvents from './browser_events.js';
 import * as dialog from './dialog.js';
 import * as dom from './utils/dom.js';
@@ -503,6 +504,29 @@ export abstract class FieldInput<T extends InputTypes> extends Field<string|T> {
 
     div!.style.left = xy.x + 'px';
     div!.style.top = xy.y + 'px';
+  }
+
+  /**
+   * Handles repositioning the WidgetDiv used for input fields when the
+   * workspace is resized. Will bump the block into the viewport and update the
+   * position of the field if necessary.
+   *
+   * @returns True for rendered workspaces, as we never want to hide the widget
+   *     div.
+   */
+  override repositionForWindowResize(): boolean {
+    const block = this.getSourceBlock();
+    // This shouldn't be possible. We should never have a WidgetDiv if not using
+    // rendered blocks.
+    if (!(block instanceof BlockSvg)) return false;
+
+    bumpObjects.bumpIntoBounds(
+        this.workspace_!,
+        this.workspace_!.getMetricsManager().getViewMetrics(true), block);
+
+    this.resizeEditor_();
+
+    return true;
   }
 
   /**

--- a/core/inject.ts
+++ b/core/inject.ts
@@ -213,7 +213,12 @@ function init(mainWorkspace: WorkspaceSvg) {
 
   const workspaceResizeHandler =
       browserEvents.conditionalBind(window, 'resize', null, function() {
-        mainWorkspace.hideChaff(true);
+        // Don't hide all the chaff. Leave the dropdown and widget divs open if
+        // possible.
+        Tooltip.hide();
+        mainWorkspace.hideComponents(true);
+        dropDownDiv.repositionForWindowResize();
+        WidgetDiv.repositionForWindowResize();
         common.svgResize(mainWorkspace);
         bumpObjects.bumpTopObjectsIntoBounds(mainWorkspace);
       });

--- a/core/widgetdiv.ts
+++ b/core/widgetdiv.ts
@@ -9,6 +9,7 @@ goog.declareModuleId('Blockly.WidgetDiv');
 
 import * as common from './common.js';
 import * as dom from './utils/dom.js';
+import type {Field} from './field.js';
 import type {Rect} from './utils/rect.js';
 import type {Size} from './utils/size.js';
 import type {WorkspaceSvg} from './workspace_svg.js';
@@ -235,5 +236,27 @@ function calculateY(
   } else {
     // The top of the widget is at the bottom of the field.
     return anchorBBox.bottom;
+  }
+}
+
+/**
+ * Determine if the owner is a field for purposes of repositioning.
+ * We can't simply check `instanceof Field` as that would introduce a circular
+ * dependency.
+ */
+function isRepositionable(item: any): item is Field {
+  return !!item?.repositionForWindowResize;
+}
+
+/**
+ * Reposition the widget div if the owner of it says to.
+ * If the owner isn't a field, just give up and hide it.
+ */
+export function repositionForWindowResize(): void {
+  if (!isRepositionable(owner) || !owner.repositionForWindowResize()) {
+    // If the owner is not a Field, or if the owner returns false from the
+    // reposition method, we should hide the widget div. Otherwise, we'll assume
+    // the owner handled any needed resize.
+    hide();
   }
 }

--- a/core/workspace_svg.ts
+++ b/core/workspace_svg.ts
@@ -2511,14 +2511,25 @@ export class WorkspaceSvg extends Workspace implements IASTNodeLocationSvg {
   /**
    * Close tooltips, context menus, dropdown selections, etc.
    *
-   * @param opt_onlyClosePopups Whether only popups should be closed.
+   * @param onlyClosePopups Whether only popups should be closed. Defaults to
+   *     false.
    */
-  hideChaff(opt_onlyClosePopups?: boolean) {
+  hideChaff(onlyClosePopups = false) {
     Tooltip.hide();
     WidgetDiv.hide();
     dropDownDiv.hideWithoutAnimation();
 
-    const onlyClosePopups = !!opt_onlyClosePopups;
+    this.hideComponents(onlyClosePopups);
+  }
+
+  /**
+   * Hide any autohideable components (like flyout, trashcan, and any
+   * user-registered components).
+   *
+   * @param onlyClosePopups Whether only popups should be closed. Defaults to
+   *     false.
+   */
+  hideComponents(onlyClosePopups = false) {
     const autoHideables = this.getComponentManager().getComponents(
         ComponentManager.Capability.AUTOHIDEABLE, true);
     autoHideables.forEach(


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [x] I ran `npm run format` and `npm run lint`

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #6915 

See that issue for a lot of additional context.

### Proposed Changes

- Doesn't hide all the chaff during a resize. In particular, tries to keep the dropdown div and widget div open.
- The dropdown div already had some unused logic to reposition itself. So I just called that logic. (For the history of this code, see the linked issue)
- The widget div is trickier. We claim not to handle positioning for the widget div, unlike the dropdown div. So we shouldn't do repositioning logic directly in the widget div (which is what Scratch does, but it's not ideal). So I've added a new method that fields can override. By default, it returns `false` which means the widget div will hide itself, the same as today. But if you override this method and return true, that means the field will handle its own reposition logic.
- Override the above mentioned method in `field_input` to resize themselves. This means subclasses of this field (text, multiline text, number, and angle, along with any custom developer fields) will resize the widget div automatically (by calling the existing `resizeEditor_` method).
    - Also, the block owning these fields will bump themselves into the visible region of the workspace first. This prevents problems where the widget div is rendered outside of the workspace and onto the application's UI (this is the behavior the Scratch fix has and I wanted to avoid).
- Renamed some parameters and variables inside a `bump_objects` method to make it more generic. Previously this method was only used to bump things into the scrollable region of the workspace. We need the exact same logic to bump it into the visible region of the workspace, and you can achieve this just by passing a different set of bounds into the function.  

#### Behavior Before Change

On resizing a window while you have a widget or dropdown div open, they would be hidden. This causes the soft keyboard on Android to make fields unusable.

#### Behavior After Change

The dropdown and widget divs attempt to keep themselves open. This allows you to resize the window while editing an input field, or use fields on Android with the soft keyboard.

### Reason for Changes

bug fixes and because some projects don't want to use the modal editor

### Test Coverage

I tested this by resizing the window while the number, text, multiline text, and angle blocks were being edited, on desktop Chrome, mobile Safari, and mobile Chrome on Android. On both mobile browsers, I also tested rotating the device while these fields were being edited.

I also tested in the multi_playground to ensure this fix works with multiple workspaces present and in RTL mode. I also checked that the context menu (which uses the widget div) closes still when resizing.

### Documentation

No, but the `modalInputs` option hasn't been documented yet. It is probably better that way since it wasn't really usable before this fix, but I'll add that to my todo list.

### Additional Information

I'm investigating a UI bug that appears in text fields in RTL mode. I'm not sure why this code would cause it, so I need to check if it's happening on develop before I merge this. After investigation, this issue is happening on develop as well (though not on the published playgrounds on GitHub or App Engine) so I'll open a separate issue for that.
