### PR TITLE
fix: collapsed toolbox categories being expanded

### DIFF
--- a/core/toolbox/collapsible_category.ts
+++ b/core/toolbox/collapsible_category.ts
@@ -113,7 +113,7 @@ export class CollapsibleToolboxCategory extends ToolboxCategory implements
 
     this.setExpanded(
         this.toolboxItemDef_['expanded'] === 'true' ||
-        !!this.toolboxItemDef_['expanded']);
+        this.toolboxItemDef_['expanded'] === true);
   }
 
   override createDom_() {
@@ -123,6 +123,8 @@ export class CollapsibleToolboxCategory extends ToolboxCategory implements
     this.subcategoriesDiv_ = this.createSubCategoriesDom_(subCategories);
     aria.setRole(this.subcategoriesDiv_, aria.Role.GROUP);
     this.htmlDiv_!.appendChild(this.subcategoriesDiv_);
+    this.closeIcon_(this.iconDom_);
+    aria.setState(this.htmlDiv_ as HTMLDivElement, aria.State.EXPANDED, false);
 
     return this.htmlDiv_!;
   }
@@ -150,6 +152,7 @@ export class CollapsibleToolboxCategory extends ToolboxCategory implements
   protected createSubCategoriesDom_(subcategories: IToolboxItem[]):
       HTMLDivElement {
     const contentsContainer = document.createElement('div');
+    contentsContainer.style.display = 'none';
     const className = this.cssConfig_['contents'];
     if (className) {
       dom.addClass(contentsContainer, className);
@@ -173,9 +176,8 @@ export class CollapsibleToolboxCategory extends ToolboxCategory implements
    * @param isExpanded True to expand the category, false to close.
    */
   setExpanded(isExpanded: boolean) {
-    if (this.expanded_ === isExpanded) {
-      return;
-    }
+    if (this.expanded_ === isExpanded) return;
+
     this.expanded_ = isExpanded;
     if (isExpanded) {
       this.subcategoriesDiv_!.style.display = 'block';


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [X] I ran `npm run format` and `npm run lint`

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #6940 

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
Makes it so that collapsed categories are actually collapsed on initialization.

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
Fixin the buggies.

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->

Just manual testing.

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
N/A
