### PR TITLE
fix: disposing during dragging

### DIFF
--- a/core/block_dragger.ts
+++ b/core/block_dragger.ts
@@ -346,6 +346,7 @@ export class BlockDragger implements IBlockDragger {
 
   /** Fire a move event at the end of a block drag. */
   protected fireMoveEvent_() {
+    if (this.draggingBlock_.isDeadOrDying()) return;
     const event = new (eventUtils.get(eventUtils.BLOCK_MOVE))(
                       this.draggingBlock_) as BlockMove;
     event.oldCoordinate = this.startXY_;


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [X] I ran `npm run format` and `npm run lint`

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #6945

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
Makes it so that block move events are not fired if a block was disposed during a drag.

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
Because of how disposing was rearranged during https://github.com/google/blockly/pull/6894 the block got removed from the workspace's list of blocks before the gesture was canceled. This meant that when the move event tried to find the block, it couldn't.

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->
Manual testing.

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->
N/A

### Additional Information

<!-- Anything else we should know? -->

1) I don't /think/ there are any other cases where this should be a problem. But if something like this comes up again we should look at rearranging the dispose order again.

2) Did not look into why this was *not* causing problems for drag targets (e.g. the trashcan) ¯\\\_(ツ)_/¯

3) This should probably go into tomorrow's patch as well.
