### PR TITLE
fix: Make Escape cancel changes in text fields.

### DIFF
--- a/core/field_input.ts
+++ b/core/field_input.ts
@@ -444,7 +444,7 @@ export abstract class FieldInput<T extends InputTypes> extends Field<string|T> {
     if (e.key === 'Enter') {
       WidgetDiv.hide();
       dropDownDiv.hideWithoutAnimation();
-    } else if (e.key === 'Esc') {
+    } else if (e.key === 'Escape') {
       this.setValue(
           this.htmlInput_!.getAttribute('data-untyped-default-value'));
       WidgetDiv.hide();


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [x] I ran `npm run format` and `npm run lint`

## The details
### Resolves

#### Behavior Before Change
Pressing Escape while editing a text field does nothing.

#### Behavior After Change
Pressing Escape cancels the edit and reverts the field to its previous value.