### PR TITLE
fix: connection locations not updating

### DIFF
--- a/core/rendered_connection.ts
+++ b/core/rendered_connection.ts
@@ -187,7 +187,7 @@ export class RenderedConnection extends Connection {
    *     was updated.
    */
   moveTo(x: number, y: number): boolean {
-    // TODO: add TODO.
+    // TODO(#6922): Readd this optimization.
     // const moved = this.x !== x || this.y !== y;
     const moved = true;
     let updated = false;

--- a/core/rendered_connection.ts
+++ b/core/rendered_connection.ts
@@ -187,7 +187,9 @@ export class RenderedConnection extends Connection {
    *     was updated.
    */
   moveTo(x: number, y: number): boolean {
-    const moved = this.x !== x || this.y !== y;
+    // TODO: add TODO.
+    // const moved = this.x !== x || this.y !== y;
+    const moved = true;
     let updated = false;
 
     if (this.trackedState_ === RenderedConnection.TrackedState.WILL_TRACK) {


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [X] I ran `npm run format` and `npm run lint`

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Aaron discovered an issue with the ternary block during testing, where blocks couldn't be connected to it. Turns out that some connection locations weren't being added to the db due to the `moved` check. I'm not sure why this is occuring, so I'm just removing it for now. This does give us a performance hit of ~20ms when moving spaghetti blocks around. But it's still ~5x faster than on master so nbd.

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
Fixes regression where connections weren't being added to the db.

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
Regressions are sad.

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->
Manual testing.

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->
N/A

### Additional Information

<!-- Anything else we should know? -->
Going to create an issue for reverting this now that I've created this PR.

This is release blocking.