### PR TITLE
chore: remove underscores from private properties and methods in some fields

### DIFF
--- a/core/field_checkbox.ts
+++ b/core/field_checkbox.ts
@@ -28,7 +28,7 @@ type CheckboxBool = BoolString|boolean;
 export class FieldCheckbox extends Field<CheckboxBool> {
   /** Default character for the checkmark. */
   static readonly CHECK_CHAR = '✓';
-  private checkChar_: string;
+  private checkChar: string;
 
   /**
    * Serializable fields are saved by the serializer, non-serializable fields
@@ -70,7 +70,7 @@ export class FieldCheckbox extends Field<CheckboxBool> {
      * Character for the check mark. Used to apply a different check mark
      * character to individual fields.
      */
-    this.checkChar_ = FieldCheckbox.CHECK_CHAR;
+    this.checkChar = FieldCheckbox.CHECK_CHAR;
 
     if (value === Field.SKIP_SETUP) return;
     if (config) {
@@ -89,7 +89,7 @@ export class FieldCheckbox extends Field<CheckboxBool> {
    */
   protected override configure_(config: FieldCheckboxConfig) {
     super.configure_(config);
-    if (config.checkCharacter) this.checkChar_ = config.checkCharacter;
+    if (config.checkCharacter) this.checkChar = config.checkCharacter;
   }
 
   /**
@@ -127,7 +127,7 @@ export class FieldCheckbox extends Field<CheckboxBool> {
   }
 
   override getDisplayText_() {
-    return this.checkChar_;
+    return this.checkChar;
   }
 
   /**
@@ -137,7 +137,7 @@ export class FieldCheckbox extends Field<CheckboxBool> {
    *     the default.
    */
   setCheckCharacter(character: string|null) {
-    this.checkChar_ = character || FieldCheckbox.CHECK_CHAR;
+    this.checkChar = character || FieldCheckbox.CHECK_CHAR;
     this.forceRerender();
   }
 

--- a/core/field_dropdown.ts
+++ b/core/field_dropdown.ts
@@ -44,7 +44,7 @@ export class FieldDropdown extends Field<string> {
   static ARROW_CHAR = '▾';
 
   /** A reference to the currently selected menu item. */
-  private selectedMenuItem_: MenuItem|null = null;
+  private selectedMenuItem: MenuItem|null = null;
 
   /** The dropdown menu. */
   protected menu_: Menu|null = null;
@@ -52,13 +52,13 @@ export class FieldDropdown extends Field<string> {
   /**
    * SVG image element if currently selected option is an image, or null.
    */
-  private imageElement_: SVGImageElement|null = null;
+  private imageElement: SVGImageElement|null = null;
 
   /** Tspan based arrow element. */
-  private arrow_: SVGTSpanElement|null = null;
+  private arrow: SVGTSpanElement|null = null;
 
   /** SVG based arrow element. */
-  private svgArrow_: SVGElement|null = null;
+  private svgArrow: SVGElement|null = null;
 
   /**
    * Serializable fields are saved by the serializer, non-serializable fields
@@ -72,7 +72,7 @@ export class FieldDropdown extends Field<string> {
   protected menuGenerator_?: MenuGenerator;
 
   /** A cache of the most recently generated options. */
-  private generatedOptions_: MenuOption[]|null = null;
+  private generatedOptions: MenuOption[]|null = null;
 
   /**
    * The prefix field label, of common words set after options are trimmed.
@@ -88,7 +88,7 @@ export class FieldDropdown extends Field<string> {
    */
   override suffixField: string|null = null;
   // TODO(b/109816955): remove '!', see go/strict-prop-init-fix.
-  private selectedOption_!: MenuOption;
+  private selectedOption!: MenuOption;
   override clickTarget_: SVGElement|null = null;
 
   /**
@@ -137,12 +137,12 @@ export class FieldDropdown extends Field<string> {
      * The currently selected option. The field is initialized with the
      * first option selected.
      */
-    this.selectedOption_ = this.getOptions(false)[0];
+    this.selectedOption = this.getOptions(false)[0];
 
     if (config) {
       this.configure_(config);
     }
-    this.setValue(this.selectedOption_[1]);
+    this.setValue(this.selectedOption[1]);
     if (validator) {
       this.setValidator(validator);
     }
@@ -191,7 +191,7 @@ export class FieldDropdown extends Field<string> {
     }
     this.createTextElement_();
 
-    this.imageElement_ = dom.createSvgElement(Svg.IMAGE, {}, this.fieldGroup_);
+    this.imageElement = dom.createSvgElement(Svg.IMAGE, {}, this.fieldGroup_);
 
     if (this.getConstants()!.FIELD_DROPDOWN_SVG_ARROW) {
       this.createSVGArrow_();
@@ -217,26 +217,26 @@ export class FieldDropdown extends Field<string> {
 
   /** Create a tspan based arrow. */
   protected createTextArrow_() {
-    this.arrow_ = dom.createSvgElement(Svg.TSPAN, {}, this.textElement_);
-    this.arrow_!.appendChild(document.createTextNode(
+    this.arrow = dom.createSvgElement(Svg.TSPAN, {}, this.textElement_);
+    this.arrow!.appendChild(document.createTextNode(
         this.getSourceBlock()?.RTL ? FieldDropdown.ARROW_CHAR + ' ' :
                                      ' ' + FieldDropdown.ARROW_CHAR));
     if (this.getSourceBlock()?.RTL) {
-      this.getTextElement().insertBefore(this.arrow_, this.textContent_);
+      this.getTextElement().insertBefore(this.arrow, this.textContent_);
     } else {
-      this.getTextElement().appendChild(this.arrow_);
+      this.getTextElement().appendChild(this.arrow);
     }
   }
 
   /** Create an SVG based arrow. */
   protected createSVGArrow_() {
-    this.svgArrow_ = dom.createSvgElement(
+    this.svgArrow = dom.createSvgElement(
         Svg.IMAGE, {
           'height': this.getConstants()!.FIELD_DROPDOWN_SVG_ARROW_SIZE + 'px',
           'width': this.getConstants()!.FIELD_DROPDOWN_SVG_ARROW_SIZE + 'px',
         },
         this.fieldGroup_);
-    this.svgArrow_!.setAttributeNS(
+    this.svgArrow!.setAttributeNS(
         dom.XLINK_NS, 'xlink:href',
         this.getConstants()!.FIELD_DROPDOWN_SVG_ARROW_DATAURI);
   }
@@ -252,7 +252,7 @@ export class FieldDropdown extends Field<string> {
     if (!block) {
       throw new UnattachedFieldError();
     }
-    this.dropdownCreate_();
+    this.dropdownCreate();
     if (e && typeof e.clientX === 'number') {
       this.menu_!.openingCoords = new Coordinate(e.clientX, e.clientY);
     } else {
@@ -281,10 +281,10 @@ export class FieldDropdown extends Field<string> {
     // view. See issue #1329.
     this.menu_!.focus();
 
-    if (this.selectedMenuItem_) {
-      this.menu_!.setHighlighted(this.selectedMenuItem_);
+    if (this.selectedMenuItem) {
+      this.menu_!.setHighlighted(this.selectedMenuItem);
       style.scrollIntoContainerView(
-          this.selectedMenuItem_.getElement()!, dropDownDiv.getContentDiv(),
+          this.selectedMenuItem.getElement()!, dropDownDiv.getContentDiv(),
           true);
     }
 
@@ -292,7 +292,7 @@ export class FieldDropdown extends Field<string> {
   }
 
   /** Create the dropdown editor. */
-  private dropdownCreate_() {
+  private dropdownCreate() {
     const block = this.getSourceBlock();
     if (!block) {
       throw new UnattachedFieldError();
@@ -302,7 +302,7 @@ export class FieldDropdown extends Field<string> {
     this.menu_ = menu;
 
     const options = this.getOptions(false);
-    this.selectedMenuItem_ = null;
+    this.selectedMenuItem = null;
     for (let i = 0; i < options.length; i++) {
       const [label, value] = options[i];
       const content = (() => {
@@ -322,9 +322,9 @@ export class FieldDropdown extends Field<string> {
       menu.addChild(menuItem);
       menuItem.setChecked(value === this.value_);
       if (value === this.value_) {
-        this.selectedMenuItem_ = menuItem;
+        this.selectedMenuItem = menuItem;
       }
-      menuItem.onAction(this.handleMenuActionEvent_, this);
+      menuItem.onAction(this.handleMenuActionEvent, this);
     }
   }
 
@@ -336,7 +336,7 @@ export class FieldDropdown extends Field<string> {
       this.menu_.dispose();
     }
     this.menu_ = null;
-    this.selectedMenuItem_ = null;
+    this.selectedMenuItem = null;
     this.applyColour();
   }
 
@@ -345,7 +345,7 @@ export class FieldDropdown extends Field<string> {
    *
    * @param menuItem The MenuItem selected within menu.
    */
-  private handleMenuActionEvent_(menuItem: MenuItem) {
+  private handleMenuActionEvent(menuItem: MenuItem) {
     dropDownDiv.hideIfOwner(this, true);
     this.onItemSelected_(this.menu_ as Menu, menuItem);
   }
@@ -384,11 +384,11 @@ export class FieldDropdown extends Field<string> {
       throw TypeError('A menu generator was never defined.');
     }
     if (Array.isArray(this.menuGenerator_)) return this.menuGenerator_;
-    if (useCache && this.generatedOptions_) return this.generatedOptions_;
+    if (useCache && this.generatedOptions) return this.generatedOptions;
 
-    this.generatedOptions_ = this.menuGenerator_();
-    validateOptions(this.generatedOptions_);
-    return this.generatedOptions_;
+    this.generatedOptions = this.menuGenerator_();
+    validateOptions(this.generatedOptions);
+    return this.generatedOptions;
   }
 
   /**
@@ -424,7 +424,7 @@ export class FieldDropdown extends Field<string> {
     const options = this.getOptions(true);
     for (let i = 0, option; option = options[i]; i++) {
       if (option[1] === this.value_) {
-        this.selectedOption_ = option;
+        this.selectedOption = option;
       }
     }
   }
@@ -445,11 +445,11 @@ export class FieldDropdown extends Field<string> {
       }
     }
     // Update arrow's colour.
-    if (this.sourceBlock_ && this.arrow_) {
+    if (this.sourceBlock_ && this.arrow) {
       if (this.sourceBlock_.isShadow()) {
-        this.arrow_.style.fill = style.colourSecondary;
+        this.arrow.style.fill = style.colourSecondary;
       } else {
-        this.arrow_.style.fill = style.colourPrimary;
+        this.arrow.style.fill = style.colourPrimary;
       }
     }
   }
@@ -458,14 +458,14 @@ export class FieldDropdown extends Field<string> {
   protected override render_() {
     // Hide both elements.
     this.getTextContent().nodeValue = '';
-    this.imageElement_!.style.display = 'none';
+    this.imageElement!.style.display = 'none';
 
     // Show correct element.
-    const option = this.selectedOption_ && this.selectedOption_[0];
+    const option = this.selectedOption && this.selectedOption[0];
     if (option && typeof option === 'object') {
-      this.renderSelectedImage_(option);
+      this.renderSelectedImage(option);
     } else {
-      this.renderSelectedText_();
+      this.renderSelectedText();
     }
 
     this.positionBorderRect_();
@@ -476,16 +476,16 @@ export class FieldDropdown extends Field<string> {
    *
    * @param imageJson Selected option that must be an image.
    */
-  private renderSelectedImage_(imageJson: ImageProperties) {
+  private renderSelectedImage(imageJson: ImageProperties) {
     const block = this.getSourceBlock();
     if (!block) {
       throw new UnattachedFieldError();
     }
-    this.imageElement_!.style.display = '';
-    this.imageElement_!.setAttributeNS(
+    this.imageElement!.style.display = '';
+    this.imageElement!.setAttributeNS(
         dom.XLINK_NS, 'xlink:href', imageJson.src);
-    this.imageElement_!.setAttribute('height', String(imageJson.height));
-    this.imageElement_!.setAttribute('width', String(imageJson.width));
+    this.imageElement!.setAttribute('height', String(imageJson.height));
+    this.imageElement!.setAttribute('width', String(imageJson.width));
 
     const imageHeight = Number(imageJson.height);
     const imageWidth = Number(imageJson.width);
@@ -498,13 +498,13 @@ export class FieldDropdown extends Field<string> {
     const xPadding =
         hasBorder ? this.getConstants()!.FIELD_BORDER_RECT_X_PADDING : 0;
     let arrowWidth = 0;
-    if (this.svgArrow_) {
-      arrowWidth = this.positionSVGArrow_(
+    if (this.svgArrow) {
+      arrowWidth = this.positionSVGArrow(
           imageWidth + xPadding,
           height / 2 - this.getConstants()!.FIELD_DROPDOWN_SVG_ARROW_SIZE / 2);
     } else {
       arrowWidth = dom.getFastTextWidth(
-          this.arrow_ as SVGTSpanElement,
+          this.arrow as SVGTSpanElement,
           this.getConstants()!.FIELD_TEXT_FONTSIZE,
           this.getConstants()!.FIELD_TEXT_FONTWEIGHT,
           this.getConstants()!.FIELD_TEXT_FONTFAMILY);
@@ -515,19 +515,19 @@ export class FieldDropdown extends Field<string> {
     let arrowX = 0;
     if (block.RTL) {
       const imageX = xPadding + arrowWidth;
-      this.imageElement_!.setAttribute('x', `${imageX}`);
+      this.imageElement!.setAttribute('x', `${imageX}`);
     } else {
       arrowX = imageWidth + arrowWidth;
       this.getTextElement().setAttribute('text-anchor', 'end');
-      this.imageElement_!.setAttribute('x', `${xPadding}`);
+      this.imageElement!.setAttribute('x', `${xPadding}`);
     }
-    this.imageElement_!.setAttribute('y', String(height / 2 - imageHeight / 2));
+    this.imageElement!.setAttribute('y', String(height / 2 - imageHeight / 2));
 
     this.positionTextElement_(arrowX + xPadding, imageWidth + arrowWidth);
   }
 
   /** Renders the selected option, which must be text. */
-  private renderSelectedText_() {
+  private renderSelectedText() {
     // Retrieves the selected option to display through getText_.
     this.getTextContent().nodeValue = this.getDisplayText_();
     const textElement = this.getTextElement();
@@ -546,8 +546,8 @@ export class FieldDropdown extends Field<string> {
     const xPadding =
         hasBorder ? this.getConstants()!.FIELD_BORDER_RECT_X_PADDING : 0;
     let arrowWidth = 0;
-    if (this.svgArrow_) {
-      arrowWidth = this.positionSVGArrow_(
+    if (this.svgArrow) {
+      arrowWidth = this.positionSVGArrow(
           textWidth + xPadding,
           height / 2 - this.getConstants()!.FIELD_DROPDOWN_SVG_ARROW_SIZE / 2);
     }
@@ -564,8 +564,8 @@ export class FieldDropdown extends Field<string> {
    * @param y Y position the arrow is being rendered at, in px.
    * @returns Amount of space the arrow is taking up, in px.
    */
-  private positionSVGArrow_(x: number, y: number): number {
-    if (!this.svgArrow_) {
+  private positionSVGArrow(x: number, y: number): number {
+    if (!this.svgArrow) {
       return 0;
     }
     const block = this.getSourceBlock();
@@ -578,7 +578,7 @@ export class FieldDropdown extends Field<string> {
     const textPadding = this.getConstants()!.FIELD_DROPDOWN_SVG_ARROW_PADDING;
     const svgArrowSize = this.getConstants()!.FIELD_DROPDOWN_SVG_ARROW_SIZE;
     const arrowX = block.RTL ? xPadding : x + textPadding;
-    this.svgArrow_.setAttribute(
+    this.svgArrow.setAttribute(
         'transform', 'translate(' + arrowX + ',' + y + ')');
     return svgArrowSize + textPadding;
   }
@@ -591,10 +591,10 @@ export class FieldDropdown extends Field<string> {
    * @returns Selected option text.
    */
   protected override getText_(): string|null {
-    if (!this.selectedOption_) {
+    if (!this.selectedOption) {
       return null;
     }
-    const option = this.selectedOption_[0];
+    const option = this.selectedOption[0];
     if (typeof option === 'object') {
       return option['alt'];
     }

--- a/core/field_image.ts
+++ b/core/field_image.ts
@@ -29,13 +29,13 @@ export class FieldImage extends Field<string> {
    */
   private static readonly Y_PADDING = 1;
   protected override size_: Size;
-  private readonly imageHeight_: number;
+  private readonly imageHeight: number;
 
   /** The function to be called when this field is clicked. */
-  private clickHandler_: ((p1: FieldImage) => void)|null = null;
+  private clickHandler: ((p1: FieldImage) => void)|null = null;
 
   /** The rendered field's image element. */
-  private imageElement_: SVGImageElement|null = null;
+  private imageElement: SVGImageElement|null = null;
 
   /**
    * Editable fields usually show some sort of UI indicating they are
@@ -51,10 +51,10 @@ export class FieldImage extends Field<string> {
   protected override isDirty_ = false;
 
   /** Whether to flip this image in RTL. */
-  private flipRtl_ = false;
+  private flipRtl = false;
 
   /** Alt text of this image. */
-  private altText_ = '';
+  private altText = '';
 
   /**
    * @param src The URL of the image.
@@ -97,10 +97,10 @@ export class FieldImage extends Field<string> {
     /**
      * Store the image height, since it is different from the field height.
      */
-    this.imageHeight_ = imageHeight;
+    this.imageHeight = imageHeight;
 
     if (typeof onClick === 'function') {
-      this.clickHandler_ = onClick;
+      this.clickHandler = onClick;
     }
 
     if (src === Field.SKIP_SETUP) return;
@@ -108,8 +108,8 @@ export class FieldImage extends Field<string> {
     if (config) {
       this.configure_(config);
     } else {
-      this.flipRtl_ = !!flipRtl;
-      this.altText_ = parsing.replaceMessageReferences(alt) || '';
+      this.flipRtl = !!flipRtl;
+      this.altText = parsing.replaceMessageReferences(alt) || '';
     }
     this.setValue(parsing.replaceMessageReferences(src));
   }
@@ -121,9 +121,9 @@ export class FieldImage extends Field<string> {
    */
   protected override configure_(config: FieldImageConfig) {
     super.configure_(config);
-    if (config.flipRtl) this.flipRtl_ = config.flipRtl;
+    if (config.flipRtl) this.flipRtl = config.flipRtl;
     if (config.alt) {
-      this.altText_ = parsing.replaceMessageReferences(config.alt);
+      this.altText = parsing.replaceMessageReferences(config.alt);
     }
   }
 
@@ -133,18 +133,18 @@ export class FieldImage extends Field<string> {
    * @internal
    */
   override initView() {
-    this.imageElement_ = dom.createSvgElement(
+    this.imageElement = dom.createSvgElement(
         Svg.IMAGE, {
-          'height': this.imageHeight_ + 'px',
+          'height': this.imageHeight + 'px',
           'width': this.size_.width + 'px',
-          'alt': this.altText_,
+          'alt': this.altText,
         },
         this.fieldGroup_);
-    this.imageElement_.setAttributeNS(
+    this.imageElement.setAttributeNS(
         dom.XLINK_NS, 'xlink:href', this.value_ as string);
 
-    if (this.clickHandler_) {
-      this.imageElement_.style.cursor = 'pointer';
+    if (this.clickHandler) {
+      this.imageElement.style.cursor = 'pointer';
     }
   }
 
@@ -172,8 +172,8 @@ export class FieldImage extends Field<string> {
    */
   protected override doValueUpdate_(newValue: string) {
     this.value_ = newValue;
-    if (this.imageElement_) {
-      this.imageElement_.setAttributeNS(
+    if (this.imageElement) {
+      this.imageElement.setAttributeNS(
           dom.XLINK_NS, 'xlink:href', this.value_);
     }
   }
@@ -184,7 +184,7 @@ export class FieldImage extends Field<string> {
    * @returns True if we should flip in RTL.
    */
   override getFlipRtl(): boolean {
-    return this.flipRtl_;
+    return this.flipRtl;
   }
 
   /**
@@ -193,12 +193,12 @@ export class FieldImage extends Field<string> {
    * @param alt New alt text.
    */
   setAlt(alt: string|null) {
-    if (alt === this.altText_) {
+    if (alt === this.altText) {
       return;
     }
-    this.altText_ = alt || '';
-    if (this.imageElement_) {
-      this.imageElement_.setAttribute('alt', this.altText_);
+    this.altText = alt || '';
+    if (this.imageElement) {
+      this.imageElement.setAttribute('alt', this.altText);
     }
   }
 
@@ -207,8 +207,8 @@ export class FieldImage extends Field<string> {
    * call the handler.
    */
   protected override showEditor_() {
-    if (this.clickHandler_) {
-      this.clickHandler_(this);
+    if (this.clickHandler) {
+      this.clickHandler(this);
     }
   }
 
@@ -219,7 +219,7 @@ export class FieldImage extends Field<string> {
    *     to remove.
    */
   setOnClickHandler(func: ((p1: FieldImage) => void)|null) {
-    this.clickHandler_ = func;
+    this.clickHandler = func;
   }
 
   /**
@@ -230,7 +230,7 @@ export class FieldImage extends Field<string> {
    * @returns The image alt text.
    */
   protected override getText_(): string|null {
-    return this.altText_;
+    return this.altText;
   }
 
   /**

--- a/core/field_image.ts
+++ b/core/field_image.ts
@@ -173,8 +173,7 @@ export class FieldImage extends Field<string> {
   protected override doValueUpdate_(newValue: string) {
     this.value_ = newValue;
     if (this.imageElement) {
-      this.imageElement.setAttributeNS(
-          dom.XLINK_NS, 'xlink:href', this.value_);
+      this.imageElement.setAttributeNS(dom.XLINK_NS, 'xlink:href', this.value_);
     }
   }
 

--- a/core/field_label.ts
+++ b/core/field_label.ts
@@ -23,7 +23,7 @@ import * as parsing from './utils/parsing.js';
  */
 export class FieldLabel extends Field<string> {
   /** The HTML class name to use for this field. */
-  private class_: string|null = null;
+  private class: string|null = null;
 
   /**
    * Editable fields usually show some sort of UI indicating they are
@@ -52,14 +52,14 @@ export class FieldLabel extends Field<string> {
     if (config) {
       this.configure_(config);
     } else {
-      this.class_ = textClass || null;
+      this.class = textClass || null;
     }
     this.setValue(value);
   }
 
   protected override configure_(config: FieldLabelConfig) {
     super.configure_(config);
-    if (config.class) this.class_ = config.class;
+    if (config.class) this.class = config.class;
   }
 
   /**
@@ -69,8 +69,8 @@ export class FieldLabel extends Field<string> {
    */
   override initView() {
     this.createTextElement_();
-    if (this.class_) {
-      dom.addClass(this.getTextElement(), this.class_);
+    if (this.class) {
+      dom.addClass(this.getTextElement(), this.class);
     }
   }
 
@@ -95,14 +95,14 @@ export class FieldLabel extends Field<string> {
    */
   setClass(cssClass: string|null) {
     if (this.textElement_) {
-      if (this.class_) {
-        dom.removeClass(this.textElement_, this.class_);
+      if (this.class) {
+        dom.removeClass(this.textElement_, this.class);
       }
       if (cssClass) {
         dom.addClass(this.textElement_, cssClass);
       }
     }
-    this.class_ = cssClass;
+    this.class = cssClass;
   }
 
   /**

--- a/core/field_number.ts
+++ b/core/field_number.ts
@@ -34,7 +34,7 @@ export class FieldNumber extends FieldInput<number> {
    * The number of decimal places to allow, or null to allow any number of
    * decimal digits.
    */
-  private decimalPlaces_: number|null = null;
+  private decimalPlaces: number|null = null;
 
   /** Don't spellcheck numbers.  Our validator does a better job. */
   protected override spellcheck_ = false;
@@ -84,9 +84,9 @@ export class FieldNumber extends FieldInput<number> {
    */
   protected override configure_(config: FieldNumberConfig) {
     super.configure_(config);
-    this.setMinInternal_(config.min);
-    this.setMaxInternal_(config.max);
-    this.setPrecisionInternal_(config.precision);
+    this.setMinInternal(config.min);
+    this.setMaxInternal(config.max);
+    this.setPrecisionInternal(config.precision);
   }
 
   /**
@@ -105,9 +105,9 @@ export class FieldNumber extends FieldInput<number> {
   setConstraints(
       min: number|string|undefined|null, max: number|string|undefined|null,
       precision: number|string|undefined|null) {
-    this.setMinInternal_(min);
-    this.setMaxInternal_(max);
-    this.setPrecisionInternal_(precision);
+    this.setMinInternal(min);
+    this.setMaxInternal(max);
+    this.setPrecisionInternal(precision);
     this.setValue(this.getValue());
   }
 
@@ -118,7 +118,7 @@ export class FieldNumber extends FieldInput<number> {
    * @param min Minimum value.
    */
   setMin(min: number|string|undefined|null) {
-    this.setMinInternal_(min);
+    this.setMinInternal(min);
     this.setValue(this.getValue());
   }
 
@@ -128,7 +128,7 @@ export class FieldNumber extends FieldInput<number> {
    *
    * @param min Minimum value.
    */
-  private setMinInternal_(min: number|string|undefined|null) {
+  private setMinInternal(min: number|string|undefined|null) {
     if (min == null) {
       this.min_ = -Infinity;
     } else {
@@ -156,7 +156,7 @@ export class FieldNumber extends FieldInput<number> {
    * @param max Maximum value.
    */
   setMax(max: number|string|undefined|null) {
-    this.setMaxInternal_(max);
+    this.setMaxInternal(max);
     this.setValue(this.getValue());
   }
 
@@ -166,7 +166,7 @@ export class FieldNumber extends FieldInput<number> {
    *
    * @param max Maximum value.
    */
-  private setMaxInternal_(max: number|string|undefined|null) {
+  private setMaxInternal(max: number|string|undefined|null) {
     if (max == null) {
       this.max_ = Infinity;
     } else {
@@ -194,7 +194,7 @@ export class FieldNumber extends FieldInput<number> {
    * @param precision The number to which the field's value is rounded.
    */
   setPrecision(precision: number|string|undefined|null) {
-    this.setPrecisionInternal_(precision);
+    this.setPrecisionInternal(precision);
     this.setValue(this.getValue());
   }
 
@@ -204,7 +204,7 @@ export class FieldNumber extends FieldInput<number> {
    *
    * @param precision The number to which the field's value is rounded.
    */
-  private setPrecisionInternal_(precision: number|string|undefined|null) {
+  private setPrecisionInternal(precision: number|string|undefined|null) {
     this.precision_ = Number(precision) || 0;
     let precisionString = String(this.precision_);
     if (precisionString.indexOf('e') !== -1) {
@@ -217,9 +217,9 @@ export class FieldNumber extends FieldInput<number> {
     if (decimalIndex === -1) {
       // If the precision is 0 (float) allow any number of decimals,
       // otherwise allow none.
-      this.decimalPlaces_ = precision ? 0 : null;
+      this.decimalPlaces = precision ? 0 : null;
     } else {
-      this.decimalPlaces_ = precisionString.length - decimalIndex - 1;
+      this.decimalPlaces = precisionString.length - decimalIndex - 1;
     }
   }
 
@@ -270,8 +270,8 @@ export class FieldNumber extends FieldInput<number> {
       n = Math.round(n / this.precision_) * this.precision_;
     }
     // Clean up floating point errors.
-    if (this.decimalPlaces_ !== null) {
-      n = Number(n.toFixed(this.decimalPlaces_));
+    if (this.decimalPlaces !== null) {
+      n = Number(n.toFixed(this.decimalPlaces));
     }
     return n;
   }

--- a/tests/mocha/field_image_test.js
+++ b/tests/mocha/field_image_test.js
@@ -94,23 +94,23 @@ suite('Image Fields', function() {
       });
       test('JS Constructor', function() {
         const field = new Blockly.FieldImage('src', 10, 10, null, this.onClick);
-        chai.assert.equal(field.clickHandler_, this.onClick);
+        chai.assert.equal(field.clickHandler, this.onClick);
       });
       test('setOnClickHandler', function() {
         const field = new Blockly.FieldImage('src', 10, 10);
         field.setOnClickHandler(this.onClick);
-        chai.assert.equal(field.clickHandler_, this.onClick);
+        chai.assert.equal(field.clickHandler, this.onClick);
       });
       test('Remove Click Handler', function() {
         const field = new Blockly.FieldImage('src', 10, 10, null, this.onClick);
         field.setOnClickHandler(null);
-        chai.assert.isNull(field.clickHandler_);
+        chai.assert.isNull(field.clickHandler);
       });
     });
     suite('Alt', function() {
       test('JS Constructor', function() {
         const field = new Blockly.FieldImage('src', 10, 10, 'alt');
-        chai.assert.equal(field.altText_, 'alt');
+        chai.assert.equal(field.getText(), 'alt');
       });
       test('JSON Definition', function() {
         const field = Blockly.FieldImage.fromJson({
@@ -119,7 +119,7 @@ suite('Image Fields', function() {
           height: 10,
           alt: 'alt',
         });
-        chai.assert.equal(field.altText_, 'alt');
+        chai.assert.equal(field.getText(), 'alt');
       });
       suite('SetAlt', function() {
         setup(function() {
@@ -142,25 +142,25 @@ suite('Image Fields', function() {
         const field = new Blockly.FieldImage('src', 10, 10, null, null, null, {
           alt: 'alt',
         });
-        chai.assert.equal(field.altText_, 'alt');
+        chai.assert.equal(field.getText(), 'alt');
       });
       test('JS Configuration - Ignore', function() {
         const field = new Blockly.FieldImage('src', 10, 10, 'alt', null, null, {
           alt: 'configAlt',
         });
-        chai.assert.equal(field.altText_, 'configAlt');
+        chai.assert.equal(field.getText(), 'configAlt');
       });
       test('JS Configuration - Ignore - \'\'', function() {
         const field = new Blockly.FieldImage('src', 10, 10, '', null, null, {
           alt: 'configAlt',
         });
-        chai.assert.equal(field.altText_, 'configAlt');
+        chai.assert.equal(field.getText(), 'configAlt');
       });
       test('JS Configuration - Ignore - Config \'\'', function() {
         const field = new Blockly.FieldImage('src', 10, 10, 'alt', null, null, {
           alt: '',
         });
-        chai.assert.equal(field.altText_, '');
+        chai.assert.equal(field.getText(), '');
       });
     });
     suite('Flip RTL', function() {


### PR DESCRIPTION
## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [x] I ran `npm run format` and `npm run lint`

## The details
### Resolves

Part of https://github.com/google/blockly/issues/6548

### Proposed Changes
Remove underscores from private property and method names. Fix uses in tests. In some cases, update tests to use existing getters.