### PR TITLE
fix: remove forced rerender from mutator

### DIFF
--- a/core/mutator.ts
+++ b/core/mutator.ts
@@ -458,21 +458,7 @@ export class Mutator extends Icon {
       const block = this.getBlock();
       const oldExtraState = BlockChange.getExtraBlockState_(block);
 
-      // Switch off rendering while the source block is rebuilt.
-      const savedRendered = block.rendered;
-      // TODO(#4288): We should not be setting the rendered property to false.
-      block.rendered = false;
-
-      // Allow the source block to rebuild itself.
       block.compose!(this.rootBlock);
-      // Restore rendering and show the changes.
-      block.rendered = savedRendered;
-      // Mutation may have added some elements that need initializing.
-      block.initSvg();
-
-      if (block.rendered) {
-        block.render();
-      }
 
       const newExtraState = BlockChange.getExtraBlockState_(block);
       if (oldExtraState !== newExtraState) {


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [X] I ran `npm run format` and `npm run lint`

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #3511 
Fixes #6953 
Work on #4288 

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
Removes the batch rendering from the mutator logic - since we now have actual batch rendering that doesn't rely on mangling the `rendered` property!

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
Code simplification.

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->
Manually tested that #4175 and #3458 do not reproduce.

Tested that mutating continues to work.

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->
N/A

### Additional Information

<!-- Anything else we should know? -->

While I do trust this code, I don't trust it enough to put it into the imminently approaching release. So I'm going to put this up as a draft.
