### PR TITLE
feat: add support for appending custom inputs

### DIFF
--- a/core/block.ts
+++ b/core/block.ts
@@ -1526,6 +1526,23 @@ export class Block implements IASTNodeLocation, IDeletable {
   }
 
   /**
+   * Appends an input with the given input type and name to the block after
+   * constructing it from the registry.
+   *
+   * @param type The name the input is registered under in the registry.
+   * @param name The name the input will have within the block.
+   * @returns The constucted input, or null if there was no constructor
+   *     associated with the type.
+   */
+  private appendInputFromRegistry(type: string, name: string): Input|null {
+    const inputConstructor =
+        registry.getClass(registry.Type.INPUT, type, false);
+    if (!inputConstructor) return null;
+    return this.appendInput(
+        new inputConstructor(inputTypes.CUSTOM, name, this, null));
+  }
+
+  /**
    * Initialize this block using a cross-platform, internationalization-friendly
    * JSON description.
    *
@@ -1862,12 +1879,7 @@ export class Block implements IASTNodeLocation, IDeletable {
         input = this.appendDummyInput(element['name']);
         break;
       default: {
-        const inputConstructor =
-            registry.getClass(registry.Type.INPUT, element['type'], false);
-        if (!inputConstructor) return null;
-        input = new inputConstructor(
-            inputTypes.CUSTOM, element['name'], this, null);
-        this.appendInput(input);
+        input = this.appendInputFromRegistry(element['type'], element['name']);
         break;
       }
     }

--- a/core/block.ts
+++ b/core/block.ts
@@ -1482,7 +1482,7 @@ export class Block implements IASTNodeLocation, IDeletable {
   }
 
   /**
-   * Shortcut for appending a value input row.
+   * Appends a value input row.
    *
    * @param name Language-neutral identifier which may used to find this input
    *     again.  Should be unique to this block.
@@ -1493,7 +1493,7 @@ export class Block implements IASTNodeLocation, IDeletable {
   }
 
   /**
-   * Shortcut for appending a statement input row.
+   * Appends a statement input row.
    *
    * @param name Language-neutral identifier which may used to find this input
    *     again.  Should be unique to this block.
@@ -1504,7 +1504,7 @@ export class Block implements IASTNodeLocation, IDeletable {
   }
 
   /**
-   * Shortcut for appending a dummy input row.
+   * Appends a dummy input row.
    *
    * @param opt_name Language-neutral identifier which may used to find this
    *     input again.  Should be unique to this block.
@@ -1512,6 +1512,16 @@ export class Block implements IASTNodeLocation, IDeletable {
    */
   appendDummyInput(opt_name?: string): Input {
     return this.appendInput_(inputTypes.DUMMY, opt_name || '');
+  }
+
+  /**
+   * Appends the given input row.
+   *
+   * Allows for custom inputs to be appended to the block.
+   */
+  appendInput(input: Input): Input {
+    this.inputList.push(input);
+    return input;
   }
 
   /**

--- a/core/block.ts
+++ b/core/block.ts
@@ -41,6 +41,7 @@ import * as arrayUtils from './utils/array.js';
 import {Coordinate} from './utils/coordinate.js';
 import * as idGenerator from './utils/idgenerator.js';
 import * as parsing from './utils/parsing.js';
+import * as registry from './registry.js';
 import {Size} from './utils/size.js';
 import type {VariableModel} from './variable_model.js';
 import type {Workspace} from './workspace.js';
@@ -1860,6 +1861,13 @@ export class Block implements IASTNodeLocation, IDeletable {
       case 'input_dummy':
         input = this.appendDummyInput(element['name']);
         break;
+      default: {
+        const inputConstructor =
+            registry.getClass(registry.Type.INPUT, element['type'], false)!;
+        input = new inputConstructor(
+            inputTypes.CUSTOM, element['name'], this, null);
+        break;
+      }
     }
     // Should never be hit because of interpolate_'s checks, but just in case.
     if (!input) {
@@ -1891,7 +1899,7 @@ export class Block implements IASTNodeLocation, IDeletable {
    */
   private isInputKeyword_(str: string): boolean {
     return str === 'input_value' || str === 'input_statement' ||
-        str === 'input_dummy';
+        str === 'input_dummy' || registry.hasItem(registry.Type.INPUT, str);
   }
 
   /**

--- a/core/block.ts
+++ b/core/block.ts
@@ -1863,9 +1863,11 @@ export class Block implements IASTNodeLocation, IDeletable {
         break;
       default: {
         const inputConstructor =
-            registry.getClass(registry.Type.INPUT, element['type'], false)!;
+            registry.getClass(registry.Type.INPUT, element['type'], false);
+        if (!inputConstructor) return null;
         input = new inputConstructor(
             inputTypes.CUSTOM, element['name'], this, null);
+        this.appendInput(input);
         break;
       }
     }

--- a/core/input.ts
+++ b/core/input.ts
@@ -48,7 +48,7 @@ export class Input {
   constructor(
       public type: number, public name: string, block: Block,
       public connection: Connection|null) {
-    if (type !== inputTypes.DUMMY && !name) {
+    if ((type === inputTypes.VALUE || type === inputTypes.STATEMENT) && !name) {
       throw Error(
           'Value inputs and statement inputs must have non-empty name.');
     }

--- a/core/input.ts
+++ b/core/input.ts
@@ -41,7 +41,9 @@ export class Input {
    * @param name Language-neutral identifier which may used to find this input
    *     again.
    * @param block The block containing this input.
-   * @param connection Optional connection for this input.
+   * @param connection Optional connection for this input. If this is a custom
+   *     input, `null` will always be passed, and then the subclass can
+   *     optionally construct a connection.
    */
   constructor(
       public type: number, public name: string, block: Block,

--- a/core/input_types.ts
+++ b/core/input_types.ts
@@ -19,5 +19,7 @@ export enum inputTypes {
   // A down-facing block stack.  E.g. 'if-do' or 'else'.
   STATEMENT = ConnectionType.NEXT_STATEMENT,
   // A dummy input.  Used to add field(s) with no input.
-  DUMMY = 5
+  DUMMY = 5,
+  // An unknown type of input defined by an external developer.
+  CUSTOM = 5
 }

--- a/core/input_types.ts
+++ b/core/input_types.ts
@@ -21,5 +21,5 @@ export enum inputTypes {
   // A dummy input.  Used to add field(s) with no input.
   DUMMY = 5,
   // An unknown type of input defined by an external developer.
-  CUSTOM = 5
+  CUSTOM = 6,
 }

--- a/core/registry.ts
+++ b/core/registry.ts
@@ -13,6 +13,7 @@ import type {IBlockDragger} from './interfaces/i_block_dragger.js';
 import type {IConnectionChecker} from './interfaces/i_connection_checker.js';
 import type {IFlyout} from './interfaces/i_flyout.js';
 import type {IMetricsManager} from './interfaces/i_metrics_manager.js';
+import type {Input} from './input.js';
 import type {ISerializer} from './interfaces/i_serializer.js';
 import type {IToolbox} from './interfaces/i_toolbox.js';
 import type {Cursor} from './keyboard_nav/cursor.js';
@@ -68,6 +69,8 @@ export class Type<_T> {
   static EVENT = new Type<Abstract>('event');
 
   static FIELD = new Type<Field>('field');
+
+  static INPUT = new Type<Input>('input');
 
   static RENDERER = new Type<Renderer>('renderer');
 

--- a/tests/mocha/block_json_test.js
+++ b/tests/mocha/block_json_test.js
@@ -490,110 +490,116 @@ suite('Block JSON initialization', function() {
       };
     });
 
-    test('Dummy', function() {
-      this.assertInput(
-          {
-            'type': 'input_dummy',
-          },
-          'input_dummy');
+    suite('input types', function() {
+      test('Dummy', function() {
+        this.assertInput(
+            {
+              'type': 'input_dummy',
+            },
+            'input_dummy');
+      });
+  
+      test('Value', function() {
+        this.assertInput(
+            {
+              'type': 'input_value',
+            },
+            'input_value');
+      });
+  
+      test('Statement', function() {
+        this.assertInput(
+            {
+              'type': 'input_statement',
+            },
+            'input_statement');
+      });
+  
+      test('Bad input type', function() {
+        this.assertInput(
+            {
+              'type': 'input_bad',
+            },
+            'input_bad');
+      });
     });
 
-    test('Value', function() {
-      this.assertInput(
-          {
-            'type': 'input_value',
-          },
-          'input_value');
+    suite('connection checks', function() {
+      test('String Check', function() {
+        this.assertInput(
+            {
+              'type': 'input_dummy',
+              'check': 'Integer',
+            },
+            'input_dummy',
+            'Integer');
+      });
+  
+      test('Array check', function() {
+        this.assertInput(
+            {
+              'type': 'input_dummy',
+              'check': ['Integer', 'Number'],
+            },
+            'input_dummy',
+            ['Integer', 'Number']);
+      });
+  
+      test('Empty check', function() {
+        this.assertInput(
+            {
+              'type': 'input_dummy',
+              'check': '',
+            },
+            'input_dummy');
+      });
+  
+      test('Null check', function() {
+        this.assertInput(
+            {
+              'type': 'input_dummy',
+              'check': null,
+            },
+            'input_dummy');
+      });
     });
 
-    test('Statement', function() {
-      this.assertInput(
-          {
-            'type': 'input_statement',
-          },
-          'input_statement');
-    });
-
-    test('Bad input type', function() {
-      this.assertInput(
-          {
-            'type': 'input_bad',
-          },
-          'input_bad');
-    });
-
-    test('String Check', function() {
-      this.assertInput(
-          {
-            'type': 'input_dummy',
-            'check': 'Integer',
-          },
-          'input_dummy',
-          'Integer');
-    });
-
-    test('Array check', function() {
-      this.assertInput(
-          {
-            'type': 'input_dummy',
-            'check': ['Integer', 'Number'],
-          },
-          'input_dummy',
-          ['Integer', 'Number']);
-    });
-
-    test('Empty check', function() {
-      this.assertInput(
-          {
-            'type': 'input_dummy',
-            'check': '',
-          },
-          'input_dummy');
-    });
-
-    test('Null check', function() {
-      this.assertInput(
-          {
-            'type': 'input_dummy',
-            'check': null,
-          },
-          'input_dummy');
-    });
-
-    test('"Left" align', function() {
-      this.assertInput(
-          {
-            'type': 'input_dummy',
-            'align': 'LEFT',
-          },
-          'input_dummy', undefined, Align.LEFT);
-    });
-
-    test('"Right" align', function() {
-      this.assertInput(
-          {
-            'type': 'input_dummy',
-            'align': 'RIGHT',
-          },
-          'input_dummy', undefined, Align.RIGHT);
-    });
-
-    test('"Center" align', function() {
-      this.assertInput(
-          {
-            'type': 'input_dummy',
-            'align': 'CENTER',
-          },
-          'input_dummy', undefined, Align.CENTRE);
-    });
-
-    test('"Centre" align', function() {
-      this.assertInput(
-          {
-            'type': 'input_dummy',
-            'align': 'CENTRE',
-          },
-          'input_dummy', undefined, Align.CENTRE);
+    suite('alignment', function() {
+      test('"Left" align', function() {
+        this.assertInput(
+            {
+              'type': 'input_dummy',
+              'align': 'LEFT',
+            },
+            'input_dummy', undefined, Align.LEFT);
+      });
+  
+      test('"Right" align', function() {
+        this.assertInput(
+            {
+              'type': 'input_dummy',
+              'align': 'RIGHT',
+            },
+            'input_dummy', undefined, Align.RIGHT);
+      });
+  
+      test('"Center" align', function() {
+        this.assertInput(
+            {
+              'type': 'input_dummy',
+              'align': 'CENTER',
+            },
+            'input_dummy', undefined, Align.CENTRE);
+      });
+  
+      test('"Centre" align', function() {
+        this.assertInput(
+            {
+              'type': 'input_dummy',
+              'align': 'CENTRE',
+            },
+            'input_dummy', undefined, Align.CENTRE);
+      });
     });
   });
 });


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [X] I ran `npm run format` and `npm run lint`

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Work on #2062 

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
Adds an `appendInput` function, and support for constructing inputs from the registry.

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
Support for custon inputs!

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->

Added a test for constructing custom inputs from JSON.

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->
N/A

### Additional Information

<!-- Anything else we should know? -->
I reorganized some tests. Relevant changes are in commit 3e6db57 =)

I'd like to consider this the minimum viable API for handling custom inputs. It has several limitations:
  * No `fromJson` method for constructing inputs, meaning custom inputs cannot be further parameterized when constructing from a JSON block definition.
  * We force external developers to construct their own connections if they want them, which may be what we want, but signalling that by passing `null` to the connection constructor parameter is not ideal.
  * Our built-in inputs are still differentiated using a `type` property, which creates inconsistency between the built-in inputs and custom ones. We also have to pass an enum to the `Input` constructor, which feels kind of jank.