### PR TITLE
fix: rtl field alignment

### DIFF
--- a/core/field_input.ts
+++ b/core/field_input.ts
@@ -29,6 +29,7 @@ import {Coordinate} from './utils/coordinate.js';
 import * as userAgent from './utils/useragent.js';
 import * as WidgetDiv from './widgetdiv.js';
 import type {WorkspaceSvg} from './workspace_svg.js';
+import * as renderManagement from './render_management.js';
 
 /**
  * Supported types for FieldInput subclasses.
@@ -465,6 +466,11 @@ export abstract class FieldInput<T extends InputTypes> extends Field<string|T> {
    */
   private onHtmlInputChange_(_e: Event) {
     this.setValue(this.getValueFromEditorText_(this.htmlInput_!.value));
+
+    // Resize the widget div after the block has finished rendering.
+    renderManagement.finishQueuedRenders().then(() => {
+      this.resizeEditor_();
+    });
   }
 
   /**


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [x] I ran `npm run format` and `npm run lint`

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #6976 

### Proposed Changes

- Resizes the widget div after block rendering is done.

#### Behavior Before Change

Misalignment of input fields in rtl

#### Behavior After Change

Fields look correct

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
