### PR TITLE
chore: 'compareDocumentPosition' to 'contains'

### DIFF
--- a/core/inject.ts
+++ b/core/inject.ts
@@ -47,8 +47,8 @@ export function inject(
     containerElement = container;
   }
   // Verify that the container is in document.
-  if (!containerElement || !dom.containsNode(document, containerElement)) {
-    throw Error('Error: container is not in current document.');
+  if (!document.contains(containerElement)) {
+    throw Error('Error: container is not in current document');
   }
   const options = new Options(opt_options || {} as BlocklyOptions);
   const subContainer = (document.createElement('div'));
@@ -56,7 +56,7 @@ export function inject(
   subContainer.tabIndex = 0;
   aria.setState(subContainer, aria.State.LABEL, Msg['WORKSPACE_ARIA_LABEL']);
 
-  containerElement.appendChild(subContainer);
+  containerElement!.appendChild(subContainer);
   const svg = createDom(subContainer, options);
 
   // Create surfaces for dragging things. These are optimizations

--- a/core/utils/dom.ts
+++ b/core/utils/dom.ts
@@ -5,6 +5,7 @@
  */
 
 import * as goog from '../../closure/goog/goog.js';
+import * as deprecation from './deprecation.js';
 goog.declareModuleId('Blockly.utils.dom');
 
 import type {Svg} from './svg.js';
@@ -33,7 +34,6 @@ export enum NodeType {
   ELEMENT_NODE = 1,
   TEXT_NODE = 3,
   COMMENT_NODE = 8,
-  DOCUMENT_POSITION_CONTAINED_BY = 16
 }
 
 /** Temporary cache of text widths. */
@@ -160,11 +160,13 @@ export function insertAfter(newNode: Element, refNode: Element) {
  * @param parent The node that should contain the other node.
  * @param descendant The node to test presence of.
  * @returns Whether the parent node contains the descendant node.
+ * @deprecated Use native 'contains' DOM method.
  */
 export function containsNode(parent: Node, descendant: Node): boolean {
-  return !!(
-      parent.compareDocumentPosition(descendant) &
-      NodeType.DOCUMENT_POSITION_CONTAINED_BY);
+ deprecation.warn(
+      'Blockly.utils.dom.containsNode', 'version 10', 'version 11',
+      'Use native "contains" DOM method');
+ return parent.contains(descendant);
 }
 
 /**

--- a/core/utils/dom.ts
+++ b/core/utils/dom.ts
@@ -163,10 +163,10 @@ export function insertAfter(newNode: Element, refNode: Element) {
  * @deprecated Use native 'contains' DOM method.
  */
 export function containsNode(parent: Node, descendant: Node): boolean {
- deprecation.warn(
+  deprecation.warn(
       'Blockly.utils.dom.containsNode', 'version 10', 'version 11',
       'Use native "contains" DOM method');
- return parent.contains(descendant);
+  return parent.contains(descendant);
 }
 
 /**

--- a/core/utils/dom.ts
+++ b/core/utils/dom.ts
@@ -5,9 +5,9 @@
  */
 
 import * as goog from '../../closure/goog/goog.js';
-import * as deprecation from './deprecation.js';
 goog.declareModuleId('Blockly.utils.dom');
 
+import * as deprecation from './deprecation.js';
 import type {Svg} from './svg.js';
 
 

--- a/core/workspace_svg.ts
+++ b/core/workspace_svg.ts
@@ -641,8 +641,8 @@ export class WorkspaceSvg extends Workspace implements IASTNodeLocationSvg {
     let x = 0;
     let y = 0;
     let scale = 1;
-    if (dom.containsNode(this.getCanvas(), element) ||
-        dom.containsNode(this.getBubbleCanvas(), element)) {
+    if (this.getCanvas().contains(element) ||
+        this.getBubbleCanvas().contains(element)) {
       // Before the SVG canvas, scale the coordinates.
       scale = this.scale;
     }


### PR DESCRIPTION
The 'compareDocumentPosition' call was inherited from Closure Library, in order to work with IE 8 and earlier.  Use the more modern 'contains' call instead.

This change was originally added here:
https://github.com/google/blockly/pull/1991

Remove the DOCUMENT_POSITION_CONTAINED_BY constant which is not a NodeType and should never have been part of that enum.

This change was originally added here:
https://github.com/google/blockly/pull/2736
