### PR TITLE
fix: update applyColour documentation

### DIFF
--- a/core/field.ts
+++ b/core/field.ts
@@ -683,13 +683,18 @@ export abstract class Field<T = any> implements IASTNodeLocationSvg,
   }
 
   /**
-   * Updates the field to match the colour/style of the block. Should only be
-   * called by BlockSvg.applyColour().
+   * Updates the field to match the colour/style of the block.
    *
-   * @internal
+   * Non-abstract sub-classes may wish to implement this if the colour of the
+   * field depends on the colour of the block. It will automatically be called
+   * at relevant times, such as when the parent block or renderer changes.
+   *
+   * See {@link
+   * https://developers.google.com/blockly/guides/create-custom-blocks/fields/customizing-fields/creating#matching_block_colours
+   * | the field documentation} for more information, or FieldDropdown for an
+   * example.
    */
   applyColour() {}
-  // Non-abstract sub-classes may wish to implement this. See FieldDropdown.
 
   /**
    * Used by getSize() to move/resize any DOM elements, and get the new size.

--- a/core/field_colour.ts
+++ b/core/field_colour.ts
@@ -177,8 +177,6 @@ export class FieldColour extends Field<string> {
 
   /**
    * Updates text field to match the colour/style of the block.
-   *
-   * @internal
    */
   override applyColour() {
     if (!this.getConstants()!.FIELD_COLOUR_FULL_BLOCK) {

--- a/core/field_dropdown.ts
+++ b/core/field_dropdown.ts
@@ -431,8 +431,6 @@ export class FieldDropdown extends Field<string> {
 
   /**
    * Updates the dropdown arrow to match the colour/style of the block.
-   *
-   * @internal
    */
   override applyColour() {
     const style = (this.sourceBlock_ as BlockSvg).style;

--- a/core/field_input.ts
+++ b/core/field_input.ts
@@ -200,8 +200,6 @@ export abstract class FieldInput<T extends InputTypes> extends Field<string|T> {
 
   /**
    * Updates text field to match the colour/style of the block.
-   *
-   * @internal
    */
   override applyColour() {
     if (!this.sourceBlock_ || !this.getConstants()!.FULL_BLOCK_FIELDS) return;


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [x] I ran `npm run format` and `npm run lint`

## The details
### Resolves

Missing documentation from reference pages.

### Proposed Changes

- Removes `@internal` tag from `applyColour` methods in fields. This method is not `@internal` because it can be overridden by subclasses. Therefore it should appear in our documentation.
- Updates the TsDoc for the method to add more information.
- Removes the statement that it should only be called by `BlockSvg.applyColour` because this method is already called by `input.ts` as well plus `FieldDropdown` calls its own method several times, and this makes sense, because you only want to update that kind of style information in one method, so it's a pattern other fields might follow.

#### Behavior Before Change

<!--TODO: Image, gif or explanation of behavior before this pull request. -->

#### Behavior After Change

<!--TODO: Image, gif or explanation of behavior after this pull request. -->

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

- Became relevant when I was looking at https://github.com/code-dot-org/code-dot-org/pull/50834#discussion_r1172960149
- `FieldDropdown` calls this method in its `dispose` method, is that weird? If we're disposing the element I don't know why we'd also be updating some (now-irrelevant) styles on it but I didn't look too deeply into this as I'm not making any code changes here
