### PR TITLE
fix: allow splicing into shadow block stacks

### DIFF
--- a/core/connection_checker.ts
+++ b/core/connection_checker.ts
@@ -250,8 +250,8 @@ export class ConnectionChecker implements IConnectionChecker {
         }
 
         // Don't offer to splice into a stack where the connected block is
-        // immovable.
-        if (b.targetBlock() && !b.targetBlock()!.isMovable()) {
+        // immovable, unless the block is a shadow block.
+        if (b.targetBlock() && !b.targetBlock()!.isMovable() && !b.targetBlock()!.isShadow()) {
           return false;
         }
         break;

--- a/core/connection_checker.ts
+++ b/core/connection_checker.ts
@@ -251,7 +251,8 @@ export class ConnectionChecker implements IConnectionChecker {
 
         // Don't offer to splice into a stack where the connected block is
         // immovable, unless the block is a shadow block.
-        if (b.targetBlock() && !b.targetBlock()!.isMovable() && !b.targetBlock()!.isShadow()) {
+        if (b.targetBlock() && !b.targetBlock()!.isMovable() &&
+            !b.targetBlock()!.isShadow()) {
           return false;
         }
         break;

--- a/tests/mocha/connection_checker_test.js
+++ b/tests/mocha/connection_checker_test.js
@@ -367,6 +367,31 @@ suite('Connection checker', function() {
           'Should connect two compatible stack blocks');
       });
 
+      test('Connect to unmovable shadow block', function() {
+        // Remove original test blocks.
+        this.workspace.clear();
+
+        // Add the same test blocks, but this time block B is a shadow block.
+        Blockly.Xml.domToWorkspace(Blockly.utils.xml.textToDom(`<xml xmlns="https://developers.google.com/blockly/xml">
+        <block type="text_print" id="A" x="-76" y="-112">
+          <next>
+            <shadow type="text_print" id="B" movable="false">
+            </shadow>
+          </next>
+        </block>
+        <block type="text_print" id="C" x="47" y="-118"/>
+      </xml>`), this.workspace);
+      [this.blockA, this.blockB, this.blockC] = this.workspace.getAllBlocks(true);
+
+      // Try to connect blockC into the input connection of blockA, replacing blockB.
+      // This is allowed because shadow blocks can always be replaced, even though
+      // they are unmovable.
+      chai.assert.isTrue(
+        this.checker.doDragChecks(
+          this.blockC.previousConnection, this.blockA.nextConnection, 9000),
+        'Should connect in place of a shadow block');
+      });
+
       test('Do not splice into unmovable stack', function() {
         // Try to connect blockC above blockB. It shouldn't work because B is not movable
         // and is already connected to A's nextConnection.


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [x] I ran `npm run format` and `npm run lint`

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #6938 

### Proposed Changes

Fixes a bug in #6800 where you couldn't splice into shadow block stacks. Adds a test case for this behavior.

#### Behavior Before Change

Couldn't replace a shadow block in a statement input.

#### Behavior After Change

Can replace shadow blocks in a statement input.

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage

Adds test case for shadow block.

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
