### PR TITLE
chore: remove underscores from private properties and methods in keyboard nav and rendering

### DIFF
--- a/core/keyboard_nav/ast_node.ts
+++ b/core/keyboard_nav/ast_node.ts
@@ -40,14 +40,14 @@ export class ASTNode {
    * workspace.
    */
   private static readonly DEFAULT_OFFSET_Y: number = -20;
-  private readonly type_: string;
-  private readonly isConnection_: boolean;
-  private readonly location_: IASTNodeLocation;
+  private readonly type: string;
+  private readonly isConnectionLocation: boolean;
+  private readonly location: IASTNodeLocation;
 
   /** The coordinate on the workspace. */
   // AnyDuringMigration because:  Type 'null' is not assignable to type
   // 'Coordinate'.
-  private wsCoordinate_: Coordinate = null as AnyDuringMigration;
+  private wsCoordinate: Coordinate = null as AnyDuringMigration;
 
   /**
    * @param type The type of the location.
@@ -64,15 +64,15 @@ export class ASTNode {
      * The type of the location.
      * One of ASTNode.types
      */
-    this.type_ = type;
+    this.type = type;
 
     /** Whether the location points to a connection. */
-    this.isConnection_ = ASTNode.isConnectionType_(type);
+    this.isConnectionLocation = ASTNode.isConnectionType(type);
 
     /** The location of the AST node. */
-    this.location_ = location;
+    this.location = location;
 
-    this.processParams_(opt_params || null);
+    this.processParams(opt_params || null);
   }
 
   /**
@@ -80,12 +80,12 @@ export class ASTNode {
    *
    * @param params The user specified parameters.
    */
-  private processParams_(params: Params|null) {
+  private processParams(params: Params|null) {
     if (!params) {
       return;
     }
     if (params.wsCoordinate) {
-      this.wsCoordinate_ = params.wsCoordinate;
+      this.wsCoordinate = params.wsCoordinate;
     }
   }
 
@@ -98,7 +98,7 @@ export class ASTNode {
    *     on.
    */
   getLocation(): IASTNodeLocation {
-    return this.location_;
+    return this.location;
   }
 
   /**
@@ -108,7 +108,7 @@ export class ASTNode {
    * @returns The type of the location.
    */
   getType(): string {
-    return this.type_;
+    return this.type;
   }
 
   /**
@@ -118,7 +118,7 @@ export class ASTNode {
    *     workspace.
    */
   getWsCoordinate(): Coordinate {
-    return this.wsCoordinate_;
+    return this.wsCoordinate;
   }
 
   /**
@@ -128,7 +128,7 @@ export class ASTNode {
    * @internal
    */
   isConnection(): boolean {
-    return this.isConnection_;
+    return this.isConnectionLocation;
   }
 
   /**
@@ -139,8 +139,8 @@ export class ASTNode {
    * @returns The AST node holding the next field or connection or null if there
    *     is no editable field or input connection after the given input.
    */
-  private findNextForInput_(): ASTNode|null {
-    const location = this.location_ as Connection;
+  private findNextForInput(): ASTNode|null {
+    const location = this.location as Connection;
     const parentInput = location.getParentInput();
     const block = parentInput!.getSourceBlock();
     // AnyDuringMigration because:  Argument of type 'Input | null' is not
@@ -169,8 +169,8 @@ export class ASTNode {
    * @returns The AST node pointing to the next field or connection or null if
    *     there is no editable field or input connection after the given input.
    */
-  private findNextForField_(): ASTNode|null {
-    const location = this.location_ as Field;
+  private findNextForField(): ASTNode|null {
+    const location = this.location as Field;
     const input = location.getParentInput();
     const block = location.getSourceBlock();
     if (!block) {
@@ -203,8 +203,8 @@ export class ASTNode {
    *
    * @returns The AST node holding the previous field or connection.
    */
-  private findPrevForInput_(): ASTNode|null {
-    const location = this.location_ as Connection;
+  private findPrevForInput(): ASTNode|null {
+    const location = this.location as Connection;
     const parentInput = location.getParentInput();
     const block = parentInput!.getSourceBlock();
     // AnyDuringMigration because:  Argument of type 'Input | null' is not
@@ -232,8 +232,8 @@ export class ASTNode {
    *
    * @returns The AST node holding the previous input or field.
    */
-  private findPrevForField_(): ASTNode|null {
-    const location = this.location_ as Field;
+  private findPrevForField(): ASTNode|null {
+    const location = this.location as Field;
     const parentInput = location.getParentInput();
     const block = location.getSourceBlock();
     if (!block) {
@@ -270,7 +270,7 @@ export class ASTNode {
    * @returns The first block of the next stack or null if there are no blocks
    *     on the workspace.
    */
-  private navigateBetweenStacks_(forward: boolean): ASTNode|null {
+  private navigateBetweenStacks(forward: boolean): ASTNode|null {
     let curLocation = this.getLocation();
     // TODO(#6097): Use instanceof checks to exit early for values of
     // curLocation that don't make sense.
@@ -311,7 +311,7 @@ export class ASTNode {
    * @param block The block that we want to find the top connection on.
    * @returns The AST node containing the top connection.
    */
-  private findTopASTNodeForBlock_(block: Block): ASTNode|null {
+  private findTopASTNodeForBlock(block: Block): ASTNode|null {
     const topConnection = getParentConnection(block);
     if (topConnection) {
       return ASTNode.createConnectionNode(topConnection);
@@ -328,7 +328,7 @@ export class ASTNode {
    * @returns The AST node pointing to the input connection or the top block of
    *     the stack this block is in.
    */
-  private getOutAstNodeForBlock_(block: Block): ASTNode|null {
+  private getOutAstNodeForBlock(block: Block): ASTNode|null {
     if (!block) {
       return null;
     }
@@ -359,7 +359,7 @@ export class ASTNode {
    * Null if there are no editable fields or inputs with connections on the
    * block.
    */
-  private findFirstFieldOrInput_(block: Block): ASTNode|null {
+  private findFirstFieldOrInput(block: Block): ASTNode|null {
     const inputs = block.inputList;
     for (let i = 0; i < inputs.length; i++) {
       const input = inputs[i];
@@ -402,32 +402,32 @@ export class ASTNode {
    *     workspace. Or null if there is no node to the right.
    */
   next(): ASTNode|null {
-    switch (this.type_) {
+    switch (this.type) {
       case ASTNode.types.STACK:
-        return this.navigateBetweenStacks_(true);
+        return this.navigateBetweenStacks(true);
 
       case ASTNode.types.OUTPUT: {
-        const connection = this.location_ as Connection;
+        const connection = this.location as Connection;
         return ASTNode.createBlockNode(connection.getSourceBlock());
       }
       case ASTNode.types.FIELD:
-        return this.findNextForField_();
+        return this.findNextForField();
 
       case ASTNode.types.INPUT:
-        return this.findNextForInput_();
+        return this.findNextForInput();
 
       case ASTNode.types.BLOCK: {
-        const block = this.location_ as Block;
+        const block = this.location as Block;
         const nextConnection = block.nextConnection;
         if (!nextConnection) return null;
         return ASTNode.createConnectionNode(nextConnection);
       }
       case ASTNode.types.PREVIOUS: {
-        const connection = this.location_ as Connection;
+        const connection = this.location as Connection;
         return ASTNode.createBlockNode(connection.getSourceBlock());
       }
       case ASTNode.types.NEXT: {
-        const connection = this.location_ as Connection;
+        const connection = this.location as Connection;
         const targetConnection = connection.targetConnection;
         return ASTNode.createConnectionNode(targetConnection!);
       }
@@ -444,9 +444,9 @@ export class ASTNode {
    *     block. Or null if there is nothing below this node.
    */
   in(): ASTNode|null {
-    switch (this.type_) {
+    switch (this.type) {
       case ASTNode.types.WORKSPACE: {
-        const workspace = this.location_ as Workspace;
+        const workspace = this.location as Workspace;
         const topBlocks = workspace.getTopBlocks(true);
         if (topBlocks.length > 0) {
           return ASTNode.createStackNode(topBlocks[0]);
@@ -454,15 +454,15 @@ export class ASTNode {
         break;
       }
       case ASTNode.types.STACK: {
-        const block = this.location_ as Block;
-        return this.findTopASTNodeForBlock_(block);
+        const block = this.location as Block;
+        return this.findTopASTNodeForBlock(block);
       }
       case ASTNode.types.BLOCK: {
-        const block = this.location_ as Block;
-        return this.findFirstFieldOrInput_(block);
+        const block = this.location as Block;
+        return this.findFirstFieldOrInput(block);
       }
       case ASTNode.types.INPUT: {
-        const connection = this.location_ as Connection;
+        const connection = this.location as Connection;
         const targetConnection = connection.targetConnection;
         return ASTNode.createConnectionNode(targetConnection!);
       }
@@ -478,27 +478,27 @@ export class ASTNode {
    *     or block. Or null if no node exists to the left. null.
    */
   prev(): ASTNode|null {
-    switch (this.type_) {
+    switch (this.type) {
       case ASTNode.types.STACK:
-        return this.navigateBetweenStacks_(false);
+        return this.navigateBetweenStacks(false);
 
       case ASTNode.types.OUTPUT:
         return null;
 
       case ASTNode.types.FIELD:
-        return this.findPrevForField_();
+        return this.findPrevForField();
 
       case ASTNode.types.INPUT:
-        return this.findPrevForInput_();
+        return this.findPrevForInput();
 
       case ASTNode.types.BLOCK: {
-        const block = this.location_ as Block;
+        const block = this.location as Block;
         const topConnection = getParentConnection(block);
         if (!topConnection) return null;
         return ASTNode.createConnectionNode(topConnection);
       }
       case ASTNode.types.PREVIOUS: {
-        const connection = this.location_ as Connection;
+        const connection = this.location as Connection;
         const targetConnection = connection.targetConnection;
         if (targetConnection && !targetConnection.getParentInput()) {
           return ASTNode.createConnectionNode(targetConnection);
@@ -506,7 +506,7 @@ export class ASTNode {
         break;
       }
       case ASTNode.types.NEXT: {
-        const connection = this.location_ as Connection;
+        const connection = this.location as Connection;
         return ASTNode.createBlockNode(connection.getSourceBlock());
       }
     }
@@ -522,9 +522,9 @@ export class ASTNode {
    *     block. Or null if we are at the workspace level.
    */
   out(): ASTNode|null {
-    switch (this.type_) {
+    switch (this.type) {
       case ASTNode.types.STACK: {
-        const block = this.location_ as Block;
+        const block = this.location as Block;
         const blockPos = block.getRelativeToSurfaceXY();
         // TODO: Make sure this is in the bounds of the workspace.
         const wsCoordinate =
@@ -532,7 +532,7 @@ export class ASTNode {
         return ASTNode.createWorkspaceNode(block.workspace, wsCoordinate);
       }
       case ASTNode.types.OUTPUT: {
-        const connection = this.location_ as Connection;
+        const connection = this.location as Connection;
         const target = connection.targetConnection;
         if (target) {
           return ASTNode.createConnectionNode(target);
@@ -540,7 +540,7 @@ export class ASTNode {
         return ASTNode.createStackNode(connection.getSourceBlock());
       }
       case ASTNode.types.FIELD: {
-        const field = this.location_ as Field;
+        const field = this.location as Field;
         const block = field.getSourceBlock();
         if (!block) {
           throw new Error(
@@ -549,20 +549,20 @@ export class ASTNode {
         return ASTNode.createBlockNode(block);
       }
       case ASTNode.types.INPUT: {
-        const connection = this.location_ as Connection;
+        const connection = this.location as Connection;
         return ASTNode.createBlockNode(connection.getSourceBlock());
       }
       case ASTNode.types.BLOCK: {
-        const block = this.location_ as Block;
-        return this.getOutAstNodeForBlock_(block);
+        const block = this.location as Block;
+        return this.getOutAstNodeForBlock(block);
       }
       case ASTNode.types.PREVIOUS: {
-        const connection = this.location_ as Connection;
-        return this.getOutAstNodeForBlock_(connection.getSourceBlock());
+        const connection = this.location as Connection;
+        return this.getOutAstNodeForBlock(connection.getSourceBlock());
       }
       case ASTNode.types.NEXT: {
-        const connection = this.location_ as Connection;
-        return this.getOutAstNodeForBlock_(connection.getSourceBlock());
+        const connection = this.location as Connection;
+        return this.getOutAstNodeForBlock(connection.getSourceBlock());
       }
     }
 
@@ -575,7 +575,7 @@ export class ASTNode {
    * @param type The type to check.  One of ASTNode.types.
    * @returns True if a node of the given type points to a connection.
    */
-  private static isConnectionType_(type: string): boolean {
+  private static isConnectionType(type: string): boolean {
     switch (type) {
       case ASTNode.types.PREVIOUS:
       case ASTNode.types.NEXT:

--- a/core/keyboard_nav/basic_cursor.ts
+++ b/core/keyboard_nav/basic_cursor.ts
@@ -116,7 +116,7 @@ export class BasicCursor extends Cursor {
     } else if (newNode) {
       return this.getNextNode_(newNode, isValid);
     }
-    const siblingOrParent = this.findSiblingOrParent_(node.out());
+    const siblingOrParent = this.findSiblingOrParent(node.out());
     if (isValid(siblingOrParent)) {
       return siblingOrParent;
     } else if (siblingOrParent) {
@@ -145,7 +145,7 @@ export class BasicCursor extends Cursor {
     let newNode: ASTNode|null = node.prev();
 
     if (newNode) {
-      newNode = this.getRightMostChild_(newNode);
+      newNode = this.getRightMostChild(newNode);
     } else {
       newNode = node.out();
     }
@@ -181,7 +181,7 @@ export class BasicCursor extends Cursor {
    * @param node The current position in the AST.
    * @returns The parent AST node or null if there are no valid parents.
    */
-  private findSiblingOrParent_(node: ASTNode|null): ASTNode|null {
+  private findSiblingOrParent(node: ASTNode|null): ASTNode|null {
     if (!node) {
       return null;
     }
@@ -189,7 +189,7 @@ export class BasicCursor extends Cursor {
     if (nextNode) {
       return nextNode;
     }
-    return this.findSiblingOrParent_(node.out());
+    return this.findSiblingOrParent(node.out());
   }
 
   /**
@@ -199,7 +199,7 @@ export class BasicCursor extends Cursor {
    * @returns The right most child of the given node, or the node if no child
    *     exists.
    */
-  private getRightMostChild_(node: ASTNode|null): ASTNode|null {
+  private getRightMostChild(node: ASTNode|null): ASTNode|null {
     if (!node!.in()) {
       return node;
     }
@@ -207,7 +207,7 @@ export class BasicCursor extends Cursor {
     while (newNode && newNode.next()) {
       newNode = newNode.next();
     }
-    return this.getRightMostChild_(newNode);
+    return this.getRightMostChild(newNode);
   }
 }
 

--- a/core/keyboard_nav/marker.ts
+++ b/core/keyboard_nav/marker.ts
@@ -30,7 +30,7 @@ export class Marker {
   /** The current location of the marker. */
   // AnyDuringMigration because:  Type 'null' is not assignable to type
   // 'ASTNode'.
-  private curNode_: ASTNode = null as AnyDuringMigration;
+  private curNode: ASTNode = null as AnyDuringMigration;
 
   /**
    * The object in charge of drawing the visual representation of the current
@@ -38,7 +38,7 @@ export class Marker {
    */
   // AnyDuringMigration because:  Type 'null' is not assignable to type
   // 'MarkerSvg'.
-  private drawer_: MarkerSvg = null as AnyDuringMigration;
+  private drawer: MarkerSvg = null as AnyDuringMigration;
 
   /** The type of the marker. */
   type = 'marker';
@@ -52,7 +52,7 @@ export class Marker {
    * @param drawer The object in charge of drawing the marker.
    */
   setDrawer(drawer: MarkerSvg) {
-    this.drawer_ = drawer;
+    this.drawer = drawer;
   }
 
   /**
@@ -61,7 +61,7 @@ export class Marker {
    * @returns The object in charge of drawing the marker.
    */
   getDrawer(): MarkerSvg {
-    return this.drawer_;
+    return this.drawer;
   }
 
   /**
@@ -70,7 +70,7 @@ export class Marker {
    * @returns The current field, connection, or block the marker is on.
    */
   getCurNode(): ASTNode {
-    return this.curNode_;
+    return this.curNode;
   }
 
   /**
@@ -81,10 +81,10 @@ export class Marker {
    * @param newNode The new location of the marker.
    */
   setCurNode(newNode: ASTNode) {
-    const oldNode = this.curNode_;
-    this.curNode_ = newNode;
-    if (this.drawer_) {
-      this.drawer_.draw(oldNode, this.curNode_);
+    const oldNode = this.curNode;
+    this.curNode = newNode;
+    if (this.drawer) {
+      this.drawer.draw(oldNode, this.curNode);
     }
   }
 
@@ -94,15 +94,15 @@ export class Marker {
    * @internal
    */
   draw() {
-    if (this.drawer_) {
-      this.drawer_.draw(this.curNode_, this.curNode_);
+    if (this.drawer) {
+      this.drawer.draw(this.curNode, this.curNode);
     }
   }
 
   /** Hide the marker SVG. */
   hide() {
-    if (this.drawer_) {
-      this.drawer_.hide();
+    if (this.drawer) {
+      this.drawer.hide();
     }
   }
 

--- a/core/renderers/common/constants.ts
+++ b/core/renderers/common/constants.ts
@@ -279,7 +279,7 @@ export class ConstantProvider {
    * The defs tag that contains all filters and patterns for this Blockly
    * instance.
    */
-  private defs_: SVGElement|null = null;
+  private defs: SVGElement|null = null;
 
   /**
    * The ID of the emboss filter, or the empty string if no filter is set.
@@ -287,7 +287,7 @@ export class ConstantProvider {
   embossFilterId = '';
 
   /** The <filter> element to use for highlighting, or null if not set. */
-  private embossFilter_: SVGElement|null = null;
+  private embossFilter: SVGElement|null = null;
 
   /**
    * The ID of the disabled pattern, or the empty string if no pattern is set.
@@ -297,7 +297,7 @@ export class ConstantProvider {
   /**
    * The <pattern> element to use for disabled blocks, or null if not set.
    */
-  private disabledPattern_: SVGElement|null = null;
+  private disabledPattern: SVGElement|null = null;
 
   /**
    * The ID of the debug filter, or the empty string if no pattern is set.
@@ -307,10 +307,10 @@ export class ConstantProvider {
   /**
    * The <filter> element to use for a debug highlight, or null if not set.
    */
-  private debugFilter_: SVGElement|null = null;
+  private debugFilter: SVGElement|null = null;
 
   /** The <style> element to use for injecting renderer specific CSS. */
-  private cssNode_: HTMLStyleElement|null = null;
+  private cssNode: HTMLStyleElement|null = null;
 
   /**
    * Cursor colour.
@@ -663,16 +663,16 @@ export class ConstantProvider {
    * Delete all DOM elements that this provider created.
    */
   dispose() {
-    if (this.embossFilter_) {
-      dom.removeNode(this.embossFilter_);
+    if (this.embossFilter) {
+      dom.removeNode(this.embossFilter);
     }
-    if (this.disabledPattern_) {
-      dom.removeNode(this.disabledPattern_);
+    if (this.disabledPattern) {
+      dom.removeNode(this.disabledPattern);
     }
-    if (this.debugFilter_) {
-      dom.removeNode(this.debugFilter_);
+    if (this.debugFilter) {
+      dom.removeNode(this.debugFilter);
     }
-    this.cssNode_ = null;
+    this.cssNode = null;
   }
 
   /**
@@ -887,7 +887,7 @@ export class ConstantProvider {
           ... filters go here ...
         </defs>
         */
-    this.defs_ = dom.createSvgElement(Svg.DEFS, {}, svg);
+    this.defs = dom.createSvgElement(Svg.DEFS, {}, svg);
     /*
           <filter id="blocklyEmbossFilter837493">
             <feGaussianBlur in="SourceAlpha" stdDeviation="1" result="blur" />
@@ -904,7 +904,7 @@ export class ConstantProvider {
         */
     const embossFilter = dom.createSvgElement(
         Svg.FILTER, {'id': 'blocklyEmbossFilter' + this.randomIdentifier},
-        this.defs_);
+        this.defs);
     dom.createSvgElement(
         Svg.FEGAUSSIANBLUR,
         {'in': 'SourceAlpha', 'stdDeviation': 1, 'result': 'blur'},
@@ -942,7 +942,7 @@ export class ConstantProvider {
         },
         embossFilter);
     this.embossFilterId = embossFilter.id;
-    this.embossFilter_ = embossFilter;
+    this.embossFilter = embossFilter;
 
     /*
           <pattern id="blocklyDisabledPattern837493"
@@ -958,14 +958,14 @@ export class ConstantProvider {
           'width': 10,
           'height': 10,
         },
-        this.defs_);
+        this.defs);
     dom.createSvgElement(
         Svg.RECT, {'width': 10, 'height': 10, 'fill': '#aaa'}, disabledPattern);
     dom.createSvgElement(
         Svg.PATH, {'d': 'M 0 0 L 10 10 M 10 0 L 0 10', 'stroke': '#cc0'},
         disabledPattern);
     this.disabledPatternId = disabledPattern.id;
-    this.disabledPattern_ = disabledPattern;
+    this.disabledPattern = disabledPattern;
 
     this.createDebugFilter();
   }
@@ -976,7 +976,7 @@ export class ConstantProvider {
    */
   private createDebugFilter() {
     // Only create the debug filter once.
-    if (!this.debugFilter_) {
+    if (!this.debugFilter) {
       const debugFilter = dom.createSvgElement(
           Svg.FILTER, {
             'id': 'blocklyDebugFilter' + this.randomIdentifier,
@@ -985,7 +985,7 @@ export class ConstantProvider {
             'y': '-30%',
             'x': '-40%',
           },
-          this.defs_);
+          this.defs);
       // Set all gaussian blur pixels to 1 opacity before applying flood
       const debugComponentTransfer = dom.createSvgElement(
           Svg.FECOMPONENTTRANSFER, {'result': 'outBlur'}, debugFilter);
@@ -1010,7 +1010,7 @@ export class ConstantProvider {
           },
           debugFilter);
       this.debugFilterId = debugFilter.id;
-      this.debugFilter_ = debugFilter;
+      this.debugFilter = debugFilter;
     }
   }
 
@@ -1023,11 +1023,11 @@ export class ConstantProvider {
   protected injectCSS_(tagName: string, selector: string) {
     const cssArray = this.getCSS_(selector);
     const cssNodeId = 'blockly-renderer-style-' + tagName;
-    this.cssNode_ = document.getElementById(cssNodeId) as HTMLStyleElement;
+    this.cssNode = document.getElementById(cssNodeId) as HTMLStyleElement;
     const text = cssArray.join('\n');
-    if (this.cssNode_) {
+    if (this.cssNode) {
       // Already injected, update if the theme changed.
-      this.cssNode_.firstChild!.textContent = text;
+      this.cssNode.firstChild!.textContent = text;
       return;
     }
     // Inject CSS tag at start of head.
@@ -1036,7 +1036,7 @@ export class ConstantProvider {
     const cssTextNode = document.createTextNode(text);
     cssNode.appendChild(cssTextNode);
     document.head.insertBefore(cssNode, document.head.firstChild);
-    this.cssNode_ = cssNode;
+    this.cssNode = cssNode;
   }
 
   /**

--- a/core/renderers/common/marker_svg.ts
+++ b/core/renderers/common/marker_svg.ts
@@ -48,7 +48,7 @@ export class MarkerSvg {
    * The workspace, field, or block that the marker SVG element should be
    * attached to.
    */
-  private parent_: IASTNodeLocationSvg|null = null;
+  private parent: IASTNodeLocationSvg|null = null;
 
   /** The current SVG element for the marker. */
   currentMarkerSvg: SVGElement|null = null;
@@ -135,17 +135,17 @@ export class MarkerSvg {
    */
   protected setParent_(newParent: IASTNodeLocationSvg) {
     if (!this.isCursor()) {
-      if (this.parent_) {
-        this.parent_.setMarkerSvg(null);
+      if (this.parent) {
+        this.parent.setMarkerSvg(null);
       }
       newParent.setMarkerSvg(this.getSvgRoot());
     } else {
-      if (this.parent_) {
-        this.parent_.setCursorSvg(null);
+      if (this.parent) {
+        this.parent.setCursorSvg(null);
       }
       newParent.setCursorSvg(this.getSvgRoot());
     }
-    this.parent_ = newParent;
+    this.parent = newParent;
   }
 
   /**
@@ -169,7 +169,7 @@ export class MarkerSvg {
 
     this.showAtLocation_(curNode);
 
-    this.fireMarkerEvent_(oldNode, curNode);
+    this.fireMarkerEvent(oldNode, curNode);
 
     // Ensures the marker will be visible immediately after the move.
     const animate = this.currentMarkerSvg!.childNodes[0];
@@ -216,7 +216,7 @@ export class MarkerSvg {
    *
    * @param curNode The node to draw the marker for.
    */
-  private showWithBlockPrevOutput_(curNode: ASTNode) {
+  private showWithBlockPrevOutput(curNode: ASTNode) {
     const block = curNode.getSourceBlock() as BlockSvg;
     const width = block.width;
     const height = block.height;
@@ -245,7 +245,7 @@ export class MarkerSvg {
    * @param curNode The node to draw the marker for.
    */
   protected showWithBlock_(curNode: ASTNode) {
-    this.showWithBlockPrevOutput_(curNode);
+    this.showWithBlockPrevOutput(curNode);
   }
 
   /**
@@ -254,7 +254,7 @@ export class MarkerSvg {
    * @param curNode The node to draw the marker for.
    */
   protected showWithPrevious_(curNode: ASTNode) {
-    this.showWithBlockPrevOutput_(curNode);
+    this.showWithBlockPrevOutput(curNode);
   }
 
   /**
@@ -263,7 +263,7 @@ export class MarkerSvg {
    * @param curNode The node to draw the marker for.
    */
   protected showWithOutput_(curNode: ASTNode) {
-    this.showWithBlockPrevOutput_(curNode);
+    this.showWithBlockPrevOutput(curNode);
   }
 
   /**
@@ -402,7 +402,7 @@ export class MarkerSvg {
     }
     this.markerBlock_.setAttribute('d', markerPath);
     if (this.workspace.RTL) {
-      this.flipRtl_(this.markerBlock_);
+      this.flipRtl(this.markerBlock_);
     }
     this.currentMarkerSvg = this.markerBlock_;
   }
@@ -467,7 +467,7 @@ export class MarkerSvg {
         svgPaths.lineOnAxis('H', width);
     this.markerBlock_.setAttribute('d', markerPath);
     if (this.workspace.RTL) {
-      this.flipRtl_(this.markerBlock_);
+      this.flipRtl(this.markerBlock_);
     }
     this.currentMarkerSvg = this.markerBlock_;
   }
@@ -497,7 +497,7 @@ export class MarkerSvg {
         svgPaths.lineOnAxis('V', markerHeight);
     this.markerBlock_.setAttribute('d', markerPath);
     if (this.workspace.RTL) {
-      this.flipRtl_(this.markerBlock_);
+      this.flipRtl(this.markerBlock_);
     }
     this.currentMarkerSvg = this.markerBlock_;
   }
@@ -527,7 +527,7 @@ export class MarkerSvg {
    *
    * @param markerSvg The marker that we want to flip.
    */
-  private flipRtl_(markerSvg: SVGElement) {
+  private flipRtl(markerSvg: SVGElement) {
     markerSvg.setAttribute('transform', 'scale(-1 1)');
   }
 
@@ -549,7 +549,7 @@ export class MarkerSvg {
    * @param oldNode The old node the marker used to be on.
    * @param curNode The new node the marker is currently on.
    */
-  private fireMarkerEvent_(oldNode: ASTNode, curNode: ASTNode) {
+  private fireMarkerEvent(oldNode: ASTNode, curNode: ASTNode) {
     const curBlock = curNode.getSourceBlock();
     const event = new (eventUtils.get(eventUtils.MARKER_MOVE))(
         curBlock, this.isCursor(), oldNode, curNode);

--- a/core/renderers/geras/highlighter.ts
+++ b/core/renderers/geras/highlighter.ts
@@ -38,7 +38,7 @@ export class Highlighter {
   RTL_: boolean;
   constants_: ConstantProvider;
   highlightConstants_: HighlightConstantProvider;
-  private readonly highlightOffset_: number;
+  private readonly highlightOffset: number;
   outsideCornerPaths_: OutsideCorner;
   insideCornerPaths_: InsideCorner;
   puzzleTabPaths_: PuzzleTab;
@@ -62,7 +62,7 @@ export class Highlighter {
 
     this.highlightConstants_ = renderer.getHighlightConstants();
     /** The offset between the block's main path and highlight path. */
-    this.highlightOffset_ = this.highlightConstants_.OFFSET;
+    this.highlightOffset = this.highlightConstants_.OFFSET;
 
     this.outsideCornerPaths_ = this.highlightConstants_.OUTSIDE_CORNER;
     this.insideCornerPaths_ = this.highlightConstants_.INSIDE_CORNER;
@@ -103,11 +103,11 @@ export class Highlighter {
         // horizontal, use its width and position for an absolute horizontal
         // move.
         this.steps_ += svgPaths.lineOnAxis(
-            'H', elem.xPos + elem.width - this.highlightOffset_);
+            'H', elem.xPos + elem.width - this.highlightOffset);
       }
     }
 
-    const right = row.xPos + row.width - this.highlightOffset_;
+    const right = row.xPos + row.width - this.highlightOffset;
     this.steps_ += svgPaths.lineOnAxis('H', right);
   }
 
@@ -119,7 +119,7 @@ export class Highlighter {
   drawJaggedEdge_(row: Row) {
     if (this.info_.RTL) {
       const remainder =
-          row.height - this.jaggedTeethPaths_.height - this.highlightOffset_;
+          row.height - this.jaggedTeethPaths_.height - this.highlightOffset;
       this.steps_ +=
           this.jaggedTeethPaths_.pathLeft + svgPaths.lineOnAxis('v', remainder);
     }
@@ -137,7 +137,7 @@ export class Highlighter {
 
       this.steps_ +=
           svgPaths.moveTo(
-              input.xPos + input.width - this.highlightOffset_, row.yPos) +
+              input.xPos + input.width - this.highlightOffset, row.yPos) +
           this.puzzleTabPaths_.pathDown(this.RTL_) +
           svgPaths.lineOnAxis('v', belowTabHeight);
     } else {
@@ -176,15 +176,15 @@ export class Highlighter {
    * @param row The row to highlight.
    */
   drawRightSideRow(row: Row) {
-    const rightEdge = row.xPos + row.width - this.highlightOffset_;
+    const rightEdge = row.xPos + row.width - this.highlightOffset;
     if (row instanceof SpacerRow && row.followsStatement) {
       this.steps_ += svgPaths.lineOnAxis('H', rightEdge);
     }
     if (this.RTL_) {
       this.steps_ += svgPaths.lineOnAxis('H', rightEdge);
-      if (row.height > this.highlightOffset_) {
+      if (row.height > this.highlightOffset) {
         this.steps_ += svgPaths.lineOnAxis(
-            'V', row.yPos + row.height - this.highlightOffset_);
+            'V', row.yPos + row.height - this.highlightOffset);
       }
     }
   }
@@ -199,13 +199,13 @@ export class Highlighter {
     // Highlighting is always from the top left, both in LTR and RTL.
     if (this.RTL_) {
       this.steps_ +=
-          svgPaths.lineOnAxis('V', row.baseline - this.highlightOffset_);
+          svgPaths.lineOnAxis('V', row.baseline - this.highlightOffset);
     } else {
       const cornerElem = this.info_.bottomRow.elements[0];
       if (Types.isLeftSquareCorner(cornerElem)) {
         this.steps_ += svgPaths.moveTo(
-            row.xPos + this.highlightOffset_,
-            row.baseline - this.highlightOffset_);
+            row.xPos + this.highlightOffset,
+            row.baseline - this.highlightOffset);
       } else if (Types.isLeftRoundedCorner(cornerElem)) {
         this.steps_ += svgPaths.moveTo(row.xPos, row.baseline);
         this.steps_ += this.outsideCornerPaths_.bottomLeft();
@@ -225,8 +225,8 @@ export class Highlighter {
       if (this.RTL_) {
         this.steps_ += svgPaths.moveTo(this.info_.startX, tabBottom);
       } else {
-        const left = this.info_.startX + this.highlightOffset_;
-        const bottom = this.info_.bottomRow.baseline - this.highlightOffset_;
+        const left = this.info_.startX + this.highlightOffset;
+        const bottom = this.info_.bottomRow.baseline - this.highlightOffset;
         this.steps_ += svgPaths.moveTo(left, bottom);
         this.steps_ += svgPaths.lineOnAxis('V', tabBottom);
       }
@@ -240,7 +240,7 @@ export class Highlighter {
             svgPaths.lineOnAxis('V', this.outsideCornerPaths_.height);
       } else {
         this.steps_ +=
-            svgPaths.lineOnAxis('V', topRow.capline + this.highlightOffset_);
+            svgPaths.lineOnAxis('V', topRow.capline + this.highlightOffset);
       }
     }
   }
@@ -251,7 +251,7 @@ export class Highlighter {
    * @param input The input to highlight.
    */
   drawInlineInput(input: InlineInput) {
-    const offset = this.highlightOffset_;
+    const offset = this.highlightOffset;
 
     // Relative to the block's left.
     const connectionRight = input.xPos + input.connectionWidth;

--- a/core/renderers/geras/renderer.ts
+++ b/core/renderers/geras/renderer.ts
@@ -30,7 +30,7 @@ import {PathObject} from './path_object.js';
  */
 export class Renderer extends BaseRenderer {
   /** The renderer's highlight constant provider. */
-  private highlightConstants_: HighlightConstantProvider|null = null;
+  private highlightConstants: HighlightConstantProvider|null = null;
 
   /**
    * @param name The renderer name.
@@ -46,8 +46,8 @@ export class Renderer extends BaseRenderer {
   override init(
       theme: Theme, opt_rendererOverrides?: {[rendererConstant: string]: any}) {
     super.init(theme, opt_rendererOverrides);
-    this.highlightConstants_ = this.makeHighlightConstants_();
-    this.highlightConstants_.init();
+    this.highlightConstants = this.makeHighlightConstants_();
+    this.highlightConstants.init();
   }
 
   override refreshDom(svg: SVGElement, theme: Theme) {
@@ -110,12 +110,12 @@ export class Renderer extends BaseRenderer {
    * @returns The highlight constant provider.
    */
   getHighlightConstants(): HighlightConstantProvider {
-    if (!this.highlightConstants_) {
+    if (!this.highlightConstants) {
       throw new Error(
           'Cannot access the highlight constants because init has not ' +
           'been called');
     }
-    return this.highlightConstants_;
+    return this.highlightConstants;
   }
 }
 

--- a/core/renderers/zelos/constants.ts
+++ b/core/renderers/zelos/constants.ts
@@ -122,7 +122,7 @@ export class ConstantProvider extends BaseConstantProvider {
   /**
    * The <filter> element to use for a selected glow, or null if not set.
    */
-  private selectedGlowFilter_: SVGElement|null = null;
+  private selectedGlowFilter: SVGElement|null = null;
 
   /**
    * The ID of the replacement glow filter, or the empty string if no filter
@@ -133,7 +133,7 @@ export class ConstantProvider extends BaseConstantProvider {
   /**
    * The <filter> element to use for a replacement glow, or null if not set.
    */
-  private replacementGlowFilter_: SVGElement|null = null;
+  private replacementGlowFilter: SVGElement|null = null;
 
   /**
    * The object containing information about the hexagon used for a boolean
@@ -270,11 +270,11 @@ export class ConstantProvider extends BaseConstantProvider {
 
   override dispose() {
     super.dispose();
-    if (this.selectedGlowFilter_) {
-      dom.removeNode(this.selectedGlowFilter_);
+    if (this.selectedGlowFilter) {
+      dom.removeNode(this.selectedGlowFilter);
     }
-    if (this.replacementGlowFilter_) {
-      dom.removeNode(this.replacementGlowFilter_);
+    if (this.replacementGlowFilter) {
+      dom.removeNode(this.replacementGlowFilter);
     }
   }
 
@@ -673,7 +673,7 @@ export class ConstantProvider extends BaseConstantProvider {
         },
         selectedGlowFilter);
     this.selectedGlowFilterId = selectedGlowFilter.id;
-    this.selectedGlowFilter_ = selectedGlowFilter;
+    this.selectedGlowFilter = selectedGlowFilter;
 
     // Using a dilate distorts the block shape.
     // Instead use a gaussian blur, and then set all alpha to 1 with a transfer.
@@ -721,7 +721,7 @@ export class ConstantProvider extends BaseConstantProvider {
         },
         replacementGlowFilter);
     this.replacementGlowFilterId = replacementGlowFilter.id;
-    this.replacementGlowFilter_ = replacementGlowFilter;
+    this.replacementGlowFilter = replacementGlowFilter;
   }
 
   override getCSS_(selector: string) {

--- a/core/renderers/zelos/info.ts
+++ b/core/renderers/zelos/info.ts
@@ -48,7 +48,7 @@ export class RenderInfo extends BaseRenderInfo {
   isMultiRow: boolean;
   hasStatementInput: boolean;
   rightSide: RightConnectionShape|null;
-  private readonly rightAlignedDummyInputs_: WeakMap<Row, Input>;
+  private readonly rightAlignedDummyInputs: WeakMap<Row, Input>;
 
   /**
    * @param renderer The renderer in use.
@@ -93,7 +93,7 @@ export class RenderInfo extends BaseRenderInfo {
      * A map of rows to right aligned dummy inputs within those rows. Used to
      * add padding between left and right aligned inputs.
      */
-    this.rightAlignedDummyInputs_ = new WeakMap();
+    this.rightAlignedDummyInputs = new WeakMap();
   }
 
   /**
@@ -246,7 +246,7 @@ export class RenderInfo extends BaseRenderInfo {
     // padding later.
     if (input.type === inputTypes.DUMMY && activeRow.hasDummyInput &&
         activeRow.align === Align.LEFT && input.align === Align.RIGHT) {
-      this.rightAlignedDummyInputs_.set(activeRow, input);
+      this.rightAlignedDummyInputs.set(activeRow, input);
     } else if (input.type === inputTypes.STATEMENT) {
       // Handle statements without next connections correctly.
       activeRow.elements.push(new StatementInput(this.constants_, input));
@@ -261,7 +261,7 @@ export class RenderInfo extends BaseRenderInfo {
   }
 
   override addAlignmentPadding_(row: Row, missingSpace: number) {
-    if (this.rightAlignedDummyInputs_.get(row)) {
+    if (this.rightAlignedDummyInputs.get(row)) {
       let alignmentDivider;
       for (let i = 0; i < row.elements.length; i++) {
         const elem = row.elements[i];
@@ -269,7 +269,7 @@ export class RenderInfo extends BaseRenderInfo {
           alignmentDivider = elem;
         }
         if (Types.isField(elem) && elem instanceof Field &&
-            elem.parentInput === this.rightAlignedDummyInputs_.get(row)) {
+            elem.parentInput === this.rightAlignedDummyInputs.get(row)) {
           break;
         }
       }

--- a/core/renderers/zelos/marker_svg.ts
+++ b/core/renderers/zelos/marker_svg.ts
@@ -27,7 +27,7 @@ export class MarkerSvg extends BaseMarkerSvg {
   // TODO(b/109816955): remove '!', see go/strict-prop-init-fix.
   constants_!: ZelosConstantProvider;
 
-  private markerCircle_: SVGCircleElement|null = null;
+  private markerCircle: SVGCircleElement|null = null;
 
   /**
    * @param workspace The workspace the marker belongs to.
@@ -45,22 +45,22 @@ export class MarkerSvg extends BaseMarkerSvg {
    *
    * @param curNode The node to draw the marker for.
    */
-  private showWithInputOutput_(curNode: ASTNode) {
+  private showWithInputOutput(curNode: ASTNode) {
     const block = curNode.getSourceBlock() as BlockSvg;
     const connection = curNode.getLocation() as RenderedConnection;
     const offsetInBlock = connection.getOffsetInBlock();
 
-    this.positionCircle_(offsetInBlock.x, offsetInBlock.y);
+    this.positionCircle(offsetInBlock.x, offsetInBlock.y);
     this.setParent_(block);
     this.showCurrent_();
   }
 
   override showWithOutput_(curNode: ASTNode) {
-    this.showWithInputOutput_(curNode);
+    this.showWithInputOutput(curNode);
   }
 
   override showWithInput_(curNode: ASTNode) {
-    this.showWithInputOutput_(curNode);
+    this.showWithInputOutput(curNode);
   }
 
   /**
@@ -86,16 +86,16 @@ export class MarkerSvg extends BaseMarkerSvg {
    * @param x The x position of the circle.
    * @param y The y position of the circle.
    */
-  private positionCircle_(x: number, y: number) {
-    this.markerCircle_?.setAttribute('cx', `${x}`);
-    this.markerCircle_?.setAttribute('cy', `${y}`);
-    this.currentMarkerSvg = this.markerCircle_;
+  private positionCircle(x: number, y: number) {
+    this.markerCircle?.setAttribute('cx', `${x}`);
+    this.markerCircle?.setAttribute('cy', `${y}`);
+    this.currentMarkerSvg = this.markerCircle;
   }
 
   override hide() {
     super.hide();
-    if (this.markerCircle_) {
-      this.markerCircle_.style.display = 'none';
+    if (this.markerCircle) {
+      this.markerCircle.style.display = 'none';
     }
   }
 
@@ -112,7 +112,7 @@ export class MarkerSvg extends BaseMarkerSvg {
     /* clang-format on */
     super.createDomInternal_();
 
-    this.markerCircle_ = dom.createSvgElement(
+    this.markerCircle = dom.createSvgElement(
         Svg.CIRCLE, {
           'r': this.constants_.CURSOR_RADIUS,
           'style': 'display: none',
@@ -123,7 +123,7 @@ export class MarkerSvg extends BaseMarkerSvg {
     // Markers and stack cursors don't blink.
     if (this.isCursor()) {
       const blinkProperties = this.getBlinkProperties_();
-      dom.createSvgElement(Svg.ANIMATE, blinkProperties, this.markerCircle_!);
+      dom.createSvgElement(Svg.ANIMATE, blinkProperties, this.markerCircle!);
     }
 
     return this.markerSvg_!;
@@ -132,12 +132,12 @@ export class MarkerSvg extends BaseMarkerSvg {
   override applyColour_(curNode: ASTNode) {
     super.applyColour_(curNode);
 
-    this.markerCircle_?.setAttribute('fill', this.colour_);
-    this.markerCircle_?.setAttribute('stroke', this.colour_);
+    this.markerCircle?.setAttribute('fill', this.colour_);
+    this.markerCircle?.setAttribute('stroke', this.colour_);
 
     if (this.isCursor()) {
       const values = this.colour_ + ';transparent;transparent;';
-      this.markerCircle_?.firstElementChild!.setAttribute('values', values);
+      this.markerCircle?.firstElementChild!.setAttribute('values', values);
     }
   }
 }

--- a/core/renderers/zelos/path_object.ts
+++ b/core/renderers/zelos/path_object.ts
@@ -23,7 +23,7 @@ import type {ConstantProvider} from './constants.js';
  */
 export class PathObject extends BasePathObject {
   /** The selected path of the block. */
-  private svgPathSelected_: SVGElement|null = null;
+  private svgPathSelected: SVGElement|null = null;
 
   /** The outline paths on the block. */
   private readonly outlines = new Map<string, SVGElement>();
@@ -58,8 +58,8 @@ export class PathObject extends BasePathObject {
 
   override setPath(pathString: string) {
     super.setPath(pathString);
-    if (this.svgPathSelected_) {
-      this.svgPathSelected_.setAttribute('d', pathString);
+    if (this.svgPathSelected) {
+      this.svgPathSelected.setAttribute('d', pathString);
     }
   }
 
@@ -88,17 +88,17 @@ export class PathObject extends BasePathObject {
   override updateSelected(enable: boolean) {
     this.setClass_('blocklySelected', enable);
     if (enable) {
-      if (!this.svgPathSelected_) {
-        this.svgPathSelected_ = this.svgPath.cloneNode(true) as SVGElement;
-        this.svgPathSelected_.setAttribute('fill', 'none');
-        this.svgPathSelected_.setAttribute(
+      if (!this.svgPathSelected) {
+        this.svgPathSelected = this.svgPath.cloneNode(true) as SVGElement;
+        this.svgPathSelected.setAttribute('fill', 'none');
+        this.svgPathSelected.setAttribute(
             'filter', 'url(#' + this.constants.selectedGlowFilterId + ')');
-        this.svgRoot.appendChild(this.svgPathSelected_);
+        this.svgRoot.appendChild(this.svgPathSelected);
       }
     } else {
-      if (this.svgPathSelected_) {
-        this.svgRoot.removeChild(this.svgPathSelected_);
-        this.svgPathSelected_ = null;
+      if (this.svgPathSelected) {
+        this.svgRoot.removeChild(this.svgPathSelected);
+        this.svgPathSelected = null;
       }
     }
   }
@@ -115,7 +115,7 @@ export class PathObject extends BasePathObject {
 
   override updateShapeForInputHighlight(conn: Connection, enable: boolean) {
     const name = conn.getParentInput()!.name;
-    const outlinePath = this.getOutlinePath_(name);
+    const outlinePath = this.getOutlinePath(name);
     if (!outlinePath) {
       return;
     }
@@ -145,7 +145,7 @@ export class PathObject extends BasePathObject {
     // remove them.
     if (this.remainingOutlines.size) {
       for (const key of this.remainingOutlines) {
-        this.removeOutlinePath_(key);
+        this.removeOutlinePath(key);
       }
     }
     this.remainingOutlines.clear();
@@ -159,7 +159,7 @@ export class PathObject extends BasePathObject {
    * @param pathString The path.
    */
   setOutlinePath(name: string, pathString: string) {
-    const outline = this.getOutlinePath_(name);
+    const outline = this.getOutlinePath(name);
     outline.setAttribute('d', pathString);
     outline.setAttribute('fill', this.style.colourTertiary);
   }
@@ -170,7 +170,7 @@ export class PathObject extends BasePathObject {
    * @param name The input name.
    * @returns The SVG outline path.
    */
-  private getOutlinePath_(name: string): SVGElement {
+  private getOutlinePath(name: string): SVGElement {
     if (!this.outlines.has(name)) {
       this.outlines.set(
           name,
@@ -193,7 +193,7 @@ export class PathObject extends BasePathObject {
    *
    * @param name The input name.
    */
-  private removeOutlinePath_(name: string) {
+  private removeOutlinePath(name: string) {
     this.outlines.get(name)?.parentNode?.removeChild(this.outlines.get(name)!);
     this.outlines.delete(name);
   }

--- a/tests/mocha/astnode_test.js
+++ b/tests/mocha/astnode_test.js
@@ -100,70 +100,70 @@ suite('ASTNode', function() {
   });
 
   suite('HelperFunctions', function() {
-    test('findNextForInput_', function() {
+    test('findNextForInput', function() {
       const input = this.blocks.statementInput1.inputList[0];
       const input2 = this.blocks.statementInput1.inputList[1];
       const connection = input.connection;
       const node = ASTNode.createConnectionNode(connection);
-      const newASTNode = node.findNextForInput_(input);
+      const newASTNode = node.findNextForInput(input);
       chai.assert.equal(newASTNode.getLocation(), input2.connection);
     });
 
-    test('findPrevForInput_', function() {
+    test('findPrevForInput', function() {
       const input = this.blocks.statementInput1.inputList[0];
       const input2 = this.blocks.statementInput1.inputList[1];
       const connection = input2.connection;
       const node = ASTNode.createConnectionNode(connection);
-      const newASTNode = node.findPrevForInput_(input2);
+      const newASTNode = node.findPrevForInput(input2);
       chai.assert.equal(newASTNode.getLocation(), input.connection);
     });
 
-    test('findNextForField_', function() {
+    test('findNextForField', function() {
       const field = this.blocks.statementInput1.inputList[0].fieldRow[0];
       const field2 = this.blocks.statementInput1.inputList[0].fieldRow[1];
       const node = ASTNode.createFieldNode(field);
-      const newASTNode = node.findNextForField_(field);
+      const newASTNode = node.findNextForField(field);
       chai.assert.equal(newASTNode.getLocation(), field2);
     });
 
-    test('findPrevForField_', function() {
+    test('findPrevForField', function() {
       const field = this.blocks.statementInput1.inputList[0].fieldRow[0];
       const field2 = this.blocks.statementInput1.inputList[0].fieldRow[1];
       const node = ASTNode.createFieldNode(field2);
-      const newASTNode = node.findPrevForField_(field2);
+      const newASTNode = node.findPrevForField(field2);
       chai.assert.equal(newASTNode.getLocation(), field);
     });
 
     test('navigateBetweenStacks_Forward', function() {
       const node = new ASTNode(
           ASTNode.types.NEXT, this.blocks.statementInput1.nextConnection);
-      const newASTNode = node.navigateBetweenStacks_(true);
+      const newASTNode = node.navigateBetweenStacks(true);
       chai.assert.equal(newASTNode.getLocation(), this.blocks.statementInput4);
     });
 
     test('navigateBetweenStacks_Backward', function() {
       const node = new ASTNode(
           ASTNode.types.BLOCK, this.blocks.statementInput4);
-      const newASTNode = node.navigateBetweenStacks_(false);
+      const newASTNode = node.navigateBetweenStacks(false);
       chai.assert.equal(newASTNode.getLocation(), this.blocks.statementInput1);
     });
-    test('getOutAstNodeForBlock_', function() {
+    test('getOutAstNodeForBlock', function() {
       const node = new ASTNode(
           ASTNode.types.BLOCK, this.blocks.statementInput2);
-      const newASTNode = node.getOutAstNodeForBlock_(this.blocks.statementInput2);
+      const newASTNode = node.getOutAstNodeForBlock(this.blocks.statementInput2);
       chai.assert.equal(newASTNode.getLocation(), this.blocks.statementInput1);
     });
     test('getOutAstNodeForBlock_OneBlock', function() {
       const node = new ASTNode(
           ASTNode.types.BLOCK, this.blocks.statementInput4);
-      const newASTNode = node.getOutAstNodeForBlock_(this.blocks.statementInput4);
+      const newASTNode = node.getOutAstNodeForBlock(this.blocks.statementInput4);
       chai.assert.equal(newASTNode.getLocation(), this.blocks.statementInput4);
     });
     test('findFirstFieldOrInput_', function() {
       const node = new ASTNode(
           ASTNode.types.BLOCK, this.blocks.statementInput4);
       const field = this.blocks.statementInput4.inputList[0].fieldRow[0];
-      const newASTNode = node.findFirstFieldOrInput_(this.blocks.statementInput4);
+      const newASTNode = node.findFirstFieldOrInput(this.blocks.statementInput4);
       chai.assert.equal(newASTNode.getLocation(), field);
     });
   });
@@ -661,8 +661,8 @@ suite('ASTNode', function() {
         const node = ASTNode.createStackNode(this.blocks.statementInput4);
         const outNode = node.out();
         chai.assert.equal(outNode.getType(), ASTNode.types.WORKSPACE);
-        chai.assert.equal(outNode.wsCoordinate_.x, 10);
-        chai.assert.equal(outNode.wsCoordinate_.y, -10);
+        chai.assert.equal(outNode.wsCoordinate.x, 10);
+        chai.assert.equal(outNode.wsCoordinate.y, -10);
         stub.restore();
       });
       test('fromPreviousToInput', function() {

--- a/tests/mocha/cursor_test.js
+++ b/tests/mocha/cursor_test.js
@@ -69,7 +69,7 @@ suite('Cursor', function() {
     blockA.nextConnection.connect(blockB.previousConnection);
     blockA.inputList[0].connection.connect(blockE.outputConnection);
     blockB.inputList[1].connection.connect(blockC.previousConnection);
-    this.cursor.drawer_ = null;
+    this.cursor.drawer = null;
     this.blocks = {
       A: blockA,
       B: blockB,


### PR DESCRIPTION
## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [x] I ran `npm run format` and `npm run lint`

## The details
### Resolves

Part of https://github.com/google/blockly/issues/6548

### Proposed Changes
Remove underscores from private property and method names. Fix uses in tests. Note that the tests are still accessing private properties. I decided not to add getters that would only exist for tests.
