### PR TITLE
chore: remove underscores from private properties and methods in connections

### DIFF
--- a/core/connection.ts
+++ b/core/connection.ts
@@ -51,10 +51,10 @@ export class Connection implements IASTNodeLocationWithBlock {
   disposed = false;
 
   /** List of compatible value types.  Null if all types are compatible. */
-  private check_: string[]|null = null;
+  private check: string[]|null = null;
 
   /** DOM representation of a shadow block, or null if none. */
-  private shadowDom_: Element|null = null;
+  private shadowDom: Element|null = null;
 
   /**
    * Horizontal location of this connection.
@@ -70,7 +70,7 @@ export class Connection implements IASTNodeLocationWithBlock {
    */
   y = 0;
 
-  private shadowState_: blocks.State|null = null;
+  private shadowState: blocks.State|null = null;
 
   /**
    * @param source The block establishing this connection.
@@ -99,7 +99,7 @@ export class Connection implements IASTNodeLocationWithBlock {
     // Make sure the parentConnection is available.
     let orphan;
     if (this.isConnected()) {
-      const shadowState = this.stashShadowState_();
+      const shadowState = this.stashShadowState();
       const target = this.targetBlock();
       if (target!.isShadow()) {
         target!.dispose(false);
@@ -107,7 +107,7 @@ export class Connection implements IASTNodeLocationWithBlock {
         this.disconnectInternal();
         orphan = target;
       }
-      this.applyShadowState_(shadowState);
+      this.applyShadowState(shadowState);
     }
 
     // Connect the new connection to the parent.
@@ -147,7 +147,7 @@ export class Connection implements IASTNodeLocationWithBlock {
     // isConnected returns true for shadows and non-shadows.
     if (this.isConnected()) {
       // Destroy the attached shadow block & its children (if it exists).
-      this.setShadowStateInternal_();
+      this.setShadowStateInternal();
 
       const targetBlock = this.targetBlock();
       if (targetBlock && !targetBlock.isDeadOrDying()) {
@@ -319,7 +319,7 @@ export class Connection implements IASTNodeLocationWithBlock {
    */
   protected respawnShadow_() {
     // Have to keep respawnShadow_ for backwards compatibility.
-    this.createShadowBlock_(true);
+    this.createShadowBlock(true);
   }
 
   /**
@@ -360,10 +360,10 @@ export class Connection implements IASTNodeLocationWithBlock {
       if (!Array.isArray(check)) {
         check = [check];
       }
-      this.check_ = check;
+      this.check = check;
       this.onCheckChanged_();
     } else {
-      this.check_ = null;
+      this.check = null;
     }
     return this;
   }
@@ -375,7 +375,7 @@ export class Connection implements IASTNodeLocationWithBlock {
    *     Null if all types are compatible.
    */
   getCheck(): string[]|null {
-    return this.check_;
+    return this.check;
   }
 
   /**
@@ -384,7 +384,7 @@ export class Connection implements IASTNodeLocationWithBlock {
    * @param shadowDom DOM representation of a block or null.
    */
   setShadowDom(shadowDom: Element|null) {
-    this.setShadowStateInternal_({shadowDom});
+    this.setShadowStateInternal({shadowDom});
   }
 
   /**
@@ -399,7 +399,7 @@ export class Connection implements IASTNodeLocationWithBlock {
   getShadowDom(returnCurrent?: boolean): Element|null {
     return returnCurrent && this.targetBlock()!.isShadow() ?
         Xml.blockToDom((this.targetBlock() as Block)) as Element :
-        this.shadowDom_;
+        this.shadowDom;
   }
 
   /**
@@ -408,7 +408,7 @@ export class Connection implements IASTNodeLocationWithBlock {
    * @param shadowState An state represetation of the block or null.
    */
   setShadowState(shadowState: blocks.State|null) {
-    this.setShadowStateInternal_({shadowState});
+    this.setShadowStateInternal({shadowState});
   }
 
   /**
@@ -425,7 +425,7 @@ export class Connection implements IASTNodeLocationWithBlock {
     if (returnCurrent && this.targetBlock() && this.targetBlock()!.isShadow()) {
       return blocks.save(this.targetBlock() as Block);
     }
-    return this.shadowState_;
+    return this.shadowState;
   }
 
   /**
@@ -506,13 +506,13 @@ export class Connection implements IASTNodeLocationWithBlock {
    *
    * @returns The state of both the shadowDom_ and shadowState_ properties.
    */
-  private stashShadowState_():
+  private stashShadowState():
       {shadowDom: Element|null, shadowState: blocks.State|null} {
     const shadowDom = this.getShadowDom(true);
     const shadowState = this.getShadowState(true);
     // Set to null so it doesn't respawn.
-    this.shadowDom_ = null;
-    this.shadowState_ = null;
+    this.shadowDom = null;
+    this.shadowState = null;
     return {shadowDom, shadowState};
   }
 
@@ -522,12 +522,12 @@ export class Connection implements IASTNodeLocationWithBlock {
    * @param param0 The state to reapply to the shadowDom_ and shadowState_
    *     properties.
    */
-  private applyShadowState_({shadowDom, shadowState}: {
+  private applyShadowState({shadowDom, shadowState}: {
     shadowDom: Element|null,
     shadowState: blocks.State|null
   }) {
-    this.shadowDom_ = shadowDom;
-    this.shadowState_ = shadowState;
+    this.shadowDom = shadowDom;
+    this.shadowState = shadowState;
   }
 
   /**
@@ -535,31 +535,31 @@ export class Connection implements IASTNodeLocationWithBlock {
    *
    * @param param0 The state to set the shadow of this connection to.
    */
-  private setShadowStateInternal_({shadowDom = null, shadowState = null}: {
+  private setShadowStateInternal({shadowDom = null, shadowState = null}: {
     shadowDom?: Element|null,
     shadowState?: blocks.State|null
   } = {}) {
     // One or both of these should always be null.
     // If neither is null, the shadowState will get priority.
-    this.shadowDom_ = shadowDom;
-    this.shadowState_ = shadowState;
+    this.shadowDom = shadowDom;
+    this.shadowState = shadowState;
 
     const target = this.targetBlock();
     if (!target) {
       this.respawnShadow_();
       if (this.targetBlock() && this.targetBlock()!.isShadow()) {
-        this.serializeShadow_(this.targetBlock());
+        this.serializeShadow(this.targetBlock());
       }
     } else if (target.isShadow()) {
       target.dispose(false);
       if (this.getSourceBlock().isDeadOrDying()) return;
       this.respawnShadow_();
       if (this.targetBlock() && this.targetBlock()!.isShadow()) {
-        this.serializeShadow_(this.targetBlock());
+        this.serializeShadow(this.targetBlock());
       }
     } else {
-      const shadow = this.createShadowBlock_(false);
-      this.serializeShadow_(shadow);
+      const shadow = this.createShadowBlock(false);
+      this.serializeShadow(shadow);
       if (shadow) {
         shadow.dispose(false);
       }
@@ -575,7 +575,7 @@ export class Connection implements IASTNodeLocationWithBlock {
    * @returns The shadow block that was created, or null if both the
    *     shadowState_ and shadowDom_ are null.
    */
-  private createShadowBlock_(attemptToConnect: boolean): Block|null {
+  private createShadowBlock(attemptToConnect: boolean): Block|null {
     const parentBlock = this.getSourceBlock();
     const shadowState = this.getShadowState();
     const shadowDom = this.getShadowDom();
@@ -626,12 +626,12 @@ export class Connection implements IASTNodeLocationWithBlock {
    *
    * @param shadow The shadow to serialize, or null.
    */
-  private serializeShadow_(shadow: Block|null) {
+  private serializeShadow(shadow: Block|null) {
     if (!shadow) {
       return;
     }
-    this.shadowDom_ = Xml.blockToDom(shadow) as Element;
-    this.shadowState_ = blocks.save(shadow);
+    this.shadowDom = Xml.blockToDom(shadow) as Element;
+    this.shadowState = blocks.save(shadow);
   }
 
   /**

--- a/core/rendered_connection.ts
+++ b/core/rendered_connection.ts
@@ -47,10 +47,10 @@ const BUMP_RANDOMNESS = 10;
 export class RenderedConnection extends Connection {
   // TODO(b/109816955): remove '!', see go/strict-prop-init-fix.
   sourceBlock_!: BlockSvg;
-  private readonly db_: ConnectionDB;
-  private readonly dbOpposite_: ConnectionDB;
-  private readonly offsetInBlock_: Coordinate;
-  private trackedState_: TrackedState;
+  private readonly db: ConnectionDB;
+  private readonly dbOpposite: ConnectionDB;
+  private readonly offsetInBlock: Coordinate;
+  private trackedState: TrackedState;
   private highlightPath: SVGPathElement|null = null;
 
   /** Connection this connection connects to.  Null if not connected. */
@@ -67,21 +67,21 @@ export class RenderedConnection extends Connection {
      * Connection database for connections of this type on the current
      * workspace.
      */
-    this.db_ = source.workspace.connectionDBList[type];
+    this.db = source.workspace.connectionDBList[type];
 
     /**
      * Connection database for connections compatible with this type on the
      * current workspace.
      */
-    this.dbOpposite_ =
+    this.dbOpposite =
         source.workspace
             .connectionDBList[internalConstants.OPPOSITE_TYPE[type]];
 
     /** Workspace units, (0, 0) is top left of block. */
-    this.offsetInBlock_ = new Coordinate(0, 0);
+    this.offsetInBlock = new Coordinate(0, 0);
 
     /** Describes the state of this connection's tracked-ness. */
-    this.trackedState_ = RenderedConnection.TrackedState.WILL_TRACK;
+    this.trackedState = RenderedConnection.TrackedState.WILL_TRACK;
   }
 
   /**
@@ -92,8 +92,8 @@ export class RenderedConnection extends Connection {
    */
   override dispose() {
     super.dispose();
-    if (this.trackedState_ === RenderedConnection.TrackedState.TRACKED) {
-      this.db_.removeConnection(this, this.y);
+    if (this.trackedState === RenderedConnection.TrackedState.TRACKED) {
+      this.db.removeConnection(this, this.y);
     }
   }
 
@@ -192,15 +192,15 @@ export class RenderedConnection extends Connection {
     const moved = true;
     let updated = false;
 
-    if (this.trackedState_ === RenderedConnection.TrackedState.WILL_TRACK) {
-      this.db_.addConnection(this, y);
-      this.trackedState_ = RenderedConnection.TrackedState.TRACKED;
+    if (this.trackedState === RenderedConnection.TrackedState.WILL_TRACK) {
+      this.db.addConnection(this, y);
+      this.trackedState = RenderedConnection.TrackedState.TRACKED;
       updated = true;
     } else if (
-        this.trackedState_ === RenderedConnection.TrackedState.TRACKED &&
+        this.trackedState === RenderedConnection.TrackedState.TRACKED &&
         moved) {
-      this.db_.removeConnection(this, this.y);
-      this.db_.addConnection(this, y);
+      this.db.removeConnection(this, this.y);
+      this.db.addConnection(this, y);
       updated = true;
     }
 
@@ -233,7 +233,7 @@ export class RenderedConnection extends Connection {
    */
   moveToOffset(blockTL: Coordinate): boolean {
     return this.moveTo(
-        blockTL.x + this.offsetInBlock_.x, blockTL.y + this.offsetInBlock_.y);
+        blockTL.x + this.offsetInBlock.x, blockTL.y + this.offsetInBlock.y);
   }
 
   /**
@@ -243,8 +243,8 @@ export class RenderedConnection extends Connection {
    * @param y The new relative y, in workspace units.
    */
   setOffsetInBlock(x: number, y: number) {
-    this.offsetInBlock_.x = x;
-    this.offsetInBlock_.y = y;
+    this.offsetInBlock.x = x;
+    this.offsetInBlock.y = y;
   }
 
   /**
@@ -254,7 +254,7 @@ export class RenderedConnection extends Connection {
    * @internal
    */
   getOffsetInBlock(): Coordinate {
-    return this.offsetInBlock_;
+    return this.offsetInBlock;
   }
 
   /**
@@ -289,7 +289,7 @@ export class RenderedConnection extends Connection {
     const block = this.targetBlock();
     if (!target || !block) return;
     const offset =
-        Coordinate.difference(this.offsetInBlock_, target.offsetInBlock_);
+        Coordinate.difference(this.offsetInBlock, target.offsetInBlock);
     block.translate(offset.x, offset.y);
   }
 
@@ -305,7 +305,7 @@ export class RenderedConnection extends Connection {
    */
   closest(maxLimit: number, dxy: Coordinate):
       {connection: RenderedConnection|null, radius: number} {
-    return this.dbOpposite_.searchForClosest(this, maxLimit, dxy);
+    return this.dbOpposite.searchForClosest(this, maxLimit, dxy);
   }
 
   /** Add highlighting around this connection. */
@@ -334,7 +334,7 @@ export class RenderedConnection extends Connection {
           (shape as unknown as PathLeftShape).pathLeft +
           svgPaths.lineOnAxis('h', xLen);
     }
-    const offset = this.offsetInBlock_;
+    const offset = this.offsetInBlock;
     this.highlightPath = dom.createSvgElement(
         Svg.PATH, {
           'class': 'blocklyHighlightedConnectionPath',
@@ -361,9 +361,9 @@ export class RenderedConnection extends Connection {
    */
   setTracking(doTracking: boolean) {
     if (doTracking &&
-            this.trackedState_ === RenderedConnection.TrackedState.TRACKED ||
+            this.trackedState === RenderedConnection.TrackedState.TRACKED ||
         !doTracking &&
-            this.trackedState_ === RenderedConnection.TrackedState.UNTRACKED) {
+            this.trackedState === RenderedConnection.TrackedState.UNTRACKED) {
       return;
     }
     if (this.sourceBlock_.isInFlyout) {
@@ -371,14 +371,14 @@ export class RenderedConnection extends Connection {
       return;
     }
     if (doTracking) {
-      this.db_.addConnection(this, this.y);
-      this.trackedState_ = RenderedConnection.TrackedState.TRACKED;
+      this.db.addConnection(this, this.y);
+      this.trackedState = RenderedConnection.TrackedState.TRACKED;
       return;
     }
-    if (this.trackedState_ === RenderedConnection.TrackedState.TRACKED) {
-      this.db_.removeConnection(this, this.y);
+    if (this.trackedState === RenderedConnection.TrackedState.TRACKED) {
+      this.db.removeConnection(this, this.y);
     }
-    this.trackedState_ = RenderedConnection.TrackedState.UNTRACKED;
+    this.trackedState = RenderedConnection.TrackedState.UNTRACKED;
   }
 
   /**
@@ -532,7 +532,7 @@ export class RenderedConnection extends Connection {
    * @internal
    */
   override neighbours(maxLimit: number): RenderedConnection[] {
-    return this.dbOpposite_.getNeighbours(this, maxLimit);
+    return this.dbOpposite.getNeighbours(this, maxLimit);
   }
 
   /**

--- a/tests/mocha/block_test.js
+++ b/tests/mocha/block_test.js
@@ -477,19 +477,19 @@ suite('Blocks', function() {
 
       this.getInputs = function() {
         return this.workspace
-            .connectionDBList[ConnectionType.INPUT_VALUE].connections_;
+            .connectionDBList[ConnectionType.INPUT_VALUE].connections;
       };
       this.getOutputs = function() {
         return this.workspace
-            .connectionDBList[ConnectionType.OUTPUT_VALUE].connections_;
+            .connectionDBList[ConnectionType.OUTPUT_VALUE].connections;
       };
       this.getNext = function() {
         return this.workspace
-            .connectionDBList[ConnectionType.NEXT_STATEMENT].connections_;
+            .connectionDBList[ConnectionType.NEXT_STATEMENT].connections;
       };
       this.getPrevious = function() {
         return this.workspace
-            .connectionDBList[ConnectionType.PREVIOUS_STATEMENT].connections_;
+            .connectionDBList[ConnectionType.PREVIOUS_STATEMENT].connections;
       };
 
       this.assertConnectionsEmpty = function() {

--- a/tests/mocha/blocks/logic_ternary_test.js
+++ b/tests/mocha/blocks/logic_ternary_test.js
@@ -34,8 +34,9 @@ suite('Logic ternary', function() {
     chai.assert.lengthOf(inputs, 3);
     const ifInput = block.getInput('IF');
     chai.assert.exists(ifInput, 'Has "IF" input');
-    chai.assert.equal(ifInput.connection.check_.length, 1);
-    chai.assert.equal(ifInput.connection.check_[0], 'Boolean');
+    const checkList = ifInput.connection.getCheck();
+    chai.assert.equal(checkList.length, 1);
+    chai.assert.equal(checkList[0], 'Boolean');
     chai.assert.exists(block.onchangeWrapper_, 'Has onchange handler');
     if (inputsInline) {
       chai.assert.isTrue(block.inputsInline);

--- a/tests/mocha/connection_db_test.js
+++ b/tests/mocha/connection_db_test.js
@@ -16,10 +16,10 @@ suite('Connection Database', function() {
     this.database = new Blockly.ConnectionDB(new Blockly.ConnectionChecker());
 
     this.assertOrder = function() {
-      const length = this.database.connections_.length;
+      const length = this.database.connections.length;
       for (let i = 1; i < length; i++) {
-        chai.assert.isAtMost(this.database.connections_[i - 1].y,
-            this.database.connections_[i].y);
+        chai.assert.isAtMost(this.database.connections[i - 1].y,
+            this.database.connections[i].y);
       }
     };
     this.createConnection = function(x, y, type, opt_database) {
@@ -52,23 +52,23 @@ suite('Connection Database', function() {
 
     this.database.addConnection(y2, 2);
     chai.assert.sameOrderedMembers(
-        this.database.connections_, [y2]);
+        this.database.connections, [y2]);
 
     this.database.addConnection(y4, 4);
     chai.assert.sameOrderedMembers(
-        this.database.connections_, [y2, y4]);
+        this.database.connections, [y2, y4]);
 
     this.database.addConnection(y1, 1);
     chai.assert.sameOrderedMembers(
-        this.database.connections_, [y1, y2, y4]);
+        this.database.connections, [y1, y2, y4]);
 
     this.database.addConnection(y3a, 3);
     chai.assert.sameOrderedMembers(
-        this.database.connections_, [y1, y2, y3a, y4]);
+        this.database.connections, [y1, y2, y3a, y4]);
 
     this.database.addConnection(y3b, 3);
     chai.assert.sameOrderedMembers(
-        this.database.connections_, [y1, y2, y3b, y3a, y4]);
+        this.database.connections, [y1, y2, y3b, y3a, y4]);
   });
   test('Remove Connection', function() {
     const y2 = {y: 2};
@@ -86,30 +86,30 @@ suite('Connection Database', function() {
     this.database.addConnection(y3a, 3);
 
     chai.assert.sameOrderedMembers(
-        this.database.connections_, [y1, y2, y3a, y3b, y3c, y4]);
+        this.database.connections, [y1, y2, y3a, y3b, y3c, y4]);
 
     this.database.removeConnection(y2, 2);
     chai.assert.sameOrderedMembers(
-        this.database.connections_, [y1, y3a, y3b, y3c, y4]);
+        this.database.connections, [y1, y3a, y3b, y3c, y4]);
 
     this.database.removeConnection(y4, 4);
     chai.assert.sameOrderedMembers(
-        this.database.connections_, [y1, y3a, y3b, y3c]);
+        this.database.connections, [y1, y3a, y3b, y3c]);
 
     this.database.removeConnection(y1, 1);
     chai.assert.sameOrderedMembers(
-        this.database.connections_, [y3a, y3b, y3c]);
+        this.database.connections, [y3a, y3b, y3c]);
 
     this.database.removeConnection(y3a, 3);
     chai.assert.sameOrderedMembers(
-        this.database.connections_, [y3b, y3c]);
+        this.database.connections, [y3b, y3c]);
 
     this.database.removeConnection(y3c, 3);
     chai.assert.sameOrderedMembers(
-        this.database.connections_, [y3b]);
+        this.database.connections, [y3b]);
 
     this.database.removeConnection(y3b, 3);
-    chai.assert.isEmpty(this.database.connections_);
+    chai.assert.isEmpty(this.database.connections);
   });
   suite('Get Neighbors', function() {
     test('Empty Database', function() {
@@ -123,7 +123,7 @@ suite('Connection Database', function() {
       const checkConnection = this.createConnection(0, 0, ConnectionType.NEXT_STATEMENT,
           new Blockly.ConnectionDB());
       const neighbors = this.database.getNeighbours(checkConnection, 4);
-      chai.assert.sameMembers(neighbors, this.database.connections_.slice(0, 5));
+      chai.assert.sameMembers(neighbors, this.database.connections.slice(0, 5));
     });
     test('Block In Middle', function() {
       this.createSimpleTestConnections();
@@ -131,7 +131,7 @@ suite('Connection Database', function() {
       const checkConnection = this.createConnection(0, 4, ConnectionType.NEXT_STATEMENT,
           new Blockly.ConnectionDB());
       const neighbors = this.database.getNeighbours(checkConnection, 2);
-      chai.assert.sameMembers(neighbors, this.database.connections_.slice(2, 7));
+      chai.assert.sameMembers(neighbors, this.database.connections.slice(2, 7));
     });
     test('Block At End', function() {
       this.createSimpleTestConnections();
@@ -139,7 +139,7 @@ suite('Connection Database', function() {
       const checkConnection = this.createConnection(0, 9, ConnectionType.NEXT_STATEMENT,
           new Blockly.ConnectionDB());
       const neighbors = this.database.getNeighbours(checkConnection, 4);
-      chai.assert.sameMembers(neighbors, this.database.connections_.slice(5, 10));
+      chai.assert.sameMembers(neighbors, this.database.connections.slice(5, 10));
     });
     test('Out of Range X', function() {
       this.createSimpleTestConnections();
@@ -240,7 +240,7 @@ suite('Connection Database', function() {
 
       const checkConnection = this.createCheckConnection(0, 14);
 
-      const last = this.database.connections_[9];
+      const last = this.database.connections[9];
       const closest = this.database.searchForClosest(
           checkConnection, 5, {x: 0, y: 0}).connection;
       chai.assert.equal(last, closest);
@@ -250,7 +250,7 @@ suite('Connection Database', function() {
 
       const checkConnection = this.createCheckConnection(0, 10);
 
-      const last = this.database.connections_[9];
+      const last = this.database.connections[9];
       const closest = this.database.searchForClosest(
           checkConnection, 5, {x: 0, y: 0}).connection;
       chai.assert.equal(last, closest);


### PR DESCRIPTION
## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [x] I ran `npm run format` and `npm run lint`

## The details
### Resolves

Part of #6548

### Proposed Changes

Remove underscores from private property and method names. Fix uses in tests. Note that the tests are still accessing private properties. I decided not to add getters that would only exist for tests.

Stop setting properties to `null` in `dispose` when not needed.

#### Behavior Before Change

No change

### Reason for Changes

Match current google style guide.