### PR TITLE
fix: mutator not resizing for flyout

### DIFF
--- a/core/mutator.ts
+++ b/core/mutator.ts
@@ -367,7 +367,9 @@ export class Mutator extends Icon {
       }
       this.resizeBubble();
       // When the mutator's workspace changes, update the source block.
-      ws.addChangeListener(this.workspaceChanged.bind(this));
+      const boundListener = this.workspaceChanged.bind(this);
+      ws.addChangeListener(boundListener);
+      if (flyout) flyout.getWorkspace().addChangeListener(boundListener);
       // Update the source block immediately after the bubble becomes visible.
       this.updateWorkspace();
       this.applyColour();


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [X] I ran `npm run format` and `npm run lint`

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #4086 

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
Adds a listener to the flyout so that changes to the flyout resize the workspace as well.

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
Fixin buggies.

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->
Manual testing with https://github.com/google/blockly-samples/pull/1638

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->
N/A

### Additional Information

<!-- Anything else we should know? -->
N/A
