### PR TITLE
chore(tests): Update configuration to test on node.js v20

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -176,7 +176,9 @@ function buildTSOverride({files, tsconfig}) {
       'jsdoc/check-param-names': ['off', {'checkDestructured': false}],
       // Allow any text in the license tag. Other checks are not relevant.
       'jsdoc/check-values': ['off'],
-      'jsdoc/newline-after-description': ['error'],
+      // Ensure there is a blank line between the body and any @tags,
+      // as required by the tsdoc spec (see #6353).
+      'jsdoc/tag-lines': ['error', 'any', {'startLines': 1}],
     },
   };
 }

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,10 +60,10 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
-    - name: Use Node.js 16.x
+    - name: Use Node.js 20.x
       uses: actions/setup-node@v3
       with:
-        node-version: 16.x
+        node-version: 20.x
 
     - name: Npm Install
       run: npm install

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
         # TODO (#2114): re-enable osx build.
         # os: [ubuntu-latest, macos-latest]
         os: [ubuntu-latest]
-        node-version: [14.x, 16.x, 18.x]
+        node-version: [14.x, 16.x, 18.x, 20.x]
         # See supported Node.js release schedule at
         # https://nodejs.org/en/about/releases/
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "concurrently": "^8.0.1",
         "eslint": "^8.4.1",
         "eslint-config-google": "^0.14.0",
-        "eslint-plugin-jsdoc": "^41.1.2",
+        "eslint-plugin-jsdoc": "^43.0.7",
         "google-closure-compiler": "^20230228.0.0",
         "google-closure-deps": "^20230228.0.0",
         "gulp": "^4.0.2",
@@ -262,17 +262,17 @@
       }
     },
     "node_modules/@es-joy/jsdoccomment": {
-      "version": "0.37.0",
-      "resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.37.0.tgz",
-      "integrity": "sha512-hjK0wnsPCYLlF+HHB4R/RbUjOWeLW2SlarB67+Do5WsKILOkmIZvvPJFbtWSmbypxcjpoECLAMzoao0D4Bg5ZQ==",
+      "version": "0.37.1",
+      "resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.37.1.tgz",
+      "integrity": "sha512-5vxWJ1gEkEF0yRd0O+uK6dHJf7adrxwQSX8PuRiPfFSAbNLnY0ZJfXaZucoz14Jj2N11xn2DnlEPwWRpYpvRjg==",
       "dev": true,
       "dependencies": {
         "comment-parser": "1.3.1",
-        "esquery": "^1.4.0",
+        "esquery": "^1.5.0",
         "jsdoc-type-pratt-parser": "~4.0.0"
       },
       "engines": {
-        "node": "^14 || ^16 || ^17 || ^18 || ^19"
+        "node": "^14 || ^16 || ^17 || ^18 || ^19 || ^20"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -4342,25 +4342,40 @@
       }
     },
     "node_modules/eslint-plugin-jsdoc": {
-      "version": "41.1.2",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-41.1.2.tgz",
-      "integrity": "sha512-MePJXdGiPW7AG06CU5GbKzYtKpoHwTq1lKijjq+RwL/cQkZtBZ59Zbv5Ep0RVxSMnq6242249/n+w4XrTZ1Afg==",
+      "version": "43.0.7",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-43.0.7.tgz",
+      "integrity": "sha512-32Sx5I9VzO/bqbtslCu3L1GHIPo+QEliwqwjWq+qzbUv76wrkH6ifUEE0EbkuNEn+cHlSIOrg/IJ1PGNN72QZA==",
       "dev": true,
       "dependencies": {
-        "@es-joy/jsdoccomment": "~0.37.0",
+        "@es-joy/jsdoccomment": "~0.37.1",
         "are-docs-informative": "^0.0.2",
         "comment-parser": "1.3.1",
         "debug": "^4.3.4",
         "escape-string-regexp": "^4.0.0",
         "esquery": "^1.5.0",
-        "semver": "^7.3.8",
+        "semver": "^7.5.0",
         "spdx-expression-parse": "^3.0.1"
       },
       "engines": {
-        "node": "^14 || ^16 || ^17 || ^18 || ^19"
+        "node": "^14 || ^16 || ^17 || ^18 || ^19 || ^20"
       },
       "peerDependencies": {
         "eslint": "^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-jsdoc/node_modules/semver": {
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.0.tgz",
+      "integrity": "sha512-+XC0AD/R7Q2mPSRuy2Id0+CGTZ98+8f+KvwirxOKIEyid+XSx6HbC63p+O4IndTHuX5Z+JxQ0TghCkO5Cg/2HA==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/eslint-scope": {
@@ -12976,13 +12991,13 @@
       "requires": {}
     },
     "@es-joy/jsdoccomment": {
-      "version": "0.37.0",
-      "resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.37.0.tgz",
-      "integrity": "sha512-hjK0wnsPCYLlF+HHB4R/RbUjOWeLW2SlarB67+Do5WsKILOkmIZvvPJFbtWSmbypxcjpoECLAMzoao0D4Bg5ZQ==",
+      "version": "0.37.1",
+      "resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.37.1.tgz",
+      "integrity": "sha512-5vxWJ1gEkEF0yRd0O+uK6dHJf7adrxwQSX8PuRiPfFSAbNLnY0ZJfXaZucoz14Jj2N11xn2DnlEPwWRpYpvRjg==",
       "dev": true,
       "requires": {
         "comment-parser": "1.3.1",
-        "esquery": "^1.4.0",
+        "esquery": "^1.5.0",
         "jsdoc-type-pratt-parser": "~4.0.0"
       }
     },
@@ -16116,19 +16131,30 @@
       "requires": {}
     },
     "eslint-plugin-jsdoc": {
-      "version": "41.1.2",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-41.1.2.tgz",
-      "integrity": "sha512-MePJXdGiPW7AG06CU5GbKzYtKpoHwTq1lKijjq+RwL/cQkZtBZ59Zbv5Ep0RVxSMnq6242249/n+w4XrTZ1Afg==",
+      "version": "43.0.7",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-43.0.7.tgz",
+      "integrity": "sha512-32Sx5I9VzO/bqbtslCu3L1GHIPo+QEliwqwjWq+qzbUv76wrkH6ifUEE0EbkuNEn+cHlSIOrg/IJ1PGNN72QZA==",
       "dev": true,
       "requires": {
-        "@es-joy/jsdoccomment": "~0.37.0",
+        "@es-joy/jsdoccomment": "~0.37.1",
         "are-docs-informative": "^0.0.2",
         "comment-parser": "1.3.1",
         "debug": "^4.3.4",
         "escape-string-regexp": "^4.0.0",
         "esquery": "^1.5.0",
-        "semver": "^7.3.8",
+        "semver": "^7.5.0",
         "spdx-expression-parse": "^3.0.1"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "7.5.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.0.tgz",
+          "integrity": "sha512-+XC0AD/R7Q2mPSRuy2Id0+CGTZ98+8f+KvwirxOKIEyid+XSx6HbC63p+O4IndTHuX5Z+JxQ0TghCkO5Cg/2HA==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        }
       }
     },
     "eslint-scope": {

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "concurrently": "^8.0.1",
     "eslint": "^8.4.1",
     "eslint-config-google": "^0.14.0",
-    "eslint-plugin-jsdoc": "^41.1.2",
+    "eslint-plugin-jsdoc": "^43.0.7",
     "google-closure-compiler": "^20230228.0.0",
     "google-closure-deps": "^20230228.0.0",
     "gulp": "^4.0.2",


### PR DESCRIPTION
## The basics

- [X] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [X] I ran `npm run format` and `npm run lint`

## The details
### Proposed Changes

* Update the test matrix to include node.js v20.
* Update some dependencies for (nominal) compatibility with the new version of node.

#### Behaviour Before Change

Test run on node.js v14, 16, and 18.

#### Behaviour After Change

Test run on node.js v14, 16, 18 and 20.

### Reason for Changes

Ensure that we are compatible with the most recent LTS version of node.js.

### Test Coverage

Yes, that's the idea.

### Additional Information

I'm going to leave v14 in our test matrix for the moment; I'll remove it in a separate PR along with some other related updates.