### PR TITLE
chore: make clang-format and eslint agree in more places

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,3 +1,4 @@
 Language:        JavaScript
 BasedOnStyle:    Google
 ColumnLimit:     80
+JavaScriptQuotes: Leave

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -6,9 +6,11 @@ const rules = {
   'max-len': [
     'error',
     {
-      'code': 100,
+      'code': 80,
       'tabWidth': 4,
+      'ignorePattern': '^(import|export)',
       'ignoreStrings': true,
+      'ignoreTemplateLiterals': true,
       'ignoreRegExpLiterals': true,
       'ignoreUrls': true,
     },

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -80,6 +80,7 @@ jobs:
     - uses: DoozyX/clang-format-lint-action@v0.15
       with:
         source: 'core generators tests/mocha'
+        exclude: 'tests/mocha/.mocharc.js'
         extensions: 'js,ts'
         # This should be as close as possible to the version that the npm
         # package supports. This can be found by running:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,7 +79,7 @@ jobs:
 
     - uses: DoozyX/clang-format-lint-action@v0.15
       with:
-        source: 'core'
+        source: 'core generators tests/mocha'
         extensions: 'js,ts'
         # This should be as close as possible to the version that the npm
         # package supports. This can be found by running:

--- a/core/renderers/zelos/marker_svg.ts
+++ b/core/renderers/zelos/marker_svg.ts
@@ -100,6 +100,7 @@ export class MarkerSvg extends BaseMarkerSvg {
   }
 
   override createDomInternal_() {
+    /* eslint-disable */
     /* clang-format off */
     /* This markup will be generated and added to the .svgGroup_:
         <g>
@@ -110,6 +111,7 @@ export class MarkerSvg extends BaseMarkerSvg {
         </g>
         */
     /* clang-format on */
+    /* eslint-enable */
     super.createDomInternal_();
 
     this.markerCircle = dom.createSvgElement(

--- a/generators/dart.js
+++ b/generators/dart.js
@@ -49,31 +49,30 @@ Dart.addReservedWords(
     'CyclicInitializationError,Error,Exception,FallThroughError,' +
     'FormatException,IntegerDivisionByZeroException,NoSuchMethodError,' +
     'NullThrownError,OutOfMemoryError,RangeError,StackOverflowError,' +
-    'StateError,TypeError,UnimplementedError,UnsupportedError'
-);
+    'StateError,TypeError,UnimplementedError,UnsupportedError');
 
 /**
  * Order of operation ENUMs.
  * https://dart.dev/guides/language/language-tour#operators
  */
-Dart.ORDER_ATOMIC = 0;         // 0 "" ...
-Dart.ORDER_UNARY_POSTFIX = 1;  // expr++ expr-- () [] . ?.
-Dart.ORDER_UNARY_PREFIX = 2;   // -expr !expr ~expr ++expr --expr
-Dart.ORDER_MULTIPLICATIVE = 3; // * / % ~/
-Dart.ORDER_ADDITIVE = 4;       // + -
-Dart.ORDER_SHIFT = 5;          // << >>
-Dart.ORDER_BITWISE_AND = 6;    // &
-Dart.ORDER_BITWISE_XOR = 7;    // ^
-Dart.ORDER_BITWISE_OR = 8;     // |
-Dart.ORDER_RELATIONAL = 9;     // >= > <= < as is is!
-Dart.ORDER_EQUALITY = 10;      // == !=
-Dart.ORDER_LOGICAL_AND = 11;   // &&
-Dart.ORDER_LOGICAL_OR = 12;    // ||
-Dart.ORDER_IF_NULL = 13;       // ??
-Dart.ORDER_CONDITIONAL = 14;   // expr ? expr : expr
-Dart.ORDER_CASCADE = 15;       // ..
-Dart.ORDER_ASSIGNMENT = 16;    // = *= /= ~/= %= += -= <<= >>= &= ^= |=
-Dart.ORDER_NONE = 99;          // (...)
+Dart.ORDER_ATOMIC = 0;          // 0 "" ...
+Dart.ORDER_UNARY_POSTFIX = 1;   // expr++ expr-- () [] . ?.
+Dart.ORDER_UNARY_PREFIX = 2;    // -expr !expr ~expr ++expr --expr
+Dart.ORDER_MULTIPLICATIVE = 3;  // * / % ~/
+Dart.ORDER_ADDITIVE = 4;        // + -
+Dart.ORDER_SHIFT = 5;           // << >>
+Dart.ORDER_BITWISE_AND = 6;     // &
+Dart.ORDER_BITWISE_XOR = 7;     // ^
+Dart.ORDER_BITWISE_OR = 8;      // |
+Dart.ORDER_RELATIONAL = 9;      // >= > <= < as is is!
+Dart.ORDER_EQUALITY = 10;       // == !=
+Dart.ORDER_LOGICAL_AND = 11;    // &&
+Dart.ORDER_LOGICAL_OR = 12;     // ||
+Dart.ORDER_IF_NULL = 13;        // ??
+Dart.ORDER_CONDITIONAL = 14;    // expr ? expr : expr
+Dart.ORDER_CASCADE = 15;        // ..
+Dart.ORDER_ASSIGNMENT = 16;     // = *= /= ~/= %= += -= <<= >>= &= ^= |=
+Dart.ORDER_NONE = 99;           // (...)
 
 /**
  * Whether the init method has been called.
@@ -103,21 +102,19 @@ Dart.init = function(workspace) {
   // Add developer variables (not created or named by the user).
   const devVarList = Variables.allDeveloperVariables(workspace);
   for (let i = 0; i < devVarList.length; i++) {
-    defvars.push(this.nameDB_.getName(devVarList[i],
-        NameType.DEVELOPER_VARIABLE));
+    defvars.push(
+        this.nameDB_.getName(devVarList[i], NameType.DEVELOPER_VARIABLE));
   }
 
   // Add user variables, but only ones that are being used.
   const variables = Variables.allUsedVarModels(workspace);
   for (let i = 0; i < variables.length; i++) {
-    defvars.push(this.nameDB_.getName(variables[i].getId(),
-        NameType.VARIABLE));
+    defvars.push(this.nameDB_.getName(variables[i].getId(), NameType.VARIABLE));
   }
 
   // Declare all of the variables.
   if (defvars.length) {
-    this.definitions_['variables'] =
-        'var ' + defvars.join(', ') + ';';
+    this.definitions_['variables'] = 'var ' + defvars.join(', ') + ';';
   }
   this.isInitialized = true;
 };
@@ -173,9 +170,9 @@ Dart.scrubNakedValue = function(line) {
 Dart.quote_ = function(string) {
   // Can't use goog.string.quote since $ must also be escaped.
   string = string.replace(/\\/g, '\\\\')
-                 .replace(/\n/g, '\\\n')
-                 .replace(/\$/g, '\\$')
-                 .replace(/'/g, '\\\'');
+               .replace(/\n/g, '\\\n')
+               .replace(/\$/g, '\\$')
+               .replace(/'/g, '\\\'');
   return '\'' + string + '\'';
 };
 
@@ -186,7 +183,7 @@ Dart.quote_ = function(string) {
  * @return {string} Dart string.
  * @protected
  */
-Dart.multiline_quote_ = function (string) {
+Dart.multiline_quote_ = function(string) {
   const lines = string.split(/\n/g).map(this.quote_);
   // Join with the following, plus a newline:
   // + '\n' +
@@ -246,8 +243,7 @@ Dart.scrub_ = function(block, code, opt_thisOnly) {
  * @param {number=} opt_order The highest order acting on this value.
  * @return {string|number}
  */
-Dart.getAdjusted = function(block, atId, opt_delta, opt_negate,
-    opt_order) {
+Dart.getAdjusted = function(block, atId, opt_delta, opt_negate, opt_order) {
   let delta = opt_delta || 0;
   let order = opt_order || this.ORDER_NONE;
   if (block.workspace.options.oneBasedIndex) {

--- a/generators/dart/colour.js
+++ b/generators/dart/colour.js
@@ -40,12 +40,9 @@ String ${Dart.FUNCTION_NAME_PLACEHOLDER_}() {
 
 Dart['colour_rgb'] = function(block) {
   // Compose a colour from RGB components expressed as percentages.
-  const red = Dart.valueToCode(block, 'RED',
-      Dart.ORDER_NONE) || 0;
-  const green = Dart.valueToCode(block, 'GREEN',
-      Dart.ORDER_NONE) || 0;
-  const blue = Dart.valueToCode(block, 'BLUE',
-      Dart.ORDER_NONE) || 0;
+  const red = Dart.valueToCode(block, 'RED', Dart.ORDER_NONE) || 0;
+  const green = Dart.valueToCode(block, 'GREEN', Dart.ORDER_NONE) || 0;
+  const blue = Dart.valueToCode(block, 'BLUE', Dart.ORDER_NONE) || 0;
 
   Dart.definitions_['import_dart_math'] = "import 'dart:math' as Math;";
   const functionName = Dart.provideFunction_('colour_rgb', `

--- a/generators/dart/math.js
+++ b/generators/dart/math.js
@@ -175,13 +175,12 @@ Dart['math_number_property'] = function(block) {
   };
   const dropdownProperty = block.getFieldValue('PROPERTY');
   const [suffix, inputOrder, outputOrder] = PROPERTIES[dropdownProperty];
-  const numberToCheck = Dart.valueToCode(block, 'NUMBER_TO_CHECK',
-      inputOrder) || '0';
+  const numberToCheck =
+      Dart.valueToCode(block, 'NUMBER_TO_CHECK', inputOrder) || '0';
   let code;
   if (dropdownProperty === 'PRIME') {
     // Prime is a special case as it is not a one-liner test.
-    Dart.definitions_['import_dart_math'] =
-        'import \'dart:math\' as Math;';
+    Dart.definitions_['import_dart_math'] = 'import \'dart:math\' as Math;';
     const functionName = Dart.provideFunction_('math_isPrime', `
 bool ${Dart.FUNCTION_NAME_PLACEHOLDER_}(n) {
   // https://en.wikipedia.org/wiki/Primality_test#Naive_methods
@@ -204,8 +203,8 @@ bool ${Dart.FUNCTION_NAME_PLACEHOLDER_}(n) {
 `);
     code = functionName + '(' + numberToCheck + ')';
   } else if (dropdownProperty === 'DIVISIBLE_BY') {
-    const divisor = Dart.valueToCode(block, 'DIVISOR',
-        Dart.ORDER_MULTIPLICATIVE) || '0';
+    const divisor =
+        Dart.valueToCode(block, 'DIVISOR', Dart.ORDER_MULTIPLICATIVE) || '0';
     if (divisor === '0') {
       return ['false', Dart.ORDER_ATOMIC];
     }

--- a/generators/javascript/lists.js
+++ b/generators/javascript/lists.js
@@ -325,8 +325,10 @@ JavaScript['lists_getSublist'] = function(block) {
     const at2Param =
         (where2 === 'FROM_END' || where2 === 'FROM_START') ? ', at2' : '';
     const functionName = JavaScript.provideFunction_(
-        'subsequence' + wherePascalCase[where1] + wherePascalCase[where2], `
-function ${JavaScript.FUNCTION_NAME_PLACEHOLDER_}(sequence${at1Param}${at2Param}) {
+        'subsequence' + wherePascalCase[where1] + wherePascalCase[where2],
+        `
+function ${JavaScript.FUNCTION_NAME_PLACEHOLDER_}(sequence${at1Param}${
+            at2Param}) {
   var start = ${getSubstringIndex('sequence', where1, 'at1')};
   var end = ${getSubstringIndex('sequence', where2, 'at2')} + 1;
   return sequence.slice(start, end);

--- a/generators/javascript/math.js
+++ b/generators/javascript/math.js
@@ -19,8 +19,8 @@ const {javascriptGenerator: JavaScript} = goog.require('Blockly.JavaScript');
 JavaScript['math_number'] = function(block) {
   // Numeric value.
   const code = Number(block.getFieldValue('NUM'));
-  const order = code >= 0 ? JavaScript.ORDER_ATOMIC :
-              JavaScript.ORDER_UNARY_NEGATION;
+  const order =
+      code >= 0 ? JavaScript.ORDER_ATOMIC : JavaScript.ORDER_UNARY_NEGATION;
   return [code, order];
 };
 
@@ -55,8 +55,9 @@ JavaScript['math_single'] = function(block) {
   let arg;
   if (operator === 'NEG') {
     // Negation is a special case given its different operator precedence.
-    arg = JavaScript.valueToCode(block, 'NUM',
-        JavaScript.ORDER_UNARY_NEGATION) || '0';
+    arg =
+        JavaScript.valueToCode(block, 'NUM', JavaScript.ORDER_UNARY_NEGATION) ||
+        '0';
     if (arg[0] === '-') {
       // --3 is not legal in JS.
       arg = ' ' + arg;
@@ -65,11 +66,10 @@ JavaScript['math_single'] = function(block) {
     return [code, JavaScript.ORDER_UNARY_NEGATION];
   }
   if (operator === 'SIN' || operator === 'COS' || operator === 'TAN') {
-    arg = JavaScript.valueToCode(block, 'NUM',
-        JavaScript.ORDER_DIVISION) || '0';
+    arg =
+        JavaScript.valueToCode(block, 'NUM', JavaScript.ORDER_DIVISION) || '0';
   } else {
-    arg = JavaScript.valueToCode(block, 'NUM',
-        JavaScript.ORDER_NONE) || '0';
+    arg = JavaScript.valueToCode(block, 'NUM', JavaScript.ORDER_NONE) || '0';
   }
   // First, handle cases which generate values that don't need parentheses
   // wrapping the code.
@@ -151,19 +151,19 @@ JavaScript['math_number_property'] = function(block) {
   const PROPERTIES = {
     'EVEN': [' % 2 === 0', JavaScript.ORDER_MODULUS, JavaScript.ORDER_EQUALITY],
     'ODD': [' % 2 === 1', JavaScript.ORDER_MODULUS, JavaScript.ORDER_EQUALITY],
-    'WHOLE': [' % 1 === 0', JavaScript.ORDER_MODULUS,
-        JavaScript.ORDER_EQUALITY],
-    'POSITIVE': [' > 0', JavaScript.ORDER_RELATIONAL,
-        JavaScript.ORDER_RELATIONAL],
-    'NEGATIVE': [' < 0', JavaScript.ORDER_RELATIONAL,
-        JavaScript.ORDER_RELATIONAL],
+    'WHOLE':
+        [' % 1 === 0', JavaScript.ORDER_MODULUS, JavaScript.ORDER_EQUALITY],
+    'POSITIVE':
+        [' > 0', JavaScript.ORDER_RELATIONAL, JavaScript.ORDER_RELATIONAL],
+    'NEGATIVE':
+        [' < 0', JavaScript.ORDER_RELATIONAL, JavaScript.ORDER_RELATIONAL],
     'DIVISIBLE_BY': [null, JavaScript.ORDER_MODULUS, JavaScript.ORDER_EQUALITY],
     'PRIME': [null, JavaScript.ORDER_NONE, JavaScript.ORDER_FUNCTION_CALL],
   };
   const dropdownProperty = block.getFieldValue('PROPERTY');
   const [suffix, inputOrder, outputOrder] = PROPERTIES[dropdownProperty];
-  const numberToCheck = JavaScript.valueToCode(block, 'NUMBER_TO_CHECK',
-      inputOrder) || '0';
+  const numberToCheck =
+      JavaScript.valueToCode(block, 'NUMBER_TO_CHECK', inputOrder) || '0';
   let code;
   if (dropdownProperty === 'PRIME') {
     // Prime is a special case as it is not a one-liner test.
@@ -189,8 +189,9 @@ function ${JavaScript.FUNCTION_NAME_PLACEHOLDER_}(n) {
 `);
     code = functionName + '(' + numberToCheck + ')';
   } else if (dropdownProperty === 'DIVISIBLE_BY') {
-    const divisor = JavaScript.valueToCode(block, 'DIVISOR',
-        JavaScript.ORDER_MODULUS) || '0';
+    const divisor =
+        JavaScript.valueToCode(block, 'DIVISOR', JavaScript.ORDER_MODULUS) ||
+        '0';
     code = numberToCheck + ' % ' + divisor + ' === 0';
   } else {
     code = numberToCheck + suffix;
@@ -200,10 +201,10 @@ function ${JavaScript.FUNCTION_NAME_PLACEHOLDER_}(n) {
 
 JavaScript['math_change'] = function(block) {
   // Add to a variable in place.
-  const argument0 = JavaScript.valueToCode(block, 'DELTA',
-      JavaScript.ORDER_ADDITION) || '0';
-  const varName = JavaScript.nameDB_.getName(
-      block.getFieldValue('VAR'), NameType.VARIABLE);
+  const argument0 =
+      JavaScript.valueToCode(block, 'DELTA', JavaScript.ORDER_ADDITION) || '0';
+  const varName =
+      JavaScript.nameDB_.getName(block.getFieldValue('VAR'), NameType.VARIABLE);
   return varName + ' = (typeof ' + varName + ' === \'number\' ? ' + varName +
       ' : 0) + ' + argument0 + ';\n';
 };
@@ -220,18 +221,18 @@ JavaScript['math_on_list'] = function(block) {
   let code;
   switch (func) {
     case 'SUM':
-      list = JavaScript.valueToCode(block, 'LIST',
-          JavaScript.ORDER_MEMBER) || '[]';
+      list = JavaScript.valueToCode(block, 'LIST', JavaScript.ORDER_MEMBER) ||
+          '[]';
       code = list + '.reduce(function(x, y) {return x + y;}, 0)';
       break;
     case 'MIN':
-      list = JavaScript.valueToCode(block, 'LIST',
-          JavaScript.ORDER_NONE) || '[]';
+      list =
+          JavaScript.valueToCode(block, 'LIST', JavaScript.ORDER_NONE) || '[]';
       code = 'Math.min.apply(null, ' + list + ')';
       break;
     case 'MAX':
-      list = JavaScript.valueToCode(block, 'LIST',
-          JavaScript.ORDER_NONE) || '[]';
+      list =
+          JavaScript.valueToCode(block, 'LIST', JavaScript.ORDER_NONE) || '[]';
       code = 'Math.max.apply(null, ' + list + ')';
       break;
     case 'AVERAGE': {
@@ -241,8 +242,8 @@ function ${JavaScript.FUNCTION_NAME_PLACEHOLDER_}(myList) {
   return myList.reduce(function(x, y) {return x + y;}, 0) / myList.length;
 }
 `);
-      list = JavaScript.valueToCode(block, 'LIST',
-          JavaScript.ORDER_NONE) || '[]';
+      list =
+          JavaScript.valueToCode(block, 'LIST', JavaScript.ORDER_NONE) || '[]';
       code = functionName + '(' + list + ')';
       break;
     }
@@ -260,8 +261,8 @@ function ${JavaScript.FUNCTION_NAME_PLACEHOLDER_}(myList) {
   }
 }
 `);
-      list = JavaScript.valueToCode(block, 'LIST',
-          JavaScript.ORDER_NONE) || '[]';
+      list =
+          JavaScript.valueToCode(block, 'LIST', JavaScript.ORDER_NONE) || '[]';
       code = functionName + '(' + list + ')';
       break;
     }
@@ -299,13 +300,14 @@ function ${JavaScript.FUNCTION_NAME_PLACEHOLDER_}(values) {
   return modes;
 }
 `);
-      list = JavaScript.valueToCode(block, 'LIST',
-          JavaScript.ORDER_NONE) || '[]';
+      list =
+          JavaScript.valueToCode(block, 'LIST', JavaScript.ORDER_NONE) || '[]';
       code = functionName + '(' + list + ')';
       break;
     }
     case 'STD_DEV': {
-      const functionName = JavaScript.provideFunction_('mathStandardDeviation', `
+      const functionName =
+          JavaScript.provideFunction_('mathStandardDeviation', `
 function ${JavaScript.FUNCTION_NAME_PLACEHOLDER_}(numbers) {
   var n = numbers.length;
   if (!n) return null;
@@ -318,8 +320,8 @@ function ${JavaScript.FUNCTION_NAME_PLACEHOLDER_}(numbers) {
   return Math.sqrt(variance);
 }
 `);
-      list = JavaScript.valueToCode(block, 'LIST',
-          JavaScript.ORDER_NONE) || '[]';
+      list =
+          JavaScript.valueToCode(block, 'LIST', JavaScript.ORDER_NONE) || '[]';
       code = functionName + '(' + list + ')';
       break;
     }
@@ -330,8 +332,8 @@ function ${JavaScript.FUNCTION_NAME_PLACEHOLDER_}(list) {
   return list[x];
 }
 `);
-      list = JavaScript.valueToCode(block, 'LIST',
-          JavaScript.ORDER_NONE) || '[]';
+      list =
+          JavaScript.valueToCode(block, 'LIST', JavaScript.ORDER_NONE) || '[]';
       code = functionName + '(' + list + ')';
       break;
     }
@@ -343,22 +345,24 @@ function ${JavaScript.FUNCTION_NAME_PLACEHOLDER_}(list) {
 
 JavaScript['math_modulo'] = function(block) {
   // Remainder computation.
-  const argument0 = JavaScript.valueToCode(block, 'DIVIDEND',
-      JavaScript.ORDER_MODULUS) || '0';
-  const argument1 = JavaScript.valueToCode(block, 'DIVISOR',
-      JavaScript.ORDER_MODULUS) || '0';
+  const argument0 =
+      JavaScript.valueToCode(block, 'DIVIDEND', JavaScript.ORDER_MODULUS) ||
+      '0';
+  const argument1 =
+      JavaScript.valueToCode(block, 'DIVISOR', JavaScript.ORDER_MODULUS) || '0';
   const code = argument0 + ' % ' + argument1;
   return [code, JavaScript.ORDER_MODULUS];
 };
 
 JavaScript['math_constrain'] = function(block) {
   // Constrain a number between two limits.
-  const argument0 = JavaScript.valueToCode(block, 'VALUE',
-      JavaScript.ORDER_NONE) || '0';
-  const argument1 = JavaScript.valueToCode(block, 'LOW',
-      JavaScript.ORDER_NONE) || '0';
-  const argument2 = JavaScript.valueToCode(block, 'HIGH',
-      JavaScript.ORDER_NONE) || 'Infinity';
+  const argument0 =
+      JavaScript.valueToCode(block, 'VALUE', JavaScript.ORDER_NONE) || '0';
+  const argument1 =
+      JavaScript.valueToCode(block, 'LOW', JavaScript.ORDER_NONE) || '0';
+  const argument2 =
+      JavaScript.valueToCode(block, 'HIGH', JavaScript.ORDER_NONE) ||
+      'Infinity';
   const code = 'Math.min(Math.max(' + argument0 + ', ' + argument1 + '), ' +
       argument2 + ')';
   return [code, JavaScript.ORDER_FUNCTION_CALL];
@@ -366,10 +370,10 @@ JavaScript['math_constrain'] = function(block) {
 
 JavaScript['math_random_int'] = function(block) {
   // Random integer between [X] and [Y].
-  const argument0 = JavaScript.valueToCode(block, 'FROM',
-      JavaScript.ORDER_NONE) || '0';
-  const argument1 = JavaScript.valueToCode(block, 'TO',
-      JavaScript.ORDER_NONE) || '0';
+  const argument0 =
+      JavaScript.valueToCode(block, 'FROM', JavaScript.ORDER_NONE) || '0';
+  const argument1 =
+      JavaScript.valueToCode(block, 'TO', JavaScript.ORDER_NONE) || '0';
   const functionName = JavaScript.provideFunction_('mathRandomInt', `
 function ${JavaScript.FUNCTION_NAME_PLACEHOLDER_}(a, b) {
   if (a > b) {
@@ -392,10 +396,12 @@ JavaScript['math_random_float'] = function(block) {
 
 JavaScript['math_atan2'] = function(block) {
   // Arctangent of point (X, Y) in degrees from -180 to 180.
-  const argument0 = JavaScript.valueToCode(block, 'X',
-      JavaScript.ORDER_NONE) || '0';
-  const argument1 = JavaScript.valueToCode(block, 'Y',
-      JavaScript.ORDER_NONE) || '0';
-  return ['Math.atan2(' + argument1 + ', ' + argument0 + ') / Math.PI * 180',
-      JavaScript.ORDER_DIVISION];
+  const argument0 =
+      JavaScript.valueToCode(block, 'X', JavaScript.ORDER_NONE) || '0';
+  const argument1 =
+      JavaScript.valueToCode(block, 'Y', JavaScript.ORDER_NONE) || '0';
+  return [
+    'Math.atan2(' + argument1 + ', ' + argument0 + ') / Math.PI * 180',
+    JavaScript.ORDER_DIVISION
+  ];
 };

--- a/generators/javascript/text.js
+++ b/generators/javascript/text.js
@@ -63,7 +63,7 @@ JavaScript['text_multiline'] = function(block) {
   // Text value.
   const code = JavaScript.multiline_quote_(block.getFieldValue('TEXT'));
   const order = code.indexOf('+') !== -1 ? JavaScript.ORDER_ADDITION :
-      JavaScript.ORDER_ATOMIC;
+                                           JavaScript.ORDER_ATOMIC;
   return [code, order];
 };
 
@@ -73,25 +73,25 @@ JavaScript['text_join'] = function(block) {
     case 0:
       return ["''", JavaScript.ORDER_ATOMIC];
     case 1: {
-      const element = JavaScript.valueToCode(block, 'ADD0',
-          JavaScript.ORDER_NONE) || "''";
+      const element =
+          JavaScript.valueToCode(block, 'ADD0', JavaScript.ORDER_NONE) || "''";
       const codeAndOrder = forceString(element);
       return codeAndOrder;
     }
     case 2: {
-      const element0 = JavaScript.valueToCode(block, 'ADD0',
-          JavaScript.ORDER_NONE) || "''";
-      const element1 = JavaScript.valueToCode(block, 'ADD1',
-          JavaScript.ORDER_NONE) || "''";
-      const code = forceString(element0)[0] +
-          ' + ' + forceString(element1)[0];
+      const element0 =
+          JavaScript.valueToCode(block, 'ADD0', JavaScript.ORDER_NONE) || "''";
+      const element1 =
+          JavaScript.valueToCode(block, 'ADD1', JavaScript.ORDER_NONE) || "''";
+      const code = forceString(element0)[0] + ' + ' + forceString(element1)[0];
       return [code, JavaScript.ORDER_ADDITION];
     }
     default: {
       const elements = new Array(block.itemCount_);
       for (let i = 0; i < block.itemCount_; i++) {
-        elements[i] = JavaScript.valueToCode(block, 'ADD' + i,
-            JavaScript.ORDER_NONE) || "''";
+        elements[i] =
+            JavaScript.valueToCode(block, 'ADD' + i, JavaScript.ORDER_NONE) ||
+            "''";
       }
       const code = '[' + elements.join(',') + '].join(\'\')';
       return [code, JavaScript.ORDER_FUNCTION_CALL];
@@ -101,37 +101,36 @@ JavaScript['text_join'] = function(block) {
 
 JavaScript['text_append'] = function(block) {
   // Append to a variable in place.
-  const varName = JavaScript.nameDB_.getName(
-      block.getFieldValue('VAR'), NameType.VARIABLE);
-  const value = JavaScript.valueToCode(block, 'TEXT',
-      JavaScript.ORDER_NONE) || "''";
-  const code = varName + ' += ' +
-      forceString(value)[0] + ';\n';
+  const varName =
+      JavaScript.nameDB_.getName(block.getFieldValue('VAR'), NameType.VARIABLE);
+  const value =
+      JavaScript.valueToCode(block, 'TEXT', JavaScript.ORDER_NONE) || "''";
+  const code = varName + ' += ' + forceString(value)[0] + ';\n';
   return code;
 };
 
 JavaScript['text_length'] = function(block) {
   // String or array length.
-  const text = JavaScript.valueToCode(block, 'VALUE',
-      JavaScript.ORDER_MEMBER) || "''";
+  const text =
+      JavaScript.valueToCode(block, 'VALUE', JavaScript.ORDER_MEMBER) || "''";
   return [text + '.length', JavaScript.ORDER_MEMBER];
 };
 
 JavaScript['text_isEmpty'] = function(block) {
   // Is the string null or array empty?
-  const text = JavaScript.valueToCode(block, 'VALUE',
-      JavaScript.ORDER_MEMBER) || "''";
+  const text =
+      JavaScript.valueToCode(block, 'VALUE', JavaScript.ORDER_MEMBER) || "''";
   return ['!' + text + '.length', JavaScript.ORDER_LOGICAL_NOT];
 };
 
 JavaScript['text_indexOf'] = function(block) {
   // Search the text for a substring.
-  const operator = block.getFieldValue('END') === 'FIRST' ?
-      'indexOf' : 'lastIndexOf';
-  const substring = JavaScript.valueToCode(block, 'FIND',
-      JavaScript.ORDER_NONE) || "''";
-  const text = JavaScript.valueToCode(block, 'VALUE',
-      JavaScript.ORDER_MEMBER) || "''";
+  const operator =
+      block.getFieldValue('END') === 'FIRST' ? 'indexOf' : 'lastIndexOf';
+  const substring =
+      JavaScript.valueToCode(block, 'FIND', JavaScript.ORDER_NONE) || "''";
+  const text =
+      JavaScript.valueToCode(block, 'VALUE', JavaScript.ORDER_MEMBER) || "''";
   const code = text + '.' + operator + '(' + substring + ')';
   // Adjust index if using one-based indices.
   if (block.workspace.options.oneBasedIndex) {
@@ -144,8 +143,8 @@ JavaScript['text_charAt'] = function(block) {
   // Get letter at index.
   // Note: Until January 2013 this block did not have the WHERE input.
   const where = block.getFieldValue('WHERE') || 'FROM_START';
-  const textOrder = (where === 'RANDOM') ? JavaScript.ORDER_NONE :
-      JavaScript.ORDER_MEMBER;
+  const textOrder =
+      (where === 'RANDOM') ? JavaScript.ORDER_NONE : JavaScript.ORDER_MEMBER;
   const text = JavaScript.valueToCode(block, 'VALUE', textOrder) || "''";
   switch (where) {
     case 'FIRST': {
@@ -185,10 +184,11 @@ JavaScript['text_getSubstring'] = function(block) {
   // Get substring.
   const where1 = block.getFieldValue('WHERE1');
   const where2 = block.getFieldValue('WHERE2');
-  const requiresLengthCall = (where1 !== 'FROM_END' && where1 !== 'LAST' &&
-      where2 !== 'FROM_END' && where2 !== 'LAST');
-  const textOrder = requiresLengthCall ? JavaScript.ORDER_MEMBER :
-      JavaScript.ORDER_NONE;
+  const requiresLengthCall =
+      (where1 !== 'FROM_END' && where1 !== 'LAST' && where2 !== 'FROM_END' &&
+       where2 !== 'LAST');
+  const textOrder =
+      requiresLengthCall ? JavaScript.ORDER_MEMBER : JavaScript.ORDER_NONE;
   const text = JavaScript.valueToCode(block, 'STRING', textOrder) || "''";
   let code;
   if (where1 === 'FIRST' && where2 === 'LAST') {
@@ -203,8 +203,8 @@ JavaScript['text_getSubstring'] = function(block) {
         at1 = JavaScript.getAdjusted(block, 'AT1');
         break;
       case 'FROM_END':
-        at1 = JavaScript.getAdjusted(block, 'AT1', 1, false,
-            JavaScript.ORDER_SUBTRACTION);
+        at1 = JavaScript.getAdjusted(
+            block, 'AT1', 1, false, JavaScript.ORDER_SUBTRACTION);
         at1 = text + '.length - ' + at1;
         break;
       case 'FIRST':
@@ -219,8 +219,8 @@ JavaScript['text_getSubstring'] = function(block) {
         at2 = JavaScript.getAdjusted(block, 'AT2', 1);
         break;
       case 'FROM_END':
-        at2 = JavaScript.getAdjusted(block, 'AT2', 0, false,
-            JavaScript.ORDER_SUBTRACTION);
+        at2 = JavaScript.getAdjusted(
+            block, 'AT2', 0, false, JavaScript.ORDER_SUBTRACTION);
         at2 = text + '.length - ' + at2;
         break;
       case 'LAST':
@@ -233,8 +233,12 @@ JavaScript['text_getSubstring'] = function(block) {
   } else {
     const at1 = JavaScript.getAdjusted(block, 'AT1');
     const at2 = JavaScript.getAdjusted(block, 'AT2');
-    const wherePascalCase = {'FIRST': 'First', 'LAST': 'Last',
-      'FROM_START': 'FromStart', 'FROM_END': 'FromEnd'};
+    const wherePascalCase = {
+      'FIRST': 'First',
+      'LAST': 'Last',
+      'FROM_START': 'FromStart',
+      'FROM_END': 'FromEnd'
+    };
     // The value for 'FROM_END' and'FROM_START' depends on `at` so
     // we add it as a parameter.
     const at1Param =
@@ -242,8 +246,10 @@ JavaScript['text_getSubstring'] = function(block) {
     const at2Param =
         (where2 === 'FROM_END' || where2 === 'FROM_START') ? ', at2' : '';
     const functionName = JavaScript.provideFunction_(
-        'subsequence' + wherePascalCase[where1] + wherePascalCase[where2], `
-function ${JavaScript.FUNCTION_NAME_PLACEHOLDER_}(sequence${at1Param}${at2Param}) {
+        'subsequence' + wherePascalCase[where1] + wherePascalCase[where2],
+        `
+function ${JavaScript.FUNCTION_NAME_PLACEHOLDER_}(sequence${at1Param}${
+            at2Param}) {
   var start = ${getSubstringIndex('sequence', where1, 'at1')};
   var end = ${getSubstringIndex('sequence', where2, 'at2')} + 1;
   return sequence.slice(start, end);
@@ -294,15 +300,15 @@ JavaScript['text_trim'] = function(block) {
     'BOTH': '.trim()',
   };
   const operator = OPERATORS[block.getFieldValue('MODE')];
-  const text = JavaScript.valueToCode(block, 'TEXT',
-      JavaScript.ORDER_MEMBER) || "''";
+  const text =
+      JavaScript.valueToCode(block, 'TEXT', JavaScript.ORDER_MEMBER) || "''";
   return [text + operator, JavaScript.ORDER_FUNCTION_CALL];
 };
 
 JavaScript['text_print'] = function(block) {
   // Print statement.
-  const msg = JavaScript.valueToCode(block, 'TEXT',
-      JavaScript.ORDER_NONE) || "''";
+  const msg =
+      JavaScript.valueToCode(block, 'TEXT', JavaScript.ORDER_NONE) || "''";
   return 'window.alert(' + msg + ');\n';
 };
 
@@ -327,10 +333,10 @@ JavaScript['text_prompt_ext'] = function(block) {
 JavaScript['text_prompt'] = JavaScript['text_prompt_ext'];
 
 JavaScript['text_count'] = function(block) {
-  const text = JavaScript.valueToCode(block, 'TEXT',
-      JavaScript.ORDER_NONE) || "''";
-  const sub = JavaScript.valueToCode(block, 'SUB',
-      JavaScript.ORDER_NONE) || "''";
+  const text =
+      JavaScript.valueToCode(block, 'TEXT', JavaScript.ORDER_NONE) || "''";
+  const sub =
+      JavaScript.valueToCode(block, 'SUB', JavaScript.ORDER_NONE) || "''";
   const functionName = JavaScript.provideFunction_('textCount', `
 function ${JavaScript.FUNCTION_NAME_PLACEHOLDER_}(haystack, needle) {
   if (needle.length === 0) {
@@ -345,15 +351,19 @@ function ${JavaScript.FUNCTION_NAME_PLACEHOLDER_}(haystack, needle) {
 };
 
 JavaScript['text_replace'] = function(block) {
-  const text = JavaScript.valueToCode(block, 'TEXT',
-      JavaScript.ORDER_NONE) || "''";
-  const from = JavaScript.valueToCode(block, 'FROM',
-      JavaScript.ORDER_NONE) || "''";
+  const text =
+      JavaScript.valueToCode(block, 'TEXT', JavaScript.ORDER_NONE) || "''";
+  const from =
+      JavaScript.valueToCode(block, 'FROM', JavaScript.ORDER_NONE) || "''";
   const to = JavaScript.valueToCode(block, 'TO', JavaScript.ORDER_NONE) || "''";
   // The regex escaping code below is taken from the implementation of
   // goog.string.regExpEscape.
-  const functionName = JavaScript.provideFunction_('textReplace', `
-function ${JavaScript.FUNCTION_NAME_PLACEHOLDER_}(haystack, needle, replacement) {
+  const functionName = JavaScript.provideFunction_(
+      'textReplace',
+      `
+function ${
+          JavaScript
+              .FUNCTION_NAME_PLACEHOLDER_}(haystack, needle, replacement) {
   needle = needle.replace(/([-()\\[\\]{}+?*.$\\^|,:#<!\\\\])/g, '\\\\$1')
                  .replace(/\\x08/g, '\\\\x08');
   return haystack.replace(new RegExp(needle, 'g'), replacement);
@@ -364,8 +374,8 @@ function ${JavaScript.FUNCTION_NAME_PLACEHOLDER_}(haystack, needle, replacement)
 };
 
 JavaScript['text_reverse'] = function(block) {
-  const text = JavaScript.valueToCode(block, 'TEXT',
-      JavaScript.ORDER_MEMBER) || "''";
+  const text =
+      JavaScript.valueToCode(block, 'TEXT', JavaScript.ORDER_MEMBER) || "''";
   const code = text + ".split('').reverse().join('')";
   return [code, JavaScript.ORDER_FUNCTION_CALL];
 };

--- a/generators/javascript/variables.js
+++ b/generators/javascript/variables.js
@@ -17,16 +17,17 @@ const {javascriptGenerator: JavaScript} = goog.require('Blockly.JavaScript');
 
 JavaScript['variables_get'] = function(block) {
   // Variable getter.
-  const code = JavaScript.nameDB_.getName(block.getFieldValue('VAR'),
-      NameType.VARIABLE);
+  const code =
+      JavaScript.nameDB_.getName(block.getFieldValue('VAR'), NameType.VARIABLE);
   return [code, JavaScript.ORDER_ATOMIC];
 };
 
 JavaScript['variables_set'] = function(block) {
   // Variable setter.
-  const argument0 = JavaScript.valueToCode(
-                        block, 'VALUE', JavaScript.ORDER_ASSIGNMENT) || '0';
-  const varName = JavaScript.nameDB_.getName(
-      block.getFieldValue('VAR'), NameType.VARIABLE);
+  const argument0 =
+      JavaScript.valueToCode(block, 'VALUE', JavaScript.ORDER_ASSIGNMENT) ||
+      '0';
+  const varName =
+      JavaScript.nameDB_.getName(block.getFieldValue('VAR'), NameType.VARIABLE);
   return varName + ' = ' + argument0 + ';\n';
 };

--- a/generators/lua/logic.js
+++ b/generators/lua/logic.js
@@ -28,7 +28,8 @@ Lua['controls_if'] = function(block) {
     let branchCode = Lua.statementToCode(block, 'DO' + n);
     if (Lua.STATEMENT_SUFFIX) {
       branchCode = Lua.prefixLines(
-          Lua.injectId(Lua.STATEMENT_SUFFIX, block), Lua.INDENT) + branchCode;
+                       Lua.injectId(Lua.STATEMENT_SUFFIX, block), Lua.INDENT) +
+          branchCode;
     }
     code +=
         (n > 0 ? 'else' : '') + 'if ' + conditionCode + ' then\n' + branchCode;

--- a/generators/lua/math.js
+++ b/generators/lua/math.js
@@ -137,8 +137,8 @@ Lua['math_number_property'] = function(block) {
   };
   const dropdownProperty = block.getFieldValue('PROPERTY');
   const [suffix, inputOrder, outputOrder] = PROPERTIES[dropdownProperty];
-  const numberToCheck = Lua.valueToCode(block, 'NUMBER_TO_CHECK',
-      inputOrder) || '0';
+  const numberToCheck =
+      Lua.valueToCode(block, 'NUMBER_TO_CHECK', inputOrder) || '0';
   let code;
   if (dropdownProperty === 'PRIME') {
     // Prime is a special case as it is not a one-liner test.
@@ -164,8 +164,8 @@ end
 `);
     code = functionName + '(' + numberToCheck + ')';
   } else if (dropdownProperty === 'DIVISIBLE_BY') {
-    const divisor = Lua.valueToCode(block, 'DIVISOR',
-        Lua.ORDER_MULTIPLICATIVE) || '0';
+    const divisor =
+        Lua.valueToCode(block, 'DIVISOR', Lua.ORDER_MULTIPLICATIVE) || '0';
     // If 'divisor' is some code that evals to 0, Lua will produce a nan.
     // Let's produce nil if we can determine this at compile-time.
     if (divisor === '0') {

--- a/generators/lua/text.js
+++ b/generators/lua/text.js
@@ -58,8 +58,7 @@ Lua['text_append'] = function(block) {
   // Append to a variable in place.
   const varName =
       Lua.nameDB_.getName(block.getFieldValue('VAR'), NameType.VARIABLE);
-  const value =
-      Lua.valueToCode(block, 'TEXT', Lua.ORDER_CONCATENATION) || "''";
+  const value = Lua.valueToCode(block, 'TEXT', Lua.ORDER_CONCATENATION) || "''";
   return varName + ' = ' + varName + ' .. ' + value + '\n';
 };
 

--- a/generators/php/math.js
+++ b/generators/php/math.js
@@ -152,9 +152,10 @@ PHP['math_number_property'] = function(block) {
     'PRIME': [null, null, PHP.ORDER_NONE, PHP.ORDER_FUNCTION_CALL],
   };
   const dropdownProperty = block.getFieldValue('PROPERTY');
-  const [prefix, suffix, inputOrder, outputOrder] = PROPERTIES[dropdownProperty];
-  const numberToCheck = PHP.valueToCode(block, 'NUMBER_TO_CHECK',
-      inputOrder) || '0';
+  const [prefix, suffix, inputOrder, outputOrder] =
+      PROPERTIES[dropdownProperty];
+  const numberToCheck =
+      PHP.valueToCode(block, 'NUMBER_TO_CHECK', inputOrder) || '0';
   let code;
   if (dropdownProperty === 'PRIME') {
     // Prime is a special case as it is not a one-liner test.
@@ -180,11 +181,9 @@ function ${PHP.FUNCTION_NAME_PLACEHOLDER_}($n) {
 `);
     code = functionName + '(' + numberToCheck + ')';
   } else if (dropdownProperty === 'DIVISIBLE_BY') {
-    const divisor = PHP.valueToCode(block, 'DIVISOR',
-        PHP.ORDER_MODULUS) || '0';
+    const divisor = PHP.valueToCode(block, 'DIVISOR', PHP.ORDER_MODULUS) || '0';
     if (divisor === '0') {
       return ['false', PHP.ORDER_ATOMIC];
-
     }
     code = numberToCheck + ' % ' + divisor + ' == 0';
   } else {

--- a/generators/python/math.js
+++ b/generators/python/math.js
@@ -164,7 +164,8 @@ Python['math_number_property'] = function(block) {
     'DIVISIBLE_BY':
         [null, Python.ORDER_MULTIPLICATIVE, Python.ORDER_RELATIONAL],
     'PRIME': [null, Python.ORDER_NONE, Python.ORDER_FUNCTION_CALL],
-  } const dropdownProperty = block.getFieldValue('PROPERTY');
+  };
+  const dropdownProperty = block.getFieldValue('PROPERTY');
   const [suffix, inputOrder, outputOrder] = PROPERTIES[dropdownProperty];
   const numberToCheck =
       Python.valueToCode(block, 'NUMBER_TO_CHECK', inputOrder) || '0';

--- a/generators/python/math.js
+++ b/generators/python/math.js
@@ -152,23 +152,22 @@ Python['math_constant'] = function(block) {
 };
 
 Python['math_number_property'] = function(block) {
-   // Check if a number is even, odd, prime, whole, positive, or negative
-   // or if it is divisible by certain number. Returns true or false.
+  // Check if a number is even, odd, prime, whole, positive, or negative
+  // or if it is divisible by certain number. Returns true or false.
   const PROPERTIES = {
     'EVEN': [' % 2 == 0', Python.ORDER_MULTIPLICATIVE, Python.ORDER_RELATIONAL],
     'ODD': [' % 2 == 1', Python.ORDER_MULTIPLICATIVE, Python.ORDER_RELATIONAL],
-    'WHOLE': [' % 1 == 0', Python.ORDER_MULTIPLICATIVE,
-        Python.ORDER_RELATIONAL],
+    'WHOLE':
+        [' % 1 == 0', Python.ORDER_MULTIPLICATIVE, Python.ORDER_RELATIONAL],
     'POSITIVE': [' > 0', Python.ORDER_RELATIONAL, Python.ORDER_RELATIONAL],
     'NEGATIVE': [' < 0', Python.ORDER_RELATIONAL, Python.ORDER_RELATIONAL],
-    'DIVISIBLE_BY': [null, Python.ORDER_MULTIPLICATIVE,
-        Python.ORDER_RELATIONAL],
+    'DIVISIBLE_BY':
+        [null, Python.ORDER_MULTIPLICATIVE, Python.ORDER_RELATIONAL],
     'PRIME': [null, Python.ORDER_NONE, Python.ORDER_FUNCTION_CALL],
-  }
-  const dropdownProperty = block.getFieldValue('PROPERTY');
+  } const dropdownProperty = block.getFieldValue('PROPERTY');
   const [suffix, inputOrder, outputOrder] = PROPERTIES[dropdownProperty];
-  const numberToCheck = Python.valueToCode(block, 'NUMBER_TO_CHECK',
-      inputOrder) || '0';
+  const numberToCheck =
+      Python.valueToCode(block, 'NUMBER_TO_CHECK', inputOrder) || '0';
   let code;
   if (dropdownProperty === 'PRIME') {
     // Prime is a special case as it is not a one-liner test.
@@ -195,10 +194,11 @@ def ${Python.FUNCTION_NAME_PLACEHOLDER_}(n):
       return False
   return True
 `);
-       code = functionName + '(' + numberToCheck + ')';
+    code = functionName + '(' + numberToCheck + ')';
   } else if (dropdownProperty === 'DIVISIBLE_BY') {
-    const divisor = Python.valueToCode(block, 'DIVISOR',
-        Python.ORDER_MULTIPLICATIVE) || '0';
+    const divisor =
+        Python.valueToCode(block, 'DIVISOR', Python.ORDER_MULTIPLICATIVE) ||
+        '0';
     // If 'divisor' is some code that evals to 0, Python will raise an error.
     if (divisor === '0') {
       return ['False', Python.ORDER_ATOMIC];
@@ -261,7 +261,7 @@ def ${Python.FUNCTION_NAME_PLACEHOLDER_}(myList):
           'from numbers import Number';
       // This operation excludes null values:
       // math_median([null, null, 1, 3]) -> 2.0
-      const functionName = Python.provideFunction_( 'math_median', `
+      const functionName = Python.provideFunction_('math_median', `
 def ${Python.FUNCTION_NAME_PLACEHOLDER_}(myList):
   localList = sorted([e for e in myList if isinstance(e, Number)])
   if not localList: return

--- a/generators/python/text.js
+++ b/generators/python/text.js
@@ -111,8 +111,7 @@ Python['text_indexOf'] = function(block) {
   const operator = block.getFieldValue('END') === 'FIRST' ? 'find' : 'rfind';
   const substring =
       Python.valueToCode(block, 'FIND', Python.ORDER_NONE) || "''";
-  const text =
-      Python.valueToCode(block, 'VALUE', Python.ORDER_MEMBER) || "''";
+  const text = Python.valueToCode(block, 'VALUE', Python.ORDER_MEMBER) || "''";
   const code = text + '.' + operator + '(' + substring + ')';
   if (block.workspace.options.oneBasedIndex) {
     return [code + ' + 1', Python.ORDER_ADDITIVE];
@@ -164,8 +163,7 @@ Python['text_getSubstring'] = function(block) {
   // Get substring.
   const where1 = block.getFieldValue('WHERE1');
   const where2 = block.getFieldValue('WHERE2');
-  const text =
-      Python.valueToCode(block, 'STRING', Python.ORDER_MEMBER) || "''";
+  const text = Python.valueToCode(block, 'STRING', Python.ORDER_MEMBER) || "''";
   let at1;
   switch (where1) {
     case 'FROM_START':

--- a/scripts/gulpfiles/build_tasks.js
+++ b/scripts/gulpfiles/build_tasks.js
@@ -723,7 +723,9 @@ function cleanBuildDir() {
 function format() {
   return gulp.src([
     'core/**/*.js', 'core/**/*.ts',
-    'blocks/**/*.js', 'blocks/**/*.ts',
+    // 'blocks/**/*.js', 'blocks/**/*.ts',
+    'generators/**/*.js', 'generators/**/*.ts',
+    'tests/mocha/**/*.js', 'tests/mocha/**/*.ts',
     '.eslintrc.js'
   ], {base: '.'})
       .pipe(clangFormatter.format('file', clangFormat))

--- a/tests/mocha/astnode_test.js
+++ b/tests/mocha/astnode_test.js
@@ -13,63 +13,64 @@ import {sharedTestSetup, sharedTestTeardown, workspaceTeardown} from './test_hel
 suite('ASTNode', function() {
   setup(function() {
     sharedTestSetup.call(this);
-    Blockly.defineBlocksWithJsonArray([{
-      "type": "input_statement",
-      "message0": "%1 %2 %3 %4",
-      "args0": [
-        {
-          "type": "field_input",
-          "name": "NAME",
-          "text": "default",
-        },
-        {
-          "type": "field_input",
-          "name": "NAME",
-          "text": "default",
-        },
-        {
-          "type": "input_value",
-          "name": "NAME",
-        },
-        {
-          "type": "input_statement",
-          "name": "NAME",
-        },
-      ],
-      "previousStatement": null,
-      "nextStatement": null,
-      "colour": 230,
-      "tooltip": "",
-      "helpUrl": "",
-    },
-    {
-      "type": "value_input",
-      "message0": "%1",
-      "args0": [
-        {
-          "type": "input_value",
-          "name": "NAME",
-        },
-      ],
-      "colour": 230,
-      "tooltip": "",
-      "helpUrl": "",
-    },
-    {
-      "type": "field_input",
-      "message0": "%1",
-      "args0": [
-        {
-          "type": "field_input",
-          "name": "NAME",
-          "text": "default",
-        },
-      ],
-      "output": null,
-      "colour": 230,
-      "tooltip": "",
-      "helpUrl": "",
-    },
+    Blockly.defineBlocksWithJsonArray([
+      {
+        "type": "input_statement",
+        "message0": "%1 %2 %3 %4",
+        "args0": [
+          {
+            "type": "field_input",
+            "name": "NAME",
+            "text": "default",
+          },
+          {
+            "type": "field_input",
+            "name": "NAME",
+            "text": "default",
+          },
+          {
+            "type": "input_value",
+            "name": "NAME",
+          },
+          {
+            "type": "input_statement",
+            "name": "NAME",
+          },
+        ],
+        "previousStatement": null,
+        "nextStatement": null,
+        "colour": 230,
+        "tooltip": "",
+        "helpUrl": "",
+      },
+      {
+        "type": "value_input",
+        "message0": "%1",
+        "args0": [
+          {
+            "type": "input_value",
+            "name": "NAME",
+          },
+        ],
+        "colour": 230,
+        "tooltip": "",
+        "helpUrl": "",
+      },
+      {
+        "type": "field_input",
+        "message0": "%1",
+        "args0": [
+          {
+            "type": "field_input",
+            "name": "NAME",
+            "text": "default",
+          },
+        ],
+        "output": null,
+        "colour": 230,
+        "tooltip": "",
+        "helpUrl": "",
+      },
     ]);
     this.workspace = new Blockly.Workspace();
     this.cursor = this.workspace.cursor;
@@ -81,10 +82,10 @@ suite('ASTNode', function() {
     const valueInput = this.workspace.newBlock('value_input');
 
     statementInput1.nextConnection.connect(statementInput2.previousConnection);
-    statementInput1.inputList[0].connection
-        .connect(fieldWithOutput.outputConnection);
-    statementInput2.inputList[1].connection
-        .connect(statementInput3.previousConnection);
+    statementInput1.inputList[0].connection.connect(
+        fieldWithOutput.outputConnection);
+    statementInput2.inputList[1].connection.connect(
+        statementInput3.previousConnection);
 
     this.blocks = {
       statementInput1: statementInput1,
@@ -142,150 +143,155 @@ suite('ASTNode', function() {
     });
 
     test('navigateBetweenStacks_Backward', function() {
-      const node = new ASTNode(
-          ASTNode.types.BLOCK, this.blocks.statementInput4);
+      const node =
+          new ASTNode(ASTNode.types.BLOCK, this.blocks.statementInput4);
       const newASTNode = node.navigateBetweenStacks(false);
       chai.assert.equal(newASTNode.getLocation(), this.blocks.statementInput1);
     });
     test('getOutAstNodeForBlock', function() {
-      const node = new ASTNode(
-          ASTNode.types.BLOCK, this.blocks.statementInput2);
-      const newASTNode = node.getOutAstNodeForBlock(this.blocks.statementInput2);
+      const node =
+          new ASTNode(ASTNode.types.BLOCK, this.blocks.statementInput2);
+      const newASTNode =
+          node.getOutAstNodeForBlock(this.blocks.statementInput2);
       chai.assert.equal(newASTNode.getLocation(), this.blocks.statementInput1);
     });
     test('getOutAstNodeForBlock_OneBlock', function() {
-      const node = new ASTNode(
-          ASTNode.types.BLOCK, this.blocks.statementInput4);
-      const newASTNode = node.getOutAstNodeForBlock(this.blocks.statementInput4);
+      const node =
+          new ASTNode(ASTNode.types.BLOCK, this.blocks.statementInput4);
+      const newASTNode =
+          node.getOutAstNodeForBlock(this.blocks.statementInput4);
       chai.assert.equal(newASTNode.getLocation(), this.blocks.statementInput4);
     });
     test('findFirstFieldOrInput_', function() {
-      const node = new ASTNode(
-          ASTNode.types.BLOCK, this.blocks.statementInput4);
+      const node =
+          new ASTNode(ASTNode.types.BLOCK, this.blocks.statementInput4);
       const field = this.blocks.statementInput4.inputList[0].fieldRow[0];
-      const newASTNode = node.findFirstFieldOrInput(this.blocks.statementInput4);
+      const newASTNode =
+          node.findFirstFieldOrInput(this.blocks.statementInput4);
       chai.assert.equal(newASTNode.getLocation(), field);
     });
   });
 
   suite('NavigationFunctions', function() {
     setup(function() {
-      Blockly.defineBlocksWithJsonArray([{
-        "type": "top_connection",
-        "message0": "",
-        "previousStatement": null,
-        "colour": 230,
-        "tooltip": "",
-        "helpUrl": "",
-      },
-      {
-        "type": "start_block",
-        "message0": "",
-        "nextStatement": null,
-        "colour": 230,
-        "tooltip": "",
-        "helpUrl": "",
-      },
-      {
-        "type": "fields_and_input",
-        "message0": "%1 hi %2 %3 %4",
-        "args0": [
-          {
-            "type": "field_input",
-            "name": "NAME",
-            "text": "default",
-          },
-          {
-            "type": "input_dummy",
-          },
-          {
-            "type": "field_input",
-            "name": "NAME",
-            "text": "default",
-          },
-          {
-            "type": "input_value",
-            "name": "NAME",
-          },
-        ],
-        "previousStatement": null,
-        "nextStatement": null,
-        "colour": 230,
-        "tooltip": "",
-        "helpUrl": "",
-      },
-      {
-        "type": "two_fields",
-        "message0": "%1 hi",
-        "args0": [
-          {
-            "type": "field_input",
-            "name": "NAME",
-            "text": "default",
-          },
-        ],
-        "colour": 230,
-        "tooltip": "",
-        "helpUrl": "",
-      },
-      {
-        "type": "fields_and_input2",
-        "message0": "%1 %2 %3 hi %4 bye",
-        "args0": [
-          {
-            "type": "input_value",
-            "name": "NAME",
-          },
-          {
-            "type": "field_input",
-            "name": "NAME",
-            "text": "default",
-          },
-          {
-            "type": "input_value",
-            "name": "NAME",
-          },
-          {
-            "type": "input_statement",
-            "name": "NAME",
-          },
-        ],
-        "colour": 230,
-        "tooltip": "",
-        "helpUrl": "",
-      },
-      {
-        "type": "dummy_input",
-        "message0": "Hello",
-        "colour": 230,
-        "tooltip": "",
-        "helpUrl": "",
-      },
-      {
-        "type": "dummy_inputValue",
-        "message0": "Hello %1  %2",
-        "args0": [
-          {
-            "type": "input_dummy",
-          },
-          {
-            "type": "input_value",
-            "name": "NAME",
-          },
-        ],
-        "colour": 230,
-        "tooltip": "",
-        "helpUrl": "",
-      },
-      {
-        "type": "output_next",
-        "message0": "",
-        "output": null,
-        "colour": 230,
-        "tooltip": "",
-        "helpUrl": "",
-        "nextStatement": null,
-      }]);
+      Blockly.defineBlocksWithJsonArray([
+        {
+          "type": "top_connection",
+          "message0": "",
+          "previousStatement": null,
+          "colour": 230,
+          "tooltip": "",
+          "helpUrl": "",
+        },
+        {
+          "type": "start_block",
+          "message0": "",
+          "nextStatement": null,
+          "colour": 230,
+          "tooltip": "",
+          "helpUrl": "",
+        },
+        {
+          "type": "fields_and_input",
+          "message0": "%1 hi %2 %3 %4",
+          "args0": [
+            {
+              "type": "field_input",
+              "name": "NAME",
+              "text": "default",
+            },
+            {
+              "type": "input_dummy",
+            },
+            {
+              "type": "field_input",
+              "name": "NAME",
+              "text": "default",
+            },
+            {
+              "type": "input_value",
+              "name": "NAME",
+            },
+          ],
+          "previousStatement": null,
+          "nextStatement": null,
+          "colour": 230,
+          "tooltip": "",
+          "helpUrl": "",
+        },
+        {
+          "type": "two_fields",
+          "message0": "%1 hi",
+          "args0": [
+            {
+              "type": "field_input",
+              "name": "NAME",
+              "text": "default",
+            },
+          ],
+          "colour": 230,
+          "tooltip": "",
+          "helpUrl": "",
+        },
+        {
+          "type": "fields_and_input2",
+          "message0": "%1 %2 %3 hi %4 bye",
+          "args0": [
+            {
+              "type": "input_value",
+              "name": "NAME",
+            },
+            {
+              "type": "field_input",
+              "name": "NAME",
+              "text": "default",
+            },
+            {
+              "type": "input_value",
+              "name": "NAME",
+            },
+            {
+              "type": "input_statement",
+              "name": "NAME",
+            },
+          ],
+          "colour": 230,
+          "tooltip": "",
+          "helpUrl": "",
+        },
+        {
+          "type": "dummy_input",
+          "message0": "Hello",
+          "colour": 230,
+          "tooltip": "",
+          "helpUrl": "",
+        },
+        {
+          "type": "dummy_inputValue",
+          "message0": "Hello %1  %2",
+          "args0": [
+            {
+              "type": "input_dummy",
+            },
+            {
+              "type": "input_value",
+              "name": "NAME",
+            },
+          ],
+          "colour": 230,
+          "tooltip": "",
+          "helpUrl": "",
+        },
+        {
+          "type": "output_next",
+          "message0": "",
+          "output": null,
+          "colour": 230,
+          "tooltip": "",
+          "helpUrl": "",
+          "nextStatement": null,
+        }
+      ]);
       const noNextConnection = this.workspace.newBlock('top_connection');
       const fieldAndInputs = this.workspace.newBlock('fields_and_input');
       const twoFields = this.workspace.newBlock('two_fields');
@@ -351,14 +357,16 @@ suite('ASTNode', function() {
       });
       test('fromInputToInput', function() {
         const input = this.blocks.statementInput1.inputList[0];
-        const inputConnection = this.blocks.statementInput1.inputList[1].connection;
+        const inputConnection =
+            this.blocks.statementInput1.inputList[1].connection;
         const node = ASTNode.createInputNode(input);
         const nextNode = node.next();
         chai.assert.equal(nextNode.getLocation(), inputConnection);
       });
       test('fromInputToStatementInput', function() {
         const input = this.blocks.fieldAndInputs2.inputList[1];
-        const inputConnection = this.blocks.fieldAndInputs2.inputList[2].connection;
+        const inputConnection =
+            this.blocks.fieldAndInputs2.inputList[2].connection;
         const node = ASTNode.createInputNode(input);
         const nextNode = node.next();
         chai.assert.equal(nextNode.getLocation(), inputConnection);
@@ -384,7 +392,8 @@ suite('ASTNode', function() {
       });
       test('fromFieldToInput', function() {
         const field = this.blocks.statementInput1.inputList[0].fieldRow[1];
-        const inputConnection = this.blocks.statementInput1.inputList[0].connection;
+        const inputConnection =
+            this.blocks.statementInput1.inputList[0].connection;
         const node = ASTNode.createFieldNode(field);
         const nextNode = node.next();
         chai.assert.equal(nextNode.getLocation(), inputConnection);
@@ -472,7 +481,8 @@ suite('ASTNode', function() {
       });
       test('fromInputToInput', function() {
         const input = this.blocks.fieldAndInputs2.inputList[2];
-        const inputConnection = this.blocks.fieldAndInputs2.inputList[1].connection;
+        const inputConnection =
+            this.blocks.fieldAndInputs2.inputList[1].connection;
         const node = ASTNode.createInputNode(input);
         const prevNode = node.prev();
         chai.assert.equal(prevNode.getLocation(), inputConnection);
@@ -491,7 +501,8 @@ suite('ASTNode', function() {
       });
       test('fromFieldToInput', function() {
         const field = this.blocks.fieldAndInputs2.inputList[1].fieldRow[0];
-        const inputConnection = this.blocks.fieldAndInputs2.inputList[0].connection;
+        const inputConnection =
+            this.blocks.fieldAndInputs2.inputList[0].connection;
         const node = ASTNode.createFieldNode(field);
         const prevNode = node.prev();
         chai.assert.equal(prevNode.getLocation(), inputConnection);
@@ -534,7 +545,8 @@ suite('ASTNode', function() {
       });
       test('fromInputToPrevious', function() {
         const input = this.blocks.statementInput2.inputList[1];
-        const previousConnection = this.blocks.statementInput3.previousConnection;
+        const previousConnection =
+            this.blocks.statementInput3.previousConnection;
         const node = ASTNode.createInputNode(input);
         const inNode = node.in();
         chai.assert.equal(inNode.getLocation(), previousConnection);
@@ -565,7 +577,8 @@ suite('ASTNode', function() {
       });
       test('fromBlockToInput_DummyInputValue', function() {
         const node = ASTNode.createBlockNode(this.blocks.dummyInputValue);
-        const inputConnection = this.blocks.dummyInputValue.inputList[1].connection;
+        const inputConnection =
+            this.blocks.dummyInputValue.inputList[1].connection;
         const inNode = node.in();
         chai.assert.equal(inNode.getLocation(), inputConnection);
       });
@@ -585,13 +598,14 @@ suite('ASTNode', function() {
         const coordinate = new Blockly.utils.Coordinate(100, 100);
         const node = ASTNode.createWorkspaceNode(this.workspace, coordinate);
         const inNode = node.in();
-        chai.assert.equal(inNode.getLocation(), this.workspace.getTopBlocks()[0]);
+        chai.assert.equal(
+            inNode.getLocation(), this.workspace.getTopBlocks()[0]);
         chai.assert.equal(inNode.getType(), ASTNode.types.STACK);
       });
       test('fromWorkspaceToNull', function() {
         const coordinate = new Blockly.utils.Coordinate(100, 100);
-        const node = ASTNode.createWorkspaceNode(
-            this.emptyWorkspace, coordinate);
+        const node =
+            ASTNode.createWorkspaceNode(this.emptyWorkspace, coordinate);
         const inNode = node.in();
         chai.assert.isNull(inNode);
       });
@@ -621,9 +635,10 @@ suite('ASTNode', function() {
       setup(function() {
         const secondBlock = this.blocks.secondBlock;
         const outputNextBlock = this.blocks.outputNextBlock;
-        this.blocks.noPrevConnection.nextConnection.connect(secondBlock.previousConnection);
-        secondBlock.inputList[0].connection
-            .connect(outputNextBlock.outputConnection);
+        this.blocks.noPrevConnection.nextConnection.connect(
+            secondBlock.previousConnection);
+        secondBlock.inputList[0].connection.connect(
+            outputNextBlock.outputConnection);
       });
 
       test('fromInputToBlock', function() {
@@ -638,7 +653,8 @@ suite('ASTNode', function() {
         const node = ASTNode.createConnectionNode(output);
         const outNode = node.out();
         chai.assert.equal(outNode.getType(), ASTNode.types.INPUT);
-        chai.assert.equal(outNode.getLocation(),
+        chai.assert.equal(
+            outNode.getLocation(),
             this.blocks.statementInput1.inputList[0].connection);
       });
       test('fromOutputToStack', function() {
@@ -656,8 +672,9 @@ suite('ASTNode', function() {
         chai.assert.equal(outNode.getLocation(), this.blocks.statementInput1);
       });
       test('fromStackToWorkspace', function() {
-        const stub = sinon.stub(this.blocks.statementInput4,
-            "getRelativeToSurfaceXY").returns({x: 10, y: 10});
+        const stub =
+            sinon.stub(this.blocks.statementInput4, "getRelativeToSurfaceXY")
+                .returns({x: 10, y: 10});
         const node = ASTNode.createStackNode(this.blocks.statementInput4);
         const outNode = node.out();
         chai.assert.equal(outNode.getType(), ASTNode.types.WORKSPACE);
@@ -667,7 +684,8 @@ suite('ASTNode', function() {
       });
       test('fromPreviousToInput', function() {
         const previous = this.blocks.statementInput3.previousConnection;
-        const inputConnection = this.blocks.statementInput2.inputList[1].connection;
+        const inputConnection =
+            this.blocks.statementInput2.inputList[1].connection;
         const node = ASTNode.createConnectionNode(previous);
         const outNode = node.out();
         chai.assert.equal(outNode.getType(), ASTNode.types.INPUT);
@@ -682,7 +700,8 @@ suite('ASTNode', function() {
       });
       test('fromNextToInput', function() {
         const next = this.blocks.statementInput3.nextConnection;
-        const inputConnection = this.blocks.statementInput2.inputList[1].connection;
+        const inputConnection =
+            this.blocks.statementInput2.inputList[1].connection;
         const node = ASTNode.createConnectionNode(next);
         const outNode = node.out();
         chai.assert.equal(outNode.getType(), ASTNode.types.INPUT);
@@ -711,7 +730,8 @@ suite('ASTNode', function() {
         const node = ASTNode.createConnectionNode(next);
         const outNode = node.out();
         chai.assert.equal(outNode.getType(), ASTNode.types.INPUT);
-        chai.assert.equal(outNode.getLocation(),
+        chai.assert.equal(
+            outNode.getLocation(),
             this.blocks.secondBlock.inputList[0].connection);
       });
       test('fromBlockToStack', function() {
@@ -772,16 +792,17 @@ suite('ASTNode', function() {
       });
       test('createWorkspaceNode', function() {
         const coordinate = new Blockly.utils.Coordinate(100, 100);
-        const node = ASTNode
-            .createWorkspaceNode(this.workspace, coordinate);
+        const node = ASTNode.createWorkspaceNode(this.workspace, coordinate);
         chai.assert.equal(node.getLocation(), this.workspace);
         chai.assert.equal(node.getType(), ASTNode.types.WORKSPACE);
         chai.assert.equal(node.getWsCoordinate(), coordinate);
         chai.assert.isFalse(node.isConnection());
       });
       test('createStatementConnectionNode', function() {
-        const nextConnection = this.blocks.statementInput1.inputList[1].connection;
-        const inputConnection = this.blocks.statementInput1.inputList[1].connection;
+        const nextConnection =
+            this.blocks.statementInput1.inputList[1].connection;
+        const inputConnection =
+            this.blocks.statementInput1.inputList[1].connection;
         const node = ASTNode.createConnectionNode(nextConnection);
         chai.assert.equal(node.getLocation(), inputConnection);
         chai.assert.equal(node.getType(), ASTNode.types.INPUT);

--- a/tests/mocha/astnode_test.js
+++ b/tests/mocha/astnode_test.js
@@ -290,7 +290,7 @@ suite('ASTNode', function() {
           "tooltip": "",
           "helpUrl": "",
           "nextStatement": null,
-        }
+        },
       ]);
       const noNextConnection = this.workspace.newBlock('top_connection');
       const fieldAndInputs = this.workspace.newBlock('fields_and_input');

--- a/tests/mocha/block_json_test.js
+++ b/tests/mocha/block_json_test.js
@@ -38,12 +38,14 @@ suite('Block JSON initialization', function() {
     });
 
     test('0 args, 1 token', function() {
-      this.assertError(['test', 1, 'test'], 0,
+      this.assertError(
+          ['test', 1, 'test'], 0,
           'Block "test": Message index %1 out of range.');
     });
 
     test('1 arg, 0 tokens', function() {
-      this.assertError(['test', 'test'], 1,
+      this.assertError(
+          ['test', 'test'], 1,
           'Block "test": Message does not reference all 1 arg(s).');
     });
 
@@ -52,17 +54,20 @@ suite('Block JSON initialization', function() {
     });
 
     test('1 arg, 2 tokens', function() {
-      this.assertError(['test', 1, 1, 'test'], 1,
+      this.assertError(
+          ['test', 1, 1, 'test'], 1,
           'Block "test": Message index %1 duplicated.');
     });
 
     test('Token out of lower bound', function() {
-      this.assertError(['test', 0, 'test'], 1,
+      this.assertError(
+          ['test', 0, 'test'], 1,
           'Block "test": Message index %0 out of range.');
     });
 
     test('Token out of upper bound', function() {
-      this.assertError(['test', 2, 'test'], 1,
+      this.assertError(
+          ['test', 2, 'test'], 1,
           'Block "test": Message index %2 out of range.');
     });
   });
@@ -77,17 +82,13 @@ suite('Block JSON initialization', function() {
           isInputKeyword_: Blockly.Block.prototype.isInputKeyword_,
         };
         chai.assert.deepEqual(
-            block.interpolateArguments_(tokens, args, lastAlign),
-            elements);
+            block.interpolateArguments_(tokens, args, lastAlign), elements);
       };
     });
 
     test('Strings to labels', function() {
       this.assertInterpolation(
-          ['test1', 'test2', 'test3', {'type': 'input_dummy'}],
-          [],
-          undefined,
-          [
+          ['test1', 'test2', 'test3', {'type': 'input_dummy'}], [], undefined, [
             {
               'type': 'field_label',
               'text': 'test1',
@@ -108,10 +109,7 @@ suite('Block JSON initialization', function() {
 
     test('Ignore empty strings', function() {
       this.assertInterpolation(
-          ['test1', '', '    ', {'type': 'input_dummy'}],
-          [],
-          undefined,
-          [
+          ['test1', '', '    ', {'type': 'input_dummy'}], [], undefined, [
             {
               'type': 'field_label',
               'text': 'test1',
@@ -139,8 +137,7 @@ suite('Block JSON initialization', function() {
               'name': 'test3',
             },
           ],
-          undefined,
-          [
+          undefined, [
             {
               'type': 'field_number',
               'name': 'test1',
@@ -161,10 +158,8 @@ suite('Block JSON initialization', function() {
 
     test('String args to labels', function() {
       this.assertInterpolation(
-          [1, 2, 3, {'type': 'input_dummy'}],
-          ['test1', 'test2', 'test3'],
-          undefined,
-          [
+          [1, 2, 3, {'type': 'input_dummy'}], ['test1', 'test2', 'test3'],
+          undefined, [
             {
               'type': 'field_label',
               'text': 'test1',
@@ -185,10 +180,8 @@ suite('Block JSON initialization', function() {
 
     test('Ignore empty string args', function() {
       this.assertInterpolation(
-          [1, 2, 3, {'type': 'input_dummy'}],
-          ['test1', '     ', '     '],
-          undefined,
-          [
+          [1, 2, 3, {'type': 'input_dummy'}], ['test1', '     ', '     '],
+          undefined, [
             {
               'type': 'field_label',
               'text': 'test1',
@@ -200,27 +193,23 @@ suite('Block JSON initialization', function() {
     });
 
     test('Add last dummy', function() {
-      this.assertInterpolation(
-          ['test1', 'test2', 'test3'],
-          [],
-          undefined,
-          [
-            {
-              'type': 'field_label',
-              'text': 'test1',
-            },
-            {
-              'type': 'field_label',
-              'text': 'test2',
-            },
-            {
-              'type': 'field_label',
-              'text': 'test3',
-            },
-            {
-              'type': 'input_dummy',
-            },
-          ]);
+      this.assertInterpolation(['test1', 'test2', 'test3'], [], undefined, [
+        {
+          'type': 'field_label',
+          'text': 'test1',
+        },
+        {
+          'type': 'field_label',
+          'text': 'test2',
+        },
+        {
+          'type': 'field_label',
+          'text': 'test3',
+        },
+        {
+          'type': 'input_dummy',
+        },
+      ]);
     });
 
     test('Add last dummy for no_field_prefix_field', function() {
@@ -230,9 +219,7 @@ suite('Block JSON initialization', function() {
               'type': 'no_field_prefix_field',
             },
           ],
-          [],
-          undefined,
-          [
+          [], undefined, [
             {
               'type': 'no_field_prefix_field',
             },
@@ -249,9 +236,7 @@ suite('Block JSON initialization', function() {
               'type': 'input_prefix_field',
             },
           ],
-          [],
-          undefined,
-          [
+          [], undefined, [
             {
               'type': 'input_prefix_field',
             },
@@ -262,48 +247,45 @@ suite('Block JSON initialization', function() {
     });
 
     test('Set last dummy alignment', function() {
-      this.assertInterpolation(
-          ['test1', 'test2', 'test3'],
-          [],
-          'CENTER',
-          [
-            {
-              'type': 'field_label',
-              'text': 'test1',
-            },
-            {
-              'type': 'field_label',
-              'text': 'test2',
-            },
-            {
-              'type': 'field_label',
-              'text': 'test3',
-            },
-            {
-              'type': 'input_dummy',
-              'align': 'CENTER',
-            },
-          ]);
+      this.assertInterpolation(['test1', 'test2', 'test3'], [], 'CENTER', [
+        {
+          'type': 'field_label',
+          'text': 'test1',
+        },
+        {
+          'type': 'field_label',
+          'text': 'test2',
+        },
+        {
+          'type': 'field_label',
+          'text': 'test3',
+        },
+        {
+          'type': 'input_dummy',
+          'align': 'CENTER',
+        },
+      ]);
     });
   });
 
   suite('fieldFromJson_', function() {
     setup(function() {
-      this.stub = sinon.stub(Blockly.fieldRegistry.TEST_ONLY, 'fromJsonInternal')
-          .callsFake(function(elem) {
-            switch (elem['type']) {
-              case 'field_label':
-                return 'field_label';
-              case 'field_number':
-                return 'field_number';
-              case 'no_field_prefix_field':
-                return 'no_field_prefix_field';
-              case 'input_prefix_field':
-                return 'input_prefix_field';
-              default:
-                return null;
-            }
-          });
+      this.stub =
+          sinon.stub(Blockly.fieldRegistry.TEST_ONLY, 'fromJsonInternal')
+              .callsFake(function(elem) {
+                switch (elem['type']) {
+                  case 'field_label':
+                    return 'field_label';
+                  case 'field_number':
+                    return 'field_number';
+                  case 'no_field_prefix_field':
+                    return 'no_field_prefix_field';
+                  case 'input_prefix_field':
+                    return 'input_prefix_field';
+                  default:
+                    return null;
+                }
+              });
 
       this.assertField = function(json, expectedType) {
         const block = {
@@ -320,115 +302,139 @@ suite('Block JSON initialization', function() {
     });
 
     test('Simple field', function() {
-      this.assertField({
-        'type': 'field_label',
-        'text': 'text',
-      }, 'field_label');
+      this.assertField(
+          {
+            'type': 'field_label',
+            'text': 'text',
+          },
+          'field_label');
     });
 
     test('Bad field', function() {
-      this.assertField({
-        'type': 'field_bad',
-      }, null);
+      this.assertField(
+          {
+            'type': 'field_bad',
+          },
+          null);
     });
 
     test('no_field_prefix_field', function() {
-      this.assertField({
-        'type': 'no_field_prefix_field',
-      }, 'no_field_prefix_field');
+      this.assertField(
+          {
+            'type': 'no_field_prefix_field',
+          },
+          'no_field_prefix_field');
     });
 
     test('input_prefix_field', function() {
-      this.assertField({
-        'type': 'input_prefix_field',
-      }, 'input_prefix_field');
+      this.assertField(
+          {
+            'type': 'input_prefix_field',
+          },
+          'input_prefix_field');
     });
 
     test('Alt string', function() {
-      this.assertField({
-        'type': 'field_undefined',
-        'alt': 'alt text',
-      }, 'field_label');
+      this.assertField(
+          {
+            'type': 'field_undefined',
+            'alt': 'alt text',
+          },
+          'field_label');
     });
 
     test('input_prefix_bad w/ alt string', function() {
-      this.assertField({
-        'type': 'input_prefix_bad',
-        'alt': 'alt string',
-      }, 'field_label');
+      this.assertField(
+          {
+            'type': 'input_prefix_bad',
+            'alt': 'alt string',
+          },
+          'field_label');
     });
 
     test('Alt other field', function() {
-      this.assertField({
-        'type': 'field_undefined',
-        'alt': {
-          'type': 'field_number',
-          'name': 'FIELDNAME',
-        },
-      }, 'field_number');
+      this.assertField(
+          {
+            'type': 'field_undefined',
+            'alt': {
+              'type': 'field_number',
+              'name': 'FIELDNAME',
+            },
+          },
+          'field_number');
     });
 
     test('Deep alt string', function() {
-      this.assertField({
-        'type': 'field_undefined1',
-        'alt': {
-          'type': 'field_undefined2',
-          'alt': {
-            'type': 'field_undefined3',
+      this.assertField(
+          {
+            'type': 'field_undefined1',
             'alt': {
-              'type': 'field_undefined4',
+              'type': 'field_undefined2',
               'alt': {
-                'type': 'field_undefined5',
-                'alt': 'text',
-              },
-            },
-          },
-        },
-      }, 'field_label');
-    });
-
-    test('Deep alt other field', function() {
-      this.assertField({
-        'type': 'field_undefined1',
-        'alt': {
-          'type': 'field_undefined2',
-          'alt': {
-            'type': 'field_undefined3',
-            'alt': {
-              'type': 'field_undefined4',
-              'alt': {
-                'type': 'field_undefined5',
+                'type': 'field_undefined3',
                 'alt': {
-                  'type': 'field_number',
-                  'name': 'FIELDNAME',
+                  'type': 'field_undefined4',
+                  'alt': {
+                    'type': 'field_undefined5',
+                    'alt': 'text',
+                  },
                 },
               },
             },
           },
-        },
-      }, 'field_number');
+          'field_label');
+    });
+
+    test('Deep alt other field', function() {
+      this.assertField(
+          {
+            'type': 'field_undefined1',
+            'alt': {
+              'type': 'field_undefined2',
+              'alt': {
+                'type': 'field_undefined3',
+                'alt': {
+                  'type': 'field_undefined4',
+                  'alt': {
+                    'type': 'field_undefined5',
+                    'alt': {
+                      'type': 'field_number',
+                      'name': 'FIELDNAME',
+                    },
+                  },
+                },
+              },
+            },
+          },
+          'field_number');
     });
 
     test('No alt', function() {
-      this.assertField({
-        'type': 'field_undefined',
-      }, null);
+      this.assertField(
+          {
+            'type': 'field_undefined',
+          },
+          null);
     });
 
     test('Bad alt', function() {
-      this.assertField({
-        'type': 'field_undefined',
-        'alt': {
-          'type': 'field_undefined',
-        },
-      }, null);
+      this.assertField(
+          {
+            'type': 'field_undefined',
+            'alt': {
+              'type': 'field_undefined',
+            },
+          },
+          null);
     });
 
     test('Spaces string alt', function() {
-      this.assertField({
-        'type': 'field_undefined',
-        'alt': '        ',
-      }, null);
+      this.assertField(
+          {
+            'type': 'field_undefined',
+            'alt': '        ',
+          },
+          null);
     });
   });
 
@@ -452,40 +458,48 @@ suite('Block JSON initialization', function() {
         const input = block.inputFromJson_(json);
         switch (type) {
           case 'input_dummy':
-            chai.assert.isTrue(block.appendDummyInput.calledOnce,
+            chai.assert.isTrue(
+                block.appendDummyInput.calledOnce,
                 'Expected a dummy input to be created.');
             break;
           case 'input_value':
-            chai.assert.isTrue(block.appendValueInput.calledOnce,
+            chai.assert.isTrue(
+                block.appendValueInput.calledOnce,
                 'Expected a value input to be created.');
             break;
           case 'input_statement':
-            chai.assert.isTrue(block.appendStatementInput.calledOnce,
+            chai.assert.isTrue(
+                block.appendStatementInput.calledOnce,
                 'Expected a statement input to be created.');
             break;
           default:
             chai.assert.isNull(input, 'Expected input to be null');
-            chai.assert.isTrue(block.appendDummyInput.notCalled,
+            chai.assert.isTrue(
+                block.appendDummyInput.notCalled,
                 'Expected no input to be created');
-            chai.assert.isTrue(block.appendValueInput.notCalled,
+            chai.assert.isTrue(
+                block.appendValueInput.notCalled,
                 'Expected no input to be created');
-            chai.assert.isTrue(block.appendStatementInput.notCalled,
+            chai.assert.isTrue(
+                block.appendStatementInput.notCalled,
                 'Expected no input to be created');
             return;
         }
         if (check) {
-          chai.assert.isTrue(input.setCheck.calledWith(check),
+          chai.assert.isTrue(
+              input.setCheck.calledWith(check),
               'Expected setCheck to be called with', check);
         } else {
-          chai.assert.isTrue(input.setCheck.notCalled,
-              'Expected setCheck to not be called');
+          chai.assert.isTrue(
+              input.setCheck.notCalled, 'Expected setCheck to not be called');
         }
         if (align !== undefined) {
-          chai.assert.isTrue(input.setAlign.calledWith(align),
+          chai.assert.isTrue(
+              input.setAlign.calledWith(align),
               'Expected setAlign to be called with', align);
         } else {
-          chai.assert.isTrue(input.setAlign.notCalled,
-              'Expected setAlign to not be called');
+          chai.assert.isTrue(
+              input.setAlign.notCalled, 'Expected setAlign to not be called');
         }
       };
     });
@@ -528,8 +542,7 @@ suite('Block JSON initialization', function() {
             'type': 'input_dummy',
             'check': 'Integer',
           },
-          'input_dummy',
-          'Integer');
+          'input_dummy', 'Integer');
     });
 
     test('Array check', function() {
@@ -538,8 +551,7 @@ suite('Block JSON initialization', function() {
             'type': 'input_dummy',
             'check': ['Integer', 'Number'],
           },
-          'input_dummy',
-          ['Integer', 'Number']);
+          'input_dummy', ['Integer', 'Number']);
     });
 
     test('Empty check', function() {

--- a/tests/mocha/block_test.js
+++ b/tests/mocha/block_test.js
@@ -51,7 +51,8 @@ suite('Blocks', function() {
         ],
         "previousStatement": null,
         "nextStatement": null,
-      }]);
+      }
+    ]);
   });
   teardown(function() {
     sharedTestTeardown.call(this);
@@ -74,9 +75,9 @@ suite('Blocks', function() {
     chai.assert.equal(blockC.getParent(), blockB);
 
     return {
-      A: blockA,  /* Parent */
-      B: blockB,  /* Middle */
-      C: blockC,  /* Child */
+      A: blockA, /* Parent */
+      B: blockB, /* Middle */
+      C: blockC, /* Child */
     };
   }
 
@@ -203,8 +204,8 @@ suite('Blocks', function() {
     suite('calling destroy', function() {
       setup(function() {
         Blockly.Blocks['destroyable_block'] = {
-          init: function() { },
-          destroy: function() { },
+          init: function() {},
+          destroy: function() {},
         };
         this.block = this.workspace.newBlock('destroyable_block');
       });
@@ -243,8 +244,7 @@ suite('Blocks', function() {
         this.block.dispose();
 
         chai.assert.isFalse(
-            disposed,
-            'Expected disposed to be false when destroy is called');
+            disposed, 'Expected disposed to be false when destroy is called');
       });
 
       test('events can be fired from destroy', function() {
@@ -423,8 +423,8 @@ suite('Blocks', function() {
       });
       test('Block Connected', function() {
         const blockB = this.workspace.newBlock('row_block');
-        this.blockA.getInput('VALUE').connection
-            .connect(blockB.outputConnection);
+        this.blockA.getInput('VALUE').connection.connect(
+            blockB.outputConnection);
 
         this.blockA.removeInput('VALUE');
         chai.assert.isFalse(blockB.disposed);
@@ -433,8 +433,8 @@ suite('Blocks', function() {
       test('Shadow Connected', function() {
         const blockB = this.workspace.newBlock('row_block');
         blockB.setShadow(true);
-        this.blockA.getInput('VALUE').connection
-            .connect(blockB.outputConnection);
+        this.blockA.getInput('VALUE').connection.connect(
+            blockB.outputConnection);
 
         this.blockA.removeInput('VALUE');
         chai.assert.isTrue(blockB.disposed);
@@ -452,8 +452,8 @@ suite('Blocks', function() {
       });
       test('Block Connected', function() {
         const blockB = this.workspace.newBlock('stack_block');
-        this.blockA.getInput('STATEMENT').connection
-            .connect(blockB.previousConnection);
+        this.blockA.getInput('STATEMENT')
+            .connection.connect(blockB.previousConnection);
 
         this.blockA.removeInput('STATEMENT');
         chai.assert.isFalse(blockB.disposed);
@@ -462,8 +462,8 @@ suite('Blocks', function() {
       test('Shadow Connected', function() {
         const blockB = this.workspace.newBlock('stack_block');
         blockB.setShadow(true);
-        this.blockA.getInput('STATEMENT').connection
-            .connect(blockB.previousConnection);
+        this.blockA.getInput('STATEMENT')
+            .connection.connect(blockB.previousConnection);
 
         this.blockA.removeInput('STATEMENT');
         chai.assert.isTrue(blockB.disposed);
@@ -476,20 +476,21 @@ suite('Blocks', function() {
       this.workspace = Blockly.inject('blocklyDiv');
 
       this.getInputs = function() {
-        return this.workspace
-            .connectionDBList[ConnectionType.INPUT_VALUE].connections;
+        return this.workspace.connectionDBList[ConnectionType.INPUT_VALUE]
+            .connections;
       };
       this.getOutputs = function() {
-        return this.workspace
-            .connectionDBList[ConnectionType.OUTPUT_VALUE].connections;
+        return this.workspace.connectionDBList[ConnectionType.OUTPUT_VALUE]
+            .connections;
       };
       this.getNext = function() {
-        return this.workspace
-            .connectionDBList[ConnectionType.NEXT_STATEMENT].connections;
+        return this.workspace.connectionDBList[ConnectionType.NEXT_STATEMENT]
+            .connections;
       };
       this.getPrevious = function() {
         return this.workspace
-            .connectionDBList[ConnectionType.PREVIOUS_STATEMENT].connections;
+            .connectionDBList[ConnectionType.PREVIOUS_STATEMENT]
+            .connections;
       };
 
       this.assertConnectionsEmpty = function() {
@@ -532,8 +533,7 @@ suite('Blocks', function() {
             '      </block>' +
             '    </next>' +
             '  </block>' +
-            '</xml>'
-        );
+            '</xml>');
         chai.assert.equal(this.getPrevious().length, 3);
         chai.assert.equal(this.getNext().length, 3);
       });
@@ -541,8 +541,7 @@ suite('Blocks', function() {
         this.deserializationHelper(
             '<xml>' +
             '  <block type="stack_block" collapsed="true"/>' +
-            '</xml>'
-        );
+            '</xml>');
         chai.assert.equal(this.getPrevious().length, 1);
         chai.assert.equal(this.getNext().length, 1);
       });
@@ -558,8 +557,7 @@ suite('Blocks', function() {
             '      </block>' +
             '    </next>' +
             '  </block>' +
-            '</xml>'
-        );
+            '</xml>');
         chai.assert.equal(this.getPrevious().length, 3);
         chai.assert.equal(this.getNext().length, 3);
       });
@@ -567,8 +565,7 @@ suite('Blocks', function() {
         this.deserializationHelper(
             '<xml>' +
             '  <block type="row_block"/>' +
-            '</xml>'
-        );
+            '</xml>');
         chai.assert.equal(this.getOutputs().length, 1);
         chai.assert.equal(this.getInputs().length, 1);
       });
@@ -584,8 +581,7 @@ suite('Blocks', function() {
             '      </block>' +
             '    </value>' +
             '  </block>' +
-            '</xml>'
-        );
+            '</xml>');
         chai.assert.equal(this.getOutputs().length, 3);
         chai.assert.equal(this.getInputs().length, 3);
       });
@@ -593,8 +589,7 @@ suite('Blocks', function() {
         this.deserializationHelper(
             '<xml>' +
             '  <block type="row_block" collapsed="true"/>' +
-            '</xml>'
-        );
+            '</xml>');
         chai.assert.equal(this.getOutputs().length, 1);
         chai.assert.equal(this.getInputs().length, 0);
       });
@@ -610,25 +605,25 @@ suite('Blocks', function() {
             '      </block>' +
             '    </value>' +
             '  </block>' +
-            '</xml>'
-        );
+            '</xml>');
         chai.assert.equal(this.getOutputs().length, 1);
         chai.assert.equal(this.getInputs().length, 0);
       });
       test('Collapsed Multi-Row Middle', function() {
-        Blockly.Xml.appendDomToWorkspace(Blockly.utils.xml.textToDom(
-            '<xml>' +
-            '  <block type="row_block">' +
-            '    <value name="INPUT">' +
-            '      <block type="row_block" collapsed="true">' +
-            '        <value name="INPUT">' +
-            '          <block type="row_block"/>' +
-            '        </value>' +
-            '      </block>' +
-            '    </value>' +
-            '  </block>' +
-            '</xml>'
-        ), this.workspace);
+        Blockly.Xml.appendDomToWorkspace(
+            Blockly.utils.xml.textToDom(
+                '<xml>' +
+                '  <block type="row_block">' +
+                '    <value name="INPUT">' +
+                '      <block type="row_block" collapsed="true">' +
+                '        <value name="INPUT">' +
+                '          <block type="row_block"/>' +
+                '        </value>' +
+                '      </block>' +
+                '    </value>' +
+                '  </block>' +
+                '</xml>'),
+            this.workspace);
         this.assertConnectionsEmpty();
         this.clock.runAll();
         chai.assert.equal(this.getOutputs().length, 2);
@@ -638,8 +633,7 @@ suite('Blocks', function() {
         this.deserializationHelper(
             '<xml>' +
             '  <block type="statement_block"/>' +
-            '</xml>'
-        );
+            '</xml>');
         chai.assert.equal(this.getPrevious().length, 1);
         chai.assert.equal(this.getNext().length, 2);
       });
@@ -655,8 +649,7 @@ suite('Blocks', function() {
             '      </block>' +
             '    </statement>' +
             '  </block>' +
-            '</xml>'
-        );
+            '</xml>');
         chai.assert.equal(this.getPrevious().length, 3);
         chai.assert.equal(this.getNext().length, 6);
       });
@@ -664,8 +657,7 @@ suite('Blocks', function() {
         this.deserializationHelper(
             '<xml>' +
             '  <block type="statement_block" collapsed="true"/>' +
-            '</xml>'
-        );
+            '</xml>');
         chai.assert.equal(this.getPrevious().length, 1);
         chai.assert.equal(this.getNext().length, 1);
       });
@@ -681,8 +673,7 @@ suite('Blocks', function() {
             '      </block>' +
             '    </statement>' +
             '  </block>' +
-            '</xml>'
-        );
+            '</xml>');
         chai.assert.equal(this.getPrevious().length, 1);
         chai.assert.equal(this.getNext().length, 1);
       });
@@ -698,8 +689,7 @@ suite('Blocks', function() {
             '      </block>' +
             '    </statement>' +
             '  </block>' +
-            '</xml>'
-        );
+            '</xml>');
         chai.assert.equal(this.getPrevious().length, 2);
         chai.assert.equal(this.getNext().length, 3);
       });
@@ -735,9 +725,9 @@ suite('Blocks', function() {
     });
     suite('setCollapsed', function() {
       test('Stack', function() {
-        const block = Blockly.Xml.domToBlock(Blockly.utils.xml.textToDom(
-            '<block type="stack_block"/>'
-        ), this.workspace);
+        const block = Blockly.Xml.domToBlock(
+            Blockly.utils.xml.textToDom('<block type="stack_block"/>'),
+            this.workspace);
         this.clock.runAll();
         chai.assert.equal(this.getPrevious().length, 1);
         chai.assert.equal(this.getNext().length, 1);
@@ -751,17 +741,18 @@ suite('Blocks', function() {
         chai.assert.equal(this.getNext().length, 1);
       });
       test('Multi-Stack', function() {
-        const block = Blockly.Xml.domToBlock(Blockly.utils.xml.textToDom(
-            '<block type="stack_block">' +
-            '  <next>' +
-            '    <block type="stack_block">' +
-            '      <next>' +
-            '        <block type="stack_block"/>' +
-            '      </next>' +
-            '    </block>' +
-            '  </next>' +
-            '</block>'
-        ), this.workspace);
+        const block = Blockly.Xml.domToBlock(
+            Blockly.utils.xml.textToDom(
+                '<block type="stack_block">' +
+                '  <next>' +
+                '    <block type="stack_block">' +
+                '      <next>' +
+                '        <block type="stack_block"/>' +
+                '      </next>' +
+                '    </block>' +
+                '  </next>' +
+                '</block>'),
+            this.workspace);
         this.assertConnectionsEmpty();
         this.clock.runAll();
         chai.assert.equal(this.getPrevious().length, 3);
@@ -776,9 +767,9 @@ suite('Blocks', function() {
         chai.assert.equal(this.getNext().length, 3);
       });
       test('Row', function() {
-        const block = Blockly.Xml.domToBlock(Blockly.utils.xml.textToDom(
-            '<block type="row_block"/>'
-        ), this.workspace);
+        const block = Blockly.Xml.domToBlock(
+            Blockly.utils.xml.textToDom('<block type="row_block"/>'),
+            this.workspace);
         this.clock.runAll();
         chai.assert.equal(this.getOutputs().length, 1);
         chai.assert.equal(this.getInputs().length, 1);
@@ -792,17 +783,18 @@ suite('Blocks', function() {
         chai.assert.equal(this.getInputs().length, 1);
       });
       test('Multi-Row', function() {
-        const block = Blockly.Xml.domToBlock(Blockly.utils.xml.textToDom(
-            '<block type="row_block">' +
-            '  <value name="INPUT">' +
-            '    <block type="row_block">' +
-            '      <value name="INPUT">' +
-            '        <block type="row_block"/>' +
-            '      </value>' +
-            '    </block>' +
-            '  </value>' +
-            '</block>'
-        ), this.workspace);
+        const block = Blockly.Xml.domToBlock(
+            Blockly.utils.xml.textToDom(
+                '<block type="row_block">' +
+                '  <value name="INPUT">' +
+                '    <block type="row_block">' +
+                '      <value name="INPUT">' +
+                '        <block type="row_block"/>' +
+                '      </value>' +
+                '    </block>' +
+                '  </value>' +
+                '</block>'),
+            this.workspace);
         this.clock.runAll();
         chai.assert.equal(this.getOutputs().length, 3);
         chai.assert.equal(this.getInputs().length, 3);
@@ -816,17 +808,18 @@ suite('Blocks', function() {
         chai.assert.equal(this.getInputs().length, 3);
       });
       test('Multi-Row Middle', function() {
-        let block = Blockly.Xml.domToBlock(Blockly.utils.xml.textToDom(
-            '<block type="row_block">' +
-            '  <value name="INPUT">' +
-            '    <block type="row_block">' +
-            '      <value name="INPUT">' +
-            '        <block type="row_block"/>' +
-            '      </value>' +
-            '    </block>' +
-            '  </value>' +
-            '</block>'
-        ), this.workspace);
+        let block = Blockly.Xml.domToBlock(
+            Blockly.utils.xml.textToDom(
+                '<block type="row_block">' +
+                '  <value name="INPUT">' +
+                '    <block type="row_block">' +
+                '      <value name="INPUT">' +
+                '        <block type="row_block"/>' +
+                '      </value>' +
+                '    </block>' +
+                '  </value>' +
+                '</block>'),
+            this.workspace);
         this.clock.runAll();
         chai.assert.equal(this.getOutputs().length, 3);
         chai.assert.equal(this.getInputs().length, 3);
@@ -843,17 +836,18 @@ suite('Blocks', function() {
       test('Multi-Row Double Collapse', function() {
         // Collapse middle -> Collapse top ->
         // Uncollapse top -> Uncollapse middle
-        const block = Blockly.Xml.domToBlock(Blockly.utils.xml.textToDom(
-            '<block type="row_block">' +
-            '  <value name="INPUT">' +
-            '    <block type="row_block">' +
-            '      <value name="INPUT">' +
-            '        <block type="row_block"/>' +
-            '      </value>' +
-            '    </block>' +
-            '  </value>' +
-            '</block>'
-        ), this.workspace);
+        const block = Blockly.Xml.domToBlock(
+            Blockly.utils.xml.textToDom(
+                '<block type="row_block">' +
+                '  <value name="INPUT">' +
+                '    <block type="row_block">' +
+                '      <value name="INPUT">' +
+                '        <block type="row_block"/>' +
+                '      </value>' +
+                '    </block>' +
+                '  </value>' +
+                '</block>'),
+            this.workspace);
         this.clock.runAll();
         chai.assert.equal(this.getOutputs().length, 3);
         chai.assert.equal(this.getInputs().length, 3);
@@ -876,9 +870,9 @@ suite('Blocks', function() {
         chai.assert.equal(this.getInputs().length, 3);
       });
       test('Statement', function() {
-        const block = Blockly.Xml.domToBlock(Blockly.utils.xml.textToDom(
-            '<block type="statement_block"/>'
-        ), this.workspace);
+        const block = Blockly.Xml.domToBlock(
+            Blockly.utils.xml.textToDom('<block type="statement_block"/>'),
+            this.workspace);
         this.clock.runAll();
         chai.assert.equal(this.getPrevious().length, 1);
         chai.assert.equal(this.getNext().length, 2);
@@ -892,17 +886,18 @@ suite('Blocks', function() {
         chai.assert.equal(this.getNext().length, 2);
       });
       test('Multi-Statement', function() {
-        const block = Blockly.Xml.domToBlock(Blockly.utils.xml.textToDom(
-            '<block type="statement_block">' +
-            '  <statement name="STATEMENT">' +
-            '    <block type="statement_block">' +
-            '      <statement name="STATEMENT">' +
-            '        <block type="statement_block"/>' +
-            '      </statement>' +
-            '    </block>' +
-            '  </statement>' +
-            '</block>'
-        ), this.workspace);
+        const block = Blockly.Xml.domToBlock(
+            Blockly.utils.xml.textToDom(
+                '<block type="statement_block">' +
+                '  <statement name="STATEMENT">' +
+                '    <block type="statement_block">' +
+                '      <statement name="STATEMENT">' +
+                '        <block type="statement_block"/>' +
+                '      </statement>' +
+                '    </block>' +
+                '  </statement>' +
+                '</block>'),
+            this.workspace);
         this.assertConnectionsEmpty();
         this.clock.runAll();
         chai.assert.equal(this.getPrevious().length, 3);
@@ -917,17 +912,18 @@ suite('Blocks', function() {
         chai.assert.equal(this.getNext().length, 6);
       });
       test('Multi-Statement Middle', function() {
-        let block = Blockly.Xml.domToBlock(Blockly.utils.xml.textToDom(
-            '<block type="statement_block">' +
-            '  <statement name="STATEMENT">' +
-            '    <block type="statement_block">' +
-            '      <statement name="STATEMENT">' +
-            '        <block type="statement_block"/>' +
-            '      </statement>' +
-            '    </block>' +
-            '  </statement>' +
-            '</block>'
-        ), this.workspace);
+        let block = Blockly.Xml.domToBlock(
+            Blockly.utils.xml.textToDom(
+                '<block type="statement_block">' +
+                '  <statement name="STATEMENT">' +
+                '    <block type="statement_block">' +
+                '      <statement name="STATEMENT">' +
+                '        <block type="statement_block"/>' +
+                '      </statement>' +
+                '    </block>' +
+                '  </statement>' +
+                '</block>'),
+            this.workspace);
         this.assertConnectionsEmpty();
         this.clock.runAll();
         chai.assert.equal(this.getPrevious().length, 3);
@@ -943,17 +939,18 @@ suite('Blocks', function() {
         chai.assert.equal(this.getNext().length, 6);
       });
       test('Multi-Statement Double Collapse', function() {
-        const block = Blockly.Xml.domToBlock(Blockly.utils.xml.textToDom(
-            '<block type="statement_block">' +
-            '  <statement name="STATEMENT">' +
-            '    <block type="statement_block">' +
-            '      <statement name="STATEMENT">' +
-            '        <block type="statement_block"/>' +
-            '      </statement>' +
-            '    </block>' +
-            '  </statement>' +
-            '</block>'
-        ), this.workspace);
+        const block = Blockly.Xml.domToBlock(
+            Blockly.utils.xml.textToDom(
+                '<block type="statement_block">' +
+                '  <statement name="STATEMENT">' +
+                '    <block type="statement_block">' +
+                '      <statement name="STATEMENT">' +
+                '        <block type="statement_block"/>' +
+                '      </statement>' +
+                '    </block>' +
+                '  </statement>' +
+                '</block>'),
+            this.workspace);
         this.assertConnectionsEmpty();
         this.clock.runAll();
         chai.assert.equal(this.getPrevious().length, 3);
@@ -979,19 +976,20 @@ suite('Blocks', function() {
     });
     suite('Setting Parent Block', function() {
       setup(function() {
-        this.printBlock = Blockly.Xml.domToBlock(Blockly.utils.xml.textToDom(
-            '<block type="text_print">' +
-            '  <value name="TEXT">' +
-            '    <block type="text_join">' +
-            '      <mutation items="2"></mutation>' +
-            '      <value name="ADD0">' +
-            '        <block type="text">' +
-            '        </block>' +
-            '      </value>' +
-            '    </block>' +
-            '  </value>' +
-            '</block>'
-        ), this.workspace);
+        this.printBlock = Blockly.Xml.domToBlock(
+            Blockly.utils.xml.textToDom(
+                '<block type="text_print">' +
+                '  <value name="TEXT">' +
+                '    <block type="text_join">' +
+                '      <mutation items="2"></mutation>' +
+                '      <value name="ADD0">' +
+                '        <block type="text">' +
+                '        </block>' +
+                '      </value>' +
+                '    </block>' +
+                '  </value>' +
+                '</block>'),
+            this.workspace);
         this.textJoinBlock = this.printBlock.getInputTargetBlock('TEXT');
         this.textBlock = this.textJoinBlock.getInputTargetBlock('ADD0');
       });
@@ -1012,44 +1010,44 @@ suite('Blocks', function() {
       }
 
       test('Setting to connected parent', function() {
-        chai.assert.doesNotThrow(this.textJoinBlock.setParent
-            .bind(this.textJoinBlock, this.printBlock));
+        chai.assert.doesNotThrow(this.textJoinBlock.setParent.bind(
+            this.textJoinBlock, this.printBlock));
         assertOriginalSetup.call(this);
       });
       test('Setting to new parent after connecting to it', function() {
         this.textJoinBlock.outputConnection.disconnect();
-        this.textBlock.outputConnection
-            .connect(this.printBlock.getInput('TEXT').connection);
-        chai.assert.doesNotThrow(this.textBlock.setParent
-            .bind(this.textBlock, this.printBlock));
+        this.textBlock.outputConnection.connect(
+            this.printBlock.getInput('TEXT').connection);
+        chai.assert.doesNotThrow(
+            this.textBlock.setParent.bind(this.textBlock, this.printBlock));
         assertBlockIsOnlyChild(this.printBlock, this.textBlock, 'TEXT');
       });
       test('Setting to new parent while connected to other block', function() {
         // Setting to grandparent with no available input connection.
-        chai.assert.throws(this.textBlock.setParent
-            .bind(this.textBlock, this.printBlock));
+        chai.assert.throws(
+            this.textBlock.setParent.bind(this.textBlock, this.printBlock));
         this.textJoinBlock.outputConnection.disconnect();
         // Setting to block with available input connection.
-        chai.assert.throws(this.textBlock.setParent
-            .bind(this.textBlock, this.printBlock));
+        chai.assert.throws(
+            this.textBlock.setParent.bind(this.textBlock, this.printBlock));
         assertNonParentAndOrphan(this.printBlock, this.textJoinBlock, 'TEXT');
         assertBlockIsOnlyChild(this.textJoinBlock, this.textBlock, 'ADD0');
       });
       test('Setting to same parent after disconnecting from it', function() {
         this.textJoinBlock.outputConnection.disconnect();
-        chai.assert.throws(this.textJoinBlock.setParent
-            .bind(this.textJoinBlock, this.printBlock));
+        chai.assert.throws(this.textJoinBlock.setParent.bind(
+            this.textJoinBlock, this.printBlock));
         assertNonParentAndOrphan(this.printBlock, this.textJoinBlock, 'TEXT');
       });
       test('Setting to new parent when orphan', function() {
         this.textBlock.outputConnection.disconnect();
         // When new parent has no available input connection.
-        chai.assert.throws(this.textBlock.setParent
-            .bind(this.textBlock, this.printBlock));
+        chai.assert.throws(
+            this.textBlock.setParent.bind(this.textBlock, this.printBlock));
         this.textJoinBlock.outputConnection.disconnect();
         // When new parent has available input connection.
-        chai.assert.throws(this.textBlock.setParent
-            .bind(this.textBlock, this.printBlock));
+        chai.assert.throws(
+            this.textBlock.setParent.bind(this.textBlock, this.printBlock));
 
         assertNonParentAndOrphan(this.printBlock, this.textJoinBlock, 'TEXT');
         assertNonParentAndOrphan(this.printBlock, this.textBlock, 'TEXT');
@@ -1057,13 +1055,12 @@ suite('Blocks', function() {
       });
       test('Setting parent to null after disconnecting', function() {
         this.textBlock.outputConnection.disconnect();
-        chai.assert.doesNotThrow(this.textBlock.setParent
-            .bind(this.textBlock, null));
+        chai.assert.doesNotThrow(
+            this.textBlock.setParent.bind(this.textBlock, null));
         assertNonParentAndOrphan(this.textJoinBlock, this.textBlock, 'ADD0');
       });
       test('Setting parent to null without disconnecting', function() {
-        chai.assert.throws(this.textBlock.setParent
-            .bind(this.textBlock, null));
+        chai.assert.throws(this.textBlock.setParent.bind(this.textBlock, null));
         assertOriginalSetup.call(this);
       });
     });
@@ -1178,9 +1175,9 @@ suite('Blocks', function() {
       });
       suite('Headless', function() {
         setup(function() {
-          this.block = Blockly.Xml.domToBlock(Blockly.utils.xml.textToDom(
-              '<block type="empty_block"/>'
-          ), this.workspace);
+          this.block = Blockly.Xml.domToBlock(
+              Blockly.utils.xml.textToDom('<block type="empty_block"/>'),
+              this.workspace);
         });
         test('Text', function() {
           this.block.setCommentText('test text');
@@ -1211,9 +1208,9 @@ suite('Blocks', function() {
             comments: true,
             scrollbars: true,
           });
-          this.block = Blockly.Xml.domToBlock(Blockly.utils.xml.textToDom(
-              '<block type="empty_block"/>'
-          ), this.workspace);
+          this.block = Blockly.Xml.domToBlock(
+              Blockly.utils.xml.textToDom('<block type="empty_block"/>'),
+              this.workspace);
         });
         teardown(function() {
           workspaceTeardown.call(this, this.workspace);
@@ -1260,8 +1257,8 @@ suite('Blocks', function() {
           this.block.setCommentText('test2');
           chai.assert.equal(this.block.getCommentText(), 'test2');
           assertCommentEvent(this.eventsFireSpy, 'test1', 'test2');
-          chai.assert.equal(icon.paragraphElement_.firstChild.textContent,
-              'test2');
+          chai.assert.equal(
+              icon.paragraphElement_.firstChild.textContent, 'test2');
         });
         test('Get Text While Editing', function() {
           this.block.setCommentText('test1');
@@ -1278,9 +1275,10 @@ suite('Blocks', function() {
   suite('Getting/Setting Field (Values)', function() {
     setup(function() {
       this.workspace = Blockly.inject('blocklyDiv');
-      this.block = Blockly.Xml.domToBlock(Blockly.utils.xml.textToDom(
-          '<block type="text"><field name = "TEXT">test</field></block>'
-      ), this.workspace);
+      this.block = Blockly.Xml.domToBlock(
+          Blockly.utils.xml.textToDom(
+              '<block type="text"><field name = "TEXT">test</field></block>'),
+          this.workspace);
     });
 
     teardown(function() {
@@ -1300,17 +1298,19 @@ suite('Blocks', function() {
       const testFunction = function() {
         return 'TEXT';
       };
-      const inputs = [1, null, testFunction, {toString: testFunction}, ['TEXT']];
+      const inputs =
+          [1, null, testFunction, {toString: testFunction}, ['TEXT']];
       for (let i = 0; i < inputs.length; i++) {
-        chai.assert.throws(this.block.getField.bind(this.block, inputs[i]),
-            TypeError);
+        chai.assert.throws(
+            this.block.getField.bind(this.block, inputs[i]), TypeError);
       }
     });
     test('Getting Value of Field with Wrong Type', function() {
       const testFunction = function() {
         return 'TEXT';
       };
-      const inputs = [1, null, testFunction, {toString: testFunction}, ['TEXT']];
+      const inputs =
+          [1, null, testFunction, {toString: testFunction}, ['TEXT']];
       for (let i = 0; i < inputs.length; i++) {
         chai.assert.throws(
             this.block.getFieldValue.bind(this.block, inputs[i]), TypeError);
@@ -1328,10 +1328,12 @@ suite('Blocks', function() {
       const testFunction = function() {
         return 'TEXT';
       };
-      const inputs = [1, null, testFunction, {toString: testFunction}, ['TEXT']];
+      const inputs =
+          [1, null, testFunction, {toString: testFunction}, ['TEXT']];
       for (let i = 0; i < inputs.length; i++) {
-        chai.assert.throws(this.block.setFieldValue.bind(this.block, 'test',
-            inputs[i]), TypeError);
+        chai.assert.throws(
+            this.block.setFieldValue.bind(this.block, 'test', inputs[i]),
+            TypeError);
       }
     });
   });
@@ -1346,9 +1348,9 @@ suite('Blocks', function() {
       });
 
       test('Has Icon', function() {
-        const block = Blockly.Xml.domToBlock(Blockly.utils.xml.textToDom(
-            '<block type="statement_block"/>'
-        ), this.workspace);
+        const block = Blockly.Xml.domToBlock(
+            Blockly.utils.xml.textToDom('<block type="statement_block"/>'),
+            this.workspace);
         block.setCommentText('test text');
         block.comment.setVisible(true);
         chai.assert.isTrue(block.comment.isVisible());
@@ -1356,13 +1358,14 @@ suite('Blocks', function() {
         chai.assert.isFalse(block.comment.isVisible());
       });
       test('Child Has Icon', function() {
-        const block = Blockly.Xml.domToBlock(Blockly.utils.xml.textToDom(
-            '<block type="statement_block">' +
-            '  <statement name="STATEMENT">' +
-            '    <block type="statement_block"/>' +
-            '  </statement>' +
-            '</block>'
-        ), this.workspace);
+        const block = Blockly.Xml.domToBlock(
+            Blockly.utils.xml.textToDom(
+                '<block type="statement_block">' +
+                '  <statement name="STATEMENT">' +
+                '    <block type="statement_block"/>' +
+                '  </statement>' +
+                '</block>'),
+            this.workspace);
         const childBlock = block.getInputTargetBlock('STATEMENT');
         childBlock.setCommentText('test text');
         childBlock.comment.setVisible(true);
@@ -1371,13 +1374,14 @@ suite('Blocks', function() {
         chai.assert.isFalse(childBlock.comment.isVisible());
       });
       test('Next Block Has Icon', function() {
-        const block = Blockly.Xml.domToBlock(Blockly.utils.xml.textToDom(
-            '<block type="statement_block">' +
-            '  <next>' +
-            '    <block type="statement_block"/>' +
-            '  </next>' +
-            '</block>'
-        ), this.workspace);
+        const block = Blockly.Xml.domToBlock(
+            Blockly.utils.xml.textToDom(
+                '<block type="statement_block">' +
+                '  <next>' +
+                '    <block type="statement_block"/>' +
+                '  </next>' +
+                '</block>'),
+            this.workspace);
         const nextBlock = block.getNextBlock();
         nextBlock.setCommentText('test text');
         nextBlock.comment.setVisible(true);
@@ -1491,8 +1495,8 @@ suite('Blocks', function() {
 
         blockA.setCollapsed(true);
         assertCollapsed(blockA);
-        blockA.getInput('STATEMENT').connection
-            .connect(blockB.previousConnection);
+        blockA.getInput('STATEMENT')
+            .connection.connect(blockB.previousConnection);
         chai.assert.isTrue(isBlockHidden(blockB));
         blockA.setCollapsed(false);
         assertNotCollapsed(blockA);
@@ -1520,8 +1524,8 @@ suite('Blocks', function() {
         const blockB = createRenderedBlock(this.workspace, 'stack_block');
         const blockC = createRenderedBlock(this.workspace, 'stack_block');
 
-        blockA.getInput('STATEMENT').connection
-            .connect(blockB.previousConnection);
+        blockA.getInput('STATEMENT')
+            .connection.connect(blockB.previousConnection);
         blockA.setCollapsed(true);
         assertCollapsed(blockA);
         chai.assert.isTrue(isBlockHidden(blockB));
@@ -1557,13 +1561,13 @@ suite('Blocks', function() {
         const blockB = createRenderedBlock(this.workspace, 'stack_block');
         const blockC = createRenderedBlock(this.workspace, 'stack_block');
 
-        blockA.getInput('STATEMENT').connection
-            .connect(blockB.previousConnection);
+        blockA.getInput('STATEMENT')
+            .connection.connect(blockB.previousConnection);
         blockA.setCollapsed(true);
         assertCollapsed(blockA);
         chai.assert.isTrue(isBlockHidden(blockB));
-        blockA.getInput('STATEMENT').connection
-            .connect(blockC.previousConnection);
+        blockA.getInput('STATEMENT')
+            .connection.connect(blockC.previousConnection);
         chai.assert.isTrue(isBlockHidden(blockC));
         // Still hidden after C is inserted between.
         chai.assert.isTrue(isBlockHidden(blockB));
@@ -1598,8 +1602,8 @@ suite('Blocks', function() {
         blockB.nextConnection.connect(blockC.previousConnection);
         blockA.setCollapsed(true);
         assertCollapsed(blockA);
-        blockA.getInput('STATEMENT').connection
-            .connect(blockB.previousConnection);
+        blockA.getInput('STATEMENT')
+            .connection.connect(blockB.previousConnection);
         chai.assert.isTrue(isBlockHidden(blockC));
         chai.assert.isTrue(isBlockHidden(blockB));
 
@@ -1623,8 +1627,8 @@ suite('Blocks', function() {
         const blockA = createRenderedBlock(this.workspace, 'statement_block');
         const blockB = createRenderedBlock(this.workspace, 'stack_block');
 
-        blockA.getInput('STATEMENT').connection
-            .connect(blockB.previousConnection);
+        blockA.getInput('STATEMENT')
+            .connection.connect(blockB.previousConnection);
         blockA.setCollapsed(true);
         assertCollapsed(blockA);
         chai.assert.isTrue(isBlockHidden(blockB));
@@ -1651,8 +1655,8 @@ suite('Blocks', function() {
         const blockB = createRenderedBlock(this.workspace, 'stack_block');
         const blockC = createRenderedBlock(this.workspace, 'stack_block');
 
-        blockA.getInput('STATEMENT').connection
-            .connect(blockB.previousConnection);
+        blockA.getInput('STATEMENT')
+            .connection.connect(blockB.previousConnection);
         blockB.nextConnection.connect(blockC.previousConnection);
         blockA.setCollapsed(true);
         assertCollapsed(blockA);
@@ -1684,8 +1688,8 @@ suite('Blocks', function() {
         const blockC = createRenderedBlock(this.workspace, 'stack_block');
 
         blockB.nextConnection.connect(blockC.previousConnection);
-        blockA.getInput('STATEMENT').connection
-            .connect(blockB.previousConnection);
+        blockA.getInput('STATEMENT')
+            .connection.connect(blockB.previousConnection);
         blockA.setCollapsed(true);
         assertCollapsed(blockA);
         chai.assert.isTrue(isBlockHidden(blockC));
@@ -1814,8 +1818,8 @@ suite('Blocks', function() {
       test('Children of Collapsed Blocks Should Enable Properly', function() {
         const blockA = createRenderedBlock(this.workspace, 'statement_block');
         const blockB = createRenderedBlock(this.workspace, 'stack_block');
-        blockA.getInput('STATEMENT').connection
-            .connect(blockB.previousConnection);
+        blockA.getInput('STATEMENT')
+            .connection.connect(blockB.previousConnection);
         // Disable the block and collapse it.
         blockA.setEnabled(false);
         blockA.setCollapsed(true);
@@ -1826,36 +1830,40 @@ suite('Blocks', function() {
 
         // The child blocks should be enabled.
         chai.assert.isFalse(blockB.disabled);
-        chai.assert.isFalse(blockB.getSvgRoot().classList.contains('blocklyDisabled'));
+        chai.assert.isFalse(
+            blockB.getSvgRoot().classList.contains('blocklyDisabled'));
       });
-      test('Disabled Children of Collapsed Blocks Should Stay Disabled', function() {
-        const blockA = createRenderedBlock(this.workspace, 'statement_block');
-        const blockB = createRenderedBlock(this.workspace, 'stack_block');
-        blockA.getInput('STATEMENT').connection
-            .connect(blockB.previousConnection);
+      test(
+          'Disabled Children of Collapsed Blocks Should Stay Disabled',
+          function() {
+            const blockA =
+                createRenderedBlock(this.workspace, 'statement_block');
+            const blockB = createRenderedBlock(this.workspace, 'stack_block');
+            blockA.getInput('STATEMENT')
+                .connection.connect(blockB.previousConnection);
 
-        // Disable the child block.
-        blockB.setEnabled(false);
+            // Disable the child block.
+            blockB.setEnabled(false);
 
-        // Collapse and disable the parent block.
-        blockA.setCollapsed(false);
-        blockA.setEnabled(false);
+            // Collapse and disable the parent block.
+            blockA.setCollapsed(false);
+            blockA.setEnabled(false);
 
-        // Enable the parent block.
-        blockA.setEnabled(true);
-        blockA.setCollapsed(true);
+            // Enable the parent block.
+            blockA.setEnabled(true);
+            blockA.setCollapsed(true);
 
-        // Child blocks should stay disabled if they have been set.
-        chai.assert.isTrue(blockB.disabled);
-      });
+            // Child blocks should stay disabled if they have been set.
+            chai.assert.isTrue(blockB.disabled);
+          });
     });
   });
   suite('Style', function() {
     suite('Headless', function() {
       setup(function() {
-        this.block = Blockly.Xml.domToBlock(Blockly.utils.xml.textToDom(
-            '<block type="empty_block"/>'
-        ), this.workspace);
+        this.block = Blockly.Xml.domToBlock(
+            Blockly.utils.xml.textToDom('<block type="empty_block"/>'),
+            this.workspace);
       });
       test('Set colour', function() {
         this.block.setColour('20');
@@ -1874,17 +1882,19 @@ suite('Blocks', function() {
     suite('Rendered', function() {
       setup(function() {
         this.workspace = Blockly.inject('blocklyDiv', {});
-        this.block = Blockly.Xml.domToBlock(Blockly.utils.xml.textToDom(
-            '<block type="empty_block"/>'
-        ), this.workspace);
-        this.workspace.setTheme(new Blockly.Theme('test', {
-          "styleOne": {
-            "colourPrimary": "#000000",
-            "colourSecondary": "#999999",
-            "colourTertiary": "#4d4d4d",
-            "hat": '',
-          },
-        }), {});
+        this.block = Blockly.Xml.domToBlock(
+            Blockly.utils.xml.textToDom('<block type="empty_block"/>'),
+            this.workspace);
+        this.workspace.setTheme(
+            new Blockly.Theme('test', {
+              "styleOne": {
+                "colourPrimary": "#000000",
+                "colourSecondary": "#999999",
+                "colourTertiary": "#4d4d4d",
+                "hat": '',
+              },
+            }),
+            {});
       });
       teardown(function() {
         workspaceTeardown.call(this, this.workspace);
@@ -1918,116 +1928,116 @@ suite('Blocks', function() {
       {
         name: 'statement block',
         xml: '<block type="controls_repeat_ext">' +
-          '<value name="TIMES">' +
+            '<value name="TIMES">' +
             '<shadow type="math_number">' +
-              '<field name="NUM">10</field>' +
-          '</shadow>' +
-          '</value>' +
-        '</block>',
+            '<field name="NUM">10</field>' +
+            '</shadow>' +
+            '</value>' +
+            '</block>',
         toString: 'repeat 10 times do ?',
       },
       {
         name: 'nested statement blocks',
         xml: '<block type="controls_repeat_ext">' +
-          '<value name="TIMES">' +
+            '<value name="TIMES">' +
             '<shadow type="math_number">' +
-              '<field name="NUM">10</field>' +
+            '<field name="NUM">10</field>' +
             '</shadow>' +
-          '</value>' +
-          '<statement name="DO">' +
+            '</value>' +
+            '<statement name="DO">' +
             '<block type="controls_if"></block>' +
-          '</statement>' +
-        '</block>',
+            '</statement>' +
+            '</block>',
         toString: 'repeat 10 times do if ? do ?',
       },
       {
         name: 'nested Boolean output blocks',
         xml: '<block type="controls_if">' +
-          '<value name="IF0">' +
+            '<value name="IF0">' +
             '<block type="logic_compare">' +
-              '<field name="OP">EQ</field>' +
-              '<value name="A">' +
-                '<block type="logic_operation">' +
-                  '<field name="OP">AND</field>' +
-                '</block>' +
-              '</value>' +
+            '<field name="OP">EQ</field>' +
+            '<value name="A">' +
+            '<block type="logic_operation">' +
+            '<field name="OP">AND</field>' +
             '</block>' +
-          '</value>' +
-        '</block>',
+            '</value>' +
+            '</block>' +
+            '</value>' +
+            '</block>',
         toString: 'if ((? and ?) = ?) do ?',
       },
       {
         name: 'output block',
         xml: '<block type="math_single">' +
-          '<field name="OP">ROOT</field>' +
-          '<value name="NUM">' +
+            '<field name="OP">ROOT</field>' +
+            '<value name="NUM">' +
             '<shadow type="math_number">' +
-              '<field name="NUM">9</field>' +
+            '<field name="NUM">9</field>' +
             '</shadow>' +
-          '</value>' +
-        '</block>',
+            '</value>' +
+            '</block>',
         toString: 'square root 9',
       },
       {
         name: 'nested Number output blocks',
         xml: '<block type="math_arithmetic">' +
-          '<field name="OP">ADD</field>' +
-          '<value name="A">' +
+            '<field name="OP">ADD</field>' +
+            '<value name="A">' +
             '<shadow type="math_number">' +
-              '<field name="NUM">1</field>' +
+            '<field name="NUM">1</field>' +
             '</shadow>' +
             '<block type="math_arithmetic">' +
-              '<field name="OP">MULTIPLY</field>' +
-              '<value name="A">' +
-                '<shadow type="math_number">' +
-                  '<field name="NUM">10</field>' +
-                '</shadow>' +
-              '</value>' +
-              '<value name="B">' +
-                '<shadow type="math_number">' +
-                  '<field name="NUM">5</field>' +
-                '</shadow>' +
-              '</value>' +
-            '</block>' +
-          '</value>' +
-          '<value name="B">' +
+            '<field name="OP">MULTIPLY</field>' +
+            '<value name="A">' +
             '<shadow type="math_number">' +
-              '<field name="NUM">3</field>' +
+            '<field name="NUM">10</field>' +
             '</shadow>' +
-          '</value>' +
-        '</block>',
+            '</value>' +
+            '<value name="B">' +
+            '<shadow type="math_number">' +
+            '<field name="NUM">5</field>' +
+            '</shadow>' +
+            '</value>' +
+            '</block>' +
+            '</value>' +
+            '<value name="B">' +
+            '<shadow type="math_number">' +
+            '<field name="NUM">3</field>' +
+            '</shadow>' +
+            '</value>' +
+            '</block>',
         toString: '(10 × 5) + 3',
       },
       {
         name: 'nested String output blocks',
         xml: '<block type="text_join">' +
-          '<mutation items="2"></mutation>' +
-          '<value name="ADD0">' +
+            '<mutation items="2"></mutation>' +
+            '<value name="ADD0">' +
             '<block type="text">' +
-              '<field name="TEXT">Hello</field>' +
+            '<field name="TEXT">Hello</field>' +
             '</block>' +
-          '</value>' +
-          '<value name="ADD1">' +
+            '</value>' +
+            '<value name="ADD1">' +
             '<block type="text">' +
-              '<field name="TEXT">World</field>' +
+            '<field name="TEXT">World</field>' +
             '</block>' +
-          '</value>' +
-        '</block>',
+            '</value>' +
+            '</block>',
         toString: 'create text with “ Hello ” “ World ”',
       },
       {
         name: 'parentheses in string literal',
         xml: '<block type="text">' +
-          '<field name="TEXT">foo ( bar ) baz</field>' +
-        '</block>',
+            '<field name="TEXT">foo ( bar ) baz</field>' +
+            '</block>',
         toString: '“ foo ( bar ) baz ”',
       },
     ];
     // Create mocha test cases for each toString test.
     toStringTests.forEach(function(t) {
       test(t.name, function() {
-        const block = Blockly.Xml.domToBlock(Blockly.utils.xml.textToDom(t.xml),
-            this.workspace);
+        const block = Blockly.Xml.domToBlock(
+            Blockly.utils.xml.textToDom(t.xml), this.workspace);
         chai.assert.equal(block.toString(), t.toString);
       });
     });
@@ -2055,9 +2065,11 @@ suite('Blocks', function() {
       chai.assert.throws(function() {
         this.workspace.newBlock('init_test_block');
       }.bind(this));
-      chai.assert.isFalse(recordUndoDuringInit,
+      chai.assert.isFalse(
+          recordUndoDuringInit,
           'recordUndo should be false during block init function');
-      chai.assert.isTrue(eventUtils.getRecordUndo(),
+      chai.assert.isTrue(
+          eventUtils.getRecordUndo(),
           'recordUndo should be reset to true after init');
       chai.assert.isTrue(initCalled, 'expected init function to be called');
     });

--- a/tests/mocha/block_test.js
+++ b/tests/mocha/block_test.js
@@ -51,7 +51,7 @@ suite('Blocks', function() {
         ],
         "previousStatement": null,
         "nextStatement": null,
-      }
+      },
     ]);
   });
   teardown(function() {

--- a/tests/mocha/blocks/lists_test.js
+++ b/tests/mocha/blocks/lists_test.js
@@ -53,13 +53,12 @@ suite('Lists', function() {
           chai.assert.equal(block.type, 'lists_getIndex');
           chai.assert.isNotTrue(block.outputConnection);
           chai.assert.isTrue(
-            block.getInput('AT').type === ConnectionType.INPUT_VALUE
-          );
+              block.getInput('AT').type === ConnectionType.INPUT_VALUE);
         },
       },
       {
         title:
-          'JSON requiring mutations and extra state for previous connection',
+            'JSON requiring mutations and extra state for previous connection',
         json: {
           type: 'statement_block',
           id: '1',
@@ -75,8 +74,7 @@ suite('Lists', function() {
         assertBlockStructure: (block) => {},
       },
       {
-        title:
-          'JSON requiring mutations with XML extra state',
+        title: 'JSON requiring mutations with XML extra state',
         json: {
           type: 'statement_block',
           id: '1',
@@ -111,10 +109,12 @@ suite('Lists', function() {
    * Test cases for serialization where JSON hooks should have null
    * implementation to avoid serializing xml mutations in json.
    * @param {!Object} serializedJson basic serialized json
-   * @param {!string} xmlMutation xml mutation that should be ignored/not reserialized in round trip
+   * @param {!string} xmlMutation xml mutation that should be ignored/not
+   *     reserialized in round trip
    * @return {Array<SerializationTestCase>} test cases
    */
-  function makeTestCasesForBlockNotNeedingExtraState_(serializedJson, xmlMutation) {
+  function makeTestCasesForBlockNotNeedingExtraState_(
+      serializedJson, xmlMutation) {
     return [
       {
         title: 'JSON not requiring mutations',
@@ -124,8 +124,7 @@ suite('Lists', function() {
         },
       },
       {
-        title:
-          'JSON with XML extra state',
+        title: 'JSON with XML extra state',
         json: {
           ...serializedJson,
           "extraState": xmlMutation,
@@ -142,16 +141,15 @@ suite('Lists', function() {
      * @type {Array<SerializationTestCase>}
      */
     const testCases = makeTestCasesForBlockNotNeedingExtraState_(
-      {
-        "type": "lists_setIndex",
-        "id": "1",
-        "fields": {
-          "MODE": "SET",
-          "WHERE": "FROM_START",
+        {
+          "type": "lists_setIndex",
+          "id": "1",
+          "fields": {
+            "MODE": "SET",
+            "WHERE": "FROM_START",
+          },
         },
-      },
-      "<mutation at=\"true\"></mutation>"
-    );
+        "<mutation at=\"true\"></mutation>");
     runSerializationTestSuite(testCases);
   });
 
@@ -160,17 +158,16 @@ suite('Lists', function() {
      * Test cases for serialization tests.
      * @type {Array<SerializationTestCase>}
      */
-     const testCases = makeTestCasesForBlockNotNeedingExtraState_(
-      {
-        "type": "lists_getSublist",
-        "id": "1",
-        "fields": {
-          "WHERE1": "FROM_START",
-          "WHERE2": "FROM_START",
+    const testCases = makeTestCasesForBlockNotNeedingExtraState_(
+        {
+          "type": "lists_getSublist",
+          "id": "1",
+          "fields": {
+            "WHERE1": "FROM_START",
+            "WHERE2": "FROM_START",
+          },
         },
-      },
-      "<mutation at1=\"true\" at2=\"true\"></mutation>"
-    );
+        "<mutation at1=\"true\" at2=\"true\"></mutation>");
     runSerializationTestSuite(testCases);
   });
 
@@ -180,15 +177,14 @@ suite('Lists', function() {
      * @type {Array<SerializationTestCase>}
      */
     const testCases = makeTestCasesForBlockNotNeedingExtraState_(
-      {
-        "type": "lists_split",
-        "id": "1",
-        "fields": {
-          "MODE": "SPLIT",
+        {
+          "type": "lists_split",
+          "id": "1",
+          "fields": {
+            "MODE": "SPLIT",
+          },
         },
-      },
-      "<mutation mode=\"SPLIT\"></mutation>"
-    );
+        "<mutation mode=\"SPLIT\"></mutation>");
     runSerializationTestSuite(testCases);
   });
 });

--- a/tests/mocha/blocks/logic_ternary_test.js
+++ b/tests/mocha/blocks/logic_ternary_test.js
@@ -56,23 +56,22 @@ suite('Logic ternary', function() {
    * @type {Array<SerializationTestCase>}
    */
   const testCases = [
-    {title: 'Empty XML', xml: '<block type="logic_ternary"/>',
-      expectedXml:
-          '<block xmlns="https://developers.google.com/blockly/xml" ' +
+    {
+      title: 'Empty XML',
+      xml: '<block type="logic_ternary"/>',
+      expectedXml: '<block xmlns="https://developers.google.com/blockly/xml" ' +
           'type="logic_ternary" id="1"></block>',
-      assertBlockStructure:
-          (block) => {
-            assertBlockStructure(block);
-          },
+      assertBlockStructure: (block) => {
+        assertBlockStructure(block);
+      },
     },
-    {title: 'Inputs inline',
-      xml:
-          '<block xmlns="https://developers.google.com/blockly/xml" ' +
+    {
+      title: 'Inputs inline',
+      xml: '<block xmlns="https://developers.google.com/blockly/xml" ' +
           'type="logic_ternary" id="1" inline="true"></block>',
-      assertBlockStructure:
-          (block) => {
-            assertBlockStructure(block, true);
-          },
+      assertBlockStructure: (block) => {
+        assertBlockStructure(block, true);
+      },
     },
   ];
   runSerializationTestSuite(testCases);
@@ -80,16 +79,19 @@ suite('Logic ternary', function() {
   suite('Connections', function() {
     function connectParentAndCheckConnections(
         block, parent, parentInputName, opt_thenInput, opt_elseInput) {
-      parent.getInput(parentInputName).connection.connect(block.outputConnection);
+      parent.getInput(parentInputName)
+          .connection.connect(block.outputConnection);
       eventUtils.TEST_ONLY.fireNow();  // Force synchronous onchange() call.
-      chai.assert.equal(block.getParent(), parent,
-          'Successful connection to parent');
+      chai.assert.equal(
+          block.getParent(), parent, 'Successful connection to parent');
       if (opt_thenInput) {
-        chai.assert.equal(opt_thenInput.getParent(), block,
+        chai.assert.equal(
+            opt_thenInput.getParent(), block,
             'Input THEN still connected after connecting parent');
       }
       if (opt_elseInput) {
-        chai.assert.equal(opt_elseInput.getParent(), block,
+        chai.assert.equal(
+            opt_elseInput.getParent(), block,
             'Input ELSE still connected after connecting parent');
       }
     }
@@ -99,11 +101,13 @@ suite('Logic ternary', function() {
       eventUtils.TEST_ONLY.fireNow();  // Force synchronous onchange() call.
       chai.assert.equal(thenInput.getParent(), block, 'THEN is connected');
       if (opt_parent) {
-        chai.assert.equal(block.getParent(), opt_parent,
+        chai.assert.equal(
+            block.getParent(), opt_parent,
             'Still connected to parent after connecting THEN');
       }
       if (opt_elseInput) {
-        chai.assert.equal(opt_elseInput.getParent(), block,
+        chai.assert.equal(
+            opt_elseInput.getParent(), block,
             'Input ELSE still connected after connecting THEN');
       }
     }
@@ -113,18 +117,21 @@ suite('Logic ternary', function() {
       eventUtils.TEST_ONLY.fireNow();  // Force synchronous onchange() call.
       chai.assert.equal(elseInput.getParent(), block, 'ELSE is connected');
       if (opt_parent) {
-        chai.assert.equal(block.getParent(), opt_parent,
+        chai.assert.equal(
+            block.getParent(), opt_parent,
             'Still connected to parent after connecting ELSE');
       }
       if (opt_thenInput) {
-        chai.assert.equal(opt_thenInput.getParent(), block,
+        chai.assert.equal(
+            opt_thenInput.getParent(), block,
             'Input THEN still connected after connecting ELSE');
       }
     }
     function connectInputsAndCheckConnections(
         block, thenInput, elseInput, opt_parent) {
       connectThenInputAndCheckConnections(block, thenInput, null, opt_parent);
-      connectElseInputAndCheckConnections(block, elseInput, thenInput, opt_parent);
+      connectElseInputAndCheckConnections(
+          block, elseInput, thenInput, opt_parent);
     }
     setup(function() {
       this.block = this.workspace.newBlock('logic_ternary');
@@ -165,7 +172,8 @@ suite('Logic ternary', function() {
         connectInputsAndCheckConnections(this.block, string, number, parent);
       });
       test('Attach inputs different types with permissive parent', function() {
-        const parent = this.workspace.newBlock('text_length');  // Allows String or Array
+        const parent =
+            this.workspace.newBlock('text_length');  // Allows String or Array
 
         connectParentAndCheckConnections(this.block, parent, 'VALUE');
 
@@ -175,7 +183,8 @@ suite('Logic ternary', function() {
         connectInputsAndCheckConnections(this.block, string, array, parent);
       });
       test('Attach mismatch type to then causes break with parent', function() {
-        const parent = this.workspace.newBlock('text_length');  // Allows String or Array
+        const parent =
+            this.workspace.newBlock('text_length');  // Allows String or Array
 
         connectParentAndCheckConnections(this.block, parent, 'VALUE');
 
@@ -186,11 +195,12 @@ suite('Logic ternary', function() {
 
         // Adding mismatching number.
         connectThenInputAndCheckConnections(this.block, number, string);
-        chai.assert.equal(this.block.getRootBlock(), this.block,
-            'Disconnected from parent');
+        chai.assert.equal(
+            this.block.getRootBlock(), this.block, 'Disconnected from parent');
       });
       test('Attach mismatch type to else causes break with parent', function() {
-        const parent = this.workspace.newBlock('text_length');  // Allows String or Array
+        const parent =
+            this.workspace.newBlock('text_length');  // Allows String or Array
 
         connectParentAndCheckConnections(this.block, parent, 'VALUE');
 
@@ -201,8 +211,8 @@ suite('Logic ternary', function() {
 
         // Adding mismatching number.
         connectElseInputAndCheckConnections(this.block, number, string);
-        chai.assert.equal(this.block.getRootBlock(), this.block,
-            'Disconnected from parent');
+        chai.assert.equal(
+            this.block.getRootBlock(), this.block, 'Disconnected from parent');
       });
     });
     suite('Attaching parent after inputs', function() {
@@ -235,8 +245,8 @@ suite('Logic ternary', function() {
         const parent = this.workspace.newBlock('text_trim');
         connectParentAndCheckConnections(
             this.block, parent, 'TEXT', null, string);
-        chai.assert.equal(number.getRootBlock(), number,
-            'Input THEN disconnected');
+        chai.assert.equal(
+            number.getRootBlock(), number, 'Input THEN disconnected');
       });
       test('Mismatch with else causes break with else', function() {
         const string = this.workspace.newBlock('text');
@@ -246,8 +256,8 @@ suite('Logic ternary', function() {
 
         const parent = this.workspace.newBlock('text_trim');
         connectParentAndCheckConnections(this.block, parent, 'TEXT', string);
-        chai.assert.equal(number.getRootBlock(), number,
-            'Input ELSE disconnected');
+        chai.assert.equal(
+            number.getRootBlock(), number, 'Input ELSE disconnected');
       });
     });
   });

--- a/tests/mocha/blocks/procedures_test.js
+++ b/tests/mocha/blocks/procedures_test.js
@@ -35,14 +35,13 @@ suite('Procedures', function() {
       defBlock.setFieldValue('new name', 'NAME');
 
       chai.assert.equal(
-        callBlock.getFieldValue('NAME'),
-        'new name',
-        'Expected the procedure block to be renamed');
+          callBlock.getFieldValue('NAME'), 'new name',
+          'Expected the procedure block to be renamed');
     });
 
     test(
         'setting an illegal name results in both the ' +
-        'procedure and the caller getting the legal name',
+            'procedure and the caller getting the legal name',
         function() {
           createProcDefBlock(this.workspace, undefined, undefined, 'procA');
           const defBlockB =
@@ -53,13 +52,11 @@ suite('Procedures', function() {
           defBlockB.setFieldValue('procA', 'NAME');
 
           chai.assert.notEqual(
-            defBlockB.getFieldValue('NAME'),
-            'procA',
-            'Expected the procedure def block to have a legal name');
+              defBlockB.getFieldValue('NAME'), 'procA',
+              'Expected the procedure def block to have a legal name');
           chai.assert.notEqual(
-            callBlockB.getFieldValue('NAME'),
-            'procA',
-            'Expected the procedure call block to have a legal name');
+              callBlockB.getFieldValue('NAME'), 'procA',
+              'Expected the procedure call block to have a legal name');
         });
   });
 
@@ -70,67 +67,72 @@ suite('Procedures', function() {
           const defBlock = createProcDefBlock(this.workspace);
           defBlock.mutator.setVisible(true);
           const mutatorWorkspace = defBlock.mutator.getWorkspace();
-          const origFlyoutParamName =
-              mutatorWorkspace.getFlyout().getWorkspace().getTopBlocks(true)[0]
-                  .getFieldValue('NAME');
+          const origFlyoutParamName = mutatorWorkspace.getFlyout()
+                                          .getWorkspace()
+                                          .getTopBlocks(true)[0]
+                                          .getFieldValue('NAME');
           Blockly.serialization.blocks.append(
-            {
-              'type': 'procedures_mutatorarg',
-              'fields': {
-                'NAME': origFlyoutParamName,
+              {
+                'type': 'procedures_mutatorarg',
+                'fields': {
+                  'NAME': origFlyoutParamName,
+                },
               },
-            },
-            mutatorWorkspace);
+              mutatorWorkspace);
           this.clock.runAll();
 
-          const newFlyoutParamName =
-              mutatorWorkspace.getFlyout().getWorkspace().getTopBlocks(true)[0]
-                  .getFieldValue('NAME');
+          const newFlyoutParamName = mutatorWorkspace.getFlyout()
+                                         .getWorkspace()
+                                         .getTopBlocks(true)[0]
+                                         .getFieldValue('NAME');
           chai.assert.notEqual(
-              newFlyoutParamName,
-              origFlyoutParamName,
+              newFlyoutParamName, origFlyoutParamName,
               'Expected the flyout param to have updated to not conflict');
         });
 
-    test('adding a parameter to the procedure updates procedure defs', function() {
-      // Create a stack of container, parameter.
-      const defBlock = createProcDefBlock(this.workspace);
-      defBlock.mutator.setVisible(true);
-      const mutatorWorkspace = defBlock.mutator.getWorkspace();
-      const containerBlock = mutatorWorkspace.getTopBlocks()[0];
-      const paramBlock = mutatorWorkspace.newBlock('procedures_mutatorarg');
-      paramBlock.setFieldValue('param1', 'NAME');
-      containerBlock.getInput('STACK').connection.connect(paramBlock.previousConnection);
-      this.clock.runAll();
+    test(
+        'adding a parameter to the procedure updates procedure defs',
+        function() {
+          // Create a stack of container, parameter.
+          const defBlock = createProcDefBlock(this.workspace);
+          defBlock.mutator.setVisible(true);
+          const mutatorWorkspace = defBlock.mutator.getWorkspace();
+          const containerBlock = mutatorWorkspace.getTopBlocks()[0];
+          const paramBlock = mutatorWorkspace.newBlock('procedures_mutatorarg');
+          paramBlock.setFieldValue('param1', 'NAME');
+          containerBlock.getInput('STACK').connection.connect(
+              paramBlock.previousConnection);
+          this.clock.runAll();
 
-      chai.assert.isNotNull(
-        defBlock.getField('PARAMS'),
-        'Expected the params field to exist');
-      chai.assert.isTrue(
-        defBlock.getFieldValue('PARAMS').includes('param1'),
-        'Expected the params field to contain the name of the new param');
-    });
+          chai.assert.isNotNull(
+              defBlock.getField('PARAMS'),
+              'Expected the params field to exist');
+          chai.assert.isTrue(
+              defBlock.getFieldValue('PARAMS').includes('param1'),
+              'Expected the params field to contain the name of the new param');
+        });
 
-    test('adding a parameter to the procedure updates procedure callers', function() {
-      // Create a stack of container, parameter.
-      const defBlock = createProcDefBlock(this.workspace);
-      const callBlock = createProcCallBlock(this.workspace);
-      defBlock.mutator.setVisible(true);
-      const mutatorWorkspace = defBlock.mutator.getWorkspace();
-      const containerBlock = mutatorWorkspace.getTopBlocks()[0];
-      const paramBlock = mutatorWorkspace.newBlock('procedures_mutatorarg');
-      paramBlock.setFieldValue('param1', 'NAME');
-      containerBlock.getInput('STACK').connection.connect(paramBlock.previousConnection);
-      this.clock.runAll();
+    test(
+        'adding a parameter to the procedure updates procedure callers',
+        function() {
+          // Create a stack of container, parameter.
+          const defBlock = createProcDefBlock(this.workspace);
+          const callBlock = createProcCallBlock(this.workspace);
+          defBlock.mutator.setVisible(true);
+          const mutatorWorkspace = defBlock.mutator.getWorkspace();
+          const containerBlock = mutatorWorkspace.getTopBlocks()[0];
+          const paramBlock = mutatorWorkspace.newBlock('procedures_mutatorarg');
+          paramBlock.setFieldValue('param1', 'NAME');
+          containerBlock.getInput('STACK').connection.connect(
+              paramBlock.previousConnection);
+          this.clock.runAll();
 
-      chai.assert.isNotNull(
-        callBlock.getInput('ARG0'),
-        'Expected the param input to exist');
-      chai.assert.equal(
-        callBlock.getFieldValue('ARGNAME0'),
-        'param1',
-        'Expected the params field to match the name of the new param');
-    });
+          chai.assert.isNotNull(
+              callBlock.getInput('ARG0'), 'Expected the param input to exist');
+          chai.assert.equal(
+              callBlock.getFieldValue('ARGNAME0'), 'param1',
+              'Expected the params field to match the name of the new param');
+        });
 
     test('undoing adding a procedure parameter removes it', function() {
       // Create a stack of container, parameter.
@@ -140,19 +142,20 @@ suite('Procedures', function() {
       const containerBlock = mutatorWorkspace.getTopBlocks()[0];
       const paramBlock = mutatorWorkspace.newBlock('procedures_mutatorarg');
       paramBlock.setFieldValue('param1', 'NAME');
-      containerBlock.getInput('STACK').connection.connect(paramBlock.previousConnection);
+      containerBlock.getInput('STACK').connection.connect(
+          paramBlock.previousConnection);
       this.clock.runAll();
 
       this.workspace.undo();
 
       chai.assert.isFalse(
-        defBlock.getFieldValue('PARAMS').includes('param1'),
-        'Expected the params field to not contain the name of the new param');
+          defBlock.getFieldValue('PARAMS').includes('param1'),
+          'Expected the params field to not contain the name of the new param');
     });
 
     test(
         'undoing and redoing adding a procedure parameter maintains ' +
-        'the same state',
+            'the same state',
         function() {
           // Create a stack of container, parameter.
           const defBlock = createProcDefBlock(this.workspace);
@@ -169,53 +172,59 @@ suite('Procedures', function() {
           this.workspace.undo(/* redo= */ true);
 
           chai.assert.isNotNull(
-            defBlock.getField('PARAMS'),
-            'Expected the params field to exist');
+              defBlock.getField('PARAMS'),
+              'Expected the params field to exist');
           chai.assert.isTrue(
-            defBlock.getFieldValue('PARAMS').includes('param1'),
-            'Expected the params field to contain the name of the new param');
+              defBlock.getFieldValue('PARAMS').includes('param1'),
+              'Expected the params field to contain the name of the new param');
         });
   });
 
   suite('deleting procedure parameters', function() {
-    test('deleting a parameter from the procedure updates procedure defs', function() {
-      // Create a stack of container, parameter.
-      const defBlock = createProcDefBlock(this.workspace);
-      defBlock.mutator.setVisible(true);
-      const mutatorWorkspace = defBlock.mutator.getWorkspace();
-      const containerBlock = mutatorWorkspace.getTopBlocks()[0];
-      const paramBlock = mutatorWorkspace.newBlock('procedures_mutatorarg');
-      paramBlock.setFieldValue('param1', 'NAME');
-      containerBlock.getInput('STACK').connection.connect(paramBlock.previousConnection);
-      this.clock.runAll();
+    test(
+        'deleting a parameter from the procedure updates procedure defs',
+        function() {
+          // Create a stack of container, parameter.
+          const defBlock = createProcDefBlock(this.workspace);
+          defBlock.mutator.setVisible(true);
+          const mutatorWorkspace = defBlock.mutator.getWorkspace();
+          const containerBlock = mutatorWorkspace.getTopBlocks()[0];
+          const paramBlock = mutatorWorkspace.newBlock('procedures_mutatorarg');
+          paramBlock.setFieldValue('param1', 'NAME');
+          containerBlock.getInput('STACK').connection.connect(
+              paramBlock.previousConnection);
+          this.clock.runAll();
 
-      paramBlock.checkAndDelete();
-      this.clock.runAll();
+          paramBlock.checkAndDelete();
+          this.clock.runAll();
 
-      chai.assert.isFalse(
-        defBlock.getFieldValue('PARAMS').includes('param1'),
-        'Expected the params field to not contain the name of the new param');
-    });
+          chai.assert.isFalse(
+              defBlock.getFieldValue('PARAMS').includes('param1'),
+              'Expected the params field to not contain the name of the new param');
+        });
 
-    test('deleting a parameter from the procedure udpates procedure callers', function() {
-      // Create a stack of container, parameter.
-      const defBlock = createProcDefBlock(this.workspace);
-      const callBlock = createProcCallBlock(this.workspace);
-      defBlock.mutator.setVisible(true);
-      const mutatorWorkspace = defBlock.mutator.getWorkspace();
-      const containerBlock = mutatorWorkspace.getTopBlocks()[0];
-      const paramBlock = mutatorWorkspace.newBlock('procedures_mutatorarg');
-      paramBlock.setFieldValue('param1', 'NAME');
-      containerBlock.getInput('STACK').connection.connect(paramBlock.previousConnection);
-      this.clock.runAll();
+    test(
+        'deleting a parameter from the procedure udpates procedure callers',
+        function() {
+          // Create a stack of container, parameter.
+          const defBlock = createProcDefBlock(this.workspace);
+          const callBlock = createProcCallBlock(this.workspace);
+          defBlock.mutator.setVisible(true);
+          const mutatorWorkspace = defBlock.mutator.getWorkspace();
+          const containerBlock = mutatorWorkspace.getTopBlocks()[0];
+          const paramBlock = mutatorWorkspace.newBlock('procedures_mutatorarg');
+          paramBlock.setFieldValue('param1', 'NAME');
+          containerBlock.getInput('STACK').connection.connect(
+              paramBlock.previousConnection);
+          this.clock.runAll();
 
-      paramBlock.checkAndDelete();
-      this.clock.runAll();
+          paramBlock.checkAndDelete();
+          this.clock.runAll();
 
-      chai.assert.isNull(
-        callBlock.getInput('ARG0'),
-        'Expected the param input to not exist');
-    });
+          chai.assert.isNull(
+              callBlock.getInput('ARG0'),
+              'Expected the param input to not exist');
+        });
 
     test('undoing deleting a procedure parameter adds it', function() {
       // Create a stack of container, parameter.
@@ -225,7 +234,8 @@ suite('Procedures', function() {
       const containerBlock = mutatorWorkspace.getTopBlocks()[0];
       const paramBlock = mutatorWorkspace.newBlock('procedures_mutatorarg');
       paramBlock.setFieldValue('param1', 'NAME');
-      containerBlock.getInput('STACK').connection.connect(paramBlock.previousConnection);
+      containerBlock.getInput('STACK').connection.connect(
+          paramBlock.previousConnection);
       this.clock.runAll();
       paramBlock.checkAndDelete();
       this.clock.runAll();
@@ -233,12 +243,13 @@ suite('Procedures', function() {
       this.workspace.undo();
 
       chai.assert.isTrue(
-        defBlock.getFieldValue('PARAMS').includes('param1'),
-        'Expected the params field to contain the name of the new param');
+          defBlock.getFieldValue('PARAMS').includes('param1'),
+          'Expected the params field to contain the name of the new param');
     });
 
-    test('undoing and redoing deleting a procedure parameter maintains ' +
-        'the same state',
+    test(
+        'undoing and redoing deleting a procedure parameter maintains ' +
+            'the same state',
         function() {
           // Create a stack of container, parameter.
           const defBlock = createProcDefBlock(this.workspace);
@@ -247,8 +258,8 @@ suite('Procedures', function() {
           const containerBlock = mutatorWorkspace.getTopBlocks()[0];
           const paramBlock = mutatorWorkspace.newBlock('procedures_mutatorarg');
           paramBlock.setFieldValue('param1', 'NAME');
-          containerBlock.getInput('STACK').connection
-              .connect(paramBlock.previousConnection);
+          containerBlock.getInput('STACK').connection.connect(
+              paramBlock.previousConnection);
           this.clock.runAll();
           paramBlock.checkAndDelete();
           this.clock.runAll();
@@ -257,8 +268,8 @@ suite('Procedures', function() {
           this.workspace.undo(/* redo= */ true);
 
           chai.assert.isFalse(
-            defBlock.getFieldValue('PARAMS').includes('param1'),
-            'Expected the params field to not contain the name of the new param');
+              defBlock.getFieldValue('PARAMS').includes('param1'),
+              'Expected the params field to not contain the name of the new param');
         });
   });
 
@@ -271,33 +282,36 @@ suite('Procedures', function() {
       const containerBlock = mutatorWorkspace.getTopBlocks()[0];
       const paramBlock = mutatorWorkspace.newBlock('procedures_mutatorarg');
       paramBlock.setFieldValue('param1', 'NAME');
-      containerBlock.getInput('STACK').connection.connect(paramBlock.previousConnection);
+      containerBlock.getInput('STACK').connection.connect(
+          paramBlock.previousConnection);
       this.clock.runAll();
 
       paramBlock.setFieldValue('new name', 'NAME');
       this.clock.runAll();
 
       chai.assert.isNotNull(
-        defBlock.getField('PARAMS'),
-        'Expected the params field to exist');
+          defBlock.getField('PARAMS'), 'Expected the params field to exist');
       chai.assert.isTrue(
-        defBlock.getFieldValue('PARAMS').includes('new name'),
-        'Expected the params field to contain the new name of the param');
+          defBlock.getFieldValue('PARAMS').includes('new name'),
+          'Expected the params field to contain the new name of the param');
     });
 
-    test('defs are updated for parameter renames when two params exist',
+    test(
+        'defs are updated for parameter renames when two params exist',
         function() {
           // Create a stack of container, parameter.
           const defBlock = createProcDefBlock(this.workspace);
           defBlock.mutator.setVisible(true);
           const mutatorWorkspace = defBlock.mutator.getWorkspace();
           const containerBlock = mutatorWorkspace.getTopBlocks()[0];
-          const paramBlock1 = mutatorWorkspace.newBlock('procedures_mutatorarg');
+          const paramBlock1 =
+              mutatorWorkspace.newBlock('procedures_mutatorarg');
           paramBlock1.setFieldValue('param1', 'NAME');
-          const paramBlock2 = mutatorWorkspace.newBlock('procedures_mutatorarg');
+          const paramBlock2 =
+              mutatorWorkspace.newBlock('procedures_mutatorarg');
           paramBlock2.setFieldValue('param2', 'NAME');
-          containerBlock.getInput('STACK').connection
-              .connect(paramBlock1.previousConnection);
+          containerBlock.getInput('STACK').connection.connect(
+              paramBlock1.previousConnection);
           paramBlock1.nextConnection.connect(paramBlock2.previousConnection);
           this.clock.runAll();
 
@@ -305,11 +319,11 @@ suite('Procedures', function() {
           this.clock.runAll();
 
           chai.assert.isNotNull(
-            defBlock.getField('PARAMS'),
-            'Expected the params field to exist');
+              defBlock.getField('PARAMS'),
+              'Expected the params field to exist');
           chai.assert.isTrue(
-            defBlock.getFieldValue('PARAMS').includes('new name'),
-            'Expected the params field to contain the new name of the param');
+              defBlock.getFieldValue('PARAMS').includes('new name'),
+              'Expected the params field to contain the new name of the param');
         });
 
     test('callers are updated for parameter renames', function() {
@@ -321,19 +335,18 @@ suite('Procedures', function() {
       const containerBlock = mutatorWorkspace.getTopBlocks()[0];
       const paramBlock = mutatorWorkspace.newBlock('procedures_mutatorarg');
       paramBlock.setFieldValue('param1', 'NAME');
-      containerBlock.getInput('STACK').connection.connect(paramBlock.previousConnection);
+      containerBlock.getInput('STACK').connection.connect(
+          paramBlock.previousConnection);
       this.clock.runAll();
 
       paramBlock.setFieldValue('new name', 'NAME');
       this.clock.runAll();
 
       chai.assert.isNotNull(
-        callBlock.getInput('ARG0'),
-        'Expected the param input to exist');
+          callBlock.getInput('ARG0'), 'Expected the param input to exist');
       chai.assert.equal(
-        callBlock.getFieldValue('ARGNAME0'),
-        'new name',
-        'Expected the params field to match the name of the new param');
+          callBlock.getFieldValue('ARGNAME0'), 'new name',
+          'Expected the params field to match the name of the new param');
     });
 
     test(
@@ -347,7 +360,8 @@ suite('Procedures', function() {
           const containerBlock = mutatorWorkspace.getTopBlocks()[0];
           const paramBlock = mutatorWorkspace.newBlock('procedures_mutatorarg');
           paramBlock.setFieldValue('param1', 'NAME');
-          containerBlock.getInput('STACK').connection.connect(paramBlock.previousConnection);
+          containerBlock.getInput('STACK').connection.connect(
+              paramBlock.previousConnection);
           this.clock.runAll();
 
           paramBlock.setFieldValue('param2', 'NAME');
@@ -368,8 +382,8 @@ suite('Procedures', function() {
           const containerBlock = mutatorWorkspace.getTopBlocks()[0];
           const paramBlock = mutatorWorkspace.newBlock('procedures_mutatorarg');
           paramBlock.setFieldValue('param1', 'NAME');
-          containerBlock.getInput('STACK').connection
-              .connect(paramBlock.previousConnection);
+          containerBlock.getInput('STACK').connection.connect(
+              paramBlock.previousConnection);
           this.clock.runAll();
           defBlock.mutator.setVisible(false);
 
@@ -394,16 +408,15 @@ suite('Procedures', function() {
           const containerBlock = mutatorWorkspace.getTopBlocks()[0];
           const paramBlock = mutatorWorkspace.newBlock('procedures_mutatorarg');
           paramBlock.setFieldValue('param1', 'NAME');
-          containerBlock.getInput('STACK').connection
-              .connect(paramBlock.previousConnection);
+          containerBlock.getInput('STACK').connection.connect(
+              paramBlock.previousConnection);
           this.clock.runAll();
 
           const variable = this.workspace.getVariable('param1', '');
           this.workspace.renameVariableById(variable.getId(), 'new name');
 
           chai.assert.equal(
-              paramBlock.getFieldValue('NAME'),
-              'new name',
+              paramBlock.getFieldValue('NAME'), 'new name',
               'Expected the params field to contain the new name of the param');
         });
 
@@ -418,8 +431,8 @@ suite('Procedures', function() {
           const containerBlock = mutatorWorkspace.getTopBlocks()[0];
           const paramBlock = mutatorWorkspace.newBlock('procedures_mutatorarg');
           paramBlock.setFieldValue('param1', 'NAME');
-          containerBlock.getInput('STACK').connection
-              .connect(paramBlock.previousConnection);
+          containerBlock.getInput('STACK').connection.connect(
+              paramBlock.previousConnection);
           this.clock.runAll();
           defBlock.mutator.setVisible(false);
 
@@ -427,12 +440,10 @@ suite('Procedures', function() {
           this.workspace.renameVariableById(variable.getId(), 'new name');
 
           chai.assert.isNotNull(
-            callBlock.getInput('ARG0'),
-            'Expected the param input to exist');
+              callBlock.getInput('ARG0'), 'Expected the param input to exist');
           chai.assert.equal(
-            callBlock.getFieldValue('ARGNAME0'),
-            'new name',
-            'Expected the params field to match the name of the new param');
+              callBlock.getFieldValue('ARGNAME0'), 'new name',
+              'Expected the params field to match the name of the new param');
         });
 
     test(
@@ -445,8 +456,8 @@ suite('Procedures', function() {
           const containerBlock = mutatorWorkspace.getTopBlocks()[0];
           const paramBlock = mutatorWorkspace.newBlock('procedures_mutatorarg');
           paramBlock.setFieldValue('param1', 'NAME');
-          containerBlock.getInput('STACK').connection
-              .connect(paramBlock.previousConnection);
+          containerBlock.getInput('STACK').connection.connect(
+              paramBlock.previousConnection);
           this.clock.runAll();
           defBlock.mutator.setVisible(false);
 
@@ -471,16 +482,15 @@ suite('Procedures', function() {
           const containerBlock = mutatorWorkspace.getTopBlocks()[0];
           const paramBlock = mutatorWorkspace.newBlock('procedures_mutatorarg');
           paramBlock.setFieldValue('param1', 'NAME');
-          containerBlock.getInput('STACK').connection
-              .connect(paramBlock.previousConnection);
+          containerBlock.getInput('STACK').connection.connect(
+              paramBlock.previousConnection);
           this.clock.runAll();
 
           const variable = this.workspace.getVariable('param1', '');
           this.workspace.renameVariableById(variable.getId(), 'preCreatedVar');
 
           chai.assert.equal(
-              paramBlock.getFieldValue('NAME'),
-              'preCreatedVar',
+              paramBlock.getFieldValue('NAME'), 'preCreatedVar',
               'Expected the params field to contain the new name of the param');
         });
 
@@ -495,8 +505,8 @@ suite('Procedures', function() {
           const containerBlock = mutatorWorkspace.getTopBlocks()[0];
           const paramBlock = mutatorWorkspace.newBlock('procedures_mutatorarg');
           paramBlock.setFieldValue('param1', 'NAME');
-          containerBlock.getInput('STACK').connection
-              .connect(paramBlock.previousConnection);
+          containerBlock.getInput('STACK').connection.connect(
+              paramBlock.previousConnection);
           this.clock.runAll();
           defBlock.mutator.setVisible(false);
 
@@ -504,17 +514,15 @@ suite('Procedures', function() {
           this.workspace.renameVariableById(variable.getId(), 'preCreatedVar');
 
           chai.assert.isNotNull(
-            callBlock.getInput('ARG0'),
-            'Expected the param input to exist');
+              callBlock.getInput('ARG0'), 'Expected the param input to exist');
           chai.assert.equal(
-            callBlock.getFieldValue('ARGNAME0'),
-            'preCreatedVar',
-            'Expected the params field to match the name of the new param');
+              callBlock.getFieldValue('ARGNAME0'), 'preCreatedVar',
+              'Expected the params field to match the name of the new param');
         });
 
     test.skip(
         'renaming a variable such that you get a parameter ' +
-        'conflict does... something!',
+            'conflict does... something!',
         function() {
 
         });
@@ -529,7 +537,8 @@ suite('Procedures', function() {
           const containerBlock = mutatorWorkspace.getTopBlocks()[0];
           const paramBlock = mutatorWorkspace.newBlock('procedures_mutatorarg');
           paramBlock.setFieldValue('param1', 'NAME');
-          containerBlock.getInput('STACK').connection.connect(paramBlock.previousConnection);
+          containerBlock.getInput('STACK').connection.connect(
+              paramBlock.previousConnection);
           this.clock.runAll();
           Blockly.Events.setGroup(true);
           paramBlock.setFieldValue('n', 'NAME');
@@ -544,8 +553,8 @@ suite('Procedures', function() {
           this.clock.runAll();
 
           chai.assert.isTrue(
-            defBlock.getFieldValue('PARAMS').includes('param1'),
-            'Expected the params field to contain the old name of the param');
+              defBlock.getFieldValue('PARAMS').includes('param1'),
+              'Expected the params field to contain the old name of the param');
         });
 
     test(
@@ -558,7 +567,8 @@ suite('Procedures', function() {
           const containerBlock = mutatorWorkspace.getTopBlocks()[0];
           const paramBlock = mutatorWorkspace.newBlock('procedures_mutatorarg');
           paramBlock.setFieldValue('param1', 'NAME');
-          containerBlock.getInput('STACK').connection.connect(paramBlock.previousConnection);
+          containerBlock.getInput('STACK').connection.connect(
+              paramBlock.previousConnection);
           this.clock.runAll();
           Blockly.Events.setGroup(true);
           paramBlock.setFieldValue('n', 'NAME');
@@ -573,40 +583,45 @@ suite('Procedures', function() {
           this.workspace.undo(/* redo= */ true);
 
           chai.assert.isTrue(
-            defBlock.getFieldValue('PARAMS').includes('new'),
-            'Expected the params field to contain the new name of the param');
+              defBlock.getFieldValue('PARAMS').includes('new'),
+              'Expected the params field to contain the new name of the param');
         });
   });
 
   suite('reordering procedure parameters', function() {
-    test('reordering procedure parameters updates procedure blocks', function() {
-      // Create a stack of container, parameter, parameter.
-      const defBlock = createProcDefBlock(this.workspace);
-      defBlock.mutator.setVisible(true);
-      const mutatorWorkspace = defBlock.mutator.getWorkspace();
-      const containerBlock = mutatorWorkspace.getTopBlocks()[0];
-      const paramBlock1 = mutatorWorkspace.newBlock('procedures_mutatorarg');
-      paramBlock1.setFieldValue('param1', 'NAME');
-      const paramBlock2 = mutatorWorkspace.newBlock('procedures_mutatorarg');
-      paramBlock2.setFieldValue('param2', 'NAME');
-      containerBlock.getInput('STACK').connection.connect(paramBlock1.previousConnection);
-      paramBlock1.nextConnection.connect(paramBlock2.previousConnection);
-      this.clock.runAll();
+    test(
+        'reordering procedure parameters updates procedure blocks', function() {
+          // Create a stack of container, parameter, parameter.
+          const defBlock = createProcDefBlock(this.workspace);
+          defBlock.mutator.setVisible(true);
+          const mutatorWorkspace = defBlock.mutator.getWorkspace();
+          const containerBlock = mutatorWorkspace.getTopBlocks()[0];
+          const paramBlock1 =
+              mutatorWorkspace.newBlock('procedures_mutatorarg');
+          paramBlock1.setFieldValue('param1', 'NAME');
+          const paramBlock2 =
+              mutatorWorkspace.newBlock('procedures_mutatorarg');
+          paramBlock2.setFieldValue('param2', 'NAME');
+          containerBlock.getInput('STACK').connection.connect(
+              paramBlock1.previousConnection);
+          paramBlock1.nextConnection.connect(paramBlock2.previousConnection);
+          this.clock.runAll();
 
-      // Reorder the parameters.
-      paramBlock2.previousConnection.disconnect();
-      paramBlock1.previousConnection.disconnect();
-      containerBlock.getInput('STACK').connection.connect(paramBlock2.previousConnection);
-      paramBlock2.nextConnection.connect(paramBlock1.previousConnection);
-      this.clock.runAll();
+          // Reorder the parameters.
+          paramBlock2.previousConnection.disconnect();
+          paramBlock1.previousConnection.disconnect();
+          containerBlock.getInput('STACK').connection.connect(
+              paramBlock2.previousConnection);
+          paramBlock2.nextConnection.connect(paramBlock1.previousConnection);
+          this.clock.runAll();
 
-      chai.assert.isNotNull(
-        defBlock.getField('PARAMS'),
-        'Expected the params field to exist');
-      chai.assert.isTrue(
-        defBlock.getFieldValue('PARAMS').includes('param2, param1'),
-        'Expected the params field order to match the parameter order');
-    });
+          chai.assert.isNotNull(
+              defBlock.getField('PARAMS'),
+              'Expected the params field to exist');
+          chai.assert.isTrue(
+              defBlock.getFieldValue('PARAMS').includes('param2, param1'),
+              'Expected the params field order to match the parameter order');
+        });
 
     test('reordering procedure parameters updates caller blocks', function() {
       // Create a stack of container, parameter, parameter.
@@ -619,36 +634,34 @@ suite('Procedures', function() {
       paramBlock1.setFieldValue('param1', 'NAME');
       const paramBlock2 = mutatorWorkspace.newBlock('procedures_mutatorarg');
       paramBlock2.setFieldValue('param2', 'NAME');
-      containerBlock.getInput('STACK').connection.connect(paramBlock1.previousConnection);
+      containerBlock.getInput('STACK').connection.connect(
+          paramBlock1.previousConnection);
       paramBlock1.nextConnection.connect(paramBlock2.previousConnection);
       this.clock.runAll();
 
       // Reorder the parameters.
       paramBlock2.previousConnection.disconnect();
       paramBlock1.previousConnection.disconnect();
-      containerBlock.getInput('STACK').connection.connect(paramBlock2.previousConnection);
+      containerBlock.getInput('STACK').connection.connect(
+          paramBlock2.previousConnection);
       paramBlock2.nextConnection.connect(paramBlock1.previousConnection);
       this.clock.runAll();
 
       chai.assert.isNotNull(
-        callBlock.getInput('ARG0'),
-        'Expected the param input to exist');
+          callBlock.getInput('ARG0'), 'Expected the param input to exist');
       chai.assert.equal(
-        callBlock.getFieldValue('ARGNAME0'),
-        'param2',
-        'Expected the params field to match the name of the second param');
+          callBlock.getFieldValue('ARGNAME0'), 'param2',
+          'Expected the params field to match the name of the second param');
       chai.assert.isNotNull(
-        callBlock.getInput('ARG1'),
-        'Expected the param input to exist');
+          callBlock.getInput('ARG1'), 'Expected the param input to exist');
       chai.assert.equal(
-        callBlock.getFieldValue('ARGNAME1'),
-        'param1',
-        'Expected the params field to match the name of the first param');
+          callBlock.getFieldValue('ARGNAME1'), 'param1',
+          'Expected the params field to match the name of the first param');
     });
 
     test(
         'reordering procedure parameters reorders the blocks ' +
-        'attached to caller inputs',
+            'attached to caller inputs',
         function() {
           // Create a stack of container, parameter, parameter.
           const defBlock = createProcDefBlock(this.workspace);
@@ -656,44 +669,46 @@ suite('Procedures', function() {
           defBlock.mutator.setVisible(true);
           const mutatorWorkspace = defBlock.mutator.getWorkspace();
           const containerBlock = mutatorWorkspace.getTopBlocks()[0];
-          const paramBlock1 = mutatorWorkspace.newBlock('procedures_mutatorarg');
+          const paramBlock1 =
+              mutatorWorkspace.newBlock('procedures_mutatorarg');
           paramBlock1.setFieldValue('param1', 'NAME');
-          const paramBlock2 = mutatorWorkspace.newBlock('procedures_mutatorarg');
+          const paramBlock2 =
+              mutatorWorkspace.newBlock('procedures_mutatorarg');
           paramBlock2.setFieldValue('param2', 'NAME');
-          containerBlock.getInput('STACK').connection.connect(paramBlock1.previousConnection);
+          containerBlock.getInput('STACK').connection.connect(
+              paramBlock1.previousConnection);
           paramBlock1.nextConnection.connect(paramBlock2.previousConnection);
           this.clock.runAll();
 
           // Add args to the parameter inputs on the caller.
           const block1 = this.workspace.newBlock('text');
           const block2 = this.workspace.newBlock('text');
-          callBlock.getInput('ARG0').connection
-              .connect(block1.outputConnection);
-          callBlock.getInput('ARG1').connection
-              .connect(block2.outputConnection);
+          callBlock.getInput('ARG0').connection.connect(
+              block1.outputConnection);
+          callBlock.getInput('ARG1').connection.connect(
+              block2.outputConnection);
 
           // Reorder the parameters.
           paramBlock2.previousConnection.disconnect();
           paramBlock1.previousConnection.disconnect();
-          containerBlock.getInput('STACK').connection.connect(paramBlock2.previousConnection);
+          containerBlock.getInput('STACK').connection.connect(
+              paramBlock2.previousConnection);
           paramBlock2.nextConnection.connect(paramBlock1.previousConnection);
           this.clock.runAll();
 
           chai.assert.equal(
-            callBlock.getInputTargetBlock('ARG0'),
-            block2,
-            'Expected the second block to be in the first slot');
+              callBlock.getInputTargetBlock('ARG0'), block2,
+              'Expected the second block to be in the first slot');
           chai.assert.equal(
-            callBlock.getInputTargetBlock('ARG1'),
-            block1,
-            'Expected the first block to be in the second slot');
+              callBlock.getInputTargetBlock('ARG1'), block1,
+              'Expected the first block to be in the second slot');
         });
   });
 
   suite('enabling and disabling procedure blocks', function() {
     test(
         'if a procedure definition is disabled, the procedure caller ' +
-        'is also disabled',
+            'is also disabled',
         function() {
           const defBlock = createProcDefBlock(this.workspace);
           const callBlock = createProcCallBlock(this.workspace);
@@ -708,7 +723,7 @@ suite('Procedures', function() {
 
     test(
         'if a procedure definition is enabled, the procedure caller ' +
-        'is also enabled',
+            'is also enabled',
         function() {
           const defBlock = createProcDefBlock(this.workspace);
           const callBlock = createProcCallBlock(this.workspace);
@@ -719,13 +734,12 @@ suite('Procedures', function() {
           this.clock.runAll();
 
           chai.assert.isTrue(
-              callBlock.isEnabled(),
-              'Expected the caller block to be enabled');
+              callBlock.isEnabled(), 'Expected the caller block to be enabled');
         });
 
     test(
         'if a procedure caller block was already disabled before ' +
-        'its definition was disabled, it is not reenabled',
+            'its definition was disabled, it is not reenabled',
         function() {
           const defBlock = createProcDefBlock(this.workspace);
           const callBlock = createProcCallBlock(this.workspace);
@@ -747,7 +761,7 @@ suite('Procedures', function() {
   suite('deleting procedure blocks', function() {
     test(
         'when the procedure definition block is deleted, all of its ' +
-        'associated callers are deleted as well',
+            'associated callers are deleted as well',
         function() {
           const defBlock = createProcDefBlock(this.workspace);
           const callBlock1 = createProcCallBlock(this.workspace);
@@ -772,11 +786,12 @@ suite('Procedures', function() {
 
     suite('xml', function() {
       test('callers without defs create new defs', function() {
-        const callBlock = Blockly.Xml.domToBlock(Blockly.utils.xml.textToDom(`
+        const callBlock = Blockly.Xml.domToBlock(
+            Blockly.utils.xml.textToDom(`
             <block type="procedures_callreturn">
               <mutation name="do something"/>
-            </block>`
-        ), this.workspace);
+            </block>`),
+            this.workspace);
         this.clock.runAll();
         assertDefBlockStructure(
             this.workspace.getBlocksByType('procedures_defreturn')[0], true);
@@ -784,9 +799,10 @@ suite('Procedures', function() {
       });
 
       test('callers without mutations create unnamed defs', function() {
-        const callBlock = Blockly.Xml.domToBlock(Blockly.utils.xml.textToDom(
-            '<block type="procedures_callreturn"></block>'
-        ), this.workspace);
+        const callBlock = Blockly.Xml.domToBlock(
+            Blockly.utils.xml.textToDom(
+                '<block type="procedures_callreturn"></block>'),
+            this.workspace);
         this.clock.runAll();
         assertDefBlockStructure(
             this.workspace.getBlocksByType('procedures_defreturn')[0], true);
@@ -794,40 +810,47 @@ suite('Procedures', function() {
       });
 
       test('callers with missing args create new defs', function() {
-        const defBlock = Blockly.Xml.domToBlock(Blockly.utils.xml.textToDom(`
+        const defBlock = Blockly.Xml.domToBlock(
+            Blockly.utils.xml.textToDom(`
             <block type="procedures_defreturn">
               <field name="NAME">do something</field>
               <mutation>
                 <arg name="x" varid="arg"></arg>
               </mutation>
             </block>
-        `), this.workspace);
-        const callBlock = Blockly.Xml.domToBlock(Blockly.utils.xml.textToDom(
-            '<block type="procedures_callreturn">' +
-            '  <mutation name="do something"/>' +
-            '</block>'
-        ), this.workspace);
+        `),
+            this.workspace);
+        const callBlock = Blockly.Xml.domToBlock(
+            Blockly.utils.xml.textToDom(
+                '<block type="procedures_callreturn">' +
+                '  <mutation name="do something"/>' +
+                '</block>'),
+            this.workspace);
         this.clock.runAll();
         assertDefBlockStructure(defBlock, true, ['x'], ['arg']);
         assertCallBlockStructure(callBlock, [], [], 'do something2');
       });
 
       test('callers with mismatched args create new defs', function() {
-        const defBlock = Blockly.Xml.domToBlock(Blockly.utils.xml.textToDom(`
+        const defBlock = Blockly.Xml.domToBlock(
+            Blockly.utils.xml.textToDom(`
             <block type="procedures_defreturn">
               <field name="NAME">do something</field>
               <mutation>
                 <arg name="x" varid="arg"></arg>
               </mutation>
             </block>
-        `), this.workspace);
-        const callBlock = Blockly.Xml.domToBlock(Blockly.utils.xml.textToDom(`
+        `),
+            this.workspace);
+        const callBlock = Blockly.Xml.domToBlock(
+            Blockly.utils.xml.textToDom(`
             <block type="procedures_callreturn">
               <mutation name="do something">
                 <arg name="y"></arg>
               </mutation>
             </block>
-        `), this.workspace);
+        `),
+            this.workspace);
         this.clock.runAll();
         assertDefBlockStructure(defBlock, true, ['x'], ['arg']);
         assertCallBlockStructure(
@@ -837,7 +860,8 @@ suite('Procedures', function() {
       test.skip(
           'callers whose defs are deserialized later do not create defs',
           function() {
-            Blockly.Xml.domToWorkspace(Blockly.utils.xml.textToDom(`
+            Blockly.Xml.domToWorkspace(
+                Blockly.utils.xml.textToDom(`
                 <xml>
                   <block type="procedures_callreturn">
                     <mutation name="do something">
@@ -851,7 +875,8 @@ suite('Procedures', function() {
                     </mutation>
                   </block>
                 </xml>
-            `), this.workspace);
+            `),
+                this.workspace);
             this.clock.runAll();
             const defBlock =
                 this.workspace.getBlocksByType('procedures_defreturn')[0];
@@ -866,12 +891,14 @@ suite('Procedures', function() {
 
     suite('json', function() {
       test('callers without defs create new defs', function() {
-        const callBlock = Blockly.serialization.blocks.append({
-          'type': 'procedures_callreturn',
-          'extraState': {
-            'name': 'do something',
-          },
-        }, this.workspace, {recordUndo: true});
+        const callBlock = Blockly.serialization.blocks.append(
+            {
+              'type': 'procedures_callreturn',
+              'extraState': {
+                'name': 'do something',
+              },
+            },
+            this.workspace, {recordUndo: true});
         this.clock.runAll();
         assertDefBlockStructure(
             this.workspace.getBlocksByType('procedures_defreturn')[0], true);
@@ -880,9 +907,11 @@ suite('Procedures', function() {
 
       test('callers without extra state create unamed defs', function() {
         // recordUndo must be true to trigger change listener.
-        const callBlock = Blockly.serialization.blocks.append({
-          'type': 'procedures_callreturn',
-        }, this.workspace, {recordUndo: true});
+        const callBlock = Blockly.serialization.blocks.append(
+            {
+              'type': 'procedures_callreturn',
+            },
+            this.workspace, {recordUndo: true});
         this.clock.runAll();
         assertDefBlockStructure(
             this.workspace.getBlocksByType('procedures_defreturn')[0], true);
@@ -890,53 +919,61 @@ suite('Procedures', function() {
       });
 
       test('callers with missing args create new defs', function() {
-        const defBlock = Blockly.serialization.blocks.append({
-          'type': 'procedures_defreturn',
-          'fields': {
-            'NAME': 'do something',
-          },
-          'extraState': {
-            'params': [
-              {
-                'name': 'x',
-                'id': 'arg',
+        const defBlock = Blockly.serialization.blocks.append(
+            {
+              'type': 'procedures_defreturn',
+              'fields': {
+                'NAME': 'do something',
               },
-            ],
-          },
-        }, this.workspace);
-        const callBlock = Blockly.serialization.blocks.append({
-          'type': 'procedures_callreturn',
-          'extraState': {
-            'name': 'do something',
-          },
-        }, this.workspace, {recordUndo: true});
+              'extraState': {
+                'params': [
+                  {
+                    'name': 'x',
+                    'id': 'arg',
+                  },
+                ],
+              },
+            },
+            this.workspace);
+        const callBlock = Blockly.serialization.blocks.append(
+            {
+              'type': 'procedures_callreturn',
+              'extraState': {
+                'name': 'do something',
+              },
+            },
+            this.workspace, {recordUndo: true});
         this.clock.runAll();
         assertDefBlockStructure(defBlock, true, ['x'], ['arg']);
         assertCallBlockStructure(callBlock, [], [], 'do something2');
       });
 
       test('callers with mismatched args create new defs', function() {
-        const defBlock = Blockly.serialization.blocks.append({
-          'type': 'procedures_defreturn',
-          'fields': {
-            'NAME': 'do something',
-          },
-          'extraState': {
-            'params': [
-              {
-                'name': 'x',
-                'id': 'arg',
+        const defBlock = Blockly.serialization.blocks.append(
+            {
+              'type': 'procedures_defreturn',
+              'fields': {
+                'NAME': 'do something',
               },
-            ],
-          },
-        }, this.workspace);
-        const callBlock = Blockly.serialization.blocks.append({
-          'type': 'procedures_callreturn',
-          'extraState': {
-            'name': 'do something',
-            'params': ['y'],
-          },
-        }, this.workspace, {recordUndo: true});
+              'extraState': {
+                'params': [
+                  {
+                    'name': 'x',
+                    'id': 'arg',
+                  },
+                ],
+              },
+            },
+            this.workspace);
+        const callBlock = Blockly.serialization.blocks.append(
+            {
+              'type': 'procedures_callreturn',
+              'extraState': {
+                'name': 'do something',
+                'params': ['y'],
+              },
+            },
+            this.workspace, {recordUndo: true});
         this.clock.runAll();
         assertDefBlockStructure(defBlock, true, ['x'], ['arg']);
         assertCallBlockStructure(
@@ -946,33 +983,35 @@ suite('Procedures', function() {
       test.skip(
           'callers whose defs are deserialized later do not create defs',
           function() {
-            Blockly.serialization.workspaces.load({
-              'blocks': {
-                'languageVersion': 0,
-                'blocks': [
-                  {
-                    'type': 'procedures_callreturn',
-                    'extraState': {
-                      'params': ['x'],
-                    },
-                  },
-                  {
-                    'type': 'procedures_defreturn',
-                    'fields': {
-                      'NAME': 'do something',
-                    },
-                    'extraState': {
-                      'params': [
-                        {
-                          'name': 'x',
-                          'id': 'arg',
+            Blockly.serialization.workspaces.load(
+                {
+                  'blocks': {
+                    'languageVersion': 0,
+                    'blocks': [
+                      {
+                        'type': 'procedures_callreturn',
+                        'extraState': {
+                          'params': ['x'],
                         },
-                      ],
-                    },
+                      },
+                      {
+                        'type': 'procedures_defreturn',
+                        'fields': {
+                          'NAME': 'do something',
+                        },
+                        'extraState': {
+                          'params': [
+                            {
+                              'name': 'x',
+                              'id': 'arg',
+                            },
+                          ],
+                        },
+                      },
+                    ],
                   },
-                ],
-              },
-            }, this.workspace);
+                },
+                this.workspace);
             this.clock.runAll();
             const defBlock =
                 this.workspace.getBlocksByType('procedures_defreturn')[0];
@@ -987,43 +1026,49 @@ suite('Procedures', function() {
   });
 
   suite('definition block context menu', function() {
-    test('the context menu includes an option for creating the caller', function() {
-      const def = Blockly.serialization.blocks.append({
-        'type': 'procedures_defnoreturn',
-        'fields': {
-          'NAME': 'test name',
-        },
-      }, this.workspace);
+    test(
+        'the context menu includes an option for creating the caller',
+        function() {
+          const def = Blockly.serialization.blocks.append(
+              {
+                'type': 'procedures_defnoreturn',
+                'fields': {
+                  'NAME': 'test name',
+                },
+              },
+              this.workspace);
 
-      const options = [];
-      def.customContextMenu(options);
+          const options = [];
+          def.customContextMenu(options);
 
-      chai.assert.isTrue(
-          options[0].text.includes('test name'),
-          'Expected the context menu to have an option to create the caller');
-    });
+          chai.assert.isTrue(
+              options[0].text.includes('test name'),
+              'Expected the context menu to have an option to create the caller');
+        });
 
     test('the context menu includes an option for each parameter', function() {
-      const def = Blockly.serialization.blocks.append({
-        'type': 'procedures_defnoreturn',
-        'fields': {
-          'NAME': 'test name',
-        },
-        'extraState': {
-          'params': [
-            {
-              'name': 'testParam1',
-              'id': 'varId1',
-              'paramId': 'paramId1',
+      const def = Blockly.serialization.blocks.append(
+          {
+            'type': 'procedures_defnoreturn',
+            'fields': {
+              'NAME': 'test name',
             },
-            {
-              'name': 'testParam2',
-              'id': 'varId2',
-              'paramId': 'paramId2',
+            'extraState': {
+              'params': [
+                {
+                  'name': 'testParam1',
+                  'id': 'varId1',
+                  'paramId': 'paramId1',
+                },
+                {
+                  'name': 'testParam2',
+                  'id': 'varId2',
+                  'paramId': 'paramId2',
+                },
+              ],
             },
-          ],
-        },
-      }, this.workspace);
+          },
+          this.workspace);
 
       const options = [];
       def.customContextMenu(options);
@@ -1078,8 +1123,10 @@ suite('Procedures', function() {
       const _ = this.workspace.newBlock('controls_if');
       const allProcedures = Blockly.Procedures.allProcedures(this.workspace);
       chai.assert.lengthOf(allProcedures, 2);
-      chai.assert.lengthOf(allProcedures[0], 0, 'No procedures_defnoreturn blocks expected');
-      chai.assert.lengthOf(allProcedures[1], 0, 'No procedures_defreturn blocks expected');
+      chai.assert.lengthOf(
+          allProcedures[0], 0, 'No procedures_defnoreturn blocks expected');
+      chai.assert.lengthOf(
+          allProcedures[1], 0, 'No procedures_defreturn blocks expected');
     });
   });
 
@@ -1102,28 +1149,29 @@ suite('Procedures', function() {
     });
 
     test('returns true if an associated procedure model exists', function() {
-      this.workspace.getProcedureMap()
-          .add(new MockProcedureModel().setName('proc name'));
+      this.workspace.getProcedureMap().add(
+          new MockProcedureModel().setName('proc name'));
       chai.assert.isTrue(
           Blockly.Procedures.isNameUsed('proc name', this.workspace));
     });
 
     test('returns false if an associated procedure model exists', function() {
-      this.workspace.getProcedureMap()
-          .add(new MockProcedureModel().setName('proc name'));
+      this.workspace.getProcedureMap().add(
+          new MockProcedureModel().setName('proc name'));
       chai.assert.isFalse(
           Blockly.Procedures.isNameUsed('other proc name', this.workspace));
     });
   });
 
   suite('Multiple block serialization', function() {
-    function assertDefAndCallBlocks(workspace, noReturnNames, returnNames, hasCallers) {
+    function assertDefAndCallBlocks(
+        workspace, noReturnNames, returnNames, hasCallers) {
       const allProcedures = Blockly.Procedures.allProcedures(workspace);
       const defNoReturnBlocks = allProcedures[0];
       chai.assert.lengthOf(
-          defNoReturnBlocks,
-          noReturnNames.length,
-          `Expected the number of no return blocks to be ${noReturnNames.length}`);
+          defNoReturnBlocks, noReturnNames.length,
+          `Expected the number of no return blocks to be ${
+              noReturnNames.length}`);
       for (let i = 0; i < noReturnNames.length; i++) {
         const expectedName = noReturnNames[i];
         chai.assert.equal(defNoReturnBlocks[i][0], expectedName);
@@ -1131,15 +1179,13 @@ suite('Procedures', function() {
           const callers =
               Blockly.Procedures.getCallers(expectedName, workspace);
           chai.assert.lengthOf(
-              callers,
-              1,
+              callers, 1,
               `Expected there to be one caller of the ${expectedName} block`);
         }
       }
       const defReturnBlocks = allProcedures[1];
       chai.assert.lengthOf(
-          defReturnBlocks,
-          returnNames.length,
+          defReturnBlocks, returnNames.length,
           `Expected the number of return blocks to be ${returnNames.length}`);
       for (let i = 0; i < returnNames.length; i++) {
         const expectedName = returnNames[i];
@@ -1148,8 +1194,7 @@ suite('Procedures', function() {
           const callers =
               Blockly.Procedures.getCallers(expectedName, workspace);
           chai.assert.lengthOf(
-              callers,
-              1,
+              callers, 1,
               `Expected there to be one caller of the ${expectedName} block`);
         }
       }
@@ -1197,8 +1242,7 @@ suite('Procedures', function() {
               </xml>`);
         Blockly.Xml.domToWorkspace(xml, this.workspace);
         this.clock.runAll();
-        assertDefAndCallBlocks(
-            this.workspace, [], ['unnamed'], true);
+        assertDefAndCallBlocks(this.workspace, [], ['unnamed'], true);
       });
 
       test('callnoreturn and callreturn (no def in xml)', function() {
@@ -1209,8 +1253,7 @@ suite('Procedures', function() {
               </xml>`);
         Blockly.Xml.domToWorkspace(xml, this.workspace);
         this.clock.runAll();
-        assertDefAndCallBlocks(
-            this.workspace, ['unnamed'], ['unnamed2'], true);
+        assertDefAndCallBlocks(this.workspace, ['unnamed'], ['unnamed2'], true);
       });
 
       test('callreturn and callnoreturn (no def in xml)', function() {
@@ -1221,8 +1264,7 @@ suite('Procedures', function() {
               </xml>`);
         Blockly.Xml.domToWorkspace(xml, this.workspace);
         this.clock.runAll();
-        assertDefAndCallBlocks(
-            this.workspace, ['unnamed2'], ['unnamed'], true);
+        assertDefAndCallBlocks(this.workspace, ['unnamed2'], ['unnamed'], true);
       });
     });
   });
@@ -1230,7 +1272,7 @@ suite('Procedures', function() {
   suite('getDefinition - Modified cases', function() {
     setup(function() {
       Blockly.Blocks['new_proc'] = {
-        init: function() { },
+        init: function() {},
         getProcedureDef: function() {
           return [this.name, [], false];
         },
@@ -1273,10 +1315,18 @@ suite('Procedures', function() {
   });
 
   const testSuites = [
-    {title: 'procedures_defreturn', hasReturn: true,
-      defType: 'procedures_defreturn', callType: 'procedures_callreturn'},
-    {title: 'procedures_defnoreturn', hasReturn: false,
-      defType: 'procedures_defnoreturn', callType: 'procedures_callnoreturn'},
+    {
+      title: 'procedures_defreturn',
+      hasReturn: true,
+      defType: 'procedures_defreturn',
+      callType: 'procedures_callreturn'
+    },
+    {
+      title: 'procedures_defnoreturn',
+      hasReturn: false,
+      defType: 'procedures_defnoreturn',
+      callType: 'procedures_callnoreturn'
+    },
   ];
 
   testSuites.forEach((testSuite) => {
@@ -1291,9 +1341,11 @@ suite('Procedures', function() {
         });
 
         test('Call block', function() {
-          this.callBlock = Blockly.serialization.blocks.append({
-            'type': testSuite.callType,
-          }, this.workspace, {recordUndo: true});
+          this.callBlock = Blockly.serialization.blocks.append(
+              {
+                'type': testSuite.callType,
+              },
+              this.workspace, {recordUndo: true});
           this.callBlock.setFieldValue('proc name', 'NAME');
           this.clock.runAll();
           assertCallBlockStructure(this.callBlock);
@@ -1301,139 +1353,137 @@ suite('Procedures', function() {
       });
       suite('rename', function() {
         setup(function() {
-          this.defBlock = Blockly.serialization.blocks.append({
-            'type': testSuite.defType,
-            'fields': {
-              'NAME': 'proc name',
-            },
-          }, this.workspace);
-          this.callBlock = Blockly.serialization.blocks.append({
-            'type': testSuite.callType,
-            'fields': {
-              'NAME': 'proc name',
-            },
-          }, this.workspace);
+          this.defBlock = Blockly.serialization.blocks.append(
+              {
+                'type': testSuite.defType,
+                'fields': {
+                  'NAME': 'proc name',
+                },
+              },
+              this.workspace);
+          this.callBlock = Blockly.serialization.blocks.append(
+              {
+                'type': testSuite.callType,
+                'fields': {
+                  'NAME': 'proc name',
+                },
+              },
+              this.workspace);
           sinon.stub(this.defBlock.getField('NAME'), 'resizeEditor_');
         });
         test('Simple, Programmatic', function() {
           this.defBlock.setFieldValue(
-              this.defBlock.getFieldValue('NAME') + '2',
-              'NAME'
-          );
-          chai.assert.equal(
-              this.defBlock.getFieldValue('NAME'), 'proc name2');
-          chai.assert.equal(
-              this.callBlock.getFieldValue('NAME'), 'proc name2');
+              this.defBlock.getFieldValue('NAME') + '2', 'NAME');
+          chai.assert.equal(this.defBlock.getFieldValue('NAME'), 'proc name2');
+          chai.assert.equal(this.callBlock.getFieldValue('NAME'), 'proc name2');
         });
         test('Simple, Input', function() {
           const defInput = this.defBlock.getField('NAME');
           defInput.htmlInput_ = document.createElement('input');
-          defInput.htmlInput_.setAttribute('data-untyped-default-value', 'proc name');
+          defInput.htmlInput_.setAttribute(
+              'data-untyped-default-value', 'proc name');
 
           defInput.htmlInput_.value = 'proc name2';
           defInput.onHtmlInputChange_(null);
-          chai.assert.equal(
-              this.defBlock.getFieldValue('NAME'), 'proc name2');
-          chai.assert.equal(
-              this.callBlock.getFieldValue('NAME'), 'proc name2');
+          chai.assert.equal(this.defBlock.getFieldValue('NAME'), 'proc name2');
+          chai.assert.equal(this.callBlock.getFieldValue('NAME'), 'proc name2');
         });
         test('lower -> CAPS', function() {
           const defInput = this.defBlock.getField('NAME');
           defInput.htmlInput_ = document.createElement('input');
-          defInput.htmlInput_.setAttribute('data-untyped-default-value', 'proc name');
+          defInput.htmlInput_.setAttribute(
+              'data-untyped-default-value', 'proc name');
 
           defInput.htmlInput_.value = 'PROC NAME';
           defInput.onHtmlInputChange_(null);
-          chai.assert.equal(
-              this.defBlock.getFieldValue('NAME'), 'PROC NAME');
-          chai.assert.equal(
-              this.callBlock.getFieldValue('NAME'), 'PROC NAME');
+          chai.assert.equal(this.defBlock.getFieldValue('NAME'), 'PROC NAME');
+          chai.assert.equal(this.callBlock.getFieldValue('NAME'), 'PROC NAME');
         });
         test('CAPS -> lower', function() {
           this.defBlock.setFieldValue('PROC NAME', 'NAME');
           this.callBlock.setFieldValue('PROC NAME', 'NAME');
           const defInput = this.defBlock.getField('NAME');
           defInput.htmlInput_ = document.createElement('input');
-          defInput.htmlInput_.setAttribute('data-untyped-default-value', 'PROC NAME');
+          defInput.htmlInput_.setAttribute(
+              'data-untyped-default-value', 'PROC NAME');
 
           defInput.htmlInput_.value = 'proc name';
           defInput.onHtmlInputChange_(null);
-          chai.assert.equal(
-              this.defBlock.getFieldValue('NAME'), 'proc name');
-          chai.assert.equal(
-              this.callBlock.getFieldValue('NAME'), 'proc name');
+          chai.assert.equal(this.defBlock.getFieldValue('NAME'), 'proc name');
+          chai.assert.equal(this.callBlock.getFieldValue('NAME'), 'proc name');
         });
         test('Whitespace', function() {
           const defInput = this.defBlock.getField('NAME');
           defInput.htmlInput_ = document.createElement('input');
-          defInput.htmlInput_.setAttribute('data-untyped-default-value', 'proc name');
+          defInput.htmlInput_.setAttribute(
+              'data-untyped-default-value', 'proc name');
 
           defInput.htmlInput_.value = 'proc name ';
           defInput.onHtmlInputChange_(null);
-          chai.assert.equal(
-              this.defBlock.getFieldValue('NAME'), 'proc name');
-          chai.assert.equal(
-              this.callBlock.getFieldValue('NAME'), 'proc name');
+          chai.assert.equal(this.defBlock.getFieldValue('NAME'), 'proc name');
+          chai.assert.equal(this.callBlock.getFieldValue('NAME'), 'proc name');
         });
         test('Whitespace then Text', function() {
           const defInput = this.defBlock.getField('NAME');
           defInput.htmlInput_ = document.createElement('input');
-          defInput.htmlInput_.setAttribute('data-untyped-default-value', 'proc name');
+          defInput.htmlInput_.setAttribute(
+              'data-untyped-default-value', 'proc name');
 
           defInput.htmlInput_.value = 'proc name ';
           defInput.onHtmlInputChange_(null);
           defInput.htmlInput_.value = 'proc name 2';
           defInput.onHtmlInputChange_(null);
-          chai.assert.equal(
-              this.defBlock.getFieldValue('NAME'), 'proc name 2');
+          chai.assert.equal(this.defBlock.getFieldValue('NAME'), 'proc name 2');
           chai.assert.equal(
               this.callBlock.getFieldValue('NAME'), 'proc name 2');
         });
         test('Set Empty', function() {
           const defInput = this.defBlock.getField('NAME');
           defInput.htmlInput_ = document.createElement('input');
-          defInput.htmlInput_.setAttribute('data-untyped-default-value', 'proc name');
+          defInput.htmlInput_.setAttribute(
+              'data-untyped-default-value', 'proc name');
 
           defInput.htmlInput_.value = '';
           defInput.onHtmlInputChange_(null);
           chai.assert.equal(
-              this.defBlock.getFieldValue('NAME'),
-              Blockly.Msg['UNNAMED_KEY']);
+              this.defBlock.getFieldValue('NAME'), Blockly.Msg['UNNAMED_KEY']);
           chai.assert.equal(
-              this.callBlock.getFieldValue('NAME'),
-              Blockly.Msg['UNNAMED_KEY']);
+              this.callBlock.getFieldValue('NAME'), Blockly.Msg['UNNAMED_KEY']);
         });
         test('Set Empty, and Create New', function() {
           const defInput = this.defBlock.getField('NAME');
           defInput.htmlInput_ = document.createElement('input');
-          defInput.htmlInput_.setAttribute('data-untyped-default-value', 'proc name');
+          defInput.htmlInput_.setAttribute(
+              'data-untyped-default-value', 'proc name');
 
           defInput.htmlInput_.value = '';
           defInput.onHtmlInputChange_(null);
           const newDefBlock = this.workspace.newBlock(testSuite.defType);
           newDefBlock.setFieldValue('new name', 'NAME');
           chai.assert.equal(
-              this.defBlock.getFieldValue('NAME'),
-              Blockly.Msg['UNNAMED_KEY']);
+              this.defBlock.getFieldValue('NAME'), Blockly.Msg['UNNAMED_KEY']);
           chai.assert.equal(
-              this.callBlock.getFieldValue('NAME'),
-              Blockly.Msg['UNNAMED_KEY']);
+              this.callBlock.getFieldValue('NAME'), Blockly.Msg['UNNAMED_KEY']);
         });
       });
       suite('getCallers', function() {
         setup(function() {
-          this.defBlock = Blockly.serialization.blocks.append({
-            'type': testSuite.defType,
-            'fields': {
-              'NAME': 'proc name',
-            },
-          }, this.workspace);
-          this.callBlock = Blockly.serialization.blocks.append({
-            'type': testSuite.callType,
-            'fields': {
-              'NAME': 'proc name',
-            },
-          }, this.workspace);
+          this.defBlock = Blockly.serialization.blocks.append(
+              {
+                'type': testSuite.defType,
+                'fields': {
+                  'NAME': 'proc name',
+                },
+              },
+              this.workspace);
+          this.callBlock = Blockly.serialization.blocks.append(
+              {
+                'type': testSuite.callType,
+                'fields': {
+                  'NAME': 'proc name',
+                },
+              },
+              this.workspace);
         });
         test('Simple', function() {
           const callers =
@@ -1503,18 +1553,22 @@ suite('Procedures', function() {
       });
       suite('getDefinition', function() {
         setup(function() {
-          this.defBlock = Blockly.serialization.blocks.append({
-            'type': testSuite.defType,
-            'fields': {
-              'NAME': 'proc name',
-            },
-          }, this.workspace);
-          this.callBlock = Blockly.serialization.blocks.append({
-            'type': testSuite.callType,
-            'fields': {
-              'NAME': 'proc name',
-            },
-          }, this.workspace);
+          this.defBlock = Blockly.serialization.blocks.append(
+              {
+                'type': testSuite.defType,
+                'fields': {
+                  'NAME': 'proc name',
+                },
+              },
+              this.workspace);
+          this.callBlock = Blockly.serialization.blocks.append(
+              {
+                'type': testSuite.callType,
+                'fields': {
+                  'NAME': 'proc name',
+                },
+              },
+              this.workspace);
         });
         test('Simple', function() {
           const def =
@@ -1553,24 +1607,28 @@ suite('Procedures', function() {
 
       suite('Mutation', function() {
         setup(function() {
-          this.defBlock = Blockly.serialization.blocks.append({
-            'type': testSuite.defType,
-            'fields': {
-              'NAME': 'proc name',
-            },
-          }, this.workspace);
-          this.callBlock = Blockly.serialization.blocks.append({
-            'type': testSuite.callType,
-            'extraState': {
-              'name': 'proc name',
-            },
-          }, this.workspace);
+          this.defBlock = Blockly.serialization.blocks.append(
+              {
+                'type': testSuite.defType,
+                'fields': {
+                  'NAME': 'proc name',
+                },
+              },
+              this.workspace);
+          this.callBlock = Blockly.serialization.blocks.append(
+              {
+                'type': testSuite.callType,
+                'extraState': {
+                  'name': 'proc name',
+                },
+              },
+              this.workspace);
         });
         suite('Composition', function() {
           suite('Statements', function() {
             function setStatementValue(mainWorkspace, defBlock, value) {
-              const mutatorWorkspace = new Blockly.Workspace(
-                  new Blockly.Options({
+              const mutatorWorkspace =
+                  new Blockly.Workspace(new Blockly.Options({
                     parentWorkspace: mainWorkspace,
                   }));
               defBlock.decompose(mutatorWorkspace);
@@ -1594,9 +1652,9 @@ suite('Procedures', function() {
                     '  <statement name="STACK">' +
                     '    <block type="procedures_ifreturn" id="test"></block>' +
                     '  </statement> ' +
-                    '</block>'
-                );
-                const defBlock = Blockly.Xml.domToBlock(blockXml, this.workspace);
+                    '</block>');
+                const defBlock =
+                    Blockly.Xml.domToBlock(blockXml, this.workspace);
                 setStatementValue(this.workspace, defBlock, false);
                 chai.assert.isNull(defBlock.getInput('STACK'));
                 setStatementValue(this.workspace, defBlock, true);
@@ -1614,9 +1672,11 @@ suite('Procedures', function() {
               this.defBlock.mutator.setVisible(true);
               this.mutatorWorkspace = this.defBlock.mutator.getWorkspace();
               this.containerBlock = this.mutatorWorkspace.getTopBlocks()[0];
-              this.connection = this.containerBlock.getInput('STACK').connection;
+              this.connection =
+                  this.containerBlock.getInput('STACK').connection;
               for (let i = 0; i < argArray.length; i++) {
-                this.argBlock = this.mutatorWorkspace.newBlock('procedures_mutatorarg');
+                this.argBlock =
+                    this.mutatorWorkspace.newBlock('procedures_mutatorarg');
                 this.argBlock.setFieldValue(argArray[i], 'NAME');
                 this.connection.connect(this.argBlock.previousConnection);
                 this.connection = this.argBlock.nextConnection;
@@ -1625,15 +1685,13 @@ suite('Procedures', function() {
             }
             function assertArgs(argArray) {
               chai.assert.equal(
-                  this.defBlock.getVars().length,
-                  argArray.length,
+                  this.defBlock.getVars().length, argArray.length,
                   'Expected the def to have the right number of arguments');
               for (let i = 0; i < argArray.length; i++) {
                 chai.assert.equal(this.defBlock.getVars()[i], argArray[i]);
               }
               chai.assert.equal(
-                  this.callBlock.getVars().length,
-                  argArray.length,
+                  this.callBlock.getVars().length, argArray.length,
                   'Expected the call to have the right number of arguments');
               for (let i = 0; i < argArray.length; i++) {
                 chai.assert.equal(this.callBlock.getVars()[i], argArray[i]);
@@ -1699,46 +1757,50 @@ suite('Procedures', function() {
           suite('Statements', function() {
             if (testSuite.defType === 'procedures_defreturn') {
               test('Has Statement Input', function() {
-                const mutatorWorkspace = new Blockly.Workspace(
-                    new Blockly.Options({
+                const mutatorWorkspace =
+                    new Blockly.Workspace(new Blockly.Options({
                       parentWorkspace: this.workspace,
                     }));
                 this.defBlock.decompose(mutatorWorkspace);
-                const statementInput = mutatorWorkspace.getTopBlocks()[0]
-                    .getInput('STATEMENT_INPUT');
+                const statementInput =
+                    mutatorWorkspace.getTopBlocks()[0].getInput(
+                        'STATEMENT_INPUT');
                 chai.assert.isNotNull(statementInput);
               });
               test('Has Statements', function() {
                 this.defBlock.hasStatements_ = true;
-                const mutatorWorkspace = new Blockly.Workspace(
-                    new Blockly.Options({
+                const mutatorWorkspace =
+                    new Blockly.Workspace(new Blockly.Options({
                       parentWorkspace: this.workspace,
                     }));
                 this.defBlock.decompose(mutatorWorkspace);
                 const statementValue = mutatorWorkspace.getTopBlocks()[0]
-                    .getField('STATEMENTS').getValueBoolean();
+                                           .getField('STATEMENTS')
+                                           .getValueBoolean();
                 chai.assert.isTrue(statementValue);
               });
               test('No Has Statements', function() {
                 this.defBlock.hasStatements_ = false;
-                const mutatorWorkspace = new Blockly.Workspace(
-                    new Blockly.Options({
+                const mutatorWorkspace =
+                    new Blockly.Workspace(new Blockly.Options({
                       parentWorkspace: this.workspace,
                     }));
                 this.defBlock.decompose(mutatorWorkspace);
                 const statementValue = mutatorWorkspace.getTopBlocks()[0]
-                    .getField('STATEMENTS').getValueBoolean();
+                                           .getField('STATEMENTS')
+                                           .getValueBoolean();
                 chai.assert.isFalse(statementValue);
               });
             } else {
               test('Has no Statement Input', function() {
-                const mutatorWorkspace = new Blockly.Workspace(
-                    new Blockly.Options({
+                const mutatorWorkspace =
+                    new Blockly.Workspace(new Blockly.Options({
                       parentWorkspace: this.workspace,
                     }));
                 this.defBlock.decompose(mutatorWorkspace);
-                const statementInput = mutatorWorkspace.getTopBlocks()[0]
-                    .getInput('STATEMENT_INPUT');
+                const statementInput =
+                    mutatorWorkspace.getTopBlocks()[0].getInput(
+                        'STATEMENT_INPUT');
                 chai.assert.isNull(statementInput);
               });
             }
@@ -1758,15 +1820,13 @@ suite('Procedures', function() {
               'type="' + testSuite.defType + '" id="1">\n' +
               '  <field name="NAME">unnamed</field>\n' +
               '</block>',
-          assertBlockStructure:
-              (block) => {
-                assertDefBlockStructure(block, testSuite.hasReturn);
-              },
+          assertBlockStructure: (block) => {
+            assertDefBlockStructure(block, testSuite.hasReturn);
+          },
         },
         {
           title: 'XML - Common definition',
-          xml:
-              '<block type="' + testSuite.defType + '">' +
+          xml: '<block type="' + testSuite.defType + '">' +
               '  <field name="NAME">do something</field>' +
               '</block>',
           expectedXml:
@@ -1774,15 +1834,13 @@ suite('Procedures', function() {
               'type="' + testSuite.defType + '" id="1">\n' +
               '  <field name="NAME">do something</field>\n' +
               '</block>',
-          assertBlockStructure:
-              (block) => {
-                assertDefBlockStructure(block, testSuite.hasReturn);
-              },
+          assertBlockStructure: (block) => {
+            assertDefBlockStructure(block, testSuite.hasReturn);
+          },
         },
         {
           title: 'XML - With vars definition',
-          xml:
-              '<block type="' + testSuite.defType + '">\n' +
+          xml: '<block type="' + testSuite.defType + '">\n' +
               '  <mutation>\n' +
               '    <arg name="x" varid="arg1"></arg>\n' +
               '    <arg name="y" varid="arg2"></arg>\n' +
@@ -1798,16 +1856,14 @@ suite('Procedures', function() {
               '  </mutation>\n' +
               '  <field name="NAME">do something</field>\n' +
               '</block>',
-          assertBlockStructure:
-              (block) => {
-                assertDefBlockStructure(
-                    block, testSuite.hasReturn, ['x', 'y'], ['arg1', 'arg2']);
-              },
+          assertBlockStructure: (block) => {
+            assertDefBlockStructure(
+                block, testSuite.hasReturn, ['x', 'y'], ['arg1', 'arg2']);
+          },
         },
         {
           title: 'XML - With pre-created vars definition',
-          xml:
-              '<block type="' + testSuite.defType + '">\n' +
+          xml: '<block type="' + testSuite.defType + '">\n' +
               '  <mutation>\n' +
               '    <arg name="preCreatedVar" varid="preCreatedVarId"></arg>\n' +
               '  </mutation>\n' +
@@ -1821,16 +1877,15 @@ suite('Procedures', function() {
               '  </mutation>\n' +
               '  <field name="NAME">do something</field>\n' +
               '</block>',
-          assertBlockStructure:
-              (block) => {
-                assertDefBlockStructure(block, testSuite.hasReturn,
-                    ['preCreatedVar'], ['preCreatedVarId']);
-              },
+          assertBlockStructure: (block) => {
+            assertDefBlockStructure(
+                block, testSuite.hasReturn, ['preCreatedVar'],
+                ['preCreatedVarId']);
+          },
         },
         {
           title: 'XML - No statements definition',
-          xml:
-              '<block type="procedures_defreturn">\n' +
+          xml: '<block type="procedures_defreturn">\n' +
               '  <mutation statements="false"></mutation>\n' +
               '  <field name="NAME">do something</field>\n' +
               '</block>',
@@ -1840,10 +1895,9 @@ suite('Procedures', function() {
               '  <mutation statements="false"></mutation>\n' +
               '  <field name="NAME">do something</field>\n' +
               '</block>',
-          assertBlockStructure:
-              (block) => {
-                assertDefBlockStructure(block, true, [], [], false);
-              },
+          assertBlockStructure: (block) => {
+            assertDefBlockStructure(block, true, [], [], false);
+          },
         },
         {
           title: 'XML - Minimal caller',
@@ -1853,15 +1907,13 @@ suite('Procedures', function() {
               'type="' + testSuite.callType + '" id="1">\n' +
               '  <mutation name="unnamed"></mutation>\n' +
               '</block>',
-          assertBlockStructure:
-              (block) => {
-                assertCallBlockStructure(block);
-              },
+          assertBlockStructure: (block) => {
+            assertCallBlockStructure(block);
+          },
         },
         {
           title: 'XML - Common caller',
-          xml:
-              '<block type="' + testSuite.callType + '">\n' +
+          xml: '<block type="' + testSuite.callType + '">\n' +
               '  <mutation name="do something"/>\n' +
               '</block>',
           expectedXml:
@@ -1869,15 +1921,13 @@ suite('Procedures', function() {
               'type="' + testSuite.callType + '" id="1">\n' +
               '  <mutation name="do something"></mutation>\n' +
               '</block>',
-          assertBlockStructure:
-              (block) => {
-                assertCallBlockStructure(block);
-              },
+          assertBlockStructure: (block) => {
+            assertCallBlockStructure(block);
+          },
         },
         {
           title: 'XML - With pre-created vars caller',
-          xml:
-              '<block type="' + testSuite.callType + '">\n' +
+          xml: '<block type="' + testSuite.callType + '">\n' +
               '  <mutation name="do something">\n' +
               '    <arg name="preCreatedVar"></arg>\n' +
               '  </mutation>\n' +
@@ -1889,10 +1939,10 @@ suite('Procedures', function() {
               '    <arg name="preCreatedVar"></arg>\n' +
               '  </mutation>\n' +
               '</block>',
-          assertBlockStructure:
-              (block) => {
-                assertCallBlockStructure(block, ['preCreatedVar'], ['preCreatedVarId']);
-              },
+          assertBlockStructure: (block) => {
+            assertCallBlockStructure(
+                block, ['preCreatedVar'], ['preCreatedVarId']);
+          },
         },
         {
           title: 'JSON - Minimal definition',
@@ -1906,10 +1956,9 @@ suite('Procedures', function() {
               'NAME': 'unnamed',
             },
           },
-          assertBlockStructure:
-              (block) => {
-                assertDefBlockStructure(block, testSuite.hasReturn);
-              },
+          assertBlockStructure: (block) => {
+            assertDefBlockStructure(block, testSuite.hasReturn);
+          },
         },
         {
           title: 'JSON - Common definition',
@@ -1926,10 +1975,9 @@ suite('Procedures', function() {
               'NAME': 'do something',
             },
           },
-          assertBlockStructure:
-              (block) => {
-                assertDefBlockStructure(block, testSuite.hasReturn);
-              },
+          assertBlockStructure: (block) => {
+            assertDefBlockStructure(block, testSuite.hasReturn);
+          },
         },
         {
           title: 'JSON - With vars definition',
@@ -1970,11 +2018,10 @@ suite('Procedures', function() {
               ],
             },
           },
-          assertBlockStructure:
-              (block) => {
-                assertDefBlockStructure(
-                    block, testSuite.hasReturn, ['x', 'y'], ['arg1', 'arg2']);
-              },
+          assertBlockStructure: (block) => {
+            assertDefBlockStructure(
+                block, testSuite.hasReturn, ['x', 'y'], ['arg1', 'arg2']);
+          },
         },
         {
           title: 'JSON - With pre-created vars definition',
@@ -2007,11 +2054,11 @@ suite('Procedures', function() {
               ],
             },
           },
-          assertBlockStructure:
-              (block) => {
-                assertDefBlockStructure(block, testSuite.hasReturn,
-                    ['preCreatedVar'], ['preCreatedVarId']);
-              },
+          assertBlockStructure: (block) => {
+            assertDefBlockStructure(
+                block, testSuite.hasReturn, ['preCreatedVar'],
+                ['preCreatedVarId']);
+          },
         },
         {
           title: 'JSON - No statements definition',
@@ -2034,10 +2081,9 @@ suite('Procedures', function() {
               'hasStatements': false,
             },
           },
-          assertBlockStructure:
-              (block) => {
-                assertDefBlockStructure(block, true, [], [], false);
-              },
+          assertBlockStructure: (block) => {
+            assertDefBlockStructure(block, true, [], [], false);
+          },
         },
         {
           title: 'JSON - Minimal caller',
@@ -2051,10 +2097,9 @@ suite('Procedures', function() {
               'name': 'unnamed',
             },
           },
-          assertBlockStructure:
-              (block) => {
-                assertCallBlockStructure(block);
-              },
+          assertBlockStructure: (block) => {
+            assertCallBlockStructure(block);
+          },
         },
         {
           title: 'JSON - Common caller',
@@ -2071,10 +2116,9 @@ suite('Procedures', function() {
               'name': 'do something',
             },
           },
-          assertBlockStructure:
-              (block) => {
-                assertCallBlockStructure(block);
-              },
+          assertBlockStructure: (block) => {
+            assertCallBlockStructure(block);
+          },
         },
         {
           title: 'JSON - With pre-created vars caller',
@@ -2097,10 +2141,10 @@ suite('Procedures', function() {
               ],
             },
           },
-          assertBlockStructure:
-              (block) => {
-                assertCallBlockStructure(block, ['preCreatedVar'], ['preCreatedVarId']);
-              },
+          assertBlockStructure: (block) => {
+            assertCallBlockStructure(
+                block, ['preCreatedVar'], ['preCreatedVarId']);
+          },
         },
       ];
       runSerializationTestSuite(testCases);

--- a/tests/mocha/blocks/procedures_test.js
+++ b/tests/mocha/blocks/procedures_test.js
@@ -1319,13 +1319,13 @@ suite('Procedures', function() {
       title: 'procedures_defreturn',
       hasReturn: true,
       defType: 'procedures_defreturn',
-      callType: 'procedures_callreturn'
+      callType: 'procedures_callreturn',
     },
     {
       title: 'procedures_defnoreturn',
       hasReturn: false,
       defType: 'procedures_defnoreturn',
-      callType: 'procedures_callnoreturn'
+      callType: 'procedures_callnoreturn',
     },
   ];
 

--- a/tests/mocha/blocks/variables_test.js
+++ b/tests/mocha/blocks/variables_test.js
@@ -59,7 +59,8 @@ suite('Variables', function() {
       createTestVarBlock(this.workspace, '3');
 
       const result = Blockly.Variables.allUsedVarModels(this.workspace);
-      chai.assert.equal(result.length, 3,
+      chai.assert.equal(
+          result.length, 3,
           'Expected three variables in the list of used variables');
     });
 
@@ -67,9 +68,11 @@ suite('Variables', function() {
       createTestVarBlock(this.workspace, '2');
 
       const result = Blockly.Variables.allUsedVarModels(this.workspace);
-      chai.assert.equal(result.length, 1,
+      chai.assert.equal(
+          result.length, 1,
           'Expected one variable in the list of used variables');
-      chai.assert.equal(result[0].getId(), '2',
+      chai.assert.equal(
+          result[0].getId(), '2',
           'Expected variable with ID 2 in the list of used variables');
     });
 
@@ -80,15 +83,18 @@ suite('Variables', function() {
       const result = Blockly.Variables.allUsedVarModels(this.workspace);
       // Using the same variable multiple times should not change the number of
       // elements in the list.
-      chai.assert.equal(result.length, 1,
+      chai.assert.equal(
+          result.length, 1,
           'Expected one variable in the list of used variables');
-      chai.assert.equal(result[0].getId(), '2',
+      chai.assert.equal(
+          result[0].getId(), '2',
           'Expected variable with ID 2 in the list of used variables');
     });
 
     test('All unused', function() {
       const result = Blockly.Variables.allUsedVarModels(this.workspace);
-      chai.assert.equal(result.length, 0,
+      chai.assert.equal(
+          result.length, 0,
           'Expected no variables in the list of used variables');
     });
   });
@@ -128,12 +134,12 @@ suite('Variables', function() {
       const var1 = this.workspace.createVariable('name1', 'type1', 'id1');
       const var2 = this.workspace.createVariable('name2', 'type1', 'id2');
       const var3 = this.workspace.createVariable('name3', 'type2', 'id3');
-      const result1 =
-          Blockly.Variables.getVariable(this.workspace, 'badId', 'name1', 'type1');
-      const result2 =
-          Blockly.Variables.getVariable(this.workspace, 'badId', 'name2', 'type1');
-      const result3 =
-          Blockly.Variables.getVariable(this.workspace, 'badId', 'name3', 'type2');
+      const result1 = Blockly.Variables.getVariable(
+          this.workspace, 'badId', 'name1', 'type1');
+      const result2 = Blockly.Variables.getVariable(
+          this.workspace, 'badId', 'name2', 'type1');
+      const result3 = Blockly.Variables.getVariable(
+          this.workspace, 'badId', 'name3', 'type2');
 
       // Searching by ID failed, but falling back onto name + type is correct.
       chai.assert.equal(var1, result1);
@@ -147,54 +153,58 @@ suite('Variables', function() {
       test(
           'conflicts within legacy procedure blocks return the procedure name',
           function() {
-            Blockly.serialization.blocks.append({
-              'type': 'procedures_defnoreturn',
-              'extraState': {
-                'params': [
-                  {
-                    'name': 'x',
-                    'id': '6l3P%Y!9EgA(Nh{E`Tl,',
+            Blockly.serialization.blocks.append(
+                {
+                  'type': 'procedures_defnoreturn',
+                  'extraState': {
+                    'params': [
+                      {
+                        'name': 'x',
+                        'id': '6l3P%Y!9EgA(Nh{E`Tl,',
+                      },
+                      {
+                        'name': 'y',
+                        'id': 'l1EtlJe%z_M[O-@uPAQ8',
+                      },
+                    ],
                   },
-                  {
-                    'name': 'y',
-                    'id': 'l1EtlJe%z_M[O-@uPAQ8',
+                  'fields': {
+                    'NAME': 'test name',
                   },
-                ],
-              },
-              'fields': {
-                'NAME': 'test name',
-              },
-            }, this.workspace);
+                },
+                this.workspace);
 
             chai.assert.equal(
                 'test name',
                 nameUsedWithConflictingParam('x', 'y', this.workspace),
                 'Expected the name of the procedure with the conflicting ' +
-                'param to be returned');
+                    'param to be returned');
           });
 
       test(
           'if no legacy block has the old var name, no procedure ' +
-          'name is returned',
+              'name is returned',
           function() {
-            Blockly.serialization.blocks.append({
-              'type': 'procedures_defnoreturn',
-              'extraState': {
-                'params': [
-                  {
-                    'name': 'definitely not x',
-                    'id': '6l3P%Y!9EgA(Nh{E`Tl,',
+            Blockly.serialization.blocks.append(
+                {
+                  'type': 'procedures_defnoreturn',
+                  'extraState': {
+                    'params': [
+                      {
+                        'name': 'definitely not x',
+                        'id': '6l3P%Y!9EgA(Nh{E`Tl,',
+                      },
+                      {
+                        'name': 'y',
+                        'id': 'l1EtlJe%z_M[O-@uPAQ8',
+                      },
+                    ],
                   },
-                  {
-                    'name': 'y',
-                    'id': 'l1EtlJe%z_M[O-@uPAQ8',
+                  'fields': {
+                    'NAME': 'test name',
                   },
-                ],
-              },
-              'fields': {
-                'NAME': 'test name',
-              },
-            }, this.workspace);
+                },
+                this.workspace);
 
             chai.assert.isNull(
                 nameUsedWithConflictingParam('x', 'y', this.workspace),
@@ -205,31 +215,31 @@ suite('Variables', function() {
           'conflicts within procedure models return the procedure name',
           function() {
             this.workspace.getProcedureMap().add(
-              new MockProcedureModel('test name')
-                .insertParameter(
-                    new MockParameterModelWithVar('x', this.workspace), 0)
-                .insertParameter(
-                    new MockParameterModelWithVar('y', this.workspace), 0));
+                new MockProcedureModel('test name')
+                    .insertParameter(
+                        new MockParameterModelWithVar('x', this.workspace), 0)
+                    .insertParameter(
+                        new MockParameterModelWithVar('y', this.workspace), 0));
 
             chai.assert.equal(
                 'test name',
                 nameUsedWithConflictingParam('x', 'y', this.workspace),
                 'Expected the name of the procedure with the conflicting ' +
-                'param to be returned');
+                    'param to be returned');
           });
 
       test(
           'if no procedure model has the old var, no procedure ' +
-          'name is returned',
+              'name is returned',
           function() {
             this.workspace.getProcedureMap().add(
-              new MockProcedureModel('test name')
-                .insertParameter(
-                    new MockParameterModelWithVar(
-                        'definitely not x', this.workspace),
-                    0)
-                .insertParameter(
-                    new MockParameterModelWithVar('y', this.workspace), 0));
+                new MockProcedureModel('test name')
+                    .insertParameter(
+                        new MockParameterModelWithVar(
+                            'definitely not x', this.workspace),
+                        0)
+                    .insertParameter(
+                        new MockParameterModelWithVar('y', this.workspace), 0));
 
             chai.assert.isNull(
                 nameUsedWithConflictingParam('x', 'y', this.workspace),

--- a/tests/mocha/comment_deserialization_test.js
+++ b/tests/mocha/comment_deserialization_test.js
@@ -46,9 +46,9 @@ suite('Comment Deserialization', function() {
       this.workspace.clear();
     });
     function createBlock(workspace) {
-      const block = Blockly.Xml.domToBlock(Blockly.utils.xml.textToDom(
-        '<block type="empty_block"/>'
-      ), workspace);
+      const block = Blockly.Xml.domToBlock(
+          Blockly.utils.xml.textToDom('<block type="empty_block"/>'),
+          workspace);
       block.setCommentText('test text');
       return block;
     }
@@ -73,7 +73,8 @@ suite('Comment Deserialization', function() {
       // Open trashcan.
       simulateClick(this.workspace.trashcan.svgGroup);
       // Place from trashcan.
-      simulateClick(this.workspace.trashcan.flyout.svgGroup_.querySelector('.blocklyDraggable'));
+      simulateClick(this.workspace.trashcan.flyout.svgGroup_.querySelector(
+          '.blocklyDraggable'));
       chai.assert.equal(this.workspace.getAllBlocks().length, 1);
       // Check comment.
       assertComment(this.workspace, 'test text');
@@ -108,7 +109,8 @@ suite('Comment Deserialization', function() {
       // Place from toolbox.
       const toolbox = this.workspace.getToolbox();
       simulateClick(toolbox.HtmlDiv.querySelector('.blocklyTreeRow'));
-      simulateClick(toolbox.getFlyout().svgGroup_.querySelector('.blocklyDraggable'));
+      simulateClick(
+          toolbox.getFlyout().svgGroup_.querySelector('.blocklyDraggable'));
       chai.assert.equal(this.workspace.getAllBlocks().length, 1);
       // Check comment.
       assertComment(this.workspace, 'test toolbox text');

--- a/tests/mocha/comment_test.js
+++ b/tests/mocha/comment_test.js
@@ -25,9 +25,9 @@ suite('Comments', function() {
       comments: true,
       scrollbars: true,
     });
-    this.block = Blockly.Xml.domToBlock(Blockly.utils.xml.textToDom(
-        '<block type="empty_block"/>'
-    ), this.workspace);
+    this.block = Blockly.Xml.domToBlock(
+        Blockly.utils.xml.textToDom('<block type="empty_block"/>'),
+        this.workspace);
     this.comment = new Blockly.Comment(this.block);
     this.comment.computeIconLocation();
   });
@@ -47,8 +47,8 @@ suite('Comments', function() {
     function assertNotEditable(comment) {
       chai.assert.isNotOk(comment.textarea_);
       chai.assert.isOk(comment.paragraphElement_);
-      chai.assert.equal(comment.paragraphElement_.firstChild.textContent,
-          'test text');
+      chai.assert.equal(
+          comment.paragraphElement_.firstChild.textContent, 'test text');
     }
     test('Editable', function() {
       this.comment.setVisible(true);
@@ -56,8 +56,8 @@ suite('Comments', function() {
       assertEditable(this.comment);
       assertEventFired(
           this.eventsFireStub, Blockly.Events.BubbleOpen,
-          {bubbleType: 'comment', isOpen: true, type: eventUtils.BUBBLE_OPEN}, this.workspace.id,
-          this.block.id);
+          {bubbleType: 'comment', isOpen: true, type: eventUtils.BUBBLE_OPEN},
+          this.workspace.id, this.block.id);
     });
     test('Not Editable', function() {
       sinon.stub(this.block, 'isEditable').returns(false);

--- a/tests/mocha/connection_checker_test.js
+++ b/tests/mocha/connection_checker_test.js
@@ -137,12 +137,12 @@ suite('Connection checker', function() {
         const prevBlock = {
           isShadow: function() {
             return true;
-          }
+          },
         };
         const nextBlock = {
           isShadow: function() {
             return false;
-          }
+          },
         };
         const prev = new Blockly.Connection(
             prevBlock, ConnectionType.PREVIOUS_STATEMENT);
@@ -156,12 +156,12 @@ suite('Connection checker', function() {
         const prevBlock = {
           isShadow: function() {
             return false;
-          }
+          },
         };
         const nextBlock = {
           isShadow: function() {
             return true;
-          }
+          },
         };
         const prev = new Blockly.Connection(
             prevBlock, ConnectionType.PREVIOUS_STATEMENT);
@@ -175,12 +175,12 @@ suite('Connection checker', function() {
         const prevBlock = {
           isShadow: function() {
             return true;
-          }
+          },
         };
         const nextBlock = {
           isShadow: function() {
             return true;
-          }
+          },
         };
         const prev = new Blockly.Connection(
             prevBlock, ConnectionType.PREVIOUS_STATEMENT);
@@ -194,12 +194,12 @@ suite('Connection checker', function() {
         const outBlock = {
           isShadow: function() {
             return true;
-          }
+          },
         };
         const inBlock = {
           isShadow: function() {
             return false;
-          }
+          },
         };
         const outCon =
             new Blockly.Connection(outBlock, ConnectionType.OUTPUT_VALUE);
@@ -213,12 +213,12 @@ suite('Connection checker', function() {
         const outBlock = {
           isShadow: function() {
             return false;
-          }
+          },
         };
         const inBlock = {
           isShadow: function() {
             return true;
-          }
+          },
         };
         const outCon =
             new Blockly.Connection(outBlock, ConnectionType.OUTPUT_VALUE);
@@ -233,12 +233,12 @@ suite('Connection checker', function() {
         const outBlock = {
           isShadow: function() {
             return true;
-          }
+          },
         };
         const inBlock = {
           isShadow: function() {
             return true;
-          }
+          },
         };
         const outCon =
             new Blockly.Connection(outBlock, ConnectionType.OUTPUT_VALUE);

--- a/tests/mocha/connection_checker_test.js
+++ b/tests/mocha/connection_checker_test.js
@@ -30,32 +30,28 @@ suite('Connection checker', function() {
     test('Target Null', function() {
       const connection = new Blockly.Connection({}, ConnectionType.INPUT_VALUE);
       assertReasonHelper(
-          this.checker,
-          connection,
-          null,
+          this.checker, connection, null,
           Blockly.Connection.REASON_TARGET_NULL);
     });
     test('Target Self', function() {
       const block = {workspace: 1};
-      const connection1 = new Blockly.Connection(block, ConnectionType.INPUT_VALUE);
-      const connection2 = new Blockly.Connection(block, ConnectionType.OUTPUT_VALUE);
+      const connection1 =
+          new Blockly.Connection(block, ConnectionType.INPUT_VALUE);
+      const connection2 =
+          new Blockly.Connection(block, ConnectionType.OUTPUT_VALUE);
 
       assertReasonHelper(
-          this.checker,
-          connection1,
-          connection2,
+          this.checker, connection1, connection2,
           Blockly.Connection.REASON_SELF_CONNECTION);
     });
     test('Different Workspaces', function() {
-      const connection1 = new Blockly.Connection(
-          {workspace: 1}, ConnectionType.INPUT_VALUE);
-      const connection2 = new Blockly.Connection(
-          {workspace: 2}, ConnectionType.OUTPUT_VALUE);
+      const connection1 =
+          new Blockly.Connection({workspace: 1}, ConnectionType.INPUT_VALUE);
+      const connection2 =
+          new Blockly.Connection({workspace: 2}, ConnectionType.OUTPUT_VALUE);
 
       assertReasonHelper(
-          this.checker,
-          connection1,
-          connection2,
+          this.checker, connection1, connection2,
           Blockly.Connection.REASON_DIFFERENT_WORKSPACES);
     });
     suite('Types', function() {
@@ -68,170 +64,189 @@ suite('Connection checker', function() {
         const inBlock = {isShadow: function() {}};
         this.previous = new Blockly.Connection(
             prevBlock, ConnectionType.PREVIOUS_STATEMENT);
-        this.next = new Blockly.Connection(
-            nextBlock, ConnectionType.NEXT_STATEMENT);
-        this.output = new Blockly.Connection(
-            outBlock, ConnectionType.OUTPUT_VALUE);
-        this.input = new Blockly.Connection(
-            inBlock, ConnectionType.INPUT_VALUE);
+        this.next =
+            new Blockly.Connection(nextBlock, ConnectionType.NEXT_STATEMENT);
+        this.output =
+            new Blockly.Connection(outBlock, ConnectionType.OUTPUT_VALUE);
+        this.input =
+            new Blockly.Connection(inBlock, ConnectionType.INPUT_VALUE);
       });
       test('Previous, Next', function() {
         assertReasonHelper(
-            this.checker,
-            this.previous,
-            this.next,
+            this.checker, this.previous, this.next,
             Blockly.Connection.CAN_CONNECT);
       });
       test('Previous, Output', function() {
         assertReasonHelper(
-            this.checker,
-            this.previous,
-            this.output,
+            this.checker, this.previous, this.output,
             Blockly.Connection.REASON_WRONG_TYPE);
       });
       test('Previous, Input', function() {
         assertReasonHelper(
-            this.checker,
-            this.previous,
-            this.input,
+            this.checker, this.previous, this.input,
             Blockly.Connection.REASON_WRONG_TYPE);
       });
       test('Next, Previous', function() {
         assertReasonHelper(
-            this.checker,
-            this.next,
-            this.previous,
+            this.checker, this.next, this.previous,
             Blockly.Connection.CAN_CONNECT);
       });
       test('Next, Output', function() {
         assertReasonHelper(
-            this.checker,
-            this.next,
-            this.output,
+            this.checker, this.next, this.output,
             Blockly.Connection.REASON_WRONG_TYPE);
       });
       test('Next, Input', function() {
         assertReasonHelper(
-            this.checker,
-            this.next,
-            this.input,
+            this.checker, this.next, this.input,
             Blockly.Connection.REASON_WRONG_TYPE);
       });
       test('Output, Previous', function() {
         assertReasonHelper(
-            this.checker,
-            this.previous,
-            this.output,
+            this.checker, this.previous, this.output,
             Blockly.Connection.REASON_WRONG_TYPE);
       });
       test('Output, Next', function() {
         assertReasonHelper(
-            this.checker,
-            this.output,
-            this.next,
+            this.checker, this.output, this.next,
             Blockly.Connection.REASON_WRONG_TYPE);
       });
       test('Output, Input', function() {
         assertReasonHelper(
-            this.checker,
-            this.output,
-            this.input,
+            this.checker, this.output, this.input,
             Blockly.Connection.CAN_CONNECT);
       });
       test('Input, Previous', function() {
         assertReasonHelper(
-            this.checker,
-            this.previous,
-            this.input,
+            this.checker, this.previous, this.input,
             Blockly.Connection.REASON_WRONG_TYPE);
       });
       test('Input, Next', function() {
         assertReasonHelper(
-            this.checker,
-            this.input,
-            this.next,
+            this.checker, this.input, this.next,
             Blockly.Connection.REASON_WRONG_TYPE);
       });
       test('Input, Output', function() {
         assertReasonHelper(
-            this.checker,
-            this.input,
-            this.output,
+            this.checker, this.input, this.output,
             Blockly.Connection.CAN_CONNECT);
       });
     });
     suite('Shadows', function() {
       test('Previous Shadow', function() {
-        const prevBlock = {isShadow: function() {return true;}};
-        const nextBlock = {isShadow: function() {return false;}};
-        const prev = new Blockly.Connection(prevBlock, ConnectionType.PREVIOUS_STATEMENT);
-        const next = new Blockly.Connection(nextBlock, ConnectionType.NEXT_STATEMENT);
+        const prevBlock = {
+          isShadow: function() {
+            return true;
+          }
+        };
+        const nextBlock = {
+          isShadow: function() {
+            return false;
+          }
+        };
+        const prev = new Blockly.Connection(
+            prevBlock, ConnectionType.PREVIOUS_STATEMENT);
+        const next =
+            new Blockly.Connection(nextBlock, ConnectionType.NEXT_STATEMENT);
 
         assertReasonHelper(
-            this.checker,
-            prev,
-            next,
-            Blockly.Connection.CAN_CONNECT);
+            this.checker, prev, next, Blockly.Connection.CAN_CONNECT);
       });
       test('Next Shadow', function() {
-        const prevBlock = {isShadow: function() {return false;}};
-        const nextBlock = {isShadow: function() {return true;}};
-        const prev = new Blockly.Connection(prevBlock, ConnectionType.PREVIOUS_STATEMENT);
-        const next = new Blockly.Connection(nextBlock, ConnectionType.NEXT_STATEMENT);
+        const prevBlock = {
+          isShadow: function() {
+            return false;
+          }
+        };
+        const nextBlock = {
+          isShadow: function() {
+            return true;
+          }
+        };
+        const prev = new Blockly.Connection(
+            prevBlock, ConnectionType.PREVIOUS_STATEMENT);
+        const next =
+            new Blockly.Connection(nextBlock, ConnectionType.NEXT_STATEMENT);
 
         assertReasonHelper(
-            this.checker,
-            prev,
-            next,
-            Blockly.Connection.REASON_SHADOW_PARENT);
+            this.checker, prev, next, Blockly.Connection.REASON_SHADOW_PARENT);
       });
       test('Prev and Next Shadow', function() {
-        const prevBlock = {isShadow: function() {return true;}};
-        const nextBlock = {isShadow: function() {return true;}};
-        const prev = new Blockly.Connection(prevBlock, ConnectionType.PREVIOUS_STATEMENT);
-        const next = new Blockly.Connection(nextBlock, ConnectionType.NEXT_STATEMENT);
+        const prevBlock = {
+          isShadow: function() {
+            return true;
+          }
+        };
+        const nextBlock = {
+          isShadow: function() {
+            return true;
+          }
+        };
+        const prev = new Blockly.Connection(
+            prevBlock, ConnectionType.PREVIOUS_STATEMENT);
+        const next =
+            new Blockly.Connection(nextBlock, ConnectionType.NEXT_STATEMENT);
 
         assertReasonHelper(
-            this.checker,
-            prev,
-            next,
-            Blockly.Connection.CAN_CONNECT);
+            this.checker, prev, next, Blockly.Connection.CAN_CONNECT);
       });
       test('Output Shadow', function() {
-        const outBlock = {isShadow: function() {return true;}};
-        const inBlock = {isShadow: function() {return false;}};
-        const outCon = new Blockly.Connection(outBlock, ConnectionType.OUTPUT_VALUE);
-        const inCon = new Blockly.Connection(inBlock, ConnectionType.INPUT_VALUE);
+        const outBlock = {
+          isShadow: function() {
+            return true;
+          }
+        };
+        const inBlock = {
+          isShadow: function() {
+            return false;
+          }
+        };
+        const outCon =
+            new Blockly.Connection(outBlock, ConnectionType.OUTPUT_VALUE);
+        const inCon =
+            new Blockly.Connection(inBlock, ConnectionType.INPUT_VALUE);
 
         assertReasonHelper(
-            this.checker,
-            outCon,
-            inCon,
-            Blockly.Connection.CAN_CONNECT);
+            this.checker, outCon, inCon, Blockly.Connection.CAN_CONNECT);
       });
       test('Input Shadow', function() {
-        const outBlock = {isShadow: function() {return false;}};
-        const inBlock = {isShadow: function() {return true;}};
-        const outCon = new Blockly.Connection(outBlock, ConnectionType.OUTPUT_VALUE);
-        const inCon = new Blockly.Connection(inBlock, ConnectionType.INPUT_VALUE);
+        const outBlock = {
+          isShadow: function() {
+            return false;
+          }
+        };
+        const inBlock = {
+          isShadow: function() {
+            return true;
+          }
+        };
+        const outCon =
+            new Blockly.Connection(outBlock, ConnectionType.OUTPUT_VALUE);
+        const inCon =
+            new Blockly.Connection(inBlock, ConnectionType.INPUT_VALUE);
 
         assertReasonHelper(
-            this.checker,
-            outCon,
-            inCon,
+            this.checker, outCon, inCon,
             Blockly.Connection.REASON_SHADOW_PARENT);
       });
       test('Output and Input Shadow', function() {
-        const outBlock = {isShadow: function() {return true;}};
-        const inBlock = {isShadow: function() {return true;}};
-        const outCon = new Blockly.Connection(outBlock, ConnectionType.OUTPUT_VALUE);
-        const inCon = new Blockly.Connection(inBlock, ConnectionType.INPUT_VALUE);
+        const outBlock = {
+          isShadow: function() {
+            return true;
+          }
+        };
+        const inBlock = {
+          isShadow: function() {
+            return true;
+          }
+        };
+        const outCon =
+            new Blockly.Connection(outBlock, ConnectionType.OUTPUT_VALUE);
+        const inCon =
+            new Blockly.Connection(inBlock, ConnectionType.INPUT_VALUE);
 
         assertReasonHelper(
-            this.checker,
-            outCon,
-            inCon,
-            Blockly.Connection.CAN_CONNECT);
+            this.checker, outCon, inCon, Blockly.Connection.CAN_CONNECT);
       });
     });
     suite('Output and Previous', function() {
@@ -249,56 +264,54 @@ suite('Connection checker', function() {
       };
       test('Output connected, adding previous', function() {
         const outBlock = {
-          isShadow: function() {
-          },
+          isShadow: function() {},
         };
         const inBlock = {
-          isShadow: function() {
-          },
+          isShadow: function() {},
         };
-        const outCon = new Blockly.Connection(outBlock, ConnectionType.OUTPUT_VALUE);
-        const inCon = new Blockly.Connection(inBlock, ConnectionType.INPUT_VALUE);
+        const outCon =
+            new Blockly.Connection(outBlock, ConnectionType.OUTPUT_VALUE);
+        const inCon =
+            new Blockly.Connection(inBlock, ConnectionType.INPUT_VALUE);
         outBlock.outputConnection = outCon;
         inBlock.inputConnection = inCon;
         connectReciprocally(inCon, outCon);
-        const prevCon = new Blockly.Connection(outBlock, ConnectionType.PREVIOUS_STATEMENT);
+        const prevCon =
+            new Blockly.Connection(outBlock, ConnectionType.PREVIOUS_STATEMENT);
         const nextBlock = {
-          isShadow: function() {
-          },
+          isShadow: function() {},
         };
-        const nextCon = new Blockly.Connection(nextBlock, ConnectionType.NEXT_STATEMENT);
+        const nextCon =
+            new Blockly.Connection(nextBlock, ConnectionType.NEXT_STATEMENT);
 
         assertReasonHelper(
-            this.checker,
-            prevCon,
-            nextCon,
+            this.checker, prevCon, nextCon,
             Blockly.Connection.REASON_PREVIOUS_AND_OUTPUT);
       });
       test('Previous connected, adding output', function() {
         const prevBlock = {
-          isShadow: function() {
-          },
+          isShadow: function() {},
         };
         const nextBlock = {
-          isShadow: function() {
-          },
+          isShadow: function() {},
         };
-        const prevCon = new Blockly.Connection(prevBlock, ConnectionType.PREVIOUS_STATEMENT);
-        const nextCon = new Blockly.Connection(nextBlock, ConnectionType.NEXT_STATEMENT);
+        const prevCon = new Blockly.Connection(
+            prevBlock, ConnectionType.PREVIOUS_STATEMENT);
+        const nextCon =
+            new Blockly.Connection(nextBlock, ConnectionType.NEXT_STATEMENT);
         prevBlock.previousConnection = prevCon;
         nextBlock.nextConnection = nextCon;
         connectReciprocally(prevCon, nextCon);
-        const outCon = new Blockly.Connection(prevBlock, ConnectionType.OUTPUT_VALUE);
+        const outCon =
+            new Blockly.Connection(prevBlock, ConnectionType.OUTPUT_VALUE);
         const inBlock = {
-          isShadow: function() {
-          },
+          isShadow: function() {},
         };
-        const inCon = new Blockly.Connection(inBlock, ConnectionType.INPUT_VALUE);
+        const inCon =
+            new Blockly.Connection(inBlock, ConnectionType.INPUT_VALUE);
 
         assertReasonHelper(
-            this.checker,
-            outCon,
-            inCon,
+            this.checker, outCon, inCon,
             Blockly.Connection.REASON_PREVIOUS_AND_OUTPUT);
       });
     });
@@ -345,8 +358,11 @@ suite('Connection checker', function() {
     suite('Stacks', function() {
       setup(function() {
         this.workspace = Blockly.inject('blocklyDiv');
-        // Load in three blocks: A and B are connected (next/prev); B is unmovable.
-        Blockly.Xml.domToWorkspace(Blockly.utils.xml.textToDom(`<xml xmlns="https://developers.google.com/blockly/xml">
+        // Load in three blocks: A and B are connected (next/prev); B is
+        // unmovable.
+        Blockly.Xml.domToWorkspace(
+            Blockly.utils.xml.textToDom(
+                `<xml xmlns="https://developers.google.com/blockly/xml">
         <block type="text_print" id="A" x="-76" y="-112">
           <next>
             <block type="text_print" id="B" movable="false">
@@ -354,17 +370,20 @@ suite('Connection checker', function() {
           </next>
         </block>
         <block type="text_print" id="C" x="47" y="-118"/>
-      </xml>`), this.workspace);
-      [this.blockA, this.blockB, this.blockC] = this.workspace.getAllBlocks(true);
-      this.checker = this.workspace.connectionChecker;
+      </xml>`),
+            this.workspace);
+        [this.blockA, this.blockB, this.blockC] =
+            this.workspace.getAllBlocks(true);
+        this.checker = this.workspace.connectionChecker;
       });
 
       test('Connect a stack', function() {
         // block C is not connected to block A; both are movable.
         chai.assert.isTrue(
-          this.checker.doDragChecks(
-            this.blockC.nextConnection, this.blockA.previousConnection, 9000),
-          'Should connect two compatible stack blocks');
+            this.checker.doDragChecks(
+                this.blockC.nextConnection, this.blockA.previousConnection,
+                9000),
+            'Should connect two compatible stack blocks');
       });
 
       test('Connect to unmovable shadow block', function() {
@@ -372,7 +391,9 @@ suite('Connection checker', function() {
         this.workspace.clear();
 
         // Add the same test blocks, but this time block B is a shadow block.
-        Blockly.Xml.domToWorkspace(Blockly.utils.xml.textToDom(`<xml xmlns="https://developers.google.com/blockly/xml">
+        Blockly.Xml.domToWorkspace(
+            Blockly.utils.xml.textToDom(
+                `<xml xmlns="https://developers.google.com/blockly/xml">
         <block type="text_print" id="A" x="-76" y="-112">
           <next>
             <shadow type="text_print" id="B" movable="false">
@@ -380,34 +401,40 @@ suite('Connection checker', function() {
           </next>
         </block>
         <block type="text_print" id="C" x="47" y="-118"/>
-      </xml>`), this.workspace);
-      [this.blockA, this.blockB, this.blockC] = this.workspace.getAllBlocks(true);
+      </xml>`),
+            this.workspace);
+        [this.blockA, this.blockB, this.blockC] =
+            this.workspace.getAllBlocks(true);
 
-      // Try to connect blockC into the input connection of blockA, replacing blockB.
-      // This is allowed because shadow blocks can always be replaced, even though
-      // they are unmovable.
-      chai.assert.isTrue(
-        this.checker.doDragChecks(
-          this.blockC.previousConnection, this.blockA.nextConnection, 9000),
-        'Should connect in place of a shadow block');
+        // Try to connect blockC into the input connection of blockA, replacing
+        // blockB. This is allowed because shadow blocks can always be replaced,
+        // even though they are unmovable.
+        chai.assert.isTrue(
+            this.checker.doDragChecks(
+                this.blockC.previousConnection, this.blockA.nextConnection,
+                9000),
+            'Should connect in place of a shadow block');
       });
 
       test('Do not splice into unmovable stack', function() {
-        // Try to connect blockC above blockB. It shouldn't work because B is not movable
-        // and is already connected to A's nextConnection.
+        // Try to connect blockC above blockB. It shouldn't work because B is
+        // not movable and is already connected to A's nextConnection.
         chai.assert.isFalse(
-          this.checker.doDragChecks(
-            this.blockC.previousConnection, this.blockA.nextConnection, 9000),
-          'Should not splice in a block above an unmovable block');
+            this.checker.doDragChecks(
+                this.blockC.previousConnection, this.blockA.nextConnection,
+                9000),
+            'Should not splice in a block above an unmovable block');
       });
 
       test('Connect to bottom of unmovable stack', function() {
         // Try to connect blockC below blockB.
-        // This is allowed even though B is not movable because it is on B's nextConnection.
+        // This is allowed even though B is not movable because it is on B's
+        // nextConnection.
         chai.assert.isTrue(
-          this.checker.doDragChecks(
-            this.blockC.previousConnection, this.blockB.nextConnection, 9000),
-          'Should connect below an unmovable stack block');
+            this.checker.doDragChecks(
+                this.blockC.previousConnection, this.blockB.nextConnection,
+                9000),
+            'Should connect below an unmovable stack block');
       });
 
       test('Connect to unconnected unmovable block', function() {
@@ -417,26 +444,30 @@ suite('Connection checker', function() {
         // Try to connect blockC above blockB.
         // This is allowed because we're not splicing into a stack.
         chai.assert.isTrue(
-          this.checker.doDragChecks(
-            this.blockC.nextConnection, this.blockB.previousConnection, 9000),
-          'Should connect above an unconnected unmovable block'
-        );
+            this.checker.doDragChecks(
+                this.blockC.nextConnection, this.blockB.previousConnection,
+                9000),
+            'Should connect above an unconnected unmovable block');
       });
     });
     suite('Rows', function() {
       setup(function() {
         this.workspace = Blockly.inject('blocklyDiv');
         // Load 3 blocks: A and B are connected (input/output); B is unmovable.
-        Blockly.Xml.domToWorkspace(Blockly.utils.xml.textToDom(`<xml xmlns="https://developers.google.com/blockly/xml">
+        Blockly.Xml.domToWorkspace(
+            Blockly.utils.xml.textToDom(
+                `<xml xmlns="https://developers.google.com/blockly/xml">
         <block type="test_basic_row" id="A" x="38" y="37">
           <value name="INPUT">
             <block type="test_basic_row" id="B" movable="false"></block>
           </value>
         </block>
         <block type="test_basic_row" id="C" x="38" y="87"></block>
-      </xml>`), this.workspace);
-      [this.blockA, this.blockB, this.blockC] = this.workspace.getAllBlocks(true);
-      this.checker = this.workspace.connectionChecker;
+      </xml>`),
+            this.workspace);
+        [this.blockA, this.blockB, this.blockC] =
+            this.workspace.getAllBlocks(true);
+        this.checker = this.workspace.connectionChecker;
       });
 
       test('Do not splice into unmovable block row', function() {
@@ -444,9 +475,9 @@ suite('Connection checker', function() {
         // A is already connected to B, which is unmovable.
         const inputConnection = this.blockA.inputList[0].connection;
         chai.assert.isFalse(
-          this.checker.doDragChecks(this.blockC.outputConnection, inputConnection, 9000),
-          'Should not splice in a block before an unmovable block'
-        );
+            this.checker.doDragChecks(
+                this.blockC.outputConnection, inputConnection, 9000),
+            'Should not splice in a block before an unmovable block');
       });
 
       test('Connect to end of unmovable block', function() {
@@ -455,21 +486,22 @@ suite('Connection checker', function() {
         // Try to connect A's output to C's input. This is allowed.
         const inputConnection = this.blockC.inputList[0].connection;
         chai.assert.isTrue(
-          this.checker.doDragChecks(this.blockA.outputConnection, inputConnection, 9000),
-          'Should connect to end of unmovable block'
-        );
+            this.checker.doDragChecks(
+                this.blockA.outputConnection, inputConnection, 9000),
+            'Should connect to end of unmovable block');
       });
 
       test('Connect to unconnected unmovable block', function() {
         this.blockB.outputConnection.disconnect();
         this.blockA.dispose();
 
-        // Try to connect C's input to B's output. Allowed because B is now unconnected.
+        // Try to connect C's input to B's output. Allowed because B is now
+        // unconnected.
         const inputConnection = this.blockC.inputList[0].connection;
         chai.assert.isTrue(
-          this.checker.doDragChecks(inputConnection, this.blockB.outputConnection, 9000),
-          'Should connect to unconnected unmovable block'
-        );
+            this.checker.doDragChecks(
+                inputConnection, this.blockB.outputConnection, 9000),
+            'Should connect to unconnected unmovable block');
       });
     });
   });

--- a/tests/mocha/connection_db_test.js
+++ b/tests/mocha/connection_db_test.js
@@ -18,8 +18,8 @@ suite('Connection Database', function() {
     this.assertOrder = function() {
       const length = this.database.connections.length;
       for (let i = 1; i < length; i++) {
-        chai.assert.isAtMost(this.database.connections[i - 1].y,
-            this.database.connections[i].y);
+        chai.assert.isAtMost(
+            this.database.connections[i - 1].y, this.database.connections[i].y);
       }
     };
     this.createConnection = function(x, y, type, opt_database) {
@@ -27,15 +27,16 @@ suite('Connection Database', function() {
         connectionDBList: [],
       };
       workspace.connectionDBList[type] = opt_database || this.database;
-      const connection = new Blockly.RenderedConnection(
-          {workspace: workspace}, type);
+      const connection =
+          new Blockly.RenderedConnection({workspace: workspace}, type);
       connection.x = x;
       connection.y = y;
       return connection;
     };
     this.createSimpleTestConnections = function() {
       for (let i = 0; i < 10; i++) {
-        const connection = this.createConnection(0, i, ConnectionType.PREVIOUS_STATEMENT);
+        const connection =
+            this.createConnection(0, i, ConnectionType.PREVIOUS_STATEMENT);
         this.database.addConnection(connection, i);
       }
     };
@@ -51,16 +52,13 @@ suite('Connection Database', function() {
     const y3b = {y: 3};
 
     this.database.addConnection(y2, 2);
-    chai.assert.sameOrderedMembers(
-        this.database.connections, [y2]);
+    chai.assert.sameOrderedMembers(this.database.connections, [y2]);
 
     this.database.addConnection(y4, 4);
-    chai.assert.sameOrderedMembers(
-        this.database.connections, [y2, y4]);
+    chai.assert.sameOrderedMembers(this.database.connections, [y2, y4]);
 
     this.database.addConnection(y1, 1);
-    chai.assert.sameOrderedMembers(
-        this.database.connections, [y1, y2, y4]);
+    chai.assert.sameOrderedMembers(this.database.connections, [y1, y2, y4]);
 
     this.database.addConnection(y3a, 3);
     chai.assert.sameOrderedMembers(
@@ -97,71 +95,69 @@ suite('Connection Database', function() {
         this.database.connections, [y1, y3a, y3b, y3c]);
 
     this.database.removeConnection(y1, 1);
-    chai.assert.sameOrderedMembers(
-        this.database.connections, [y3a, y3b, y3c]);
+    chai.assert.sameOrderedMembers(this.database.connections, [y3a, y3b, y3c]);
 
     this.database.removeConnection(y3a, 3);
-    chai.assert.sameOrderedMembers(
-        this.database.connections, [y3b, y3c]);
+    chai.assert.sameOrderedMembers(this.database.connections, [y3b, y3c]);
 
     this.database.removeConnection(y3c, 3);
-    chai.assert.sameOrderedMembers(
-        this.database.connections, [y3b]);
+    chai.assert.sameOrderedMembers(this.database.connections, [y3b]);
 
     this.database.removeConnection(y3b, 3);
     chai.assert.isEmpty(this.database.connections);
   });
   suite('Get Neighbors', function() {
     test('Empty Database', function() {
-      const connection = this.createConnection(0, 0, ConnectionType.NEXT_STATEMENT,
-          new Blockly.ConnectionDB());
+      const connection = this.createConnection(
+          0, 0, ConnectionType.NEXT_STATEMENT, new Blockly.ConnectionDB());
       chai.assert.isEmpty(this.database.getNeighbours(connection), 100);
     });
     test('Block At Top', function() {
       this.createSimpleTestConnections();
 
-      const checkConnection = this.createConnection(0, 0, ConnectionType.NEXT_STATEMENT,
-          new Blockly.ConnectionDB());
+      const checkConnection = this.createConnection(
+          0, 0, ConnectionType.NEXT_STATEMENT, new Blockly.ConnectionDB());
       const neighbors = this.database.getNeighbours(checkConnection, 4);
       chai.assert.sameMembers(neighbors, this.database.connections.slice(0, 5));
     });
     test('Block In Middle', function() {
       this.createSimpleTestConnections();
 
-      const checkConnection = this.createConnection(0, 4, ConnectionType.NEXT_STATEMENT,
-          new Blockly.ConnectionDB());
+      const checkConnection = this.createConnection(
+          0, 4, ConnectionType.NEXT_STATEMENT, new Blockly.ConnectionDB());
       const neighbors = this.database.getNeighbours(checkConnection, 2);
       chai.assert.sameMembers(neighbors, this.database.connections.slice(2, 7));
     });
     test('Block At End', function() {
       this.createSimpleTestConnections();
 
-      const checkConnection = this.createConnection(0, 9, ConnectionType.NEXT_STATEMENT,
-          new Blockly.ConnectionDB());
+      const checkConnection = this.createConnection(
+          0, 9, ConnectionType.NEXT_STATEMENT, new Blockly.ConnectionDB());
       const neighbors = this.database.getNeighbours(checkConnection, 4);
-      chai.assert.sameMembers(neighbors, this.database.connections.slice(5, 10));
+      chai.assert.sameMembers(
+          neighbors, this.database.connections.slice(5, 10));
     });
     test('Out of Range X', function() {
       this.createSimpleTestConnections();
 
-      const checkConnection = this.createConnection(10, 9, ConnectionType.NEXT_STATEMENT,
-          new Blockly.ConnectionDB());
+      const checkConnection = this.createConnection(
+          10, 9, ConnectionType.NEXT_STATEMENT, new Blockly.ConnectionDB());
       const neighbors = this.database.getNeighbours(checkConnection, 4);
       chai.assert.isEmpty(neighbors);
     });
     test('Out of Range Y', function() {
       this.createSimpleTestConnections();
 
-      const checkConnection = this.createConnection(0, 19, ConnectionType.NEXT_STATEMENT,
-          new Blockly.ConnectionDB());
+      const checkConnection = this.createConnection(
+          0, 19, ConnectionType.NEXT_STATEMENT, new Blockly.ConnectionDB());
       const neighbors = this.database.getNeighbours(checkConnection, 4);
       chai.assert.isEmpty(neighbors);
     });
     test('Out of Range Diagonal', function() {
       this.createSimpleTestConnections();
 
-      const checkConnection = this.createConnection(-2, -2, ConnectionType.NEXT_STATEMENT,
-          new Blockly.ConnectionDB());
+      const checkConnection = this.createConnection(
+          -2, -2, ConnectionType.NEXT_STATEMENT, new Blockly.ConnectionDB());
       const neighbors = this.database.getNeighbours(checkConnection, 2);
       chai.assert.isEmpty(neighbors);
     });
@@ -169,12 +165,14 @@ suite('Connection Database', function() {
   suite('Ordering', function() {
     test('Simple', function() {
       for (let i = 0; i < 10; i++) {
-        const connection = this.createConnection(0, i, ConnectionType.NEXT_STATEMENT);
+        const connection =
+            this.createConnection(0, i, ConnectionType.NEXT_STATEMENT);
         this.database.addConnection(connection, i);
       }
       this.assertOrder();
     });
     test('Quasi-Random', function() {
+      // clang-format off
       const xCoords = [-29, -47, -77, 2, 43, 34, -59, -52, -90, -36, -91, 38,
         87, -20, 60, 4, -57, 65, -37, -81, 57, 58, -96, 1, 67, -79, 34, 93,
         -90, -99, -62, 4, 11, -36, -51, -72, 3, -50, -24, -45, -92, -38, 37,
@@ -189,11 +187,12 @@ suite('Connection Database', function() {
         63, -97, 45, 98, 99, 34, 27, 52, -18, -45, 66, -32, -38, 70, -73,
         -23, 5, -2, -13, -9, 48, 74, -97, -11, 35, -79, -16, -77, 83, -57,
         -53, 35, -44, 100, -27, -15, 5, 39, 33, -19, -20, -95];
+      // clang-format on
 
       const length = xCoords.length;
       for (let i = 0; i < length; i++) {
-        const connection = this.createConnection(xCoords[i], yCoords[i],
-            ConnectionType.NEXT_STATEMENT);
+        const connection = this.createConnection(
+            xCoords[i], yCoords[i], ConnectionType.NEXT_STATEMENT);
         this.database.addConnection(connection, yCoords[i]);
       }
       this.assertOrder();
@@ -203,8 +202,7 @@ suite('Connection Database', function() {
   suite('Search For Closest', function() {
     setup(function() {
       // Ignore type checks.
-      sinon.stub(this.database.connectionChecker, 'doTypeChecks')
-          .returns(true);
+      sinon.stub(this.database.connectionChecker, 'doTypeChecks').returns(true);
       // Ignore safety checks.
       sinon.stub(this.database.connectionChecker, 'doSafetyChecks')
           .returns(Blockly.Connection.CAN_CONNECT);
@@ -215,25 +213,28 @@ suite('Connection Database', function() {
           });
 
       this.createCheckConnection = function(x, y) {
-        const checkConnection = this.createConnection(x, y, ConnectionType.NEXT_STATEMENT,
-            new Blockly.ConnectionDB());
+        const checkConnection = this.createConnection(
+            x, y, ConnectionType.NEXT_STATEMENT, new Blockly.ConnectionDB());
         return checkConnection;
       };
     });
     test('Empty Database', function() {
-      const checkConnection = this.createConnection(0, 0, ConnectionType.NEXT_STATEMENT,
-          new Blockly.ConnectionDB());
-      chai.assert.isNull(this.database.searchForClosest(
-          checkConnection, 100, {x: 0, y: 0}).connection);
+      const checkConnection = this.createConnection(
+          0, 0, ConnectionType.NEXT_STATEMENT, new Blockly.ConnectionDB());
+      chai.assert.isNull(
+          this.database.searchForClosest(checkConnection, 100, {x: 0, y: 0})
+              .connection);
     });
     test('Too Far', function() {
-      const connection = this.createConnection(0, 100, ConnectionType.PREVIOUS_STATEMENT);
+      const connection =
+          this.createConnection(0, 100, ConnectionType.PREVIOUS_STATEMENT);
       this.database.addConnection(connection, 100);
 
-      const checkConnection = this.createConnection(0, 0, ConnectionType.NEXT_STATEMENT,
-          new Blockly.ConnectionDB());
-      chai.assert.isNull(this.database.searchForClosest(
-          checkConnection, 50, {x: 0, y: 0}).connection);
+      const checkConnection = this.createConnection(
+          0, 0, ConnectionType.NEXT_STATEMENT, new Blockly.ConnectionDB());
+      chai.assert.isNull(
+          this.database.searchForClosest(checkConnection, 50, {x: 0, y: 0})
+              .connection);
     });
     test('Single in Range', function() {
       this.createSimpleTestConnections();
@@ -241,8 +242,9 @@ suite('Connection Database', function() {
       const checkConnection = this.createCheckConnection(0, 14);
 
       const last = this.database.connections[9];
-      const closest = this.database.searchForClosest(
-          checkConnection, 5, {x: 0, y: 0}).connection;
+      const closest =
+          this.database.searchForClosest(checkConnection, 5, {x: 0, y: 0})
+              .connection;
       chai.assert.equal(last, closest);
     });
     test('Many in Range', function() {
@@ -251,20 +253,24 @@ suite('Connection Database', function() {
       const checkConnection = this.createCheckConnection(0, 10);
 
       const last = this.database.connections[9];
-      const closest = this.database.searchForClosest(
-          checkConnection, 5, {x: 0, y: 0}).connection;
+      const closest =
+          this.database.searchForClosest(checkConnection, 5, {x: 0, y: 0})
+              .connection;
       chai.assert.equal(last, closest);
     });
     test('No Y-Coord Priority', function() {
-      const connection1 = this.createConnection(6, 6, ConnectionType.PREVIOUS_STATEMENT);
+      const connection1 =
+          this.createConnection(6, 6, ConnectionType.PREVIOUS_STATEMENT);
       this.database.addConnection(connection1, 6);
-      const connection2 = this.createConnection(5, 5, ConnectionType.PREVIOUS_STATEMENT);
+      const connection2 =
+          this.createConnection(5, 5, ConnectionType.PREVIOUS_STATEMENT);
       this.database.addConnection(connection2, 5);
 
       const checkConnection = this.createCheckConnection(4, 6);
 
-      const closest = this.database.searchForClosest(
-          checkConnection, 3, {x: 0, y: 0}).connection;
+      const closest =
+          this.database.searchForClosest(checkConnection, 3, {x: 0, y: 0})
+              .connection;
       chai.assert.equal(connection2, closest);
     });
   });

--- a/tests/mocha/connection_test.js
+++ b/tests/mocha/connection_test.js
@@ -18,7 +18,9 @@ suite('Connection', function() {
     this.createConnection = function(type) {
       const block = {
         workspace: this.workspace,
-        isShadow: function() {return false;},
+        isShadow: function() {
+          return false;
+        },
       };
       const connection = new Blockly.Connection(block, type);
       return connection;
@@ -31,7 +33,8 @@ suite('Connection', function() {
 
   suite('Set Shadow', function() {
     function assertBlockMatches(block, isShadow, opt_id) {
-      chai.assert.equal(block.isShadow(), isShadow,
+      chai.assert.equal(
+          block.isShadow(), isShadow,
           `expected block ${block.id} to ${isShadow ? '' : 'not'} be a shadow`);
       if (opt_id) {
         chai.assert.equal(block.id, opt_id);
@@ -40,33 +43,39 @@ suite('Connection', function() {
 
     function assertInputHasBlock(parent, inputName, isShadow, opt_name) {
       const block = parent.getInputTargetBlock(inputName);
-      chai.assert.exists(block,
+      chai.assert.exists(
+          block,
           `expected block ${opt_name || ''} to be attached to ${inputName}`);
       assertBlockMatches(block, isShadow, opt_name);
     }
 
     function assertNextHasBlock(parent, isShadow, opt_name) {
       const block = parent.getNextBlock();
-      chai.assert.exists(block,
+      chai.assert.exists(
+          block,
           `expected block ${opt_name || ''} to be attached to next connection`);
       assertBlockMatches(block, isShadow, opt_name);
     }
 
     function assertInputNotHasBlock(parent, inputName) {
       const block = parent.getInputTargetBlock(inputName);
-      chai.assert.notExists(block,
-          `expected block ${block && block.id} to not be attached to ${inputName}`);
+      chai.assert.notExists(
+          block,
+          `expected block ${block && block.id} to not be attached to ${
+              inputName}`);
     }
 
     function assertNextNotHasBlock(parent) {
       const block = parent.getNextBlock();
-      chai.assert.notExists(block,
-          `expected block ${block && block.id} to not be attached to next connection`);
+      chai.assert.notExists(
+          block,
+          `expected block ${
+              block && block.id} to not be attached to next connection`);
     }
 
     function assertSerialization(block, jso, xmlText) {
-      const actualJso = Blockly.serialization.blocks
-          .save(block, {addNextBlocks: true});
+      const actualJso =
+          Blockly.serialization.blocks.save(block, {addNextBlocks: true});
       const actualXml = Blockly.Xml.domToText(Blockly.Xml.blockToDom(block));
       chai.assert.deepEqual(actualJso, jso);
       chai.assert.equal(actualXml, xmlText);
@@ -109,36 +118,37 @@ suite('Connection', function() {
           suite('Add - No Block Connected', function() {
             // These are defined separately in each suite.
             function createRowBlock(workspace) {
-              const block = Blockly.Xml.domToBlock(Blockly.utils.xml.textToDom(
-                  '<block type="row_block" id="id0"/>'
-              ), workspace);
+              const block = Blockly.Xml.domToBlock(
+                  Blockly.utils.xml.textToDom(
+                      '<block type="row_block" id="id0"/>'),
+                  workspace);
               return block;
             }
 
             function createStatementBlock(workspace) {
-              const block = Blockly.Xml.domToBlock(Blockly.utils.xml.textToDom(
-                  '<block type="statement_block" id="id0"/>'
-              ), workspace);
+              const block = Blockly.Xml.domToBlock(
+                  Blockly.utils.xml.textToDom(
+                      '<block type="statement_block" id="id0"/>'),
+                  workspace);
               return block;
             }
 
             function createStackBlock(workspace) {
-              const block = Blockly.Xml.domToBlock(Blockly.utils.xml.textToDom(
-                  '<block type="stack_block" id="id0"/>'
-              ), workspace);
+              const block = Blockly.Xml.domToBlock(
+                  Blockly.utils.xml.textToDom(
+                      '<block type="stack_block" id="id0"/>'),
+                  workspace);
               return block;
             }
 
             test('Value', function() {
               const parent = createRowBlock(this.workspace);
               const xml = Blockly.utils.xml.textToDom(
-                  '<shadow type="row_block" id="id1"/>'
-              );
+                  '<shadow type="row_block" id="id1"/>');
               parent.getInput('INPUT').connection.setShadowDom(xml);
               assertInputHasBlock(parent, 'INPUT', true);
               assertSerialization(
-                  parent,
-                  {
+                  parent, {
                     'type': 'row_block',
                     'id': 'id0',
                     'inputs': {
@@ -151,12 +161,11 @@ suite('Connection', function() {
                     },
                   },
                   '<block xmlns="https://developers.google.com/blockly/xml" ' +
-                  'type="row_block" id="id0">' +
-                  '<value name="INPUT">' +
-                  '<shadow type="row_block" id="id1"></shadow>' +
-                  '</value>' +
-                  '</block>'
-              );
+                      'type="row_block" id="id0">' +
+                      '<value name="INPUT">' +
+                      '<shadow type="row_block" id="id1"></shadow>' +
+                      '</value>' +
+                      '</block>');
             });
 
             test('Multiple Value', function() {
@@ -166,15 +175,13 @@ suite('Connection', function() {
                   '  <value name="INPUT">' +
                   '    <shadow type="row_block" id="id2"/>' +
                   '  </value>' +
-                  '</shadow>'
-              );
+                  '</shadow>');
               parent.getInput('INPUT').connection.setShadowDom(xml);
               assertInputHasBlock(parent, 'INPUT', true);
               assertInputHasBlock(
                   parent.getInputTargetBlock('INPUT'), 'INPUT', true);
               assertSerialization(
-                  parent,
-                  {
+                  parent, {
                     'type': 'row_block',
                     'id': 'id0',
                     'inputs': {
@@ -195,28 +202,25 @@ suite('Connection', function() {
                     },
                   },
                   '<block xmlns="https://developers.google.com/blockly/xml" ' +
-                  'type="row_block" id="id0">' +
-                  '<value name="INPUT">' +
-                  '<shadow type="row_block" id="id1">' +
-                  '<value name="INPUT">' +
-                  '<shadow type="row_block" id="id2"></shadow>' +
-                  '</value>' +
-                  '</shadow>' +
-                  '</value>' +
-                  '</block>'
-              );
+                      'type="row_block" id="id0">' +
+                      '<value name="INPUT">' +
+                      '<shadow type="row_block" id="id1">' +
+                      '<value name="INPUT">' +
+                      '<shadow type="row_block" id="id2"></shadow>' +
+                      '</value>' +
+                      '</shadow>' +
+                      '</value>' +
+                      '</block>');
             });
 
             test('Statement', function() {
               const parent = createStatementBlock(this.workspace);
               const xml = Blockly.utils.xml.textToDom(
-                  '<shadow type="statement_block" id="id1"/>'
-              );
+                  '<shadow type="statement_block" id="id1"/>');
               parent.getInput('NAME').connection.setShadowDom(xml);
               assertInputHasBlock(parent, 'NAME', true);
               assertSerialization(
-                  parent,
-                  {
+                  parent, {
                     'type': 'statement_block',
                     'id': 'id0',
                     'inputs': {
@@ -229,12 +233,11 @@ suite('Connection', function() {
                     },
                   },
                   '<block xmlns="https://developers.google.com/blockly/xml" ' +
-                  'type="statement_block" id="id0">' +
-                  '<statement name="NAME">' +
-                  '<shadow type="statement_block" id="id1"></shadow>' +
-                  '</statement>' +
-                  '</block>'
-              );
+                      'type="statement_block" id="id0">' +
+                      '<statement name="NAME">' +
+                      '<shadow type="statement_block" id="id1"></shadow>' +
+                      '</statement>' +
+                      '</block>');
             });
 
             test('Multiple Statement', function() {
@@ -244,15 +247,13 @@ suite('Connection', function() {
                   '  <statement name="NAME">' +
                   '    <shadow type="statement_block" id="id2"/>' +
                   '  </statement>' +
-                  '</shadow>'
-              );
+                  '</shadow>');
               parent.getInput('NAME').connection.setShadowDom(xml);
               assertInputHasBlock(parent, 'NAME', true);
               assertInputHasBlock(
                   parent.getInputTargetBlock('NAME'), 'NAME', true);
               assertSerialization(
-                  parent,
-                  {
+                  parent, {
                     'type': 'statement_block',
                     'id': 'id0',
                     'inputs': {
@@ -273,28 +274,25 @@ suite('Connection', function() {
                     },
                   },
                   '<block xmlns="https://developers.google.com/blockly/xml" ' +
-                  'type="statement_block" id="id0">' +
-                  '<statement name="NAME">' +
-                  '<shadow type="statement_block" id="id1">' +
-                  '<statement name="NAME">' +
-                  '<shadow type="statement_block" id="id2"></shadow>' +
-                  '</statement>' +
-                  '</shadow>' +
-                  '</statement>' +
-                  '</block>'
-              );
+                      'type="statement_block" id="id0">' +
+                      '<statement name="NAME">' +
+                      '<shadow type="statement_block" id="id1">' +
+                      '<statement name="NAME">' +
+                      '<shadow type="statement_block" id="id2"></shadow>' +
+                      '</statement>' +
+                      '</shadow>' +
+                      '</statement>' +
+                      '</block>');
             });
 
             test('Next', function() {
               const parent = createStackBlock(this.workspace);
               const xml = Blockly.utils.xml.textToDom(
-                  '<shadow type="stack_block" id="id1"/>'
-              );
+                  '<shadow type="stack_block" id="id1"/>');
               parent.nextConnection.setShadowDom(xml);
               assertNextHasBlock(parent, true);
               assertSerialization(
-                  parent,
-                  {
+                  parent, {
                     'type': 'stack_block',
                     'id': 'id0',
                     'next': {
@@ -305,12 +303,11 @@ suite('Connection', function() {
                     },
                   },
                   '<block xmlns="https://developers.google.com/blockly/xml" ' +
-                  'type="stack_block" id="id0">' +
-                  '<next>' +
-                  '<shadow type="stack_block" id="id1"></shadow>' +
-                  '</next>' +
-                  '</block>'
-              );
+                      'type="stack_block" id="id0">' +
+                      '<next>' +
+                      '<shadow type="stack_block" id="id1"></shadow>' +
+                      '</next>' +
+                      '</block>');
             });
 
             test('Multiple Next', function() {
@@ -320,14 +317,12 @@ suite('Connection', function() {
                   '  <next>' +
                   '    <shadow type="stack_block" id="id2"/>' +
                   '  </next>' +
-                  '</shadow>'
-              );
+                  '</shadow>');
               parent.nextConnection.setShadowDom(xml);
               assertNextHasBlock(parent, true);
               assertNextHasBlock(parent.getNextBlock(), true);
               assertSerialization(
-                  parent,
-                  {
+                  parent, {
                     'type': 'stack_block',
                     'id': 'id0',
                     'next': {
@@ -344,66 +339,66 @@ suite('Connection', function() {
                     },
                   },
                   '<block xmlns="https://developers.google.com/blockly/xml" ' +
-                  'type="stack_block" id="id0">' +
-                  '<next>' +
-                  '<shadow type="stack_block" id="id1">' +
-                  '<next>' +
-                  '<shadow type="stack_block" id="id2"></shadow>' +
-                  '</next>' +
-                  '</shadow>' +
-                  '</next>' +
-                  '</block>'
-              );
+                      'type="stack_block" id="id0">' +
+                      '<next>' +
+                      '<shadow type="stack_block" id="id1">' +
+                      '<next>' +
+                      '<shadow type="stack_block" id="id2"></shadow>' +
+                      '</next>' +
+                      '</shadow>' +
+                      '</next>' +
+                      '</block>');
             });
           });
 
           suite('Add - With Block Connected', function() {
             // These are defined separately in each suite.
             function createRowBlocks(workspace) {
-              const block = Blockly.Xml.domToBlock(Blockly.utils.xml.textToDom(
-                  '<block type="row_block" id="id0">' +
-                  '  <value name="INPUT">' +
-                  '    <block type="row_block" id="idA"/>' +
-                  '  </value>' +
-                  '</block>'
-              ), workspace);
+              const block = Blockly.Xml.domToBlock(
+                  Blockly.utils.xml.textToDom(
+                      '<block type="row_block" id="id0">' +
+                      '  <value name="INPUT">' +
+                      '    <block type="row_block" id="idA"/>' +
+                      '  </value>' +
+                      '</block>'),
+                  workspace);
               return block;
             }
 
             function createStatementBlocks(workspace) {
-              const block = Blockly.Xml.domToBlock(Blockly.utils.xml.textToDom(
-                  '<block type="statement_block" id="id0">' +
-                  '  <statement name="NAME">' +
-                  '    <block type="statement_block" id="idA"/>' +
-                  '  </statement>' +
-                  '</block>'
-              ), workspace);
+              const block = Blockly.Xml.domToBlock(
+                  Blockly.utils.xml.textToDom(
+                      '<block type="statement_block" id="id0">' +
+                      '  <statement name="NAME">' +
+                      '    <block type="statement_block" id="idA"/>' +
+                      '  </statement>' +
+                      '</block>'),
+                  workspace);
               return block;
             }
 
             function createStackBlocks(workspace) {
-              const block = Blockly.Xml.domToBlock(Blockly.utils.xml.textToDom(
-                  '<block type="stack_block" id="id0">' +
-                  '  <next>' +
-                  '    <block type="stack_block" id="idA"/>' +
-                  '  </next>' +
-                  '</block>'
-              ), workspace);
+              const block = Blockly.Xml.domToBlock(
+                  Blockly.utils.xml.textToDom(
+                      '<block type="stack_block" id="id0">' +
+                      '  <next>' +
+                      '    <block type="stack_block" id="idA"/>' +
+                      '  </next>' +
+                      '</block>'),
+                  workspace);
               return block;
             }
 
             test('Value', function() {
               const parent = createRowBlocks(this.workspace);
               const xml = Blockly.utils.xml.textToDom(
-                  '<shadow type="row_block" id="id1"/>'
-              );
+                  '<shadow type="row_block" id="id1"/>');
               parent.getInput('INPUT').connection.setShadowDom(xml);
               assertInputHasBlock(parent, 'INPUT', false);
               parent.getInput('INPUT').connection.disconnect();
               assertInputHasBlock(parent, 'INPUT', true);
               assertSerialization(
-                  parent,
-                  {
+                  parent, {
                     'type': 'row_block',
                     'id': 'id0',
                     'inputs': {
@@ -416,12 +411,11 @@ suite('Connection', function() {
                     },
                   },
                   '<block xmlns="https://developers.google.com/blockly/xml" ' +
-                  'type="row_block" id="id0">' +
-                  '<value name="INPUT">' +
-                  '<shadow type="row_block" id="id1"></shadow>' +
-                  '</value>' +
-                  '</block>'
-              );
+                      'type="row_block" id="id0">' +
+                      '<value name="INPUT">' +
+                      '<shadow type="row_block" id="id1"></shadow>' +
+                      '</value>' +
+                      '</block>');
             });
 
             test('Multiple Value', function() {
@@ -431,18 +425,17 @@ suite('Connection', function() {
                   '  <value name="INPUT">' +
                   '    <shadow type="row_block" id="id2"/>' +
                   '  </value>' +
-                  '</shadow>'
-              );
+                  '</shadow>');
               parent.getInput('INPUT').connection.setShadowDom(xml);
               assertInputHasBlock(parent, 'INPUT', false);
-              assertInputNotHasBlock(parent.getInputTargetBlock('INPUT'), 'INPUT');
+              assertInputNotHasBlock(
+                  parent.getInputTargetBlock('INPUT'), 'INPUT');
               parent.getInput('INPUT').connection.disconnect();
               assertInputHasBlock(parent, 'INPUT', true);
               assertInputHasBlock(
                   parent.getInputTargetBlock('INPUT'), 'INPUT', true);
               assertSerialization(
-                  parent,
-                  {
+                  parent, {
                     'type': 'row_block',
                     'id': 'id0',
                     'inputs': {
@@ -463,30 +456,27 @@ suite('Connection', function() {
                     },
                   },
                   '<block xmlns="https://developers.google.com/blockly/xml" ' +
-                  'type="row_block" id="id0">' +
-                  '<value name="INPUT">' +
-                  '<shadow type="row_block" id="id1">' +
-                  '<value name="INPUT">' +
-                  '<shadow type="row_block" id="id2"></shadow>' +
-                  '</value>' +
-                  '</shadow>' +
-                  '</value>' +
-                  '</block>'
-              );
+                      'type="row_block" id="id0">' +
+                      '<value name="INPUT">' +
+                      '<shadow type="row_block" id="id1">' +
+                      '<value name="INPUT">' +
+                      '<shadow type="row_block" id="id2"></shadow>' +
+                      '</value>' +
+                      '</shadow>' +
+                      '</value>' +
+                      '</block>');
             });
 
             test('Statement', function() {
               const parent = createStatementBlocks(this.workspace);
               const xml = Blockly.utils.xml.textToDom(
-                  '<shadow type="statement_block" id="id1"/>'
-              );
+                  '<shadow type="statement_block" id="id1"/>');
               parent.getInput('NAME').connection.setShadowDom(xml);
               assertInputHasBlock(parent, 'NAME', false);
               parent.getInput('NAME').connection.disconnect();
               assertInputHasBlock(parent, 'NAME', true);
               assertSerialization(
-                  parent,
-                  {
+                  parent, {
                     'type': 'statement_block',
                     'id': 'id0',
                     'inputs': {
@@ -499,12 +489,11 @@ suite('Connection', function() {
                     },
                   },
                   '<block xmlns="https://developers.google.com/blockly/xml" ' +
-                  'type="statement_block" id="id0">' +
-                  '<statement name="NAME">' +
-                  '<shadow type="statement_block" id="id1"></shadow>' +
-                  '</statement>' +
-                  '</block>'
-              );
+                      'type="statement_block" id="id0">' +
+                      '<statement name="NAME">' +
+                      '<shadow type="statement_block" id="id1"></shadow>' +
+                      '</statement>' +
+                      '</block>');
             });
 
             test('Multiple Statement', function() {
@@ -514,8 +503,7 @@ suite('Connection', function() {
                   '  <statement name="NAME">' +
                   '    <shadow type="statement_block" id="id2"/>' +
                   '  </statement>' +
-                  '</shadow>'
-              );
+                  '</shadow>');
               parent.getInput('NAME').connection.setShadowDom(xml);
               assertInputHasBlock(parent, 'NAME', false);
               assertInputNotHasBlock(
@@ -525,8 +513,7 @@ suite('Connection', function() {
               assertInputHasBlock(
                   parent.getInputTargetBlock('NAME'), 'NAME', true);
               assertSerialization(
-                  parent,
-                  {
+                  parent, {
                     'type': 'statement_block',
                     'id': 'id0',
                     'inputs': {
@@ -547,30 +534,27 @@ suite('Connection', function() {
                     },
                   },
                   '<block xmlns="https://developers.google.com/blockly/xml" ' +
-                  'type="statement_block" id="id0">' +
-                  '<statement name="NAME">' +
-                  '<shadow type="statement_block" id="id1">' +
-                  '<statement name="NAME">' +
-                  '<shadow type="statement_block" id="id2"></shadow>' +
-                  '</statement>' +
-                  '</shadow>' +
-                  '</statement>' +
-                  '</block>'
-              );
+                      'type="statement_block" id="id0">' +
+                      '<statement name="NAME">' +
+                      '<shadow type="statement_block" id="id1">' +
+                      '<statement name="NAME">' +
+                      '<shadow type="statement_block" id="id2"></shadow>' +
+                      '</statement>' +
+                      '</shadow>' +
+                      '</statement>' +
+                      '</block>');
             });
 
             test('Next', function() {
               const parent = createStackBlocks(this.workspace);
               const xml = Blockly.utils.xml.textToDom(
-                  '<shadow type="stack_block" id="id1"/>'
-              );
+                  '<shadow type="stack_block" id="id1"/>');
               parent.nextConnection.setShadowDom(xml);
               assertNextHasBlock(parent, false);
               parent.nextConnection.disconnect();
               assertNextHasBlock(parent, true);
               assertSerialization(
-                  parent,
-                  {
+                  parent, {
                     'type': 'stack_block',
                     'id': 'id0',
                     'next': {
@@ -581,12 +565,11 @@ suite('Connection', function() {
                     },
                   },
                   '<block xmlns="https://developers.google.com/blockly/xml" ' +
-                  'type="stack_block" id="id0">' +
-                  '<next>' +
-                  '<shadow type="stack_block" id="id1"></shadow>' +
-                  '</next>' +
-                  '</block>'
-              );
+                      'type="stack_block" id="id0">' +
+                      '<next>' +
+                      '<shadow type="stack_block" id="id1"></shadow>' +
+                      '</next>' +
+                      '</block>');
             });
 
             test('Multiple Next', function() {
@@ -596,8 +579,7 @@ suite('Connection', function() {
                   '  <next>' +
                   '    <shadow type="stack_block" id="id2"/>' +
                   '  </next>' +
-                  '</shadow>'
-              );
+                  '</shadow>');
               parent.nextConnection.setShadowDom(xml);
               assertNextHasBlock(parent, false);
               assertNextNotHasBlock(parent.getNextBlock());
@@ -605,8 +587,7 @@ suite('Connection', function() {
               assertNextHasBlock(parent, true);
               assertNextHasBlock(parent.getNextBlock(), true);
               assertSerialization(
-                  parent,
-                  {
+                  parent, {
                     'type': 'stack_block',
                     'id': 'id0',
                     'next': {
@@ -623,56 +604,56 @@ suite('Connection', function() {
                     },
                   },
                   '<block xmlns="https://developers.google.com/blockly/xml" ' +
-                  'type="stack_block" id="id0">' +
-                  '<next>' +
-                  '<shadow type="stack_block" id="id1">' +
-                  '<next>' +
-                  '<shadow type="stack_block" id="id2"></shadow>' +
-                  '</next>' +
-                  '</shadow>' +
-                  '</next>' +
-                  '</block>'
-              );
+                      'type="stack_block" id="id0">' +
+                      '<next>' +
+                      '<shadow type="stack_block" id="id1">' +
+                      '<next>' +
+                      '<shadow type="stack_block" id="id2"></shadow>' +
+                      '</next>' +
+                      '</shadow>' +
+                      '</next>' +
+                      '</block>');
             });
           });
 
           suite('Add - With Shadow Connected', function() {
             // These are defined separately in each suite.
             function createRowBlock(workspace) {
-              const block = Blockly.Xml.domToBlock(Blockly.utils.xml.textToDom(
-                  '<block type="row_block" id="id0"/>'
-              ), workspace);
+              const block = Blockly.Xml.domToBlock(
+                  Blockly.utils.xml.textToDom(
+                      '<block type="row_block" id="id0"/>'),
+                  workspace);
               return block;
             }
 
             function createStatementBlock(workspace) {
-              const block = Blockly.Xml.domToBlock(Blockly.utils.xml.textToDom(
-                  '<block type="statement_block" id="id0"/>'
-              ), workspace);
+              const block = Blockly.Xml.domToBlock(
+                  Blockly.utils.xml.textToDom(
+                      '<block type="statement_block" id="id0"/>'),
+                  workspace);
               return block;
             }
 
             function createStackBlock(workspace) {
-              const block = Blockly.Xml.domToBlock(Blockly.utils.xml.textToDom(
-                  '<block type="stack_block" id="id0"/>'
-              ), workspace);
+              const block = Blockly.Xml.domToBlock(
+                  Blockly.utils.xml.textToDom(
+                      '<block type="stack_block" id="id0"/>'),
+                  workspace);
               return block;
             }
 
             test('Value', function() {
               const parent = createRowBlock(this.workspace);
               const xml1 = Blockly.utils.xml.textToDom(
-                  '<shadow type="row_block" id="1"/>'
-              );
+                  '<shadow type="row_block" id="1"/>');
               parent.getInput('INPUT').connection.setShadowDom(xml1);
               assertInputHasBlock(parent, 'INPUT', true, '1');
-              const xml2 =
-                  Blockly.utils.xml.textToDom('<shadow type="row_block" id="2"/>');
+              const xml2 = Blockly.utils.xml.textToDom(
+                  '<shadow type="row_block" id="2"/>');
               parent.getInput('INPUT').connection.setShadowDom(xml2);
               assertInputHasBlock(parent, 'INPUT', true, '2');
               assertSerialization(
-                  parent,
-                  {
+                  parent, {
                     'type': 'row_block',
                     'id': 'id0',
                     'inputs': {
@@ -685,12 +666,11 @@ suite('Connection', function() {
                     },
                   },
                   '<block xmlns="https://developers.google.com/blockly/xml" ' +
-                  'type="row_block" id="id0">' +
-                  '<value name="INPUT">' +
-                  '<shadow type="row_block" id="2"></shadow>' +
-                  '</value>' +
-                  '</block>'
-              );
+                      'type="row_block" id="id0">' +
+                      '<value name="INPUT">' +
+                      '<shadow type="row_block" id="2"></shadow>' +
+                      '</value>' +
+                      '</block>');
             });
 
             test('Multiple Value', function() {
@@ -716,8 +696,7 @@ suite('Connection', function() {
               assertInputHasBlock(
                   parent.getInputTargetBlock('INPUT'), 'INPUT', true, 'b');
               assertSerialization(
-                  parent,
-                  {
+                  parent, {
                     'type': 'row_block',
                     'id': 'id0',
                     'inputs': {
@@ -738,16 +717,15 @@ suite('Connection', function() {
                     },
                   },
                   '<block xmlns="https://developers.google.com/blockly/xml" ' +
-                  'type="row_block" id="id0">' +
-                  '<value name="INPUT">' +
-                  '<shadow type="row_block" id="2">' +
-                  '<value name="INPUT">' +
-                  '<shadow type="row_block" id="b"></shadow>' +
-                  '</value>' +
-                  '</shadow>' +
-                  '</value>' +
-                  '</block>'
-              );
+                      'type="row_block" id="id0">' +
+                      '<value name="INPUT">' +
+                      '<shadow type="row_block" id="2">' +
+                      '<value name="INPUT">' +
+                      '<shadow type="row_block" id="b"></shadow>' +
+                      '</value>' +
+                      '</shadow>' +
+                      '</value>' +
+                      '</block>');
             });
 
             test('Statement', function() {
@@ -761,8 +739,7 @@ suite('Connection', function() {
               parent.getInput('NAME').connection.setShadowDom(xml2);
               assertInputHasBlock(parent, 'NAME', true, '2');
               assertSerialization(
-                  parent,
-                  {
+                  parent, {
                     'type': 'statement_block',
                     'id': 'id0',
                     'inputs': {
@@ -775,12 +752,11 @@ suite('Connection', function() {
                     },
                   },
                   '<block xmlns="https://developers.google.com/blockly/xml" ' +
-                  'type="statement_block" id="id0">' +
-                  '<statement name="NAME">' +
-                  '<shadow type="statement_block" id="2"></shadow>' +
-                  '</statement>' +
-                  '</block>'
-              );
+                      'type="statement_block" id="id0">' +
+                      '<statement name="NAME">' +
+                      '<shadow type="statement_block" id="2"></shadow>' +
+                      '</statement>' +
+                      '</block>');
             });
 
             test('Multiple Statement', function() {
@@ -806,8 +782,7 @@ suite('Connection', function() {
               assertInputHasBlock(
                   parent.getInputTargetBlock('NAME'), 'NAME', true, 'b');
               assertSerialization(
-                  parent,
-                  {
+                  parent, {
                     'type': 'statement_block',
                     'id': 'id0',
                     'inputs': {
@@ -828,31 +803,29 @@ suite('Connection', function() {
                     },
                   },
                   '<block xmlns="https://developers.google.com/blockly/xml" ' +
-                  'type="statement_block" id="id0">' +
-                  '<statement name="NAME">' +
-                  '<shadow type="statement_block" id="2">' +
-                  '<statement name="NAME">' +
-                  '<shadow type="statement_block" id="b"></shadow>' +
-                  '</statement>' +
-                  '</shadow>' +
-                  '</statement>' +
-                  '</block>'
-              );
+                      'type="statement_block" id="id0">' +
+                      '<statement name="NAME">' +
+                      '<shadow type="statement_block" id="2">' +
+                      '<statement name="NAME">' +
+                      '<shadow type="statement_block" id="b"></shadow>' +
+                      '</statement>' +
+                      '</shadow>' +
+                      '</statement>' +
+                      '</block>');
             });
 
             test('Next', function() {
               const parent = createStackBlock(this.workspace);
-              const xml1 =
-                  Blockly.utils.xml.textToDom('<shadow type="stack_block" id="1"/>');
+              const xml1 = Blockly.utils.xml.textToDom(
+                  '<shadow type="stack_block" id="1"/>');
               parent.nextConnection.setShadowDom(xml1);
               assertNextHasBlock(parent, true, '1');
-              const xml2 =
-                  Blockly.utils.xml.textToDom('<shadow type="stack_block" id="2"/>');
+              const xml2 = Blockly.utils.xml.textToDom(
+                  '<shadow type="stack_block" id="2"/>');
               parent.nextConnection.setShadowDom(xml2);
               assertNextHasBlock(parent, true, '2');
               assertSerialization(
-                  parent,
-                  {
+                  parent, {
                     'type': 'stack_block',
                     'id': 'id0',
                     'next': {
@@ -863,12 +836,11 @@ suite('Connection', function() {
                     },
                   },
                   '<block xmlns="https://developers.google.com/blockly/xml" ' +
-                  'type="stack_block" id="id0">' +
-                  '<next>' +
-                  '<shadow type="stack_block" id="2"></shadow>' +
-                  '</next>' +
-                  '</block>'
-              );
+                      'type="stack_block" id="id0">' +
+                      '<next>' +
+                      '<shadow type="stack_block" id="2"></shadow>' +
+                      '</next>' +
+                      '</block>');
             });
 
             test('Multiple Next', function() {
@@ -892,8 +864,7 @@ suite('Connection', function() {
               assertNextHasBlock(parent, true, '2');
               assertNextHasBlock(parent.getNextBlock(), true, 'b');
               assertSerialization(
-                  parent,
-                  {
+                  parent, {
                     'type': 'stack_block',
                     'id': 'id0',
                     'next': {
@@ -910,51 +881,53 @@ suite('Connection', function() {
                     },
                   },
                   '<block xmlns="https://developers.google.com/blockly/xml" ' +
-                  'type="stack_block" id="id0">' +
-                  '<next>' +
-                  '<shadow type="stack_block" id="2">' +
-                  '<next>' +
-                  '<shadow type="stack_block" id="b"></shadow>' +
-                  '</next>' +
-                  '</shadow>' +
-                  '</next>' +
-                  '</block>'
-              );
+                      'type="stack_block" id="id0">' +
+                      '<next>' +
+                      '<shadow type="stack_block" id="2">' +
+                      '<next>' +
+                      '<shadow type="stack_block" id="b"></shadow>' +
+                      '</next>' +
+                      '</shadow>' +
+                      '</next>' +
+                      '</block>');
             });
           });
 
           suite('Remove - No Block Connected', function() {
             // These are defined separately in each suite.
             function createRowBlock(workspace) {
-              const block = Blockly.Xml.domToBlock(Blockly.utils.xml.textToDom(
-                  '<block type="row_block" id="id0">' +
-                  '  <value name="INPUT">' +
-                  '    <shadow type="row_block" id="idA"/>' +
-                  '  </value>' +
-                  '</block>'
-              ), workspace);
+              const block = Blockly.Xml.domToBlock(
+                  Blockly.utils.xml.textToDom(
+                      '<block type="row_block" id="id0">' +
+                      '  <value name="INPUT">' +
+                      '    <shadow type="row_block" id="idA"/>' +
+                      '  </value>' +
+                      '</block>'),
+                  workspace);
               return block;
             }
 
             function createStatementBlock(workspace) {
-              const block = Blockly.Xml.domToBlock(Blockly.utils.xml.textToDom(
-                  '<block type="statement_block" id="id0">' +
-                  '  <statement name="NAME">' +
-                  '    <shadow type="statement_block" id="idA"/>' +
-                  '  </statement>' +
-                  '</block>'
-              ), workspace);
+              const block = Blockly.Xml.domToBlock(
+                  Blockly.utils.xml.textToDom(
+                      '<block type="statement_block" id="id0">' +
+                      '  <statement name="NAME">' +
+                      '    <shadow type="statement_block" id="idA"/>' +
+                      '  </statement>' +
+                      '</block>'),
+                  workspace);
               return block;
             }
 
             function createStackBlock(workspace) {
-              const block = Blockly.Xml.domToBlock(Blockly.utils.xml.textToDom(
-                  '<block type="stack_block" id="id0">' +
-                  '  <next>' +
-                  '    <shadow type="stack_block" id="idA"/>' +
-                  '  </next>' +
-                  '</block>'
-              ), workspace);
+              const block = Blockly.Xml.domToBlock(
+                  Blockly.utils.xml.textToDom(
+                      '<block type="stack_block" id="id0">' +
+                      '  <next>' +
+                      '    <shadow type="stack_block" id="idA"/>' +
+                      '  </next>' +
+                      '</block>'),
+                  workspace);
               return block;
             }
 
@@ -963,15 +936,13 @@ suite('Connection', function() {
               parent.getInput('INPUT').connection.setShadowDom(null);
               assertInputNotHasBlock(parent, 'INPUT');
               assertSerialization(
-                  parent,
-                  {
+                  parent, {
                     'type': 'row_block',
                     'id': 'id0',
                   },
                   '<block xmlns="https://developers.google.com/blockly/xml" ' +
-                  'type="row_block" id="id0">' +
-                  '</block>'
-              );
+                      'type="row_block" id="id0">' +
+                      '</block>');
             });
 
             test('Statement', function() {
@@ -979,15 +950,13 @@ suite('Connection', function() {
               parent.getInput('NAME').connection.setShadowDom(null);
               assertInputNotHasBlock(parent, 'STATEMENT');
               assertSerialization(
-                  parent,
-                  {
+                  parent, {
                     'type': 'statement_block',
                     'id': 'id0',
                   },
                   '<block xmlns="https://developers.google.com/blockly/xml" ' +
-                  'type="statement_block" id="id0">' +
-                  '</block>'
-              );
+                      'type="statement_block" id="id0">' +
+                      '</block>');
             });
 
             test('Next', function() {
@@ -995,53 +964,54 @@ suite('Connection', function() {
               parent.nextConnection.setShadowDom(null);
               assertNextNotHasBlock(parent);
               assertSerialization(
-                  parent,
-                  {
+                  parent, {
                     'type': 'stack_block',
                     'id': 'id0',
                   },
                   '<block xmlns="https://developers.google.com/blockly/xml" ' +
-                  'type="stack_block" id="id0">' +
-                  '</block>'
-              );
+                      'type="stack_block" id="id0">' +
+                      '</block>');
             });
           });
 
           suite('Remove - Block Connected', function() {
             // These are defined separately in each suite.
             function createRowBlock(workspace) {
-              const block = Blockly.Xml.domToBlock(Blockly.utils.xml.textToDom(
-                  '<block type="row_block" id="id0">' +
-                  '  <value name="INPUT">' +
-                  '    <shadow type="row_block" id="idA"/>' +
-                  '    <block type="row_block" id="idB"/>' +
-                  '  </value>' +
-                  '</block>'
-              ), workspace);
+              const block = Blockly.Xml.domToBlock(
+                  Blockly.utils.xml.textToDom(
+                      '<block type="row_block" id="id0">' +
+                      '  <value name="INPUT">' +
+                      '    <shadow type="row_block" id="idA"/>' +
+                      '    <block type="row_block" id="idB"/>' +
+                      '  </value>' +
+                      '</block>'),
+                  workspace);
               return block;
             }
 
             function createStatementBlock(workspace) {
-              const block = Blockly.Xml.domToBlock(Blockly.utils.xml.textToDom(
-                  '<block type="statement_block" id="id0">' +
-                  '  <statement name="NAME">' +
-                  '    <shadow type="statement_block" id="idA"/>' +
-                  '    <block type="statement_block" id="idB"/>' +
-                  '  </statement>' +
-                  '</block>'
-              ), workspace);
+              const block = Blockly.Xml.domToBlock(
+                  Blockly.utils.xml.textToDom(
+                      '<block type="statement_block" id="id0">' +
+                      '  <statement name="NAME">' +
+                      '    <shadow type="statement_block" id="idA"/>' +
+                      '    <block type="statement_block" id="idB"/>' +
+                      '  </statement>' +
+                      '</block>'),
+                  workspace);
               return block;
             }
 
             function createStackBlock(workspace) {
-              const block = Blockly.Xml.domToBlock(Blockly.utils.xml.textToDom(
-                  '<block type="stack_block" id="id0">' +
-                  '  <next>' +
-                  '    <shadow type="stack_block" id="idA"/>' +
-                  '    <block type="stack_block" id="idB"/>' +
-                  '  </next>' +
-                  '</block>'
-              ), workspace);
+              const block = Blockly.Xml.domToBlock(
+                  Blockly.utils.xml.textToDom(
+                      '<block type="stack_block" id="id0">' +
+                      '  <next>' +
+                      '    <shadow type="stack_block" id="idA"/>' +
+                      '    <block type="stack_block" id="idB"/>' +
+                      '  </next>' +
+                      '</block>'),
+                  workspace);
               return block;
             }
 
@@ -1052,15 +1022,13 @@ suite('Connection', function() {
               parent.getInput('INPUT').connection.disconnect();
               assertInputNotHasBlock(parent, 'INPUT');
               assertSerialization(
-                  parent,
-                  {
+                  parent, {
                     'type': 'row_block',
                     'id': 'id0',
                   },
                   '<block xmlns="https://developers.google.com/blockly/xml" ' +
-                  'type="row_block" id="id0">' +
-                  '</block>'
-              );
+                      'type="row_block" id="id0">' +
+                      '</block>');
             });
 
             test('Statement', function() {
@@ -1070,15 +1038,13 @@ suite('Connection', function() {
               parent.getInput('NAME').connection.disconnect();
               assertInputNotHasBlock(parent, 'NAME');
               assertSerialization(
-                  parent,
-                  {
+                  parent, {
                     'type': 'statement_block',
                     'id': 'id0',
                   },
                   '<block xmlns="https://developers.google.com/blockly/xml" ' +
-                  'type="statement_block" id="id0">' +
-                  '</block>'
-              );
+                      'type="statement_block" id="id0">' +
+                      '</block>');
             });
 
             test('Next', function() {
@@ -1088,50 +1054,49 @@ suite('Connection', function() {
               parent.nextConnection.disconnect();
               assertNextNotHasBlock(parent);
               assertSerialization(
-                  parent,
-                  {
+                  parent, {
                     'type': 'stack_block',
                     'id': 'id0',
                   },
                   '<block xmlns="https://developers.google.com/blockly/xml" ' +
-                  'type="stack_block" id="id0">' +
-                  '</block>'
-              );
+                      'type="stack_block" id="id0">' +
+                      '</block>');
             });
           });
 
           suite('Add - Connect & Disconnect - Remove', function() {
             // These are defined separately in each suite.
             function createRowBlock(workspace) {
-              const block = Blockly.Xml.domToBlock(Blockly.utils.xml.textToDom(
-                  '<block type="row_block"/>'
-              ), workspace);
+              const block = Blockly.Xml.domToBlock(
+                  Blockly.utils.xml.textToDom('<block type="row_block"/>'),
+                  workspace);
               return block;
             }
 
             function createStatementBlock(workspace) {
-              const block = Blockly.Xml.domToBlock(Blockly.utils.xml.textToDom(
-                  '<block type="statement_block"/>'
-              ), workspace);
+              const block = Blockly.Xml.domToBlock(
+                  Blockly.utils.xml.textToDom(
+                      '<block type="statement_block"/>'),
+                  workspace);
               return block;
             }
 
             function createStackBlock(workspace) {
-              const block = Blockly.Xml.domToBlock(Blockly.utils.xml.textToDom(
-                  '<block type="stack_block"/>'
-              ), workspace);
+              const block = Blockly.Xml.domToBlock(
+                  Blockly.utils.xml.textToDom('<block type="stack_block"/>'),
+                  workspace);
               return block;
             }
 
             test('Value', function() {
               const parent = createRowBlock(this.workspace);
-              const xml = Blockly.utils.xml.textToDom(
-                  '<shadow type="row_block"/>'
-              );
+              const xml =
+                  Blockly.utils.xml.textToDom('<shadow type="row_block"/>');
               parent.getInput('INPUT').connection.setShadowDom(xml);
               assertInputHasBlock(parent, 'INPUT', true);
               const child = createRowBlock(this.workspace);
-              parent.getInput('INPUT').connection.connect(child.outputConnection);
+              parent.getInput('INPUT').connection.connect(
+                  child.outputConnection);
               assertInputHasBlock(parent, 'INPUT', false);
               parent.getInput('INPUT').connection.disconnect();
               assertInputHasBlock(parent, 'INPUT', true);
@@ -1146,14 +1111,14 @@ suite('Connection', function() {
                   '  <value name="INPUT">' +
                   '    <shadow type="row_block"/>' +
                   '  </value>' +
-                  '</shadow>'
-              );
+                  '</shadow>');
               parent.getInput('INPUT').connection.setShadowDom(xml);
               assertInputHasBlock(parent, 'INPUT', true);
               assertInputHasBlock(
                   parent.getInputTargetBlock('INPUT'), 'INPUT', true);
               const child = createRowBlock(this.workspace);
-              parent.getInput('INPUT').connection.connect(child.outputConnection);
+              parent.getInput('INPUT').connection.connect(
+                  child.outputConnection);
               assertInputHasBlock(parent, 'INPUT', false);
               parent.getInput('INPUT').connection.disconnect();
               assertInputHasBlock(parent, 'INPUT', true);
@@ -1166,13 +1131,12 @@ suite('Connection', function() {
             test('Statement', function() {
               const parent = createStatementBlock(this.workspace);
               const xml = Blockly.utils.xml.textToDom(
-                  '<shadow type="statement_block"/>'
-              );
+                  '<shadow type="statement_block"/>');
               parent.getInput('NAME').connection.setShadowDom(xml);
               assertInputHasBlock(parent, 'NAME', true);
               const child = createStatementBlock(this.workspace);
-              parent.getInput('NAME').connection
-                  .connect(child.previousConnection);
+              parent.getInput('NAME').connection.connect(
+                  child.previousConnection);
               assertInputHasBlock(parent, 'NAME', false);
               parent.getInput('NAME').connection.disconnect();
               assertInputHasBlock(parent, 'NAME', true);
@@ -1187,15 +1151,14 @@ suite('Connection', function() {
                   '  <statement name="NAME">' +
                   '    <shadow type="statement_block"/>' +
                   '  </statement>' +
-                  '</shadow>'
-              );
+                  '</shadow>');
               parent.getInput('NAME').connection.setShadowDom(xml);
               assertInputHasBlock(parent, 'NAME', true);
               assertInputHasBlock(
                   parent.getInputTargetBlock('NAME'), 'NAME', true);
               const child = createStatementBlock(this.workspace);
-              parent.getInput('NAME').connection
-                  .connect(child.previousConnection);
+              parent.getInput('NAME').connection.connect(
+                  child.previousConnection);
               assertInputHasBlock(parent, 'NAME', false);
               parent.getInput('NAME').connection.disconnect();
               assertInputHasBlock(parent, 'NAME', true);
@@ -1207,9 +1170,8 @@ suite('Connection', function() {
 
             test('Next', function() {
               const parent = createStackBlock(this.workspace);
-              const xml = Blockly.utils.xml.textToDom(
-                  '<shadow type="stack_block"/>'
-              );
+              const xml =
+                  Blockly.utils.xml.textToDom('<shadow type="stack_block"/>');
               parent.nextConnection.setShadowDom(xml);
               assertNextHasBlock(parent, true);
               const child = createStatementBlock(this.workspace);
@@ -1228,8 +1190,7 @@ suite('Connection', function() {
                   '  <next>' +
                   '    <shadow type="stack_block" id="child"/>' +
                   '  </next>' +
-                  '</shadow>'
-              );
+                  '</shadow>');
               parent.nextConnection.setShadowDom(xml);
               assertNextHasBlock(parent, true);
               assertNextHasBlock(parent.getNextBlock(), true);
@@ -1247,37 +1208,40 @@ suite('Connection', function() {
           suite('Invalid', function() {
             test('Attach to output', function() {
               const block = this.workspace.newBlock('row_block');
-              chai.assert.throws(() =>
-                block.outputConnection.setShadowDom(Blockly.utils.xml.textToDom(
-                    '<block type="row_block">')));
+              chai.assert.throws(
+                  () => block.outputConnection.setShadowDom(
+                      Blockly.utils.xml.textToDom('<block type="row_block">')));
             });
 
             test('Attach to previous', function() {
               const block = this.workspace.newBlock('stack_block');
-              chai.assert.throws(() =>
-                block.previousConnection.setShadowDom(Blockly.utils.xml.textToDom(
-                    '<block type="stack_block">')));
+              chai.assert.throws(
+                  () => block.previousConnection.setShadowDom(
+                      Blockly.utils.xml.textToDom(
+                          '<block type="stack_block">')));
             });
 
             test('Missing output', function() {
               const block = this.workspace.newBlock('row_block');
-              chai.assert.throws(() =>
-                block.outputConnection.setShadowDom(Blockly.utils.xml.textToDom(
-                    '<block type="stack_block">')));
+              chai.assert.throws(
+                  () => block.outputConnection.setShadowDom(
+                      Blockly.utils.xml.textToDom(
+                          '<block type="stack_block">')));
             });
 
             test('Missing previous', function() {
               const block = this.workspace.newBlock('stack_block');
-              chai.assert.throws(() =>
-                block.previousConnection.setShadowDom(Blockly.utils.xml.textToDom(
-                    '<block type="row_block">')));
+              chai.assert.throws(
+                  () => block.previousConnection.setShadowDom(
+                      Blockly.utils.xml.textToDom('<block type="row_block">')));
             });
 
             test('Invalid connection checks, output', function() {
               const block = this.workspace.newBlock('logic_operation');
-              chai.assert.throws(() =>
-                block.getInput('A').connection.setShadowDom(
-                    Blockly.utils.xml.textToDom('<block type="stack_block">')));
+              chai.assert.throws(
+                  () => block.getInput('A').connection.setShadowDom(
+                      Blockly.utils.xml.textToDom(
+                          '<block type="stack_block">')));
             });
 
             test('Invalid connection checks, previous', function() {
@@ -1288,9 +1252,10 @@ suite('Connection', function() {
                 "nextStatement": "check 2",
               }]);
               const block = this.workspace.newBlock('stack_checks_block');
-              chai.assert.throws(() =>
-                block.nextConnection.setShadowDom(Blockly.utils.xml.textToDom(
-                    '<block type="stack_checks_block">')));
+              chai.assert.throws(
+                  () => block.nextConnection.setShadowDom(
+                      Blockly.utils.xml.textToDom(
+                          '<block type="stack_checks_block">')));
             });
           });
         });
@@ -1315,12 +1280,11 @@ suite('Connection', function() {
 
             test('Value', function() {
               const parent = createRowBlock(this.workspace);
-              parent.getInput('INPUT').connection
-                  .setShadowState({'type': 'row_block', 'id': 'id1'});
+              parent.getInput('INPUT').connection.setShadowState(
+                  {'type': 'row_block', 'id': 'id1'});
               assertInputHasBlock(parent, 'INPUT', true);
               assertSerialization(
-                  parent,
-                  {
+                  parent, {
                     'type': 'row_block',
                     'id': 'id0',
                     'inputs': {
@@ -1333,12 +1297,11 @@ suite('Connection', function() {
                     },
                   },
                   '<block xmlns="https://developers.google.com/blockly/xml" ' +
-                  'type="row_block" id="id0">' +
-                  '<value name="INPUT">' +
-                  '<shadow type="row_block" id="id1"></shadow>' +
-                  '</value>' +
-                  '</block>'
-              );
+                      'type="row_block" id="id0">' +
+                      '<value name="INPUT">' +
+                      '<shadow type="row_block" id="id1"></shadow>' +
+                      '</value>' +
+                      '</block>');
             });
 
             test('Multiple Value', function() {
@@ -1359,8 +1322,7 @@ suite('Connection', function() {
               assertInputHasBlock(
                   parent.getInputTargetBlock('INPUT'), 'INPUT', true);
               assertSerialization(
-                  parent,
-                  {
+                  parent, {
                     'type': 'row_block',
                     'id': 'id0',
                     'inputs': {
@@ -1381,26 +1343,24 @@ suite('Connection', function() {
                     },
                   },
                   '<block xmlns="https://developers.google.com/blockly/xml" ' +
-                  'type="row_block" id="id0">' +
-                  '<value name="INPUT">' +
-                  '<shadow type="row_block" id="id1">' +
-                  '<value name="INPUT">' +
-                  '<shadow type="row_block" id="id2"></shadow>' +
-                  '</value>' +
-                  '</shadow>' +
-                  '</value>' +
-                  '</block>'
-              );
+                      'type="row_block" id="id0">' +
+                      '<value name="INPUT">' +
+                      '<shadow type="row_block" id="id1">' +
+                      '<value name="INPUT">' +
+                      '<shadow type="row_block" id="id2"></shadow>' +
+                      '</value>' +
+                      '</shadow>' +
+                      '</value>' +
+                      '</block>');
             });
 
             test('Statement', function() {
               const parent = createStatementBlock(this.workspace);
-              parent.getInput('NAME').connection
-                  .setShadowState({'type': 'statement_block', 'id': 'id1'});
+              parent.getInput('NAME').connection.setShadowState(
+                  {'type': 'statement_block', 'id': 'id1'});
               assertInputHasBlock(parent, 'NAME', true);
               assertSerialization(
-                  parent,
-                  {
+                  parent, {
                     'type': 'statement_block',
                     'id': 'id0',
                     'inputs': {
@@ -1413,12 +1373,11 @@ suite('Connection', function() {
                     },
                   },
                   '<block xmlns="https://developers.google.com/blockly/xml" ' +
-                  'type="statement_block" id="id0">' +
-                  '<statement name="NAME">' +
-                  '<shadow type="statement_block" id="id1"></shadow>' +
-                  '</statement>' +
-                  '</block>'
-              );
+                      'type="statement_block" id="id0">' +
+                      '<statement name="NAME">' +
+                      '<shadow type="statement_block" id="id1"></shadow>' +
+                      '</statement>' +
+                      '</block>');
             });
 
             test('Multiple Statment', function() {
@@ -1439,8 +1398,7 @@ suite('Connection', function() {
               assertInputHasBlock(
                   parent.getInputTargetBlock('NAME'), 'NAME', true);
               assertSerialization(
-                  parent,
-                  {
+                  parent, {
                     'type': 'statement_block',
                     'id': 'id0',
                     'inputs': {
@@ -1461,26 +1419,24 @@ suite('Connection', function() {
                     },
                   },
                   '<block xmlns="https://developers.google.com/blockly/xml" ' +
-                  'type="statement_block" id="id0">' +
-                  '<statement name="NAME">' +
-                  '<shadow type="statement_block" id="id1">' +
-                  '<statement name="NAME">' +
-                  '<shadow type="statement_block" id="id2"></shadow>' +
-                  '</statement>' +
-                  '</shadow>' +
-                  '</statement>' +
-                  '</block>'
-              );
+                      'type="statement_block" id="id0">' +
+                      '<statement name="NAME">' +
+                      '<shadow type="statement_block" id="id1">' +
+                      '<statement name="NAME">' +
+                      '<shadow type="statement_block" id="id2"></shadow>' +
+                      '</statement>' +
+                      '</shadow>' +
+                      '</statement>' +
+                      '</block>');
             });
 
             test('Next', function() {
               const parent = createStackBlock(this.workspace);
-              parent.nextConnection
-                  .setShadowState({'type': 'stack_block', 'id': 'id1'});
+              parent.nextConnection.setShadowState(
+                  {'type': 'stack_block', 'id': 'id1'});
               assertNextHasBlock(parent, true);
               assertSerialization(
-                  parent,
-                  {
+                  parent, {
                     'type': 'stack_block',
                     'id': 'id0',
                     'next': {
@@ -1491,12 +1447,11 @@ suite('Connection', function() {
                     },
                   },
                   '<block xmlns="https://developers.google.com/blockly/xml" ' +
-                  'type="stack_block" id="id0">' +
-                  '<next>' +
-                  '<shadow type="stack_block" id="id1"></shadow>' +
-                  '</next>' +
-                  '</block>'
-              );
+                      'type="stack_block" id="id0">' +
+                      '<next>' +
+                      '<shadow type="stack_block" id="id1"></shadow>' +
+                      '</next>' +
+                      '</block>');
             });
             test('Multiple Next', function() {
               const parent = createStackBlock(this.workspace);
@@ -1513,8 +1468,7 @@ suite('Connection', function() {
               assertNextHasBlock(parent, true);
               assertNextHasBlock(parent.getNextBlock(), true);
               assertSerialization(
-                  parent,
-                  {
+                  parent, {
                     'type': 'stack_block',
                     'id': 'id0',
                     'next': {
@@ -1531,16 +1485,15 @@ suite('Connection', function() {
                     },
                   },
                   '<block xmlns="https://developers.google.com/blockly/xml" ' +
-                  'type="stack_block" id="id0">' +
-                  '<next>' +
-                  '<shadow type="stack_block" id="id1">' +
-                  '<next>' +
-                  '<shadow type="stack_block" id="id2"></shadow>' +
-                  '</next>' +
-                  '</shadow>' +
-                  '</next>' +
-                  '</block>'
-              );
+                      'type="stack_block" id="id0">' +
+                      '<next>' +
+                      '<shadow type="stack_block" id="id1">' +
+                      '<next>' +
+                      '<shadow type="stack_block" id="id2"></shadow>' +
+                      '</next>' +
+                      '</shadow>' +
+                      '</next>' +
+                      '</block>');
             });
           });
 
@@ -1597,14 +1550,13 @@ suite('Connection', function() {
 
             test('Value', function() {
               const parent = createRowBlocks(this.workspace);
-              parent.getInput('INPUT').connection
-                  .setShadowState({'type': 'row_block', 'id': 'id1'});
+              parent.getInput('INPUT').connection.setShadowState(
+                  {'type': 'row_block', 'id': 'id1'});
               assertInputHasBlock(parent, 'INPUT', false);
               parent.getInput('INPUT').connection.disconnect();
               assertInputHasBlock(parent, 'INPUT', true);
               assertSerialization(
-                  parent,
-                  {
+                  parent, {
                     'type': 'row_block',
                     'id': 'id0',
                     'inputs': {
@@ -1617,39 +1569,36 @@ suite('Connection', function() {
                     },
                   },
                   '<block xmlns="https://developers.google.com/blockly/xml" ' +
-                  'type="row_block" id="id0">' +
-                  '<value name="INPUT">' +
-                  '<shadow type="row_block" id="id1"></shadow>' +
-                  '</value>' +
-                  '</block>'
-              );
+                      'type="row_block" id="id0">' +
+                      '<value name="INPUT">' +
+                      '<shadow type="row_block" id="id1"></shadow>' +
+                      '</value>' +
+                      '</block>');
             });
 
             test('Multiple Value', function() {
               const parent = createRowBlocks(this.workspace);
-              parent.getInput('INPUT').connection.setShadowState(
-                  {
-                    'type': 'row_block',
-                    'id': 'id1',
-                    'inputs': {
-                      'INPUT': {
-                        'shadow': {
-                          'type': 'row_block',
-                          'id': 'id2',
-                        },
-                      },
+              parent.getInput('INPUT').connection.setShadowState({
+                'type': 'row_block',
+                'id': 'id1',
+                'inputs': {
+                  'INPUT': {
+                    'shadow': {
+                      'type': 'row_block',
+                      'id': 'id2',
                     },
-                  }
-              );
+                  },
+                },
+              });
               assertInputHasBlock(parent, 'INPUT', false);
-              assertInputNotHasBlock(parent.getInputTargetBlock('INPUT'), 'INPUT');
+              assertInputNotHasBlock(
+                  parent.getInputTargetBlock('INPUT'), 'INPUT');
               parent.getInput('INPUT').connection.disconnect();
               assertInputHasBlock(parent, 'INPUT', true);
               assertInputHasBlock(
                   parent.getInputTargetBlock('INPUT'), 'INPUT', true);
               assertSerialization(
-                  parent,
-                  {
+                  parent, {
                     'type': 'row_block',
                     'id': 'id0',
                     'inputs': {
@@ -1670,28 +1619,26 @@ suite('Connection', function() {
                     },
                   },
                   '<block xmlns="https://developers.google.com/blockly/xml" ' +
-                  'type="row_block" id="id0">' +
-                  '<value name="INPUT">' +
-                  '<shadow type="row_block" id="id1">' +
-                  '<value name="INPUT">' +
-                  '<shadow type="row_block" id="id2"></shadow>' +
-                  '</value>' +
-                  '</shadow>' +
-                  '</value>' +
-                  '</block>'
-              );
+                      'type="row_block" id="id0">' +
+                      '<value name="INPUT">' +
+                      '<shadow type="row_block" id="id1">' +
+                      '<value name="INPUT">' +
+                      '<shadow type="row_block" id="id2"></shadow>' +
+                      '</value>' +
+                      '</shadow>' +
+                      '</value>' +
+                      '</block>');
             });
 
             test('Statement', function() {
               const parent = createStatementBlocks(this.workspace);
-              parent.getInput('NAME').connection
-                  .setShadowState({'type': 'statement_block', 'id': 'id1'});
+              parent.getInput('NAME').connection.setShadowState(
+                  {'type': 'statement_block', 'id': 'id1'});
               assertInputHasBlock(parent, 'NAME', false);
               parent.getInput('NAME').connection.disconnect();
               assertInputHasBlock(parent, 'NAME', true);
               assertSerialization(
-                  parent,
-                  {
+                  parent, {
                     'type': 'statement_block',
                     'id': 'id0',
                     'inputs': {
@@ -1704,30 +1651,27 @@ suite('Connection', function() {
                     },
                   },
                   '<block xmlns="https://developers.google.com/blockly/xml" ' +
-                  'type="statement_block" id="id0">' +
-                  '<statement name="NAME">' +
-                  '<shadow type="statement_block" id="id1"></shadow>' +
-                  '</statement>' +
-                  '</block>'
-              );
+                      'type="statement_block" id="id0">' +
+                      '<statement name="NAME">' +
+                      '<shadow type="statement_block" id="id1"></shadow>' +
+                      '</statement>' +
+                      '</block>');
             });
 
             test('Multiple Statement', function() {
               const parent = createStatementBlocks(this.workspace);
-              parent.getInput('NAME').connection.setShadowState(
-                  {
-                    'type': 'statement_block',
-                    'id': 'id1',
-                    'inputs': {
-                      'NAME': {
-                        'shadow': {
-                          'type': 'statement_block',
-                          'id': 'id2',
-                        },
-                      },
+              parent.getInput('NAME').connection.setShadowState({
+                'type': 'statement_block',
+                'id': 'id1',
+                'inputs': {
+                  'NAME': {
+                    'shadow': {
+                      'type': 'statement_block',
+                      'id': 'id2',
                     },
-                  }
-              );
+                  },
+                },
+              });
               assertInputHasBlock(parent, 'NAME', false);
               assertInputNotHasBlock(
                   parent.getInputTargetBlock('NAME'), 'NAME');
@@ -1736,8 +1680,7 @@ suite('Connection', function() {
               assertInputHasBlock(
                   parent.getInputTargetBlock('NAME'), 'NAME', true);
               assertSerialization(
-                  parent,
-                  {
+                  parent, {
                     'type': 'statement_block',
                     'id': 'id0',
                     'inputs': {
@@ -1758,28 +1701,26 @@ suite('Connection', function() {
                     },
                   },
                   '<block xmlns="https://developers.google.com/blockly/xml" ' +
-                  'type="statement_block" id="id0">' +
-                  '<statement name="NAME">' +
-                  '<shadow type="statement_block" id="id1">' +
-                  '<statement name="NAME">' +
-                  '<shadow type="statement_block" id="id2"></shadow>' +
-                  '</statement>' +
-                  '</shadow>' +
-                  '</statement>' +
-                  '</block>'
-              );
+                      'type="statement_block" id="id0">' +
+                      '<statement name="NAME">' +
+                      '<shadow type="statement_block" id="id1">' +
+                      '<statement name="NAME">' +
+                      '<shadow type="statement_block" id="id2"></shadow>' +
+                      '</statement>' +
+                      '</shadow>' +
+                      '</statement>' +
+                      '</block>');
             });
 
             test('Next', function() {
               const parent = createStackBlocks(this.workspace);
-              parent.nextConnection
-                  .setShadowState({'type': 'stack_block', 'id': 'id1'});
+              parent.nextConnection.setShadowState(
+                  {'type': 'stack_block', 'id': 'id1'});
               assertNextHasBlock(parent, false);
               parent.nextConnection.disconnect();
               assertNextHasBlock(parent, true);
               assertSerialization(
-                  parent,
-                  {
+                  parent, {
                     'type': 'stack_block',
                     'id': 'id0',
                     'next': {
@@ -1790,36 +1731,32 @@ suite('Connection', function() {
                     },
                   },
                   '<block xmlns="https://developers.google.com/blockly/xml" ' +
-                  'type="stack_block" id="id0">' +
-                  '<next>' +
-                  '<shadow type="stack_block" id="id1"></shadow>' +
-                  '</next>' +
-                  '</block>'
-              );
+                      'type="stack_block" id="id0">' +
+                      '<next>' +
+                      '<shadow type="stack_block" id="id1"></shadow>' +
+                      '</next>' +
+                      '</block>');
             });
 
             test('Multiple Next', function() {
               const parent = createStackBlocks(this.workspace);
-              parent.nextConnection.setShadowState(
-                  {
+              parent.nextConnection.setShadowState({
+                'type': 'stack_block',
+                'id': 'id1',
+                'next': {
+                  'shadow': {
                     'type': 'stack_block',
-                    'id': 'id1',
-                    'next': {
-                      'shadow': {
-                        'type': 'stack_block',
-                        'id': 'id2',
-                      },
-                    },
-                  }
-              );
+                    'id': 'id2',
+                  },
+                },
+              });
               assertNextHasBlock(parent, false);
               assertNextNotHasBlock(parent.getNextBlock());
               parent.nextConnection.disconnect();
               assertNextHasBlock(parent, true);
               assertNextHasBlock(parent.getNextBlock(), true);
               assertSerialization(
-                  parent,
-                  {
+                  parent, {
                     'type': 'stack_block',
                     'id': 'id0',
                     'next': {
@@ -1836,16 +1773,15 @@ suite('Connection', function() {
                     },
                   },
                   '<block xmlns="https://developers.google.com/blockly/xml" ' +
-                  'type="stack_block" id="id0">' +
-                  '<next>' +
-                  '<shadow type="stack_block" id="id1">' +
-                  '<next>' +
-                  '<shadow type="stack_block" id="id2"></shadow>' +
-                  '</next>' +
-                  '</shadow>' +
-                  '</next>' +
-                  '</block>'
-              );
+                      'type="stack_block" id="id0">' +
+                      '<next>' +
+                      '<shadow type="stack_block" id="id1">' +
+                      '<next>' +
+                      '<shadow type="stack_block" id="id2"></shadow>' +
+                      '</next>' +
+                      '</shadow>' +
+                      '</next>' +
+                      '</block>');
             });
           });
 
@@ -1868,15 +1804,14 @@ suite('Connection', function() {
 
             test('Value', function() {
               const parent = createRowBlock(this.workspace);
-              parent.getInput('INPUT').connection
-                  .setShadowState({'type': 'row_block', 'id': '1'});
+              parent.getInput('INPUT').connection.setShadowState(
+                  {'type': 'row_block', 'id': '1'});
               assertInputHasBlock(parent, 'INPUT', true, '1');
-              parent.getInput('INPUT').connection
-                  .setShadowState({'type': 'row_block', 'id': '2'});
+              parent.getInput('INPUT').connection.setShadowState(
+                  {'type': 'row_block', 'id': '2'});
               assertInputHasBlock(parent, 'INPUT', true, '2');
               assertSerialization(
-                  parent,
-                  {
+                  parent, {
                     'type': 'row_block',
                     'id': 'id0',
                     'inputs': {
@@ -1889,53 +1824,47 @@ suite('Connection', function() {
                     },
                   },
                   '<block xmlns="https://developers.google.com/blockly/xml" ' +
-                  'type="row_block" id="id0">' +
-                  '<value name="INPUT">' +
-                  '<shadow type="row_block" id="2"></shadow>' +
-                  '</value>' +
-                  '</block>'
-              );
+                      'type="row_block" id="id0">' +
+                      '<value name="INPUT">' +
+                      '<shadow type="row_block" id="2"></shadow>' +
+                      '</value>' +
+                      '</block>');
             });
 
             test('Multiple Value', function() {
               const parent = createRowBlock(this.workspace);
-              parent.getInput('INPUT').connection.setShadowState(
-                  {
-                    'type': 'row_block',
-                    'id': '1',
-                    'inputs': {
-                      'INPUT': {
-                        'shadow': {
-                          'type': 'row_block',
-                          'id': 'a',
-                        },
-                      },
+              parent.getInput('INPUT').connection.setShadowState({
+                'type': 'row_block',
+                'id': '1',
+                'inputs': {
+                  'INPUT': {
+                    'shadow': {
+                      'type': 'row_block',
+                      'id': 'a',
                     },
-                  }
-              );
+                  },
+                },
+              });
               assertInputHasBlock(parent, 'INPUT', true, '1');
               assertInputHasBlock(
                   parent.getInputTargetBlock('INPUT'), 'INPUT', true, 'a');
-              parent.getInput('INPUT').connection.setShadowState(
-                  {
-                    'type': 'row_block',
-                    'id': '2',
-                    'inputs': {
-                      'INPUT': {
-                        'shadow': {
-                          'type': 'row_block',
-                          'id': 'b',
-                        },
-                      },
+              parent.getInput('INPUT').connection.setShadowState({
+                'type': 'row_block',
+                'id': '2',
+                'inputs': {
+                  'INPUT': {
+                    'shadow': {
+                      'type': 'row_block',
+                      'id': 'b',
                     },
-                  }
-              );
+                  },
+                },
+              });
               assertInputHasBlock(parent, 'INPUT', true, '2');
               assertInputHasBlock(
                   parent.getInputTargetBlock('INPUT'), 'INPUT', true, 'b');
               assertSerialization(
-                  parent,
-                  {
+                  parent, {
                     'type': 'row_block',
                     'id': 'id0',
                     'inputs': {
@@ -1956,29 +1885,27 @@ suite('Connection', function() {
                     },
                   },
                   '<block xmlns="https://developers.google.com/blockly/xml" ' +
-                  'type="row_block" id="id0">' +
-                  '<value name="INPUT">' +
-                  '<shadow type="row_block" id="2">' +
-                  '<value name="INPUT">' +
-                  '<shadow type="row_block" id="b"></shadow>' +
-                  '</value>' +
-                  '</shadow>' +
-                  '</value>' +
-                  '</block>'
-              );
+                      'type="row_block" id="id0">' +
+                      '<value name="INPUT">' +
+                      '<shadow type="row_block" id="2">' +
+                      '<value name="INPUT">' +
+                      '<shadow type="row_block" id="b"></shadow>' +
+                      '</value>' +
+                      '</shadow>' +
+                      '</value>' +
+                      '</block>');
             });
 
             test('Statement', function() {
               const parent = createStatementBlock(this.workspace);
-              parent.getInput('NAME').connection
-                  .setShadowState({'type': 'statement_block', 'id': '1'});
+              parent.getInput('NAME').connection.setShadowState(
+                  {'type': 'statement_block', 'id': '1'});
               assertInputHasBlock(parent, 'NAME', true, '1');
-              parent.getInput('NAME').connection
-                  .setShadowState({'type': 'statement_block', 'id': '2'});
+              parent.getInput('NAME').connection.setShadowState(
+                  {'type': 'statement_block', 'id': '2'});
               assertInputHasBlock(parent, 'NAME', true, '2');
               assertSerialization(
-                  parent,
-                  {
+                  parent, {
                     'type': 'statement_block',
                     'id': 'id0',
                     'inputs': {
@@ -1991,53 +1918,47 @@ suite('Connection', function() {
                     },
                   },
                   '<block xmlns="https://developers.google.com/blockly/xml" ' +
-                  'type="statement_block" id="id0">' +
-                  '<statement name="NAME">' +
-                  '<shadow type="statement_block" id="2"></shadow>' +
-                  '</statement>' +
-                  '</block>'
-              );
+                      'type="statement_block" id="id0">' +
+                      '<statement name="NAME">' +
+                      '<shadow type="statement_block" id="2"></shadow>' +
+                      '</statement>' +
+                      '</block>');
             });
 
             test('Multiple Statement', function() {
               const parent = createStatementBlock(this.workspace);
-              parent.getInput('NAME').connection.setShadowState(
-                  {
-                    'type': 'statement_block',
-                    'id': '1',
-                    'inputs': {
-                      'NAME': {
-                        'shadow': {
-                          'type': 'statement_block',
-                          'id': 'a',
-                        },
-                      },
+              parent.getInput('NAME').connection.setShadowState({
+                'type': 'statement_block',
+                'id': '1',
+                'inputs': {
+                  'NAME': {
+                    'shadow': {
+                      'type': 'statement_block',
+                      'id': 'a',
                     },
-                  }
-              );
+                  },
+                },
+              });
               assertInputHasBlock(parent, 'NAME', true, '1');
               assertInputHasBlock(
                   parent.getInputTargetBlock('NAME'), 'NAME', true, 'a');
-              parent.getInput('NAME').connection.setShadowState(
-                  {
-                    'type': 'statement_block',
-                    'id': '2',
-                    'inputs': {
-                      'NAME': {
-                        'shadow': {
-                          'type': 'statement_block',
-                          'id': 'b',
-                        },
-                      },
+              parent.getInput('NAME').connection.setShadowState({
+                'type': 'statement_block',
+                'id': '2',
+                'inputs': {
+                  'NAME': {
+                    'shadow': {
+                      'type': 'statement_block',
+                      'id': 'b',
                     },
-                  }
-              );
+                  },
+                },
+              });
               assertInputHasBlock(parent, 'NAME', true, '2');
               assertInputHasBlock(
                   parent.getInputTargetBlock('NAME'), 'NAME', true, 'b');
               assertSerialization(
-                  parent,
-                  {
+                  parent, {
                     'type': 'statement_block',
                     'id': 'id0',
                     'inputs': {
@@ -2058,29 +1979,27 @@ suite('Connection', function() {
                     },
                   },
                   '<block xmlns="https://developers.google.com/blockly/xml" ' +
-                  'type="statement_block" id="id0">' +
-                  '<statement name="NAME">' +
-                  '<shadow type="statement_block" id="2">' +
-                  '<statement name="NAME">' +
-                  '<shadow type="statement_block" id="b"></shadow>' +
-                  '</statement>' +
-                  '</shadow>' +
-                  '</statement>' +
-                  '</block>'
-              );
+                      'type="statement_block" id="id0">' +
+                      '<statement name="NAME">' +
+                      '<shadow type="statement_block" id="2">' +
+                      '<statement name="NAME">' +
+                      '<shadow type="statement_block" id="b"></shadow>' +
+                      '</statement>' +
+                      '</shadow>' +
+                      '</statement>' +
+                      '</block>');
             });
 
             test('Next', function() {
               const parent = createStackBlock(this.workspace);
-              parent.nextConnection
-                  .setShadowState({'type': 'stack_block', 'id': '1'});
+              parent.nextConnection.setShadowState(
+                  {'type': 'stack_block', 'id': '1'});
               assertNextHasBlock(parent, true, '1');
-              parent.nextConnection
-                  .setShadowState({'type': 'stack_block', 'id': '2'});
+              parent.nextConnection.setShadowState(
+                  {'type': 'stack_block', 'id': '2'});
               assertNextHasBlock(parent, true, '2');
               assertSerialization(
-                  parent,
-                  {
+                  parent, {
                     'type': 'stack_block',
                     'id': 'id0',
                     'next': {
@@ -2091,47 +2010,41 @@ suite('Connection', function() {
                     },
                   },
                   '<block xmlns="https://developers.google.com/blockly/xml" ' +
-                  'type="stack_block" id="id0">' +
-                  '<next>' +
-                  '<shadow type="stack_block" id="2"></shadow>' +
-                  '</next>' +
-                  '</block>'
-              );
+                      'type="stack_block" id="id0">' +
+                      '<next>' +
+                      '<shadow type="stack_block" id="2"></shadow>' +
+                      '</next>' +
+                      '</block>');
             });
 
             test('Multiple Next', function() {
               const parent = createStackBlock(this.workspace);
-              parent.nextConnection.setShadowState(
-                  {
+              parent.nextConnection.setShadowState({
+                'type': 'stack_block',
+                'id': '1',
+                'next': {
+                  'shadow': {
                     'type': 'stack_block',
-                    'id': '1',
-                    'next': {
-                      'shadow': {
-                        'type': 'stack_block',
-                        'id': 'a',
-                      },
-                    },
-                  }
-              );
+                    'id': 'a',
+                  },
+                },
+              });
               assertNextHasBlock(parent, true, '1');
               assertNextHasBlock(parent.getNextBlock(), true, 'a');
-              parent.nextConnection.setShadowState(
-                  {
+              parent.nextConnection.setShadowState({
+                'type': 'stack_block',
+                'id': '2',
+                'next': {
+                  'shadow': {
                     'type': 'stack_block',
-                    'id': '2',
-                    'next': {
-                      'shadow': {
-                        'type': 'stack_block',
-                        'id': 'b',
-                      },
-                    },
-                  }
-              );
+                    'id': 'b',
+                  },
+                },
+              });
               assertNextHasBlock(parent, true, '2');
               assertNextHasBlock(parent.getNextBlock(), true, 'b');
               assertSerialization(
-                  parent,
-                  {
+                  parent, {
                     'type': 'stack_block',
                     'id': 'id0',
                     'next': {
@@ -2148,16 +2061,15 @@ suite('Connection', function() {
                     },
                   },
                   '<block xmlns="https://developers.google.com/blockly/xml" ' +
-                  'type="stack_block" id="id0">' +
-                  '<next>' +
-                  '<shadow type="stack_block" id="2">' +
-                  '<next>' +
-                  '<shadow type="stack_block" id="b"></shadow>' +
-                  '</next>' +
-                  '</shadow>' +
-                  '</next>' +
-                  '</block>'
-              );
+                      'type="stack_block" id="id0">' +
+                      '<next>' +
+                      '<shadow type="stack_block" id="2">' +
+                      '<next>' +
+                      '<shadow type="stack_block" id="b"></shadow>' +
+                      '</next>' +
+                      '</shadow>' +
+                      '</next>' +
+                      '</block>');
             });
           });
 
@@ -2217,15 +2129,13 @@ suite('Connection', function() {
               parent.getInput('INPUT').connection.setShadowState(null);
               assertInputNotHasBlock(parent, 'INPUT');
               assertSerialization(
-                  parent,
-                  {
+                  parent, {
                     'type': 'row_block',
                     'id': 'id0',
                   },
                   '<block xmlns="https://developers.google.com/blockly/xml" ' +
-                  'type="row_block" id="id0">' +
-                  '</block>'
-              );
+                      'type="row_block" id="id0">' +
+                      '</block>');
             });
 
             test('Statement', function() {
@@ -2233,15 +2143,13 @@ suite('Connection', function() {
               parent.getInput('NAME').connection.setShadowState(null);
               assertInputNotHasBlock(parent, 'NAME');
               assertSerialization(
-                  parent,
-                  {
+                  parent, {
                     'type': 'statement_block',
                     'id': 'id0',
                   },
                   '<block xmlns="https://developers.google.com/blockly/xml" ' +
-                  'type="statement_block" id="id0">' +
-                  '</block>'
-              );
+                      'type="statement_block" id="id0">' +
+                      '</block>');
             });
 
             test('Next', function() {
@@ -2249,15 +2157,13 @@ suite('Connection', function() {
               parent.nextConnection.setShadowState(null);
               assertNextNotHasBlock(parent);
               assertSerialization(
-                  parent,
-                  {
+                  parent, {
                     'type': 'stack_block',
                     'id': 'id0',
                   },
                   '<block xmlns="https://developers.google.com/blockly/xml" ' +
-                  'type="stack_block" id="id0">' +
-                  '</block>'
-              );
+                      'type="stack_block" id="id0">' +
+                      '</block>');
             });
           });
 
@@ -2331,15 +2237,13 @@ suite('Connection', function() {
               parent.getInput('INPUT').connection.disconnect();
               assertInputNotHasBlock(parent, 'INPUT');
               assertSerialization(
-                  parent,
-                  {
+                  parent, {
                     'type': 'row_block',
                     'id': 'id0',
                   },
                   '<block xmlns="https://developers.google.com/blockly/xml" ' +
-                  'type="row_block" id="id0">' +
-                  '</block>'
-              );
+                      'type="row_block" id="id0">' +
+                      '</block>');
             });
 
             test('Statement', function() {
@@ -2349,15 +2253,13 @@ suite('Connection', function() {
               parent.getInput('NAME').connection.disconnect();
               assertInputNotHasBlock(parent, 'NAME');
               assertSerialization(
-                  parent,
-                  {
+                  parent, {
                     'type': 'statement_block',
                     'id': 'id0',
                   },
                   '<block xmlns="https://developers.google.com/blockly/xml" ' +
-                  'type="statement_block" id="id0">' +
-                  '</block>'
-              );
+                      'type="statement_block" id="id0">' +
+                      '</block>');
             });
 
             test('Next', function() {
@@ -2367,15 +2269,13 @@ suite('Connection', function() {
               parent.nextConnection.disconnect();
               assertNextNotHasBlock(parent);
               assertSerialization(
-                  parent,
-                  {
+                  parent, {
                     'type': 'stack_block',
                     'id': 'id0',
                   },
                   '<block xmlns="https://developers.google.com/blockly/xml" ' +
-                  'type="stack_block" id="id0">' +
-                  '</block>'
-              );
+                      'type="stack_block" id="id0">' +
+                      '</block>');
             });
           });
 
@@ -2398,11 +2298,12 @@ suite('Connection', function() {
 
             test('Value', function() {
               const parent = createRowBlock(this.workspace);
-              parent.getInput('INPUT').connection
-                  .setShadowState({'type': 'row_block'});
+              parent.getInput('INPUT').connection.setShadowState(
+                  {'type': 'row_block'});
               assertInputHasBlock(parent, 'INPUT', true);
               const child = createRowBlock(this.workspace);
-              parent.getInput('INPUT').connection.connect(child.outputConnection);
+              parent.getInput('INPUT').connection.connect(
+                  child.outputConnection);
               assertInputHasBlock(parent, 'INPUT', false);
               parent.getInput('INPUT').connection.disconnect();
               assertInputHasBlock(parent, 'INPUT', true);
@@ -2426,7 +2327,8 @@ suite('Connection', function() {
               assertInputHasBlock(
                   parent.getInputTargetBlock('INPUT'), 'INPUT', true);
               const child = createRowBlock(this.workspace);
-              parent.getInput('INPUT').connection.connect(child.outputConnection);
+              parent.getInput('INPUT').connection.connect(
+                  child.outputConnection);
               assertInputHasBlock(parent, 'INPUT', false);
               parent.getInput('INPUT').connection.disconnect();
               assertInputHasBlock(parent, 'INPUT', true);
@@ -2438,12 +2340,12 @@ suite('Connection', function() {
 
             test('Statement', function() {
               const parent = createStatementBlock(this.workspace);
-              parent.getInput('NAME').connection
-                  .setShadowState({'type': 'statement_block'});
+              parent.getInput('NAME').connection.setShadowState(
+                  {'type': 'statement_block'});
               assertInputHasBlock(parent, 'NAME', true);
               const child = createStatementBlock(this.workspace);
-              parent.getInput('NAME').connection
-                  .connect(child.previousConnection);
+              parent.getInput('NAME').connection.connect(
+                  child.previousConnection);
               assertInputHasBlock(parent, 'NAME', false);
               parent.getInput('NAME').connection.disconnect();
               assertInputHasBlock(parent, 'NAME', true);
@@ -2467,8 +2369,8 @@ suite('Connection', function() {
               assertInputHasBlock(
                   parent.getInputTargetBlock('NAME'), 'NAME', true);
               const child = createStatementBlock(this.workspace);
-              parent.getInput('NAME').connection
-                  .connect(child.previousConnection);
+              parent.getInput('NAME').connection.connect(
+                  child.previousConnection);
               assertInputHasBlock(parent, 'NAME', false);
               parent.getInput('NAME').connection.disconnect();
               assertInputHasBlock(parent, 'NAME', true);
@@ -2516,34 +2418,37 @@ suite('Connection', function() {
           suite('Invalid', function() {
             test('Attach to output', function() {
               const block = this.workspace.newBlock('row_block');
-              chai.assert.throws(() =>
-                block.outputConnection.setShadowState({'type': 'row_block'}));
+              chai.assert.throws(
+                  () => block.outputConnection.setShadowState(
+                      {'type': 'row_block'}));
             });
 
             test('Attach to previous', function() {
               const block = this.workspace.newBlock('stack_block');
-              chai.assert.throws(() =>
-                block.previousConnection.setShadowState(
-                    {'type': 'stack_block'}));
+              chai.assert.throws(
+                  () => block.previousConnection.setShadowState(
+                      {'type': 'stack_block'}));
             });
 
             test('Missing output', function() {
               const block = this.workspace.newBlock('row_block');
-              chai.assert.throws(() =>
-                block.outputConnection.setShadowState({'type': 'stack_block'}));
+              chai.assert.throws(
+                  () => block.outputConnection.setShadowState(
+                      {'type': 'stack_block'}));
             });
 
             test('Missing previous', function() {
               const block = this.workspace.newBlock('stack_block');
-              chai.assert.throws(() =>
-                block.previousConnection.setShadowState({'type': 'row_block'}));
+              chai.assert.throws(
+                  () => block.previousConnection.setShadowState(
+                      {'type': 'row_block'}));
             });
 
             test('Invalid connection checks, output', function() {
               const block = this.workspace.newBlock('logic_operation');
-              chai.assert.throws(() =>
-                block.getInput('A').connection.setShadowState(
-                    {'type': 'math_number'}));
+              chai.assert.throws(
+                  () => block.getInput('A').connection.setShadowState(
+                      {'type': 'math_number'}));
             });
 
             test('Invalid connection checks, previous', function() {
@@ -2554,9 +2459,9 @@ suite('Connection', function() {
                 "nextStatement": "check 2",
               }]);
               const block = this.workspace.newBlock('stack_checks_block');
-              chai.assert.throws(() =>
-                block.nextConnection.setShadowState(
-                    {'type': 'stack_checks_block'}));
+              chai.assert.throws(
+                  () => block.nextConnection.setShadowState(
+                      {'type': 'stack_checks_block'}));
             });
           });
         });
@@ -2761,10 +2666,8 @@ suite('Connection', function() {
         const newParent = this.workspace.newBlock('statement_block');
         const child = this.workspace.newBlock('stack_block');
 
-        oldParent.getInput('NAME').connection
-            .connect(child.previousConnection);
-        newParent.getInput('NAME').connection
-            .connect(child.previousConnection);
+        oldParent.getInput('NAME').connection.connect(child.previousConnection);
+        newParent.getInput('NAME').connection.connect(child.previousConnection);
 
         chai.assert.isFalse(
             oldParent.getInput('NAME').connection.isConnected());
@@ -2788,9 +2691,7 @@ suite('Connection', function() {
       test('Value', function() {
         const newParent = this.workspace.newBlock('row_block');
         const child = this.workspace.newBlock('row_block');
-        const xml = Blockly.utils.xml.textToDom(
-            '<shadow type="row_block"/>'
-        );
+        const xml = Blockly.utils.xml.textToDom('<shadow type="row_block"/>');
         newParent.getInput('INPUT').connection.setShadowDom(xml);
         chai.assert.isTrue(newParent.getInputTargetBlock('INPUT').isShadow());
 
@@ -2803,27 +2704,20 @@ suite('Connection', function() {
       test('Statement', function() {
         const newParent = this.workspace.newBlock('statement_block');
         const child = this.workspace.newBlock('stack_block');
-        const xml = Blockly.utils.xml.textToDom(
-            '<shadow type="stack_block"/>'
-        );
+        const xml = Blockly.utils.xml.textToDom('<shadow type="stack_block"/>');
         newParent.getInput('NAME').connection.setShadowDom(xml);
-        chai.assert.isTrue(
-            newParent.getInputTargetBlock('NAME').isShadow());
+        chai.assert.isTrue(newParent.getInputTargetBlock('NAME').isShadow());
 
-        newParent.getInput('NAME').connection
-            .connect(child.previousConnection);
+        newParent.getInput('NAME').connection.connect(child.previousConnection);
 
-        chai.assert.isFalse(
-            newParent.getInputTargetBlock('NAME').isShadow());
+        chai.assert.isFalse(newParent.getInputTargetBlock('NAME').isShadow());
         this.assertBlockCount(2);
       });
 
       test('Next', function() {
         const newParent = this.workspace.newBlock('stack_block');
         const child = this.workspace.newBlock('stack_block');
-        const xml = Blockly.utils.xml.textToDom(
-            '<shadow type="stack_block"/>'
-        );
+        const xml = Blockly.utils.xml.textToDom('<shadow type="stack_block"/>');
         newParent.nextConnection.setShadowDom(xml);
         chai.assert.isTrue(newParent.getNextBlock().isShadow());
 
@@ -2838,9 +2732,7 @@ suite('Connection', function() {
       test('Value', function() {
         const newParent = this.workspace.newBlock('row_block');
         const child = this.workspace.newBlock('row_block');
-        const xml = Blockly.utils.xml.textToDom(
-            '<shadow type="row_block"/>'
-        );
+        const xml = Blockly.utils.xml.textToDom('<shadow type="row_block"/>');
         newParent.getInput('INPUT').connection.setShadowDom(xml);
         newParent.getInputTargetBlock('INPUT').setFieldValue('new', 'FIELD');
 
@@ -2856,15 +2748,11 @@ suite('Connection', function() {
       test('Statement', function() {
         const newParent = this.workspace.newBlock('statement_block');
         const child = this.workspace.newBlock('stack_block');
-        const xml = Blockly.utils.xml.textToDom(
-            '<shadow type="stack_block"/>'
-        );
+        const xml = Blockly.utils.xml.textToDom('<shadow type="stack_block"/>');
         newParent.getInput('NAME').connection.setShadowDom(xml);
-        newParent.getInputTargetBlock('NAME')
-            .setFieldValue('new', 'FIELD');
+        newParent.getInputTargetBlock('NAME').setFieldValue('new', 'FIELD');
 
-        newParent.getInput('NAME').connection
-            .connect(child.previousConnection);
+        newParent.getInput('NAME').connection.connect(child.previousConnection);
         newParent.getInput('NAME').connection.disconnect();
 
         const target = newParent.getInputTargetBlock('NAME');
@@ -2876,9 +2764,7 @@ suite('Connection', function() {
       test('Next', function() {
         const newParent = this.workspace.newBlock('stack_block');
         const child = this.workspace.newBlock('stack_block');
-        const xml = Blockly.utils.xml.textToDom(
-            '<shadow type="stack_block"/>'
-        );
+        const xml = Blockly.utils.xml.textToDom('<shadow type="stack_block"/>');
         newParent.nextConnection.setShadowDom(xml);
         newParent.getNextBlock().setFieldValue('new', 'FIELD');
 
@@ -2899,54 +2785,48 @@ suite('Connection', function() {
             const parent = this.workspace.newBlock('row_block');
             const oldChild = this.workspace.newBlock('row_block');
             const newChild = this.workspace.newBlock('row_block_noend');
-            parent.getInput('INPUT').connection
-                .connect(oldChild.outputConnection);
+            parent.getInput('INPUT').connection.connect(
+                oldChild.outputConnection);
 
-            parent.getInput('INPUT').connection
-                .connect(newChild.outputConnection);
+            parent.getInput('INPUT').connection.connect(
+                newChild.outputConnection);
 
             chai.assert.isTrue(
                 parent.getInput('INPUT').connection.isConnected());
-            chai.assert.equal(
-                parent.getInputTargetBlock('INPUT'), newChild);
-            chai.assert.isFalse(
-                oldChild.outputConnection.isConnected());
+            chai.assert.equal(parent.getInputTargetBlock('INPUT'), newChild);
+            chai.assert.isFalse(oldChild.outputConnection.isConnected());
           });
 
           test('All statements', function() {
             const parent = this.workspace.newBlock('row_block');
             const oldChild = this.workspace.newBlock('row_block');
             const newChild = this.workspace.newBlock('output_to_statements');
-            parent.getInput('INPUT').connection
-                .connect(oldChild.outputConnection);
+            parent.getInput('INPUT').connection.connect(
+                oldChild.outputConnection);
 
-            parent.getInput('INPUT').connection
-                .connect(newChild.outputConnection);
+            parent.getInput('INPUT').connection.connect(
+                newChild.outputConnection);
 
             chai.assert.isTrue(
                 parent.getInput('INPUT').connection.isConnected());
-            chai.assert.equal(
-                parent.getInputTargetBlock('INPUT'), newChild);
-            chai.assert.isFalse(
-                oldChild.outputConnection.isConnected());
+            chai.assert.equal(parent.getInputTargetBlock('INPUT'), newChild);
+            chai.assert.isFalse(oldChild.outputConnection.isConnected());
           });
 
           test('Bad checks', function() {
             const parent = this.workspace.newBlock('row_block');
             const oldChild = this.workspace.newBlock('row_block');
             const newChild = this.workspace.newBlock('row_block_2to1');
-            parent.getInput('INPUT').connection
-                .connect(oldChild.outputConnection);
+            parent.getInput('INPUT').connection.connect(
+                oldChild.outputConnection);
 
-            parent.getInput('INPUT').connection
-                .connect(newChild.outputConnection);
+            parent.getInput('INPUT').connection.connect(
+                newChild.outputConnection);
 
             chai.assert.isTrue(
                 parent.getInput('INPUT').connection.isConnected());
-            chai.assert.equal(
-                parent.getInputTargetBlock('INPUT'), newChild);
-            chai.assert.isFalse(
-                oldChild.outputConnection.isConnected());
+            chai.assert.equal(parent.getInputTargetBlock('INPUT'), newChild);
+            chai.assert.isFalse(oldChild.outputConnection.isConnected());
           });
 
           test('Through different types', function() {
@@ -2955,20 +2835,18 @@ suite('Connection', function() {
             const newChild = this.workspace.newBlock('row_block_2to1');
             const otherChild = this.workspace.newBlock('row_block_1to2');
 
-            parent.getInput('INPUT').connection
-                .connect(oldChild.outputConnection);
-            newChild.getInput('INPUT').connection
-                .connect(otherChild.outputConnection);
+            parent.getInput('INPUT').connection.connect(
+                oldChild.outputConnection);
+            newChild.getInput('INPUT').connection.connect(
+                otherChild.outputConnection);
 
-            parent.getInput('INPUT').connection
-                .connect(newChild.outputConnection);
+            parent.getInput('INPUT').connection.connect(
+                newChild.outputConnection);
 
             chai.assert.isTrue(
                 parent.getInput('INPUT').connection.isConnected());
-            chai.assert.equal(
-                parent.getInputTargetBlock('INPUT'), newChild);
-            chai.assert.isFalse(
-                oldChild.outputConnection.isConnected());
+            chai.assert.equal(parent.getInputTargetBlock('INPUT'), newChild);
+            chai.assert.isFalse(oldChild.outputConnection.isConnected());
           });
         });
 
@@ -2977,70 +2855,64 @@ suite('Connection', function() {
             test('Top block', function() {
               const parent = this.workspace.newBlock('row_block');
               const oldChild = this.workspace.newBlock('row_block');
-              const newChild = this.workspace.newBlock(
-                  'row_block_multiple_inputs');
+              const newChild =
+                  this.workspace.newBlock('row_block_multiple_inputs');
 
-              parent.getInput('INPUT').connection
-                  .connect(oldChild.outputConnection);
+              parent.getInput('INPUT').connection.connect(
+                  oldChild.outputConnection);
 
-              parent.getInput('INPUT').connection
-                  .connect(newChild.outputConnection);
+              parent.getInput('INPUT').connection.connect(
+                  newChild.outputConnection);
 
               chai.assert.isTrue(
                   parent.getInput('INPUT').connection.isConnected());
-              chai.assert.equal(
-                  parent.getInputTargetBlock('INPUT'), newChild);
-              chai.assert.isFalse(
-                  oldChild.outputConnection.isConnected());
+              chai.assert.equal(parent.getInputTargetBlock('INPUT'), newChild);
+              chai.assert.isFalse(oldChild.outputConnection.isConnected());
             });
 
             test('Child blocks', function() {
               const parent = this.workspace.newBlock('row_block');
               const oldChild = this.workspace.newBlock('row_block');
-              const newChild = this.workspace.newBlock(
-                  'row_block_multiple_inputs');
+              const newChild =
+                  this.workspace.newBlock('row_block_multiple_inputs');
               const childX = this.workspace.newBlock('row_block');
               const childY = this.workspace.newBlock('row_block');
 
-              parent.getInput('INPUT').connection
-                  .connect(oldChild.outputConnection);
-              newChild.getInput('INPUT').connection
-                  .connect(childX.outputConnection);
-              newChild.getInput('INPUT2').connection
-                  .connect(childY.outputConnection);
+              parent.getInput('INPUT').connection.connect(
+                  oldChild.outputConnection);
+              newChild.getInput('INPUT').connection.connect(
+                  childX.outputConnection);
+              newChild.getInput('INPUT2').connection.connect(
+                  childY.outputConnection);
 
-              parent.getInput('INPUT').connection
-                  .connect(newChild.outputConnection);
+              parent.getInput('INPUT').connection.connect(
+                  newChild.outputConnection);
 
               chai.assert.isTrue(
                   parent.getInput('INPUT').connection.isConnected());
-              chai.assert.equal(
-                  parent.getInputTargetBlock('INPUT'), newChild);
-              chai.assert.isFalse(
-                  oldChild.outputConnection.isConnected());
+              chai.assert.equal(parent.getInputTargetBlock('INPUT'), newChild);
+              chai.assert.isFalse(oldChild.outputConnection.isConnected());
             });
 
             test('Spots filled', function() {
               const parent = this.workspace.newBlock('row_block');
               const oldChild = this.workspace.newBlock('row_block');
-              const newChild = this.workspace.newBlock(
-                  'row_block_multiple_inputs');
+              const newChild =
+                  this.workspace.newBlock('row_block_multiple_inputs');
               const otherChild = this.workspace.newBlock('row_block_noend');
 
-              parent.getInput('INPUT').connection
-                  .connect(oldChild.outputConnection);
-              newChild.getInput('INPUT').connection
-                  .connect(otherChild.outputConnection);
+              parent.getInput('INPUT').connection.connect(
+                  oldChild.outputConnection);
+              newChild.getInput('INPUT').connection.connect(
+                  otherChild.outputConnection);
 
-              parent.getInput('INPUT').connection
-                  .connect(newChild.outputConnection);
+              parent.getInput('INPUT').connection.connect(
+                  newChild.outputConnection);
 
               chai.assert.isTrue(
                   parent.getInput('INPUT').connection.isConnected());
-              chai.assert.equal(
-                  parent.getInputTargetBlock('INPUT'), newChild);
-              chai.assert.isFalse(
-                  oldChild.outputConnection.isConnected());
+              chai.assert.equal(parent.getInputTargetBlock('INPUT'), newChild);
+              chai.assert.isFalse(oldChild.outputConnection.isConnected());
             });
           });
 
@@ -3048,85 +2920,84 @@ suite('Connection', function() {
             test('Top block', function() {
               const parent = this.workspace.newBlock('row_block');
               const oldChild = this.workspace.newBlock('row_block');
-              const newChild = this.workspace.newBlock(
-                  'row_block_multiple_inputs');
+              const newChild =
+                  this.workspace.newBlock('row_block_multiple_inputs');
 
-              parent.getInput('INPUT').connection
-                  .connect(oldChild.outputConnection);
+              parent.getInput('INPUT').connection.connect(
+                  oldChild.outputConnection);
               newChild.getInput('INPUT').connection.setShadowDom(
-                  Blockly.utils.xml.textToDom('<xml><shadow type="row_block"/></xml>')
+                  Blockly.utils.xml
+                      .textToDom('<xml><shadow type="row_block"/></xml>')
                       .firstChild);
               newChild.getInput('INPUT2').connection.setShadowDom(
-                  Blockly.utils.xml.textToDom('<xml><shadow type="row_block"/></xml>')
+                  Blockly.utils.xml
+                      .textToDom('<xml><shadow type="row_block"/></xml>')
                       .firstChild);
 
-              parent.getInput('INPUT').connection
-                  .connect(newChild.outputConnection);
+              parent.getInput('INPUT').connection.connect(
+                  newChild.outputConnection);
 
               chai.assert.isTrue(
                   parent.getInput('INPUT').connection.isConnected());
-              chai.assert.equal(
-                  parent.getInputTargetBlock('INPUT'), newChild);
-              chai.assert.isFalse(
-                  oldChild.outputConnection.isConnected());
+              chai.assert.equal(parent.getInputTargetBlock('INPUT'), newChild);
+              chai.assert.isFalse(oldChild.outputConnection.isConnected());
             });
 
             test('Child blocks', function() {
               const parent = this.workspace.newBlock('row_block');
               const oldChild = this.workspace.newBlock('row_block');
-              const newChild = this.workspace.newBlock(
-                  'row_block_multiple_inputs');
+              const newChild =
+                  this.workspace.newBlock('row_block_multiple_inputs');
               const childX = this.workspace.newBlock('row_block');
               const childY = this.workspace.newBlock('row_block');
 
-              parent.getInput('INPUT').connection
-                  .connect(oldChild.outputConnection);
-              newChild.getInput('INPUT').connection
-                  .connect(childX.outputConnection);
-              newChild.getInput('INPUT2').connection
-                  .connect(childY.outputConnection);
+              parent.getInput('INPUT').connection.connect(
+                  oldChild.outputConnection);
+              newChild.getInput('INPUT').connection.connect(
+                  childX.outputConnection);
+              newChild.getInput('INPUT2').connection.connect(
+                  childY.outputConnection);
               childX.getInput('INPUT').connection.setShadowDom(
-                  Blockly.utils.xml.textToDom('<xml><shadow type="row_block"/></xml>')
+                  Blockly.utils.xml
+                      .textToDom('<xml><shadow type="row_block"/></xml>')
                       .firstChild);
               childY.getInput('INPUT').connection.setShadowDom(
-                  Blockly.utils.xml.textToDom('<xml><shadow type="row_block"/></xml>')
+                  Blockly.utils.xml
+                      .textToDom('<xml><shadow type="row_block"/></xml>')
                       .firstChild);
 
-              parent.getInput('INPUT').connection
-                  .connect(newChild.outputConnection);
+              parent.getInput('INPUT').connection.connect(
+                  newChild.outputConnection);
 
               chai.assert.isTrue(
                   parent.getInput('INPUT').connection.isConnected());
-              chai.assert.equal(
-                  parent.getInputTargetBlock('INPUT'), newChild);
-              chai.assert.isFalse(
-                  oldChild.outputConnection.isConnected());
+              chai.assert.equal(parent.getInputTargetBlock('INPUT'), newChild);
+              chai.assert.isFalse(oldChild.outputConnection.isConnected());
             });
 
             test('Spots filled', function() {
               const parent = this.workspace.newBlock('row_block');
               const oldChild = this.workspace.newBlock('row_block');
-              const newChild = this.workspace.newBlock(
-                  'row_block_multiple_inputs');
+              const newChild =
+                  this.workspace.newBlock('row_block_multiple_inputs');
               const otherChild = this.workspace.newBlock('row_block_noend');
 
-              parent.getInput('INPUT').connection
-                  .connect(oldChild.outputConnection);
-              newChild.getInput('INPUT').connection
-                  .connect(otherChild.outputConnection);
+              parent.getInput('INPUT').connection.connect(
+                  oldChild.outputConnection);
+              newChild.getInput('INPUT').connection.connect(
+                  otherChild.outputConnection);
               newChild.getInput('INPUT2').connection.setShadowDom(
-                  Blockly.utils.xml.textToDom('<xml><shadow type="row_block"/></xml>')
+                  Blockly.utils.xml
+                      .textToDom('<xml><shadow type="row_block"/></xml>')
                       .firstChild);
 
-              parent.getInput('INPUT').connection
-                  .connect(newChild.outputConnection);
+              parent.getInput('INPUT').connection.connect(
+                  newChild.outputConnection);
 
               chai.assert.isTrue(
                   parent.getInput('INPUT').connection.isConnected());
-              chai.assert.equal(
-                  parent.getInputTargetBlock('INPUT'), newChild);
-              chai.assert.isFalse(
-                  oldChild.outputConnection.isConnected());
+              chai.assert.equal(parent.getInputTargetBlock('INPUT'), newChild);
+              chai.assert.isFalse(oldChild.outputConnection.isConnected());
             });
           });
         });
@@ -3137,20 +3008,18 @@ suite('Connection', function() {
             const oldChild = this.workspace.newBlock('row_block');
             const newChild = this.workspace.newBlock('row_block');
 
-            parent.getInput('INPUT').connection
-                .connect(oldChild.outputConnection);
+            parent.getInput('INPUT').connection.connect(
+                oldChild.outputConnection);
 
-            parent.getInput('INPUT').connection
-                .connect(newChild.outputConnection);
+            parent.getInput('INPUT').connection.connect(
+                newChild.outputConnection);
 
             chai.assert.isTrue(
                 parent.getInput('INPUT').connection.isConnected());
-            chai.assert.equal(
-                parent.getInputTargetBlock('INPUT'), newChild);
+            chai.assert.equal(parent.getInputTargetBlock('INPUT'), newChild);
             chai.assert.isTrue(
                 newChild.getInput('INPUT').connection.isConnected());
-            chai.assert.equal(
-                newChild.getInputTargetBlock('INPUT'), oldChild);
+            chai.assert.equal(newChild.getInputTargetBlock('INPUT'), oldChild);
           });
 
           test('Shadows', function() {
@@ -3158,23 +3027,22 @@ suite('Connection', function() {
             const oldChild = this.workspace.newBlock('row_block');
             const newChild = this.workspace.newBlock('row_block');
 
-            parent.getInput('INPUT').connection
-                .connect(oldChild.outputConnection);
+            parent.getInput('INPUT').connection.connect(
+                oldChild.outputConnection);
             newChild.getInput('INPUT').connection.setShadowDom(
-                Blockly.utils.xml.textToDom('<xml><shadow type="row_block"/></xml>')
+                Blockly.utils.xml
+                    .textToDom('<xml><shadow type="row_block"/></xml>')
                     .firstChild);
 
-            parent.getInput('INPUT').connection
-                .connect(newChild.outputConnection);
+            parent.getInput('INPUT').connection.connect(
+                newChild.outputConnection);
 
             chai.assert.isTrue(
                 parent.getInput('INPUT').connection.isConnected());
-            chai.assert.equal(
-                parent.getInputTargetBlock('INPUT'), newChild);
+            chai.assert.equal(parent.getInputTargetBlock('INPUT'), newChild);
             chai.assert.isTrue(
                 newChild.getInput('INPUT').connection.isConnected());
-            chai.assert.equal(
-                newChild.getInputTargetBlock('INPUT'), oldChild);
+            chai.assert.equal(newChild.getInputTargetBlock('INPUT'), oldChild);
           });
         });
       });
@@ -3185,16 +3053,15 @@ suite('Connection', function() {
             const parent = this.workspace.newBlock('statement_block');
             const oldChild = this.workspace.newBlock('stack_block');
             const newChild = this.workspace.newBlock('stack_block');
-            parent.getInput('NAME').connection
-                .connect(oldChild.previousConnection);
+            parent.getInput('NAME').connection.connect(
+                oldChild.previousConnection);
 
-            parent.getInput('NAME').connection
-                .connect(newChild.previousConnection);
+            parent.getInput('NAME').connection.connect(
+                newChild.previousConnection);
 
             chai.assert.isTrue(
                 parent.getInput('NAME').connection.isConnected());
-            chai.assert.equal(
-                parent.getInputTargetBlock('NAME'), newChild);
+            chai.assert.equal(parent.getInputTargetBlock('NAME'), newChild);
             chai.assert.isTrue(newChild.nextConnection.isConnected());
             chai.assert.equal(newChild.getNextBlock(), oldChild);
             this.assertBlockCount(3);
@@ -3205,17 +3072,16 @@ suite('Connection', function() {
             const oldChild = this.workspace.newBlock('stack_block');
             const newChild1 = this.workspace.newBlock('stack_block_1to2');
             const newChild2 = this.workspace.newBlock('stack_block_2to1');
-            parent.getInput('NAME').connection
-                .connect(oldChild.previousConnection);
+            parent.getInput('NAME').connection.connect(
+                oldChild.previousConnection);
             newChild1.nextConnection.connect(newChild2.previousConnection);
 
-            parent.getInput('NAME').connection
-                .connect(newChild1.previousConnection);
+            parent.getInput('NAME').connection.connect(
+                newChild1.previousConnection);
 
             chai.assert.isTrue(
                 parent.getInput('NAME').connection.isConnected());
-            chai.assert.equal(
-                parent.getInputTargetBlock('NAME'), newChild1);
+            chai.assert.equal(parent.getInputTargetBlock('NAME'), newChild1);
             chai.assert.isTrue(newChild2.nextConnection.isConnected());
             chai.assert.equal(newChild2.getNextBlock(), oldChild);
             this.assertBlockCount(4);
@@ -3225,17 +3091,17 @@ suite('Connection', function() {
             const parent = this.workspace.newBlock('statement_block');
             const oldChild = this.workspace.newBlock('stack_block');
             const newChild = this.workspace.newBlock('stack_block_1to2');
-            parent.getInput('NAME').connection
-                .connect(oldChild.previousConnection);
-            const spy = sinon.spy(oldChild.previousConnection, 'onFailedConnect');
+            parent.getInput('NAME').connection.connect(
+                oldChild.previousConnection);
+            const spy =
+                sinon.spy(oldChild.previousConnection, 'onFailedConnect');
 
-            parent.getInput('NAME').connection
-                .connect(newChild.previousConnection);
+            parent.getInput('NAME').connection.connect(
+                newChild.previousConnection);
 
             chai.assert.isTrue(
                 parent.getInput('NAME').connection.isConnected());
-            chai.assert.equal(
-                parent.getInputTargetBlock('NAME'), newChild);
+            chai.assert.equal(parent.getInputTargetBlock('NAME'), newChild);
             chai.assert.isFalse(newChild.nextConnection.isConnected());
             chai.assert.isTrue(spy.calledOnce);
             this.assertBlockCount(3);
@@ -3245,17 +3111,17 @@ suite('Connection', function() {
             const parent = this.workspace.newBlock('statement_block');
             const oldChild = this.workspace.newBlock('stack_block');
             const newChild = this.workspace.newBlock('stack_block_noend');
-            parent.getInput('NAME').connection
-                .connect(oldChild.previousConnection);
-            const spy = sinon.spy(oldChild.previousConnection, 'onFailedConnect');
+            parent.getInput('NAME').connection.connect(
+                oldChild.previousConnection);
+            const spy =
+                sinon.spy(oldChild.previousConnection, 'onFailedConnect');
 
-            parent.getInput('NAME').connection
-                .connect(newChild.previousConnection);
+            parent.getInput('NAME').connection.connect(
+                newChild.previousConnection);
 
             chai.assert.isTrue(
                 parent.getInput('NAME').connection.isConnected());
-            chai.assert.equal(
-                parent.getInputTargetBlock('NAME'), newChild);
+            chai.assert.equal(parent.getInputTargetBlock('NAME'), newChild);
             chai.assert.isTrue(spy.calledOnce);
             this.assertBlockCount(3);
           });
@@ -3266,20 +3132,18 @@ suite('Connection', function() {
             const parent = this.workspace.newBlock('statement_block');
             const oldChild = this.workspace.newBlock('stack_block');
             const newChild = this.workspace.newBlock('stack_block');
-            parent.getInput('NAME').connection
-                .connect(oldChild.previousConnection);
-            const xml = Blockly.utils.xml.textToDom(
-                '<shadow type="stack_block"/>'
-            );
+            parent.getInput('NAME').connection.connect(
+                oldChild.previousConnection);
+            const xml =
+                Blockly.utils.xml.textToDom('<shadow type="stack_block"/>');
             newChild.nextConnection.setShadowDom(xml);
 
-            parent.getInput('NAME').connection
-                .connect(newChild.previousConnection);
+            parent.getInput('NAME').connection.connect(
+                newChild.previousConnection);
 
             chai.assert.isTrue(
                 parent.getInput('NAME').connection.isConnected());
-            chai.assert.equal(
-                parent.getInputTargetBlock('NAME'), newChild);
+            chai.assert.equal(parent.getInputTargetBlock('NAME'), newChild);
             chai.assert.isTrue(newChild.nextConnection.isConnected());
             chai.assert.equal(newChild.getNextBlock(), oldChild);
             this.assertBlockCount(3);
@@ -3290,21 +3154,19 @@ suite('Connection', function() {
             const oldChild = this.workspace.newBlock('stack_block');
             const newChild1 = this.workspace.newBlock('stack_block_1to2');
             const newChild2 = this.workspace.newBlock('stack_block_2to1');
-            parent.getInput('NAME').connection
-                .connect(oldChild.previousConnection);
+            parent.getInput('NAME').connection.connect(
+                oldChild.previousConnection);
             newChild1.nextConnection.connect(newChild2.previousConnection);
-            const xml = Blockly.utils.xml.textToDom(
-                '<shadow type="stack_block"/>'
-            );
+            const xml =
+                Blockly.utils.xml.textToDom('<shadow type="stack_block"/>');
             newChild2.nextConnection.setShadowDom(xml);
 
-            parent.getInput('NAME').connection
-                .connect(newChild1.previousConnection);
+            parent.getInput('NAME').connection.connect(
+                newChild1.previousConnection);
 
             chai.assert.isTrue(
                 parent.getInput('NAME').connection.isConnected());
-            chai.assert.equal(
-                parent.getInputTargetBlock('NAME'), newChild1);
+            chai.assert.equal(parent.getInputTargetBlock('NAME'), newChild1);
             chai.assert.isTrue(newChild2.nextConnection.isConnected());
             chai.assert.equal(newChild2.getNextBlock(), oldChild);
             this.assertBlockCount(4);
@@ -3314,21 +3176,20 @@ suite('Connection', function() {
             const parent = this.workspace.newBlock('statement_block');
             const oldChild = this.workspace.newBlock('stack_block');
             const newChild = this.workspace.newBlock('stack_block_1to2');
-            parent.getInput('NAME').connection
-                .connect(oldChild.previousConnection);
+            parent.getInput('NAME').connection.connect(
+                oldChild.previousConnection);
             const xml = Blockly.utils.xml.textToDom(
-                '<shadow type="stack_block_2to1"/>'
-            );
+                '<shadow type="stack_block_2to1"/>');
             newChild.nextConnection.setShadowDom(xml);
-            const spy = sinon.spy(oldChild.previousConnection, 'onFailedConnect');
+            const spy =
+                sinon.spy(oldChild.previousConnection, 'onFailedConnect');
 
-            parent.getInput('NAME').connection
-                .connect(newChild.previousConnection);
+            parent.getInput('NAME').connection.connect(
+                newChild.previousConnection);
 
             chai.assert.isTrue(
                 parent.getInput('NAME').connection.isConnected());
-            chai.assert.equal(
-                parent.getInputTargetBlock('NAME'), newChild);
+            chai.assert.equal(parent.getInputTargetBlock('NAME'), newChild);
             chai.assert.isTrue(newChild.nextConnection.isConnected());
             chai.assert.isTrue(newChild.getNextBlock().isShadow());
             chai.assert.isTrue(spy.calledOnce);
@@ -3376,7 +3237,8 @@ suite('Connection', function() {
             const oldChild = this.workspace.newBlock('stack_block');
             const newChild = this.workspace.newBlock('stack_block_1to2');
             parent.nextConnection.connect(oldChild.previousConnection);
-            const spy = sinon.spy(oldChild.previousConnection, 'onFailedConnect');
+            const spy =
+                sinon.spy(oldChild.previousConnection, 'onFailedConnect');
 
             parent.nextConnection.connect(newChild.previousConnection);
 
@@ -3392,7 +3254,8 @@ suite('Connection', function() {
             const oldChild = this.workspace.newBlock('stack_block');
             const newChild = this.workspace.newBlock('stack_block_noend');
             parent.nextConnection.connect(oldChild.previousConnection);
-            const spy = sinon.spy(oldChild.previousConnection, 'onFailedConnect');
+            const spy =
+                sinon.spy(oldChild.previousConnection, 'onFailedConnect');
 
             parent.nextConnection.connect(newChild.previousConnection);
 
@@ -3409,9 +3272,8 @@ suite('Connection', function() {
             const oldChild = this.workspace.newBlock('stack_block');
             const newChild = this.workspace.newBlock('stack_block');
             parent.nextConnection.connect(oldChild.previousConnection);
-            const xml = Blockly.utils.xml.textToDom(
-                '<shadow type="stack_block"/>'
-            );
+            const xml =
+                Blockly.utils.xml.textToDom('<shadow type="stack_block"/>');
             newChild.nextConnection.setShadowDom(xml);
 
             parent.nextConnection.connect(newChild.previousConnection);
@@ -3430,9 +3292,8 @@ suite('Connection', function() {
             const newChild2 = this.workspace.newBlock('stack_block_2to1');
             parent.nextConnection.connect(oldChild.previousConnection);
             newChild1.nextConnection.connect(newChild2.previousConnection);
-            const xml = Blockly.utils.xml.textToDom(
-                '<shadow type="stack_block"/>'
-            );
+            const xml =
+                Blockly.utils.xml.textToDom('<shadow type="stack_block"/>');
             newChild2.nextConnection.setShadowDom(xml);
 
             parent.nextConnection.connect(newChild1.previousConnection);
@@ -3450,10 +3311,10 @@ suite('Connection', function() {
             const newChild = this.workspace.newBlock('stack_block_1to2');
             parent.nextConnection.connect(oldChild.previousConnection);
             const xml = Blockly.utils.xml.textToDom(
-                '<shadow type="stack_block_2to1"/>'
-            );
+                '<shadow type="stack_block_2to1"/>');
             newChild.nextConnection.setShadowDom(xml);
-            const spy = sinon.spy(oldChild.previousConnection, 'onFailedConnect');
+            const spy =
+                sinon.spy(oldChild.previousConnection, 'onFailedConnect');
 
             parent.nextConnection.connect(newChild.previousConnection);
 

--- a/tests/mocha/contextmenu_items_test.js
+++ b/tests/mocha/contextmenu_items_test.js
@@ -38,7 +38,8 @@ suite('Context Menu Items', function() {
 
       test('Disabled when nothing to undo', function() {
         const precondition = this.undoOption.preconditionFn(this.scope);
-        chai.assert.equal(precondition, 'disabled',
+        chai.assert.equal(
+            precondition, 'disabled',
             'Should be disabled when there is nothing to undo');
       });
 
@@ -46,7 +47,8 @@ suite('Context Menu Items', function() {
         // Create a new block, which should be undoable.
         this.workspace.newBlock('text');
         const precondition = this.undoOption.preconditionFn(this.scope);
-        chai.assert.equal(precondition, 'enabled',
+        chai.assert.equal(
+            precondition, 'enabled',
             'Should be enabled when there are actions to undo');
       });
 
@@ -54,7 +56,8 @@ suite('Context Menu Items', function() {
         this.workspace.newBlock('text');
         chai.assert.equal(this.workspace.getTopBlocks(false).length, 1);
         this.undoOption.callback(this.scope);
-        chai.assert.equal(this.workspace.getTopBlocks(false).length, 0,
+        chai.assert.equal(
+            this.workspace.getTopBlocks(false).length, 0,
             'Should be no blocks after undo');
       });
 
@@ -72,16 +75,19 @@ suite('Context Menu Items', function() {
         // Create a new block. There should be something to undo, but not redo.
         this.workspace.newBlock('text');
         const precondition = this.redoOption.preconditionFn(this.scope);
-        chai.assert.equal(precondition, 'disabled',
+        chai.assert.equal(
+            precondition, 'disabled',
             'Should be disabled when there is nothing to redo');
       });
 
       test('Enabled when something to redo', function() {
-        // Create a new block, then undo it, which means there is something to redo.
+        // Create a new block, then undo it, which means there is something to
+        // redo.
         this.workspace.newBlock('text');
         this.workspace.undo(false);
         const precondition = this.redoOption.preconditionFn(this.scope);
-        chai.assert.equal(precondition, 'enabled',
+        chai.assert.equal(
+            precondition, 'enabled',
             'Should be enabled when there are actions to redo');
       });
 
@@ -91,7 +97,8 @@ suite('Context Menu Items', function() {
         this.workspace.undo(false);
         chai.assert.equal(this.workspace.getTopBlocks(false).length, 0);
         this.redoOption.callback(this.scope);
-        chai.assert.equal(this.workspace.getTopBlocks(false).length, 1,
+        chai.assert.equal(
+            this.workspace.getTopBlocks(false).length, 1,
             'Should be 1 block after redo');
       });
 
@@ -109,18 +116,21 @@ suite('Context Menu Items', function() {
       test('Enabled when multiple blocks', function() {
         this.workspace.newBlock('text');
         this.workspace.newBlock('text');
-        chai.assert.equal(this.cleanupOption.preconditionFn(this.scope), 'enabled',
+        chai.assert.equal(
+            this.cleanupOption.preconditionFn(this.scope), 'enabled',
             'Should be enabled if there are multiple blocks');
       });
 
       test('Disabled when no blocks', function() {
-        chai.assert.equal(this.cleanupOption.preconditionFn(this.scope), 'disabled',
+        chai.assert.equal(
+            this.cleanupOption.preconditionFn(this.scope), 'disabled',
             'Should be disabled if there are no blocks');
       });
 
       test('Hidden when not movable', function() {
         sinon.stub(this.workspace, 'isMovable').returns(false);
-        chai.assert.equal(this.cleanupOption.preconditionFn(this.scope), 'hidden',
+        chai.assert.equal(
+            this.cleanupOption.preconditionFn(this.scope), 'hidden',
             'Should be hidden if the workspace is not movable');
       });
 
@@ -143,22 +153,26 @@ suite('Context Menu Items', function() {
         this.workspace.newBlock('text');
         const block2 = this.workspace.newBlock('text');
         block2.setCollapsed(true);
-        chai.assert.equal(this.collapseOption.preconditionFn(this.scope), 'enabled',
+        chai.assert.equal(
+            this.collapseOption.preconditionFn(this.scope), 'enabled',
             'Should be enabled when any blocks are expanded');
       });
 
       test('Disabled when all blocks collapsed', function() {
         this.workspace.newBlock('text').setCollapsed(true);
-        chai.assert.equal(this.collapseOption.preconditionFn(this.scope), 'disabled',
+        chai.assert.equal(
+            this.collapseOption.preconditionFn(this.scope), 'disabled',
             'Should be disabled when no blocks are expanded');
       });
 
       test('Hidden when no collapse option', function() {
-        const workspaceWithOptions = new Blockly.Workspace(new Blockly.Options({collapse: false}));
+        const workspaceWithOptions =
+            new Blockly.Workspace(new Blockly.Options({collapse: false}));
         this.scope.workspace = workspaceWithOptions;
 
         try {
-          chai.assert.equal(this.collapseOption.preconditionFn(this.scope), 'hidden',
+          chai.assert.equal(
+              this.collapseOption.preconditionFn(this.scope), 'hidden',
               'Should be hidden if collapse is disabled in options');
         } finally {
           workspaceTeardown.call(this, workspaceWithOptions);
@@ -177,9 +191,11 @@ suite('Context Menu Items', function() {
         this.collapseOption.callback(this.scope);
         this.clock.runAll();
 
-        chai.assert.isTrue(block1.isCollapsed(),
+        chai.assert.isTrue(
+            block1.isCollapsed(),
             'Previously collapsed block should still be collapsed');
-        chai.assert.isTrue(block2.isCollapsed(),
+        chai.assert.isTrue(
+            block2.isCollapsed(),
             'Previously expanded block should now be collapsed');
       });
 
@@ -198,22 +214,26 @@ suite('Context Menu Items', function() {
         const block2 = this.workspace.newBlock('text');
         block2.setCollapsed(true);
 
-        chai.assert.equal(this.expandOption.preconditionFn(this.scope), 'enabled',
+        chai.assert.equal(
+            this.expandOption.preconditionFn(this.scope), 'enabled',
             'Should be enabled when any blocks are collapsed');
       });
 
       test('Disabled when no collapsed blocks', function() {
         this.workspace.newBlock('text');
-        chai.assert.equal(this.expandOption.preconditionFn(this.scope), 'disabled',
+        chai.assert.equal(
+            this.expandOption.preconditionFn(this.scope), 'disabled',
             'Should be disabled when no blocks are collapsed');
       });
 
       test('Hidden when no collapse option', function() {
-        const workspaceWithOptions = new Blockly.Workspace(new Blockly.Options({collapse: false}));
+        const workspaceWithOptions =
+            new Blockly.Workspace(new Blockly.Options({collapse: false}));
         this.scope.workspace = workspaceWithOptions;
 
         try {
-          chai.assert.equal(this.expandOption.preconditionFn(this.scope), 'hidden',
+          chai.assert.equal(
+              this.expandOption.preconditionFn(this.scope), 'hidden',
               'Should be hidden if collapse is disabled in options');
         } finally {
           workspaceTeardown.call(this, workspaceWithOptions);
@@ -232,9 +252,11 @@ suite('Context Menu Items', function() {
         this.expandOption.callback(this.scope);
         this.clock.runAll();
 
-        chai.assert.isFalse(block1.isCollapsed(),
+        chai.assert.isFalse(
+            block1.isCollapsed(),
             'Previously expanded block should still be expanded');
-        chai.assert.isFalse(block2.isCollapsed(),
+        chai.assert.isFalse(
+            block2.isCollapsed(),
             'Previously collapsed block should now be expanded');
       });
 
@@ -250,17 +272,21 @@ suite('Context Menu Items', function() {
 
       test('Enabled when blocks to delete', function() {
         this.workspace.newBlock('text');
-        chai.assert.equal(this.deleteOption.preconditionFn(this.scope), 'enabled');
+        chai.assert.equal(
+            this.deleteOption.preconditionFn(this.scope), 'enabled');
       });
 
       test('Disabled when no blocks to delete', function() {
-        chai.assert.equal(this.deleteOption.preconditionFn(this.scope), 'disabled');
+        chai.assert.equal(
+            this.deleteOption.preconditionFn(this.scope), 'disabled');
       });
 
       test('Deletes all blocks after confirming', function() {
-        // Mocks the confirmation dialog and calls the callback with 'true' simulating ok.
-        const confirmStub = sinon.stub(
-          Blockly.dialog.TEST_ONLY, 'confirmInternal').callsArgWith(1, true);
+        // Mocks the confirmation dialog and calls the callback with 'true'
+        // simulating ok.
+        const confirmStub =
+            sinon.stub(Blockly.dialog.TEST_ONLY, 'confirmInternal')
+                .callsArgWith(1, true);
 
         this.workspace.newBlock('text');
         this.workspace.newBlock('text');
@@ -271,9 +297,11 @@ suite('Context Menu Items', function() {
       });
 
       test('Does not delete blocks if not confirmed', function() {
-        // Mocks the confirmation dialog and calls the callback with 'false' simulating cancel.
-        const confirmStub = sinon.stub(
-          Blockly.dialog.TEST_ONLY, 'confirmInternal').callsArgWith(1, false);
+        // Mocks the confirmation dialog and calls the callback with 'false'
+        // simulating cancel.
+        const confirmStub =
+            sinon.stub(Blockly.dialog.TEST_ONLY, 'confirmInternal')
+                .callsArgWith(1, false);
 
         this.workspace.newBlock('text');
         this.workspace.newBlock('text');
@@ -284,7 +312,8 @@ suite('Context Menu Items', function() {
       });
 
       test('No dialog for single block', function() {
-        const confirmStub = sinon.stub(Blockly.dialog.TEST_ONLY, 'confirmInternal');
+        const confirmStub =
+            sinon.stub(Blockly.dialog.TEST_ONLY, 'confirmInternal');
         this.workspace.newBlock('text');
         this.deleteOption.callback(this.scope);
         this.clock.runAll();
@@ -297,12 +326,14 @@ suite('Context Menu Items', function() {
         this.workspace.newBlock('text');
         this.workspace.newBlock('text');
 
-        chai.assert.equal(this.deleteOption.displayText(this.scope), 'Delete 2 Blocks');
+        chai.assert.equal(
+            this.deleteOption.displayText(this.scope), 'Delete 2 Blocks');
       });
 
       test('Has correct label for single block', function() {
         this.workspace.newBlock('text');
-        chai.assert.equal(this.deleteOption.displayText(this.scope), 'Delete Block');
+        chai.assert.equal(
+            this.deleteOption.displayText(this.scope), 'Delete Block');
       });
     });
   });
@@ -320,17 +351,20 @@ suite('Context Menu Items', function() {
 
       test('Enabled when block is duplicatable', function() {
         // Block is duplicatable by default
-        chai.assert.equal(this.duplicateOption.preconditionFn(this.scope), 'enabled');
+        chai.assert.equal(
+            this.duplicateOption.preconditionFn(this.scope), 'enabled');
       });
 
       test('Disabled when block is not dupicatable', function() {
         sinon.stub(this.block, 'isDuplicatable').returns(false);
-        chai.assert.equal(this.duplicateOption.preconditionFn(this.scope), 'disabled');
+        chai.assert.equal(
+            this.duplicateOption.preconditionFn(this.scope), 'disabled');
       });
 
       test('Hidden when in flyout', function() {
         this.block.isInFlyout = true;
-        chai.assert.equal(this.duplicateOption.preconditionFn(this.scope), 'hidden');
+        chai.assert.equal(
+            this.duplicateOption.preconditionFn(this.scope), 'hidden');
       });
 
       test('Calls duplicate', function() {
@@ -353,7 +387,8 @@ suite('Context Menu Items', function() {
       });
 
       test('Enabled for normal block', function() {
-        chai.assert.equal(this.commentOption.preconditionFn(this.scope), 'enabled');
+        chai.assert.equal(
+            this.commentOption.preconditionFn(this.scope), 'enabled');
       });
 
       test('Hidden for collapsed block', function() {
@@ -362,30 +397,37 @@ suite('Context Menu Items', function() {
         this.block.render();
         this.block.setCollapsed(true);
 
-        chai.assert.equal(this.commentOption.preconditionFn(this.scope), 'hidden');
+        chai.assert.equal(
+            this.commentOption.preconditionFn(this.scope), 'hidden');
       });
 
       test('Creates comment if one did not exist', function() {
-        chai.assert.isNull(this.block.getCommentIcon(), 'New block should not have a comment');
+        chai.assert.isNull(
+            this.block.getCommentIcon(), 'New block should not have a comment');
         this.commentOption.callback(this.scope);
         chai.assert.exists(this.block.getCommentIcon());
-        chai.assert.isEmpty(this.block.getCommentText(), 'Block should have empty comment text');
+        chai.assert.isEmpty(
+            this.block.getCommentText(),
+            'Block should have empty comment text');
       });
 
       test('Removes comment if block had one', function() {
         this.block.setCommentText('Test comment');
         this.commentOption.callback(this.scope);
-        chai.assert.isNull(this.block.getCommentText(),
+        chai.assert.isNull(
+            this.block.getCommentText(),
             'Block should not have comment after removal');
       });
 
       test('Has correct label for add comment', function() {
-        chai.assert.equal(this.commentOption.displayText(this.scope), 'Add Comment');
+        chai.assert.equal(
+            this.commentOption.displayText(this.scope), 'Add Comment');
       });
 
       test('Has correct label for remove comment', function() {
         this.block.setCommentText('Test comment');
-        chai.assert.equal(this.commentOption.displayText(this.scope), 'Remove Comment');
+        chai.assert.equal(
+            this.commentOption.displayText(this.scope), 'Remove Comment');
       });
     });
 
@@ -397,7 +439,8 @@ suite('Context Menu Items', function() {
       test('Enabled when inputs to inline', function() {
         this.block.appendValueInput('test1');
         this.block.appendValueInput('test2');
-        chai.assert.equal(this.inlineOption.preconditionFn(this.scope), 'enabled');
+        chai.assert.equal(
+            this.inlineOption.preconditionFn(this.scope), 'enabled');
       });
     });
   });

--- a/tests/mocha/cursor_test.js
+++ b/tests/mocha/cursor_test.js
@@ -13,50 +13,51 @@ import {ASTNode} from '../../build/src/core/keyboard_nav/ast_node.js';
 suite('Cursor', function() {
   setup(function() {
     sharedTestSetup.call(this);
-    Blockly.defineBlocksWithJsonArray([{
-      "type": "input_statement",
-      "message0": "%1 %2 %3 %4",
-      "args0": [
-        {
-          "type": "field_input",
-          "name": "NAME",
-          "text": "default",
-        },
-        {
-          "type": "field_input",
-          "name": "NAME",
-          "text": "default",
-        },
-        {
-          "type": "input_value",
-          "name": "NAME",
-        },
-        {
-          "type": "input_statement",
-          "name": "NAME",
-        },
-      ],
-      "previousStatement": null,
-      "nextStatement": null,
-      "colour": 230,
-      "tooltip": "",
-      "helpUrl": "",
-    },
-    {
-      "type": "field_input",
-      "message0": "%1",
-      "args0": [
-        {
-          "type": "field_input",
-          "name": "NAME",
-          "text": "default",
-        },
-      ],
-      "output": null,
-      "colour": 230,
-      "tooltip": "",
-      "helpUrl": "",
-    },
+    Blockly.defineBlocksWithJsonArray([
+      {
+        "type": "input_statement",
+        "message0": "%1 %2 %3 %4",
+        "args0": [
+          {
+            "type": "field_input",
+            "name": "NAME",
+            "text": "default",
+          },
+          {
+            "type": "field_input",
+            "name": "NAME",
+            "text": "default",
+          },
+          {
+            "type": "input_value",
+            "name": "NAME",
+          },
+          {
+            "type": "input_statement",
+            "name": "NAME",
+          },
+        ],
+        "previousStatement": null,
+        "nextStatement": null,
+        "colour": 230,
+        "tooltip": "",
+        "helpUrl": "",
+      },
+      {
+        "type": "field_input",
+        "message0": "%1",
+        "args0": [
+          {
+            "type": "field_input",
+            "name": "NAME",
+            "text": "default",
+          },
+        ],
+        "output": null,
+        "colour": 230,
+        "tooltip": "",
+        "helpUrl": "",
+      },
     ]);
     this.workspace = Blockly.inject('blocklyDiv', {});
     this.cursor = this.workspace.getCursor();
@@ -82,15 +83,19 @@ suite('Cursor', function() {
     sharedTestTeardown.call(this);
   });
 
-  test('Next - From a Previous skip over next connection and block', function() {
-    const prevNode = ASTNode.createConnectionNode(this.blocks.A.previousConnection);
-    this.cursor.setCurNode(prevNode);
-    this.cursor.next();
-    const curNode = this.cursor.getCurNode();
-    chai.assert.equal(curNode.getLocation(), this.blocks.B.previousConnection);
-  });
+  test(
+      'Next - From a Previous skip over next connection and block', function() {
+        const prevNode =
+            ASTNode.createConnectionNode(this.blocks.A.previousConnection);
+        this.cursor.setCurNode(prevNode);
+        this.cursor.next();
+        const curNode = this.cursor.getCurNode();
+        chai.assert.equal(
+            curNode.getLocation(), this.blocks.B.previousConnection);
+      });
   test('Next - From last block in a stack go to next connection', function() {
-    const prevNode = ASTNode.createConnectionNode(this.blocks.B.previousConnection);
+    const prevNode =
+        ASTNode.createConnectionNode(this.blocks.B.previousConnection);
     this.cursor.setCurNode(prevNode);
     this.cursor.next();
     const curNode = this.cursor.getCurNode();
@@ -99,11 +104,13 @@ suite('Cursor', function() {
 
   test('In - From output connection', function() {
     const fieldBlock = this.blocks.E;
-    const outputNode = ASTNode.createConnectionNode(fieldBlock.outputConnection);
+    const outputNode =
+        ASTNode.createConnectionNode(fieldBlock.outputConnection);
     this.cursor.setCurNode(outputNode);
     this.cursor.in();
     const curNode = this.cursor.getCurNode();
-    chai.assert.equal(curNode.getLocation(), fieldBlock.inputList[0].fieldRow[0]);
+    chai.assert.equal(
+        curNode.getLocation(), fieldBlock.inputList[0].fieldRow[0]);
   });
 
   test('Prev - From previous connection skip over next connection', function() {

--- a/tests/mocha/dropdowndiv_test.js
+++ b/tests/mocha/dropdowndiv_test.js
@@ -13,8 +13,8 @@ suite('DropDownDiv', function() {
   suite('Positioning', function() {
     setup(function() {
       sharedTestSetup.call(this);
-      this.boundsStub = sinon.stub(Blockly.DropDownDiv.TEST_ONLY, 'getBoundsInfo')
-          .returns({
+      this.boundsStub =
+          sinon.stub(Blockly.DropDownDiv.TEST_ONLY, 'getBoundsInfo').returns({
             left: 0,
             right: 100,
             top: 0,
@@ -22,21 +22,26 @@ suite('DropDownDiv', function() {
             width: 100,
             height: 100,
           });
-      this.sizeStub = sinon.stub(Blockly.utils.style.TEST_ONLY, 'getSizeInternal')
-          .returns({
+      this.sizeStub =
+          sinon.stub(Blockly.utils.style.TEST_ONLY, 'getSizeInternal').returns({
             width: 60,
             height: 60,
           });
-      this.clientHeightStub = sinon.stub(document.documentElement, 'clientHeight')
-          .get(function() {return 1000;});
-      this.clientTopStub = sinon.stub(document.documentElement, 'clientTop')
-          .get(function() {return 0;});
+      this.clientHeightStub =
+          sinon.stub(document.documentElement, 'clientHeight').get(function() {
+            return 1000;
+          });
+      this.clientTopStub =
+          sinon.stub(document.documentElement, 'clientTop').get(function() {
+            return 0;
+          });
     });
     teardown(function() {
       sharedTestTeardown.call(this);
     });
     test('Below, in Bounds', function() {
-      const metrics = Blockly.DropDownDiv.TEST_ONLY.getPositionMetrics(50, 0, 50, -10);
+      const metrics =
+          Blockly.DropDownDiv.TEST_ONLY.getPositionMetrics(50, 0, 50, -10);
       // "Above" in value actually means below in render.
       chai.assert.isAtLeast(metrics.initialY, 0);
       chai.assert.isAbove(metrics.finalY, 0);
@@ -44,7 +49,8 @@ suite('DropDownDiv', function() {
       chai.assert.isTrue(metrics.arrowAtTop);
     });
     test('Above, in Bounds', function() {
-      const metrics = Blockly.DropDownDiv.TEST_ONLY.getPositionMetrics(50, 100, 50, 90);
+      const metrics =
+          Blockly.DropDownDiv.TEST_ONLY.getPositionMetrics(50, 100, 50, 90);
       // "Below" in value actually means above in render.
       chai.assert.isAtMost(metrics.initialY, 100);
       chai.assert.isBelow(metrics.finalY, 100);
@@ -52,7 +58,8 @@ suite('DropDownDiv', function() {
       chai.assert.isFalse(metrics.arrowAtTop);
     });
     test('Below, out of Bounds', function() {
-      const metrics = Blockly.DropDownDiv.TEST_ONLY.getPositionMetrics(50, 60, 50, 50);
+      const metrics =
+          Blockly.DropDownDiv.TEST_ONLY.getPositionMetrics(50, 60, 50, 50);
       // "Above" in value actually means below in render.
       chai.assert.isAtLeast(metrics.initialY, 60);
       chai.assert.isAbove(metrics.finalY, 60);
@@ -60,7 +67,8 @@ suite('DropDownDiv', function() {
       chai.assert.isTrue(metrics.arrowAtTop);
     });
     test('Above, in Bounds', function() {
-      const metrics = Blockly.DropDownDiv.TEST_ONLY.getPositionMetrics(50, 100, 50, 90);
+      const metrics =
+          Blockly.DropDownDiv.TEST_ONLY.getPositionMetrics(50, 100, 50, 90);
       // "Below" in value actually means above in render.
       chai.assert.isAtMost(metrics.initialY, 100);
       chai.assert.isBelow(metrics.finalY, 100);
@@ -68,8 +76,11 @@ suite('DropDownDiv', function() {
       chai.assert.isFalse(metrics.arrowAtTop);
     });
     test('No Solution, Render At Top', function() {
-      this.clientHeightStub.get(function() {return 100;});
-      const metrics = Blockly.DropDownDiv.TEST_ONLY.getPositionMetrics(50, 60, 50, 50);
+      this.clientHeightStub.get(function() {
+        return 100;
+      });
+      const metrics =
+          Blockly.DropDownDiv.TEST_ONLY.getPositionMetrics(50, 60, 50, 50);
       // "Above" in value actually means below in render.
       chai.assert.equal(metrics.initialY, 0);
       chai.assert.equal(metrics.finalY, 0);

--- a/tests/mocha/event_block_create_test.js
+++ b/tests/mocha/event_block_create_test.js
@@ -44,11 +44,9 @@ suite('Block Create Event', function() {
     Blockly.Events.enable();
     block.getInput('INPUT').connection.disconnect();
     assertEventFired(
-        this.eventsFireStub,
-        Blockly.Events.BlockCreate,
+        this.eventsFireStub, Blockly.Events.BlockCreate,
         {'recordUndo': false, 'type': eventUtils.BLOCK_CREATE},
-        this.workspace.id,
-        'shadowId');
+        this.workspace.id, 'shadowId');
     const calls = this.eventsFireStub.getCalls();
     const event = calls[calls.length - 1].args[0];
     chai.assert.equal(event.xml.tagName, 'shadow');
@@ -62,7 +60,7 @@ suite('Block Create Event', function() {
       const json = origEvent.toJson();
       const newEvent = new Blockly.Events.fromJson(json, this.workspace);
       delete origEvent.xml;  // xml fails deep equals for some reason.
-      delete newEvent.xml;  // xml fails deep equals for some reason.
+      delete newEvent.xml;   // xml fails deep equals for some reason.
 
       chai.assert.deepEqual(newEvent, origEvent);
     });

--- a/tests/mocha/event_block_delete_test.js
+++ b/tests/mocha/event_block_delete_test.js
@@ -23,7 +23,7 @@ suite('Block Delete Event', function() {
   suite('Receiving', function() {
     test('blocks do not receive their own delete events', function() {
       Blockly.Blocks['test'] = {
-        onchange: function(e) { },
+        onchange: function(e) {},
       };
       // Need to stub the definition, because the property on the definition is
       // what gets registered as an event listener.
@@ -45,7 +45,7 @@ suite('Block Delete Event', function() {
       const json = origEvent.toJson();
       const newEvent = new Blockly.Events.fromJson(json, this.workspace);
       delete origEvent.oldXml;  // xml fails deep equals for some reason.
-      delete newEvent.oldXml;  // xml fails deep equals for some reason.
+      delete newEvent.oldXml;   // xml fails deep equals for some reason.
 
       chai.assert.deepEqual(newEvent, origEvent);
     });

--- a/tests/mocha/event_bubble_open_test.js
+++ b/tests/mocha/event_bubble_open_test.js
@@ -26,9 +26,8 @@ suite('Bubble Open Event', function() {
   suite('Serialization', function() {
     test('events round-trip through JSON', function() {
       const block = this.workspace.newBlock('jso_block', 'block_id');
-      const origEvent =
-          new Blockly.Events.BubbleOpen(
-              block, true, Blockly.Events.BubbleType.MUTATOR);
+      const origEvent = new Blockly.Events.BubbleOpen(
+          block, true, Blockly.Events.BubbleType.MUTATOR);
 
       const json = origEvent.toJson();
       const newEvent = new Blockly.Events.fromJson(json, this.workspace);

--- a/tests/mocha/event_click_test.js
+++ b/tests/mocha/event_click_test.js
@@ -24,9 +24,8 @@ suite('Click Event', function() {
   suite('Serialization', function() {
     test('events round-trip through JSON', function() {
       const block = this.workspace.newBlock('row_block', 'block_id');
-      const origEvent =
-          new Blockly.Events.Click(
-              block, undefined, Blockly.Events.ClickTarget.BLOCK);
+      const origEvent = new Blockly.Events.Click(
+          block, undefined, Blockly.Events.ClickTarget.BLOCK);
 
       const json = origEvent.toJson();
       const newEvent = new Blockly.Events.fromJson(json, this.workspace);

--- a/tests/mocha/event_comment_create_test.js
+++ b/tests/mocha/event_comment_create_test.js
@@ -29,7 +29,7 @@ suite('Comment Create Event', function() {
       const json = origEvent.toJson();
       const newEvent = new Blockly.Events.fromJson(json, this.workspace);
       delete origEvent.xml;  // xml fails deep equals for some reason.
-      delete newEvent.xml;  // xml fails deep equals for some reason.
+      delete newEvent.xml;   // xml fails deep equals for some reason.
 
       chai.assert.deepEqual(newEvent, origEvent);
     });

--- a/tests/mocha/event_comment_delete_test.js
+++ b/tests/mocha/event_comment_delete_test.js
@@ -29,7 +29,7 @@ suite('Comment Delete Event', function() {
       const json = origEvent.toJson();
       const newEvent = new Blockly.Events.fromJson(json, this.workspace);
       delete origEvent.xml;  // xml fails deep equals for some reason.
-      delete newEvent.xml;  // xml fails deep equals for some reason.
+      delete newEvent.xml;   // xml fails deep equals for some reason.
 
       chai.assert.deepEqual(newEvent, origEvent);
     });

--- a/tests/mocha/event_comment_move_test.js
+++ b/tests/mocha/event_comment_move_test.js
@@ -31,7 +31,7 @@ suite('Comment Move Event', function() {
       const json = origEvent.toJson();
       const newEvent = new Blockly.Events.fromJson(json, this.workspace);
       delete origEvent.comment_;  // Ignore private properties.
-      delete newEvent.comment_;  // Ignore private properties.
+      delete newEvent.comment_;   // Ignore private properties.
 
       chai.assert.deepEqual(newEvent, origEvent);
     });

--- a/tests/mocha/event_marker_move_test.js
+++ b/tests/mocha/event_marker_move_test.js
@@ -28,7 +28,8 @@ suite('Marker Move Event', function() {
       const block2 = this.workspace.newBlock('row_block', 'test_id2');
       const node1 = new Blockly.ASTNode(Blockly.ASTNode.types.BLOCK, block1);
       const node2 = new Blockly.ASTNode(Blockly.ASTNode.types.BLOCK, block2);
-      const origEvent = new Blockly.Events.MarkerMove(block2, false, node1, node2);
+      const origEvent =
+          new Blockly.Events.MarkerMove(block2, false, node1, node2);
 
       const json = origEvent.toJson();
       const newEvent = new Blockly.Events.fromJson(json, this.workspace);

--- a/tests/mocha/event_test.js
+++ b/tests/mocha/event_test.js
@@ -20,21 +20,23 @@ suite('Events', function() {
     sharedTestSetup.call(this, {fireEventsNow: false});
     this.eventsFireSpy = sinon.spy(eventUtils.TEST_ONLY, 'fireInternal');
     this.workspace = new Blockly.Workspace();
-    Blockly.defineBlocksWithJsonArray([{
-      'type': 'field_variable_test_block',
-      'message0': '%1',
-      'args0': [
-        {
-          'type': 'field_variable',
-          'name': 'VAR',
-          'variable': 'item',
-        },
-      ],
-    },
-    {
-      'type': 'simple_test_block',
-      'message0': 'simple test block',
-    }]);
+    Blockly.defineBlocksWithJsonArray([
+      {
+        'type': 'field_variable_test_block',
+        'message0': '%1',
+        'args0': [
+          {
+            'type': 'field_variable',
+            'name': 'VAR',
+            'variable': 'item',
+          },
+        ],
+      },
+      {
+        'type': 'simple_test_block',
+        'message0': 'simple test block',
+      }
+    ]);
   });
 
   teardown(function() {
@@ -49,8 +51,7 @@ suite('Events', function() {
     let block;
     try {
       eventUtils.setGroup('unused');
-      block = new Blockly.Block(
-          workspace, 'simple_test_block');
+      block = new Blockly.Block(workspace, 'simple_test_block');
     } finally {
       eventUtils.setGroup(false);
     }
@@ -69,32 +70,39 @@ suite('Events', function() {
 
     test('UI event without block', function() {
       const event = new Blockly.Events.UiBase(this.workspace.id);
-      assertEventEquals(event, '', this.workspace.id, undefined, {
-        'recordUndo': false,
-        'group': '',
-      }, true);
+      assertEventEquals(
+          event, '', this.workspace.id, undefined, {
+            'recordUndo': false,
+            'group': '',
+          },
+          true);
     });
 
     test('Click without block', function() {
-      const event = new Blockly.Events.Click(null, this.workspace.id, 'workspace');
-      assertEventEquals(event, Blockly.Events.CLICK, this.workspace.id, null, {
-        'targetType': 'workspace',
-        'recordUndo': false,
-        'group': '',
-      }, true);
+      const event =
+          new Blockly.Events.Click(null, this.workspace.id, 'workspace');
+      assertEventEquals(
+          event, Blockly.Events.CLICK, this.workspace.id, null, {
+            'targetType': 'workspace',
+            'recordUndo': false,
+            'group': '',
+          },
+          true);
     });
 
     test('Old UI event without block', function() {
       const TEST_GROUP_ID = 'testGroup';
       eventUtils.setGroup(TEST_GROUP_ID);
       const event = new Blockly.Events.Ui(null, 'foo', 'bar', 'baz');
-      assertEventEquals(event, Blockly.Events.UI, '', null, {
-        'element': 'foo',
-        'oldValue': 'bar',
-        'newValue': 'baz',
-        'recordUndo': false,
-        'group': TEST_GROUP_ID,
-      }, true);
+      assertEventEquals(
+          event, Blockly.Events.UI, '', null, {
+            'element': 'foo',
+            'oldValue': 'bar',
+            'newValue': 'baz',
+            'recordUndo': false,
+            'group': TEST_GROUP_ID,
+          },
+          true);
     });
 
     suite('With simple blocks', function() {
@@ -110,20 +118,18 @@ suite('Events', function() {
       test('Block base', function() {
         const event = new Blockly.Events.BlockBase(this.block);
         sinon.assert.calledOnce(this.genUidStub);
-        assertEventEquals(event, '',
-            this.workspace.id, this.TEST_BLOCK_ID,
-            {
-              'recordUndo': true,
-              'group': '',
-            });
+        assertEventEquals(event, '', this.workspace.id, this.TEST_BLOCK_ID, {
+          'recordUndo': true,
+          'group': '',
+        });
       });
 
       test('Block create', function() {
         const event = new Blockly.Events.BlockCreate(this.block);
         sinon.assert.calledOnce(this.genUidStub);
-        assertEventEquals(event, Blockly.Events.BLOCK_CREATE,
-            this.workspace.id, this.TEST_BLOCK_ID,
-            {
+        assertEventEquals(
+            event, Blockly.Events.BLOCK_CREATE, this.workspace.id,
+            this.TEST_BLOCK_ID, {
               'recordUndo': true,
               'group': '',
             });
@@ -132,9 +138,9 @@ suite('Events', function() {
       test('Block delete', function() {
         const event = new Blockly.Events.BlockDelete(this.block);
         sinon.assert.calledOnce(this.genUidStub);
-        assertEventEquals(event, Blockly.Events.BLOCK_DELETE,
-            this.workspace.id, this.TEST_BLOCK_ID,
-            {
+        assertEventEquals(
+            event, Blockly.Events.BLOCK_DELETE, this.workspace.id,
+            this.TEST_BLOCK_ID, {
               'recordUndo': true,
               'group': '',
             });
@@ -145,27 +151,29 @@ suite('Events', function() {
         eventUtils.setGroup(TEST_GROUP_ID);
         const event = new Blockly.Events.Ui(this.block, 'foo', 'bar', 'baz');
         sinon.assert.calledOnce(this.genUidStub);
-        assertEventEquals(event, Blockly.Events.UI, this.workspace.id,
-            this.TEST_BLOCK_ID,
-            {
+        assertEventEquals(
+            event, Blockly.Events.UI, this.workspace.id, this.TEST_BLOCK_ID, {
               'element': 'foo',
               'oldValue': 'bar',
               'newValue': 'baz',
               'recordUndo': false,
               'group': TEST_GROUP_ID,
-            }, true);
+            },
+            true);
       });
 
       test('Click with block', function() {
         const TEST_GROUP_ID = 'testGroup';
         eventUtils.setGroup(TEST_GROUP_ID);
         const event = new Blockly.Events.Click(this.block, null, 'block');
-        assertEventEquals(event, Blockly.Events.CLICK, this.workspace.id,
-            this.TEST_BLOCK_ID, {
+        assertEventEquals(
+            event, Blockly.Events.CLICK, this.workspace.id, this.TEST_BLOCK_ID,
+            {
               'targetType': 'block',
               'recordUndo': false,
               'group': TEST_GROUP_ID,
-            }, true);
+            },
+            true);
       });
 
       suite('Block Move', function() {
@@ -175,7 +183,8 @@ suite('Events', function() {
 
           const event = new Blockly.Events.BlockMove(this.block);
           sinon.assert.calledOnce(this.genUidStub);
-          assertEventEquals(event, Blockly.Events.BLOCK_MOVE, this.workspace.id,
+          assertEventEquals(
+              event, Blockly.Events.BLOCK_MOVE, this.workspace.id,
               this.TEST_BLOCK_ID, {
                 'oldParentId': undefined,
                 'oldInputName': undefined,
@@ -192,7 +201,8 @@ suite('Events', function() {
             this.block.xy_ = new Blockly.utils.Coordinate(3, 4);
             const event = new Blockly.Events.BlockMove(this.block);
             sinon.assert.calledTwice(this.genUidStub);
-            assertEventEquals(event, Blockly.Events.BLOCK_MOVE, this.workspace.id,
+            assertEventEquals(
+                event, Blockly.Events.BLOCK_MOVE, this.workspace.id,
                 this.TEST_BLOCK_ID, {
                   'oldParentId': this.TEST_PARENT_ID,
                   'oldInputName': undefined,
@@ -222,22 +232,20 @@ suite('Events', function() {
       test('Block base', function() {
         const event = new Blockly.Events.BlockBase(this.block);
         sinon.assert.calledOnce(this.genUidStub);
-        assertEventEquals(event, '',
-            this.workspace.id, this.TEST_BLOCK_ID,
-            {
-              'varId': undefined,
-              'recordUndo': true,
-              'group': '',
-            });
+        assertEventEquals(event, '', this.workspace.id, this.TEST_BLOCK_ID, {
+          'varId': undefined,
+          'recordUndo': true,
+          'group': '',
+        });
       });
 
       test('Block change', function() {
         const event = new Blockly.Events.BlockChange(
             this.block, 'field', 'FIELD_NAME', 'old', 'new');
         sinon.assert.calledOnce(this.genUidStub);
-        assertEventEquals(event, Blockly.Events.BLOCK_CHANGE,
-            this.workspace.id, this.TEST_BLOCK_ID,
-            {
+        assertEventEquals(
+            event, Blockly.Events.BLOCK_CHANGE, this.workspace.id,
+            this.TEST_BLOCK_ID, {
               'varId': undefined,
               'element': 'field',
               'name': 'FIELD_NAME',
@@ -251,9 +259,9 @@ suite('Events', function() {
       test('Block create', function() {
         const event = new Blockly.Events.BlockCreate(this.block);
         sinon.assert.calledOnce(this.genUidStub);
-        assertEventEquals(event, Blockly.Events.BLOCK_CREATE,
-            this.workspace.id, this.TEST_BLOCK_ID,
-            {
+        assertEventEquals(
+            event, Blockly.Events.BLOCK_CREATE, this.workspace.id,
+            this.TEST_BLOCK_ID, {
               'recordUndo': false,
               'group': '',
             });
@@ -262,9 +270,9 @@ suite('Events', function() {
       test('Block delete', function() {
         const event = new Blockly.Events.BlockDelete(this.block);
         sinon.assert.calledOnce(this.genUidStub);
-        assertEventEquals(event, Blockly.Events.BLOCK_DELETE,
-            this.workspace.id, this.TEST_BLOCK_ID,
-            {
+        assertEventEquals(
+            event, Blockly.Events.BLOCK_DELETE, this.workspace.id,
+            this.TEST_BLOCK_ID, {
               'recordUndo': false,
               'group': '',
             });
@@ -277,9 +285,9 @@ suite('Events', function() {
           this.block.xy_ = new Blockly.utils.Coordinate(3, 4);
           const event = new Blockly.Events.BlockMove(this.block);
           sinon.assert.calledTwice(this.genUidStub);
-          assertEventEquals(event, Blockly.Events.BLOCK_MOVE, this.workspace.id,
-              this.TEST_BLOCK_ID,
-              {
+          assertEventEquals(
+              event, Blockly.Events.BLOCK_MOVE, this.workspace.id,
+              this.TEST_BLOCK_ID, {
                 'oldParentId': this.TEST_PARENT_ID,
                 'oldInputName': undefined,
                 'oldCoordinate': undefined,
@@ -299,16 +307,16 @@ suite('Events', function() {
             [this.TEST_BLOCK_ID, 'test_var_id', 'test_group_id']);
         // Disabling events when creating a block with variable can cause issues
         // at workspace dispose.
-        this.block = new Blockly.Block(
-            this.workspace, 'field_variable_test_block');
+        this.block =
+            new Blockly.Block(this.workspace, 'field_variable_test_block');
       });
 
       test('Block change', function() {
         const event = new Blockly.Events.BlockChange(
             this.block, 'field', 'VAR', 'id1', 'id2');
-        assertEventEquals(event, Blockly.Events.BLOCK_CHANGE, this.workspace.id,
-            this.TEST_BLOCK_ID,
-            {
+        assertEventEquals(
+            event, Blockly.Events.BLOCK_CHANGE, this.workspace.id,
+            this.TEST_BLOCK_ID, {
               'element': 'field',
               'name': 'VAR',
               'oldValue': 'id1',
@@ -336,109 +344,235 @@ suite('Events', function() {
       });
     };
     const variableEventTestCases = [
-      {title: 'Var create', class: Blockly.Events.VarCreate,
+      {
+        title: 'Var create',
+        class: Blockly.Events.VarCreate,
         getArgs: (thisObj) => [thisObj.variable],
-        getExpectedJson: () => ({type: 'var_create', group: '', varId: 'id1',
-          varType: 'type1', varName: 'name1'})},
-      {title: 'Var delete', class: Blockly.Events.VarDelete,
+        getExpectedJson: () => ({
+          type: 'var_create',
+          group: '',
+          varId: 'id1',
+          varType: 'type1',
+          varName: 'name1'
+        })
+      },
+      {
+        title: 'Var delete',
+        class: Blockly.Events.VarDelete,
         getArgs: (thisObj) => [thisObj.variable],
-        getExpectedJson: () => ({type: 'var_delete', group: '', varId: 'id1',
-          varType: 'type1', varName: 'name1'})},
-      {title: 'Var rename', class: Blockly.Events.VarRename,
+        getExpectedJson: () => ({
+          type: 'var_delete',
+          group: '',
+          varId: 'id1',
+          varType: 'type1',
+          varName: 'name1'
+        })
+      },
+      {
+        title: 'Var rename',
+        class: Blockly.Events.VarRename,
         getArgs: (thisObj) => [thisObj.variable, 'name2'],
-        getExpectedJson: () => ({type: 'var_rename', group: '', varId: 'id1',
-          oldName: 'name1', newName: 'name2'})},
+        getExpectedJson: () => ({
+          type: 'var_rename',
+          group: '',
+          varId: 'id1',
+          oldName: 'name1',
+          newName: 'name2'
+        })
+      },
     ];
     const uiEventTestCases = [
-      {title: 'Bubble open', class: Blockly.Events.BubbleOpen,
+      {
+        title: 'Bubble open',
+        class: Blockly.Events.BubbleOpen,
         getArgs: (thisObj) => [thisObj.block, true, 'mutator'],
-        getExpectedJson: (thisObj) => ({type: 'bubble_open', group: '', isOpen: true,
-          bubbleType: 'mutator', blockId: thisObj.block.id})},
-      {title: 'Block click', class: Blockly.Events.Click,
+        getExpectedJson: (thisObj) => ({
+          type: 'bubble_open',
+          group: '',
+          isOpen: true,
+          bubbleType: 'mutator',
+          blockId: thisObj.block.id
+        })
+      },
+      {
+        title: 'Block click',
+        class: Blockly.Events.Click,
         getArgs: (thisObj) => [thisObj.block, null, 'block'],
-        getExpectedJson: (thisObj) => ({type: 'click', group: '', targetType: 'block',
-          blockId: thisObj.block.id})},
-      {title: 'Workspace click', class: Blockly.Events.Click,
+        getExpectedJson: (thisObj) => ({
+          type: 'click',
+          group: '',
+          targetType: 'block',
+          blockId: thisObj.block.id
+        })
+      },
+      {
+        title: 'Workspace click',
+        class: Blockly.Events.Click,
         getArgs: (thisObj) => [null, thisObj.workspace.id, 'workspace'],
-        getExpectedJson: (thisObj) => ({type: 'click', group: '',
-          targetType: 'workspace'})},
-      {title: 'Drag start', class: Blockly.Events.BlockDrag,
+        getExpectedJson: (thisObj) =>
+            ({type: 'click', group: '', targetType: 'workspace'})
+      },
+      {
+        title: 'Drag start',
+        class: Blockly.Events.BlockDrag,
         getArgs: (thisObj) => [thisObj.block, true, [thisObj.block]],
-        getExpectedJson: (thisObj) => ({type: 'drag', group: '',
-          isStart: true, blockId: thisObj.block.id, blocks: [thisObj.block]})},
-      {title: 'Drag end', class: Blockly.Events.BlockDrag,
+        getExpectedJson: (thisObj) => ({
+          type: 'drag',
+          group: '',
+          isStart: true,
+          blockId: thisObj.block.id,
+          blocks: [thisObj.block]
+        })
+      },
+      {
+        title: 'Drag end',
+        class: Blockly.Events.BlockDrag,
         getArgs: (thisObj) => [thisObj.block, false, [thisObj.block]],
-        getExpectedJson: (thisObj) => ({type: 'drag', group: '',
-          isStart: false, blockId: thisObj.block.id, blocks: [thisObj.block]})},
-      {title: 'null to Block Marker move', class: Blockly.Events.MarkerMove,
-        getArgs: (thisObj) => [thisObj.block, true, null,
-          new ASTNode(ASTNode.types.BLOCK, thisObj.block)],
-        getExpectedJson: (thisObj) => ({type: 'marker_move', group: '',
-          isCursor: true, blockId: thisObj.block.id, oldNode: undefined,
-          newNode: new ASTNode(ASTNode.types.BLOCK,
-              thisObj.block)})},
-      {title: 'null to Workspace Marker move', class: Blockly.Events.MarkerMove,
-        getArgs: (thisObj) => [null, true, null,
-          ASTNode.createWorkspaceNode(thisObj.workspace,
-              new Blockly.utils.Coordinate(0, 0))],
-        getExpectedJson: (thisObj) => ({type: 'marker_move', group: '',
-          isCursor: true, blockId: undefined, oldNode: undefined,
-          newNode: ASTNode.createWorkspaceNode(thisObj.workspace,
-              new Blockly.utils.Coordinate(0, 0))})},
-      {title: 'Workspace to Block Marker move',
+        getExpectedJson: (thisObj) => ({
+          type: 'drag',
+          group: '',
+          isStart: false,
+          blockId: thisObj.block.id,
+          blocks: [thisObj.block]
+        })
+      },
+      {
+        title: 'null to Block Marker move',
         class: Blockly.Events.MarkerMove,
-        getArgs: (thisObj) => [thisObj.block, true,
-          ASTNode.createWorkspaceNode(thisObj.workspace,
-              new Blockly.utils.Coordinate(0, 0)),
-          new ASTNode(ASTNode.types.BLOCK, thisObj.block)],
-        getExpectedJson: (thisObj) => ({type: 'marker_move', group: '',
-          isCursor: true, blockId: thisObj.block.id,
-          oldNode: ASTNode.createWorkspaceNode(thisObj.workspace,
-              new Blockly.utils.Coordinate(0, 0)),
-          newNode: new ASTNode(ASTNode.types.BLOCK,
-              thisObj.block)})},
-      {title: 'Block to Workspace Marker move',
+        getArgs: (thisObj) =>
+            [thisObj.block, true, null,
+             new ASTNode(ASTNode.types.BLOCK, thisObj.block)],
+        getExpectedJson: (thisObj) => ({
+          type: 'marker_move',
+          group: '',
+          isCursor: true,
+          blockId: thisObj.block.id,
+          oldNode: undefined,
+          newNode: new ASTNode(ASTNode.types.BLOCK, thisObj.block)
+        })
+      },
+      {
+        title: 'null to Workspace Marker move',
         class: Blockly.Events.MarkerMove,
-        getArgs: (thisObj) => [null, true,
-          new ASTNode(ASTNode.types.BLOCK, thisObj.block),
-          ASTNode.createWorkspaceNode(thisObj.workspace,
-              new Blockly.utils.Coordinate(0, 0))]},
-      {title: 'Selected', class: Blockly.Events.Selected,
+        getArgs: (thisObj) =>
+            [null, true, null,
+             ASTNode.createWorkspaceNode(
+                 thisObj.workspace, new Blockly.utils.Coordinate(0, 0))],
+        getExpectedJson: (thisObj) => ({
+          type: 'marker_move',
+          group: '',
+          isCursor: true,
+          blockId: undefined,
+          oldNode: undefined,
+          newNode: ASTNode.createWorkspaceNode(
+              thisObj.workspace, new Blockly.utils.Coordinate(0, 0))
+        })
+      },
+      {
+        title: 'Workspace to Block Marker move',
+        class: Blockly.Events.MarkerMove,
+        getArgs: (thisObj) =>
+            [thisObj.block, true,
+             ASTNode.createWorkspaceNode(
+                 thisObj.workspace, new Blockly.utils.Coordinate(0, 0)),
+             new ASTNode(ASTNode.types.BLOCK, thisObj.block)],
+        getExpectedJson: (thisObj) => ({
+          type: 'marker_move',
+          group: '',
+          isCursor: true,
+          blockId: thisObj.block.id,
+          oldNode: ASTNode.createWorkspaceNode(
+              thisObj.workspace, new Blockly.utils.Coordinate(0, 0)),
+          newNode: new ASTNode(ASTNode.types.BLOCK, thisObj.block)
+        })
+      },
+      {
+        title: 'Block to Workspace Marker move',
+        class: Blockly.Events.MarkerMove,
+        getArgs: (thisObj) =>
+            [null, true, new ASTNode(ASTNode.types.BLOCK, thisObj.block),
+             ASTNode.createWorkspaceNode(
+                 thisObj.workspace, new Blockly.utils.Coordinate(0, 0))]
+      },
+      {
+        title: 'Selected',
+        class: Blockly.Events.Selected,
         getArgs: (thisObj) => [null, thisObj.block.id, thisObj.workspace.id],
-        getExpectedJson: (thisObj) => ({type: 'selected', group: '',
-          newElementId: thisObj.block.id})},
-      {title: 'Selected (deselect)', class: Blockly.Events.Selected,
+        getExpectedJson: (thisObj) =>
+            ({type: 'selected', group: '', newElementId: thisObj.block.id})
+      },
+      {
+        title: 'Selected (deselect)',
+        class: Blockly.Events.Selected,
         getArgs: (thisObj) => [thisObj.block.id, null, thisObj.workspace.id],
-        getExpectedJson: (thisObj) => ({type: 'selected', group: '',
-          oldElementId: thisObj.block.id})},
-      {title: 'Theme Change', class: Blockly.Events.ThemeChange,
+        getExpectedJson: (thisObj) =>
+            ({type: 'selected', group: '', oldElementId: thisObj.block.id})
+      },
+      {
+        title: 'Theme Change',
+        class: Blockly.Events.ThemeChange,
         getArgs: (thisObj) => ['classic', thisObj.workspace.id],
-        getExpectedJson: () => ({type: 'theme_change', group: '', themeName: 'classic'})},
-      {title: 'Toolbox item select',
+        getExpectedJson: () =>
+            ({type: 'theme_change', group: '', themeName: 'classic'})
+      },
+      {
+        title: 'Toolbox item select',
         class: Blockly.Events.ToolboxItemSelect,
         getArgs: (thisObj) => ['Math', 'Loops', thisObj.workspace.id],
-        getExpectedJson: () => ({type: 'toolbox_item_select', group: '', oldItem: 'Math',
-          newItem: 'Loops'})},
-      {title: 'Toolbox item select (no previous)',
+        getExpectedJson: () => ({
+          type: 'toolbox_item_select',
+          group: '',
+          oldItem: 'Math',
+          newItem: 'Loops'
+        })
+      },
+      {
+        title: 'Toolbox item select (no previous)',
         class: Blockly.Events.ToolboxItemSelect,
         getArgs: (thisObj) => [null, 'Loops', thisObj.workspace.id],
-        getExpectedJson: () => ({type: 'toolbox_item_select', group: '',
-          newItem: 'Loops'})},
-      {title: 'Toolbox item select (deselect)',
+        getExpectedJson: () =>
+            ({type: 'toolbox_item_select', group: '', newItem: 'Loops'})
+      },
+      {
+        title: 'Toolbox item select (deselect)',
         class: Blockly.Events.ToolboxItemSelect,
         getArgs: (thisObj) => ['Math', null, thisObj.workspace.id],
-        getExpectedJson: () => ({type: 'toolbox_item_select', group: '', oldItem: 'Math'})},
-      {title: 'Trashcan open', class: Blockly.Events.TrashcanOpen,
+        getExpectedJson: () =>
+            ({type: 'toolbox_item_select', group: '', oldItem: 'Math'})
+      },
+      {
+        title: 'Trashcan open',
+        class: Blockly.Events.TrashcanOpen,
         getArgs: (thisObj) => [true, thisObj.workspace.id],
-        getExpectedJson: () => ({type: 'trashcan_open', group: '', isOpen: true})},
-      {title: 'Viewport change', class: Blockly.Events.ViewportChange,
+        getExpectedJson: () =>
+            ({type: 'trashcan_open', group: '', isOpen: true})
+      },
+      {
+        title: 'Viewport change',
+        class: Blockly.Events.ViewportChange,
         getArgs: (thisObj) => [2.666, 1.333, 1.2, thisObj.workspace.id, 1],
-        getExpectedJson: () => ({type: 'viewport_change', group: '', viewTop: 2.666,
-          viewLeft: 1.333, scale: 1.2, oldScale: 1})},
-      {title: 'Viewport change (0,0)', class: Blockly.Events.ViewportChange,
+        getExpectedJson: () => ({
+          type: 'viewport_change',
+          group: '',
+          viewTop: 2.666,
+          viewLeft: 1.333,
+          scale: 1.2,
+          oldScale: 1
+        })
+      },
+      {
+        title: 'Viewport change (0,0)',
+        class: Blockly.Events.ViewportChange,
         getArgs: (thisObj) => [0, 0, 1.2, thisObj.workspace.id, 1],
-        getExpectedJson: () => ({type: 'viewport_change', group: '', viewTop: 0,
-          viewLeft: 0, scale: 1.2, oldScale: 1})},
+        getExpectedJson: () => ({
+          type: 'viewport_change',
+          group: '',
+          viewTop: 0,
+          viewLeft: 0,
+          scale: 1.2,
+          oldScale: 1
+        })
+      },
     ];
     const blockEventTestCases = [
       {
@@ -564,55 +698,93 @@ suite('Events', function() {
       },
     ];
     const workspaceEventTestCases = [
-      {title: 'Finished Loading', class: Blockly.Events.FinishedLoading,
+      {
+        title: 'Finished Loading',
+        class: Blockly.Events.FinishedLoading,
         getArgs: (thisObj) => [thisObj.workspace],
-        getExpectedJson: (thisObj) => ({type: 'finished_loading', group: '',
-          workspaceId: thisObj.workspace.id})},
+        getExpectedJson: (thisObj) => ({
+          type: 'finished_loading',
+          group: '',
+          workspaceId: thisObj.workspace.id
+        })
+      },
     ];
     const workspaceCommentEventTestCases = [
-      {title: 'Comment change', class: Blockly.Events.CommentChange,
+      {
+        title: 'Comment change',
+        class: Blockly.Events.CommentChange,
         getArgs: (thisObj) => [thisObj.comment, 'bar', 'foo'],
-        getExpectedJson: (thisObj) => ({type: 'comment_change', group: '',
-          commentId: thisObj.comment.id, oldContents: 'bar',
-          newContents: 'foo'})},
-      {title: 'Comment create', class: Blockly.Events.CommentCreate,
-        getArgs: (thisObj) => [thisObj.comment],
-        getExpectedJson: (thisObj) => ({type: 'comment_create', group: '',
+        getExpectedJson: (thisObj) => ({
+          type: 'comment_change',
+          group: '',
           commentId: thisObj.comment.id,
-          xml: Blockly.Xml.domToText(thisObj.comment.toXmlWithXY())})},
-      {title: 'Comment delete', class: Blockly.Events.CommentDelete,
+          oldContents: 'bar',
+          newContents: 'foo'
+        })
+      },
+      {
+        title: 'Comment create',
+        class: Blockly.Events.CommentCreate,
         getArgs: (thisObj) => [thisObj.comment],
-        getExpectedJson: (thisObj) => ({type: 'comment_delete', group: '',
+        getExpectedJson: (thisObj) => ({
+          type: 'comment_create',
+          group: '',
           commentId: thisObj.comment.id,
-          xml: Blockly.Xml.domToText(thisObj.comment.toXmlWithXY())})},
+          xml: Blockly.Xml.domToText(thisObj.comment.toXmlWithXY())
+        })
+      },
+      {
+        title: 'Comment delete',
+        class: Blockly.Events.CommentDelete,
+        getArgs: (thisObj) => [thisObj.comment],
+        getExpectedJson: (thisObj) => ({
+          type: 'comment_delete',
+          group: '',
+          commentId: thisObj.comment.id,
+          xml: Blockly.Xml.domToText(thisObj.comment.toXmlWithXY())
+        })
+      },
       // TODO(#4577) Test serialization of move event coordinate properties.
     ];
     const testSuites = [
-      {title: 'Variable events', testCases: variableEventTestCases,
+      {
+        title: 'Variable events',
+        testCases: variableEventTestCases,
         setup: (thisObj) => {
           thisObj.variable =
               thisObj.workspace.createVariable('name1', 'type1', 'id1');
-        }},
-      {title: 'UI events', testCases: uiEventTestCases,
+        }
+      },
+      {
+        title: 'UI events',
+        testCases: uiEventTestCases,
         setup: (thisObj) => {
           thisObj.block = createSimpleTestBlock(thisObj.workspace);
-        }},
-      {title: 'Block events', testCases: blockEventTestCases,
+        }
+      },
+      {
+        title: 'Block events',
+        testCases: blockEventTestCases,
         setup: (thisObj) => {
           createGenUidStubWithReturns(['testBlockId1', 'testBlockId2']);
           thisObj.block = createSimpleTestBlock(thisObj.workspace);
           thisObj.shadowBlock = createSimpleTestBlock(thisObj.workspace);
           thisObj.shadowBlock.setShadow(true);
-        }},
-      {title: 'Workspace events',
+        }
+      },
+      {
+        title: 'Workspace events',
         testCases: workspaceEventTestCases,
-        setup: (_) => {}},
-      {title: 'WorkspaceComment events',
+        setup: (_) => {}
+      },
+      {
+        title: 'WorkspaceComment events',
         testCases: workspaceCommentEventTestCases,
         setup: (thisObj) => {
           thisObj.comment = new Blockly.WorkspaceComment(
               thisObj.workspace, 'comment text', 0, 0, 'comment id');
-        }},
+        }
+      },
     ];
     testSuites.forEach((testSuite) => {
       suite(testSuite.title, function() {
@@ -656,7 +828,7 @@ suite('Events', function() {
 
     /**
      * Check if a variable with the given values exists.
-     * @param {Blockly.Workspace|Blockly.VariableMap} container The workspace  or
+     * @param {Blockly.Workspace|Blockly.VariableMap} container The workspace or
      *     variableMap the checked variable belongs to.
      * @param {!string} name The expected name of the variable.
      * @param {!string} type The expected type of the variable.
@@ -682,9 +854,8 @@ suite('Events', function() {
 
       test('Var create', function() {
         const event = new Blockly.Events.VarCreate(this.variable);
-        assertEventEquals(event, Blockly.Events.VAR_CREATE, this.workspace.id,
-            undefined,
-            {
+        assertEventEquals(
+            event, Blockly.Events.VAR_CREATE, this.workspace.id, undefined, {
               'varId': 'id1',
               'varType': 'type1',
               'varName': 'name1',
@@ -695,9 +866,8 @@ suite('Events', function() {
 
       test('Var delete', function() {
         const event = new Blockly.Events.VarDelete(this.variable);
-        assertEventEquals(event, Blockly.Events.VAR_DELETE, this.workspace.id,
-            undefined,
-            {
+        assertEventEquals(
+            event, Blockly.Events.VAR_DELETE, this.workspace.id, undefined, {
               'varId': 'id1',
               'varType': 'type1',
               'varName': 'name1',
@@ -708,9 +878,8 @@ suite('Events', function() {
 
       test('Var rename', function() {
         const event = new Blockly.Events.VarRename(this.variable, 'name2');
-        assertEventEquals(event, Blockly.Events.VAR_RENAME, this.workspace.id,
-            undefined,
-            {
+        assertEventEquals(
+            event, Blockly.Events.VAR_RENAME, this.workspace.id, undefined, {
               'varId': 'id1',
               'oldName': 'name1',
               'newName': 'name2',
@@ -722,8 +891,12 @@ suite('Events', function() {
 
     suite('Run Forward', function() {
       test('Var create', function() {
-        const json = {type: "var_create", varId: "id2", varType: "type2",
-          varName: "name2"};
+        const json = {
+          type: "var_create",
+          varId: "id2",
+          varType: "type2",
+          varName: "name2"
+        };
         const event = eventUtils.fromJson(json, this.workspace);
         const x = this.workspace.getVariableById('id2');
         chai.assert.isNull(x);
@@ -753,8 +926,12 @@ suite('Events', function() {
       });
 
       test('Var delete', function() {
-        const json = {type: "var_delete", varId: "id2", varType: "type2",
-          varName: "name2"};
+        const json = {
+          type: "var_delete",
+          varId: "id2",
+          varType: "type2",
+          varName: "name2"
+        };
         const event = eventUtils.fromJson(json, this.workspace);
         chai.assert.isNull(this.workspace.getVariableById('id2'));
         event.run(false);
@@ -792,11 +969,14 @@ suite('Events', function() {
         new Blockly.Events.Click(block),
       ];
       const filteredEvents = eventUtils.filter(events, true);
-      chai.assert.equal(filteredEvents.length, 4);  // no event should have been removed.
+      chai.assert.equal(
+          filteredEvents.length, 4);  // no event should have been removed.
       // test that the order hasn't changed
-      chai.assert.isTrue(filteredEvents[0] instanceof Blockly.Events.BlockCreate);
+      chai.assert.isTrue(
+          filteredEvents[0] instanceof Blockly.Events.BlockCreate);
       chai.assert.isTrue(filteredEvents[1] instanceof Blockly.Events.BlockMove);
-      chai.assert.isTrue(filteredEvents[2] instanceof Blockly.Events.BlockChange);
+      chai.assert.isTrue(
+          filteredEvents[2] instanceof Blockly.Events.BlockChange);
       chai.assert.isTrue(filteredEvents[3] instanceof Blockly.Events.Click);
     });
 
@@ -810,7 +990,8 @@ suite('Events', function() {
         new Blockly.Events.BlockMove(block2),
       ];
       const filteredEvents = eventUtils.filter(events, true);
-      chai.assert.equal(filteredEvents.length, 4);  // no event should have been removed.
+      chai.assert.equal(
+          filteredEvents.length, 4);  // no event should have been removed.
     });
 
     test('Forward', function() {
@@ -820,9 +1001,12 @@ suite('Events', function() {
       addMoveEvent(events, block, 2, 2);
       addMoveEvent(events, block, 3, 3);
       const filteredEvents = eventUtils.filter(events, true);
-      chai.assert.equal(filteredEvents.length, 2);  // duplicate moves should have been removed.
+      chai.assert.equal(
+          filteredEvents.length,
+          2);  // duplicate moves should have been removed.
       // test that the order hasn't changed
-      chai.assert.isTrue(filteredEvents[0] instanceof Blockly.Events.BlockCreate);
+      chai.assert.isTrue(
+          filteredEvents[0] instanceof Blockly.Events.BlockCreate);
       chai.assert.isTrue(filteredEvents[1] instanceof Blockly.Events.BlockMove);
       chai.assert.equal(filteredEvents[1].newCoordinate.x, 3);
       chai.assert.equal(filteredEvents[1].newCoordinate.y, 3);
@@ -835,9 +1019,12 @@ suite('Events', function() {
       addMoveEvent(events, block, 2, 2);
       addMoveEvent(events, block, 3, 3);
       const filteredEvents = eventUtils.filter(events, false);
-      chai.assert.equal(filteredEvents.length, 2);  // duplicate event should have been removed.
+      chai.assert.equal(
+          filteredEvents.length,
+          2);  // duplicate event should have been removed.
       // test that the order hasn't changed
-      chai.assert.isTrue(filteredEvents[0] instanceof Blockly.Events.BlockCreate);
+      chai.assert.isTrue(
+          filteredEvents[0] instanceof Blockly.Events.BlockCreate);
       chai.assert.isTrue(filteredEvents[1] instanceof Blockly.Events.BlockMove);
       chai.assert.equal(filteredEvents[1].newCoordinate.x, 1);
       chai.assert.equal(filteredEvents[1].newCoordinate.y, 1);
@@ -849,7 +1036,8 @@ suite('Events', function() {
       addMoveEvent(events, block, 0, 0);
       addMoveEvent(events, block, 1, 1);
       const filteredEvents = eventUtils.filter(events, true);
-      chai.assert.equal(filteredEvents.length, 1);  // second move event merged into first
+      chai.assert.equal(
+          filteredEvents.length, 1);  // second move event merged into first
       chai.assert.equal(filteredEvents[0].newCoordinate.x, 1);
       chai.assert.equal(filteredEvents[0].newCoordinate.y, 1);
     });
@@ -858,10 +1046,12 @@ suite('Events', function() {
       const block1 = this.workspace.newBlock('field_variable_test_block', '1');
       const events = [
         new Blockly.Events.BlockChange(block1, 'field', 'VAR', 'item', 'item1'),
-        new Blockly.Events.BlockChange(block1, 'field', 'VAR', 'item1', 'item2'),
+        new Blockly.Events.BlockChange(
+            block1, 'field', 'VAR', 'item1', 'item2'),
       ];
       const filteredEvents = eventUtils.filter(events, true);
-      chai.assert.equal(filteredEvents.length, 1);  // second change event merged into first
+      chai.assert.equal(
+          filteredEvents.length, 1);  // second change event merged into first
       chai.assert.equal(filteredEvents[0].oldValue, 'item');
       chai.assert.equal(filteredEvents[0].newValue, 'item2');
     });
@@ -872,7 +1062,8 @@ suite('Events', function() {
         new Blockly.Events.ViewportChange(5, 6, 7, this.workspace, 8),
       ];
       const filteredEvents = eventUtils.filter(events, true);
-      chai.assert.equal(filteredEvents.length, 1);  // second change event merged into first
+      chai.assert.equal(
+          filteredEvents.length, 1);  // second change event merged into first
       chai.assert.equal(filteredEvents[0].viewTop, 5);
       chai.assert.equal(filteredEvents[0].viewLeft, 6);
       chai.assert.equal(filteredEvents[0].scale, 7);
@@ -894,9 +1085,12 @@ suite('Events', function() {
       const filteredEvents = eventUtils.filter(events, true);
       // click event merged into corresponding *Open event
       chai.assert.equal(filteredEvents.length, 3);
-      chai.assert.isTrue(filteredEvents[0] instanceof Blockly.Events.BubbleOpen);
-      chai.assert.isTrue(filteredEvents[1] instanceof Blockly.Events.BubbleOpen);
-      chai.assert.isTrue(filteredEvents[2] instanceof Blockly.Events.BubbleOpen);
+      chai.assert.isTrue(
+          filteredEvents[0] instanceof Blockly.Events.BubbleOpen);
+      chai.assert.isTrue(
+          filteredEvents[1] instanceof Blockly.Events.BubbleOpen);
+      chai.assert.isTrue(
+          filteredEvents[2] instanceof Blockly.Events.BubbleOpen);
       chai.assert.equal(filteredEvents[0].bubbleType, 'comment');
       chai.assert.equal(filteredEvents[1].bubbleType, 'mutator');
       chai.assert.equal(filteredEvents[2].bubbleType, 'warning');
@@ -957,7 +1151,8 @@ suite('Events', function() {
       // test that the order hasn't changed
       chai.assert.isTrue(filteredEvents[0] instanceof Blockly.Events.BlockMove);
       chai.assert.isTrue(filteredEvents[1] instanceof Blockly.Events.BlockMove);
-      chai.assert.isTrue(filteredEvents[2] instanceof Blockly.Events.BlockDelete);
+      chai.assert.isTrue(
+          filteredEvents[2] instanceof Blockly.Events.BlockDelete);
       chai.assert.isTrue(filteredEvents[3] instanceof Blockly.Events.BlockMove);
     });
   });
@@ -973,8 +1168,8 @@ suite('Events', function() {
         const toolbox = document.getElementById('toolbox-categories');
         workspaceSvg = Blockly.inject('blocklyDiv', {toolbox: toolbox});
         const TEST_BLOCK_ID = 'test_block_id';
-        const genUidStub = createGenUidStubWithReturns(
-            [TEST_BLOCK_ID, 'test_group_id']);
+        const genUidStub =
+            createGenUidStubWithReturns([TEST_BLOCK_ID, 'test_group_id']);
 
         const block = workspaceSvg.newBlock('');
         block.initSvg();
@@ -998,8 +1193,7 @@ suite('Events', function() {
 
         assertNthCallEventArgEquals(
             this.eventsFireSpy, 0, Blockly.Events.BlockDelete,
-            {oldXml: expectedOldXml, group: ''},
-            workspaceSvg.id, expectedId);
+            {oldXml: expectedOldXml, group: ''}, workspaceSvg.id, expectedId);
 
         // Expect the workspace to not have a variable with ID 'test_block_id'.
         chai.assert.isNull(this.workspace.getVariableById(TEST_BLOCK_ID));
@@ -1020,8 +1214,8 @@ suite('Events', function() {
       // Run all queued events.
       this.clock.runAll();
 
-      // Expect three calls to genUid: one to set the block's ID, one for the event
-      // group's ID, and one for the variable's ID.
+      // Expect three calls to genUid: one to set the block's ID, one for the
+      // event group's ID, and one for the variable's ID.
       sinon.assert.calledThrice(genUidStub);
 
       // Expect two events fired: varCreate and block create.
@@ -1029,8 +1223,8 @@ suite('Events', function() {
       // Expect both events to trigger change listener.
       sinon.assert.calledTwice(this.changeListenerSpy);
       // Both events should be on undo stack
-      chai.assert.equal(this.workspace.undoStack_.length, 2,
-          'Undo stack length');
+      chai.assert.equal(
+          this.workspace.undoStack_.length, 2, 'Undo stack length');
 
       assertNthCallEventArgEquals(
           this.changeListenerSpy, 0, Blockly.Events.VarCreate,
@@ -1074,8 +1268,8 @@ suite('Events', function() {
       // The first varCreate and move event should have been ignored.
       sinon.assert.callCount(this.changeListenerSpy, 3);
       // Expect two events on undo stack: varCreate and block create.
-      chai.assert.equal(this.workspace.undoStack_.length, 2,
-          'Undo stack length');
+      chai.assert.equal(
+          this.workspace.undoStack_.length, 2, 'Undo stack length');
 
       assertNthCallEventArgEquals(
           this.changeListenerSpy, 0, Blockly.Events.VarCreate,
@@ -1112,7 +1306,8 @@ suite('Events', function() {
       // Fire all events
       this.clock.runAll();
 
-      chai.assert.isFalse(block.isEnabled(),
+      chai.assert.isFalse(
+          block.isEnabled(),
           'Expected orphan block to be disabled after creation');
     });
     test('Created procedure block is enabled', function() {
@@ -1126,7 +1321,8 @@ suite('Events', function() {
       // Fire all events
       this.clock.runAll();
 
-      chai.assert.isTrue(functionBlock.isEnabled(),
+      chai.assert.isTrue(
+          functionBlock.isEnabled(),
           'Expected top-level procedure block to be enabled');
     });
     test('Moving a block to top-level disables it', function() {
@@ -1148,8 +1344,8 @@ suite('Events', function() {
       // Fire all events
       this.clock.runAll();
 
-      chai.assert.isFalse(block.isEnabled(),
-          'Expected disconnected block to be disabled');
+      chai.assert.isFalse(
+          block.isEnabled(), 'Expected disconnected block to be disabled');
     });
     test('Giving block a parent enables it', function() {
       this.workspace.addChangeListener(eventUtils.disableOrphans);
@@ -1167,7 +1363,8 @@ suite('Events', function() {
       // Fire all events
       this.clock.runAll();
 
-      chai.assert.isTrue(block.isEnabled(),
+      chai.assert.isTrue(
+          block.isEnabled(),
           'Expected block to be enabled after connecting to parent');
     });
     test('disableOrphans events are not undoable', function() {
@@ -1192,8 +1389,8 @@ suite('Events', function() {
       const disabledEvents = this.workspace.getUndoStack().filter(function(e) {
         return e.element === 'disabled';
       });
-      chai.assert.isEmpty(disabledEvents,
-          'Undo stack should not contain any disabled events');
+      chai.assert.isEmpty(
+          disabledEvents, 'Undo stack should not contain any disabled events');
     });
   });
 });

--- a/tests/mocha/event_test.js
+++ b/tests/mocha/event_test.js
@@ -35,7 +35,7 @@ suite('Events', function() {
       {
         'type': 'simple_test_block',
         'message0': 'simple test block',
-      }
+      },
     ]);
   });
 
@@ -353,8 +353,8 @@ suite('Events', function() {
           group: '',
           varId: 'id1',
           varType: 'type1',
-          varName: 'name1'
-        })
+          varName: 'name1',
+        }),
       },
       {
         title: 'Var delete',
@@ -365,8 +365,8 @@ suite('Events', function() {
           group: '',
           varId: 'id1',
           varType: 'type1',
-          varName: 'name1'
-        })
+          varName: 'name1',
+        }),
       },
       {
         title: 'Var rename',
@@ -377,8 +377,8 @@ suite('Events', function() {
           group: '',
           varId: 'id1',
           oldName: 'name1',
-          newName: 'name2'
-        })
+          newName: 'name2',
+        }),
       },
     ];
     const uiEventTestCases = [
@@ -391,8 +391,8 @@ suite('Events', function() {
           group: '',
           isOpen: true,
           bubbleType: 'mutator',
-          blockId: thisObj.block.id
-        })
+          blockId: thisObj.block.id,
+        }),
       },
       {
         title: 'Block click',
@@ -402,15 +402,15 @@ suite('Events', function() {
           type: 'click',
           group: '',
           targetType: 'block',
-          blockId: thisObj.block.id
-        })
+          blockId: thisObj.block.id,
+        }),
       },
       {
         title: 'Workspace click',
         class: Blockly.Events.Click,
         getArgs: (thisObj) => [null, thisObj.workspace.id, 'workspace'],
         getExpectedJson: (thisObj) =>
-            ({type: 'click', group: '', targetType: 'workspace'})
+            ({type: 'click', group: '', targetType: 'workspace'}),
       },
       {
         title: 'Drag start',
@@ -421,8 +421,8 @@ suite('Events', function() {
           group: '',
           isStart: true,
           blockId: thisObj.block.id,
-          blocks: [thisObj.block]
-        })
+          blocks: [thisObj.block],
+        }),
       },
       {
         title: 'Drag end',
@@ -433,8 +433,8 @@ suite('Events', function() {
           group: '',
           isStart: false,
           blockId: thisObj.block.id,
-          blocks: [thisObj.block]
-        })
+          blocks: [thisObj.block],
+        }),
       },
       {
         title: 'null to Block Marker move',
@@ -448,8 +448,8 @@ suite('Events', function() {
           isCursor: true,
           blockId: thisObj.block.id,
           oldNode: undefined,
-          newNode: new ASTNode(ASTNode.types.BLOCK, thisObj.block)
-        })
+          newNode: new ASTNode(ASTNode.types.BLOCK, thisObj.block),
+        }),
       },
       {
         title: 'null to Workspace Marker move',
@@ -465,8 +465,8 @@ suite('Events', function() {
           blockId: undefined,
           oldNode: undefined,
           newNode: ASTNode.createWorkspaceNode(
-              thisObj.workspace, new Blockly.utils.Coordinate(0, 0))
-        })
+              thisObj.workspace, new Blockly.utils.Coordinate(0, 0)),
+        }),
       },
       {
         title: 'Workspace to Block Marker move',
@@ -483,8 +483,8 @@ suite('Events', function() {
           blockId: thisObj.block.id,
           oldNode: ASTNode.createWorkspaceNode(
               thisObj.workspace, new Blockly.utils.Coordinate(0, 0)),
-          newNode: new ASTNode(ASTNode.types.BLOCK, thisObj.block)
-        })
+          newNode: new ASTNode(ASTNode.types.BLOCK, thisObj.block),
+        }),
       },
       {
         title: 'Block to Workspace Marker move',
@@ -492,28 +492,28 @@ suite('Events', function() {
         getArgs: (thisObj) =>
             [null, true, new ASTNode(ASTNode.types.BLOCK, thisObj.block),
              ASTNode.createWorkspaceNode(
-                 thisObj.workspace, new Blockly.utils.Coordinate(0, 0))]
+                 thisObj.workspace, new Blockly.utils.Coordinate(0, 0))],
       },
       {
         title: 'Selected',
         class: Blockly.Events.Selected,
         getArgs: (thisObj) => [null, thisObj.block.id, thisObj.workspace.id],
         getExpectedJson: (thisObj) =>
-            ({type: 'selected', group: '', newElementId: thisObj.block.id})
+            ({type: 'selected', group: '', newElementId: thisObj.block.id}),
       },
       {
         title: 'Selected (deselect)',
         class: Blockly.Events.Selected,
         getArgs: (thisObj) => [thisObj.block.id, null, thisObj.workspace.id],
         getExpectedJson: (thisObj) =>
-            ({type: 'selected', group: '', oldElementId: thisObj.block.id})
+            ({type: 'selected', group: '', oldElementId: thisObj.block.id}),
       },
       {
         title: 'Theme Change',
         class: Blockly.Events.ThemeChange,
         getArgs: (thisObj) => ['classic', thisObj.workspace.id],
         getExpectedJson: () =>
-            ({type: 'theme_change', group: '', themeName: 'classic'})
+            ({type: 'theme_change', group: '', themeName: 'classic'}),
       },
       {
         title: 'Toolbox item select',
@@ -523,29 +523,29 @@ suite('Events', function() {
           type: 'toolbox_item_select',
           group: '',
           oldItem: 'Math',
-          newItem: 'Loops'
-        })
+          newItem: 'Loops',
+        }),
       },
       {
         title: 'Toolbox item select (no previous)',
         class: Blockly.Events.ToolboxItemSelect,
         getArgs: (thisObj) => [null, 'Loops', thisObj.workspace.id],
         getExpectedJson: () =>
-            ({type: 'toolbox_item_select', group: '', newItem: 'Loops'})
+            ({type: 'toolbox_item_select', group: '', newItem: 'Loops'}),
       },
       {
         title: 'Toolbox item select (deselect)',
         class: Blockly.Events.ToolboxItemSelect,
         getArgs: (thisObj) => ['Math', null, thisObj.workspace.id],
         getExpectedJson: () =>
-            ({type: 'toolbox_item_select', group: '', oldItem: 'Math'})
+            ({type: 'toolbox_item_select', group: '', oldItem: 'Math'}),
       },
       {
         title: 'Trashcan open',
         class: Blockly.Events.TrashcanOpen,
         getArgs: (thisObj) => [true, thisObj.workspace.id],
         getExpectedJson: () =>
-            ({type: 'trashcan_open', group: '', isOpen: true})
+            ({type: 'trashcan_open', group: '', isOpen: true}),
       },
       {
         title: 'Viewport change',
@@ -557,8 +557,8 @@ suite('Events', function() {
           viewTop: 2.666,
           viewLeft: 1.333,
           scale: 1.2,
-          oldScale: 1
-        })
+          oldScale: 1,
+        }),
       },
       {
         title: 'Viewport change (0,0)',
@@ -570,8 +570,8 @@ suite('Events', function() {
           viewTop: 0,
           viewLeft: 0,
           scale: 1.2,
-          oldScale: 1
-        })
+          oldScale: 1,
+        }),
       },
     ];
     const blockEventTestCases = [
@@ -705,8 +705,8 @@ suite('Events', function() {
         getExpectedJson: (thisObj) => ({
           type: 'finished_loading',
           group: '',
-          workspaceId: thisObj.workspace.id
-        })
+          workspaceId: thisObj.workspace.id,
+        }),
       },
     ];
     const workspaceCommentEventTestCases = [
@@ -719,8 +719,8 @@ suite('Events', function() {
           group: '',
           commentId: thisObj.comment.id,
           oldContents: 'bar',
-          newContents: 'foo'
-        })
+          newContents: 'foo',
+        }),
       },
       {
         title: 'Comment create',
@@ -730,8 +730,8 @@ suite('Events', function() {
           type: 'comment_create',
           group: '',
           commentId: thisObj.comment.id,
-          xml: Blockly.Xml.domToText(thisObj.comment.toXmlWithXY())
-        })
+          xml: Blockly.Xml.domToText(thisObj.comment.toXmlWithXY()),
+        }),
       },
       {
         title: 'Comment delete',
@@ -741,8 +741,8 @@ suite('Events', function() {
           type: 'comment_delete',
           group: '',
           commentId: thisObj.comment.id,
-          xml: Blockly.Xml.domToText(thisObj.comment.toXmlWithXY())
-        })
+          xml: Blockly.Xml.domToText(thisObj.comment.toXmlWithXY()),
+        }),
       },
       // TODO(#4577) Test serialization of move event coordinate properties.
     ];
@@ -753,14 +753,14 @@ suite('Events', function() {
         setup: (thisObj) => {
           thisObj.variable =
               thisObj.workspace.createVariable('name1', 'type1', 'id1');
-        }
+        },
       },
       {
         title: 'UI events',
         testCases: uiEventTestCases,
         setup: (thisObj) => {
           thisObj.block = createSimpleTestBlock(thisObj.workspace);
-        }
+        },
       },
       {
         title: 'Block events',
@@ -770,12 +770,12 @@ suite('Events', function() {
           thisObj.block = createSimpleTestBlock(thisObj.workspace);
           thisObj.shadowBlock = createSimpleTestBlock(thisObj.workspace);
           thisObj.shadowBlock.setShadow(true);
-        }
+        },
       },
       {
         title: 'Workspace events',
         testCases: workspaceEventTestCases,
-        setup: (_) => {}
+        setup: (_) => {},
       },
       {
         title: 'WorkspaceComment events',
@@ -783,7 +783,7 @@ suite('Events', function() {
         setup: (thisObj) => {
           thisObj.comment = new Blockly.WorkspaceComment(
               thisObj.workspace, 'comment text', 0, 0, 'comment id');
-        }
+        },
       },
     ];
     testSuites.forEach((testSuite) => {
@@ -895,7 +895,7 @@ suite('Events', function() {
           type: "var_create",
           varId: "id2",
           varType: "type2",
-          varName: "name2"
+          varName: "name2",
         };
         const event = eventUtils.fromJson(json, this.workspace);
         const x = this.workspace.getVariableById('id2');
@@ -930,7 +930,7 @@ suite('Events', function() {
           type: "var_delete",
           varId: "id2",
           varType: "type2",
-          varName: "name2"
+          varName: "name2",
         };
         const event = eventUtils.fromJson(json, this.workspace);
         chai.assert.isNull(this.workspace.getVariableById('id2'));

--- a/tests/mocha/event_toolbox_item_select_test.js
+++ b/tests/mocha/event_toolbox_item_select_test.js
@@ -49,9 +49,8 @@ suite('Toolbox Item Select Event', function() {
   suite('Serialization', function() {
     test('events round-trip through JSON', function() {
       const items = this.workspace.getToolbox().getToolboxItems();
-      const origEvent =
-          new Blockly.Events.ToolboxItemSelect(
-              items[0].getName(), items[1].getName(), this.workspace.id);
+      const origEvent = new Blockly.Events.ToolboxItemSelect(
+          items[0].getName(), items[1].getName(), this.workspace.id);
 
       const json = origEvent.toJson();
       const newEvent = new Blockly.Events.fromJson(json, this.workspace);

--- a/tests/mocha/extensions_test.js
+++ b/tests/mocha/extensions_test.js
@@ -155,24 +155,23 @@ suite('Extensions', function() {
           "mutator": "mutator_test",
         }]);
 
-        // Events code calls mutationToDom and expects it to give back a meaningful
-        // value.
+        // Events code calls mutationToDom and expects it to give back a
+        // meaningful value.
         Blockly.Events.disable();
-        Blockly.Extensions.registerMutator('mutator_test',
-            {
-              domToMutation: function() {
-                return 'domToMutationFn';
-              },
-              mutationToDom: function() {
-                return 'mutationToDomFn';
-              },
-              compose: function() {
-                return 'composeFn';
-              },
-              decompose: function() {
-                return 'decomposeFn';
-              },
-            });
+        Blockly.Extensions.registerMutator('mutator_test', {
+          domToMutation: function() {
+            return 'domToMutationFn';
+          },
+          mutationToDom: function() {
+            return 'mutationToDomFn';
+          },
+          compose: function() {
+            return 'composeFn';
+          },
+          decompose: function() {
+            return 'decomposeFn';
+          },
+        });
 
         const block = new Blockly.Block(this.workspace, 'mutator_test_block');
 
@@ -198,8 +197,8 @@ suite('Extensions', function() {
         chai.assert.isUndefined(
             Blockly.Extensions.TEST_ONLY.allExtensions['extensions_test']);
         const helperFunctionSpy = sinon.spy();
-        Blockly.Extensions.registerMutator('extensions_test',
-            {
+        Blockly.Extensions.registerMutator(
+            'extensions_test', {
               domToMutation: function() {
                 return 'domToMutationFn';
               },
@@ -207,8 +206,7 @@ suite('Extensions', function() {
                 return 'mutationToDomFn';
               },
             },
-            helperFunctionSpy
-        );
+            helperFunctionSpy);
 
         const _ = new Blockly.Block(this.workspace, 'mutator_test_block');
 
@@ -229,15 +227,14 @@ suite('Extensions', function() {
         Blockly.Events.disable();
         chai.assert.isUndefined(
             Blockly.Extensions.TEST_ONLY.allExtensions['mutator_test']);
-        Blockly.Extensions.registerMutator('mutator_test',
-            {
-              domToMutation: function() {
-                return 'domToMutationFn';
-              },
-              mutationToDom: function() {
-                return 'mutationToDomFn';
-              },
-            });
+        Blockly.Extensions.registerMutator('mutator_test', {
+          domToMutation: function() {
+            return 'domToMutationFn';
+          },
+          mutationToDom: function() {
+            return 'mutationToDomFn';
+          },
+        });
 
         const block = new Blockly.Block(this.workspace, 'mutator_test_block');
 
@@ -298,7 +295,7 @@ suite('Extensions', function() {
       this.extensionsCleanup_.push('mixin_bad_colour_');
 
       const TEST_MIXIN_BAD_COLOUR = {
-        colour_: 'bad colour_', // Defined on prototype
+        colour_: 'bad colour_',  // Defined on prototype
       };
 
       chai.assert.isUndefined(
@@ -336,15 +333,14 @@ suite('Extensions', function() {
       Blockly.Events.disable();
       chai.assert.isUndefined(
           Blockly.Extensions.TEST_ONLY.allExtensions['mutator_test']);
-      Blockly.Extensions.registerMutator('mutator_test',
-          {
-            domToMutation: function() {
-              return 'domToMutationFn';
-            },
-            mutationToDom: function() {
-              return 'mutationToDomFn';
-            },
-          });
+      Blockly.Extensions.registerMutator('mutator_test', {
+        domToMutation: function() {
+          return 'domToMutationFn';
+        },
+        mutationToDom: function() {
+          return 'mutationToDomFn';
+        },
+      });
 
       const workspace = this.workspace;
       chai.assert.throws(function() {
@@ -369,15 +365,14 @@ suite('Extensions', function() {
       Blockly.Events.disable();
       chai.assert.isUndefined(
           Blockly.Extensions.TEST_ONLY.allExtensions['mutator_test']);
-      Blockly.Extensions.registerMixin('mutator_test',
-          {
-            domToMutation: function() {
-              return 'domToMutationFn';
-            },
-            mutationToDom: function() {
-              return 'mutationToDomFn';
-            },
-          });
+      Blockly.Extensions.registerMixin('mutator_test', {
+        domToMutation: function() {
+          return 'domToMutationFn';
+        },
+        mutationToDom: function() {
+          return 'mutationToDomFn';
+        },
+      });
 
       const workspace = this.workspace;
       chai.assert.throws(function() {
@@ -448,123 +443,116 @@ suite('Extensions', function() {
       test('No domToMutation', function() {
         this.extensionsCleanup_.push('mutator_test');
         chai.assert.throws(function() {
-          Blockly.Extensions.registerMutator('mutator_test',
-              {
-                mutationToDom: function() {
-                  return 'mutationToDomFn';
-                },
-                compose: function() {
-                  return 'composeFn';
-                },
-                decompose: function() {
-                  return 'decomposeFn';
-                },
-              });
+          Blockly.Extensions.registerMutator('mutator_test', {
+            mutationToDom: function() {
+              return 'mutationToDomFn';
+            },
+            compose: function() {
+              return 'composeFn';
+            },
+            decompose: function() {
+              return 'decomposeFn';
+            },
+          });
         }, /domToMutation/);
       });
 
       test('No mutationToDom', function() {
         this.extensionsCleanup_.push('mutator_test');
         chai.assert.throws(function() {
-          Blockly.Extensions.registerMutator('mutator_test',
-              {
-                domToMutation: function() {
-                  return 'domToMutationFn';
-                },
-                compose: function() {
-                  return 'composeFn';
-                },
-                decompose: function() {
-                  return 'decomposeFn';
-                },
-              });
+          Blockly.Extensions.registerMutator('mutator_test', {
+            domToMutation: function() {
+              return 'domToMutationFn';
+            },
+            compose: function() {
+              return 'composeFn';
+            },
+            decompose: function() {
+              return 'decomposeFn';
+            },
+          });
         }, /mutationToDom/);
       });
 
       test('No saveExtraState', function() {
         this.extensionsCleanup_.push('mutator_test');
         chai.assert.throws(function() {
-          Blockly.Extensions.registerMutator('mutator_test',
-              {
-                loadExtraState: function() {
-                  return 'loadExtraState';
-                },
-                compose: function() {
-                  return 'composeFn';
-                },
-                decompose: function() {
-                  return 'decomposeFn';
-                },
-              });
+          Blockly.Extensions.registerMutator('mutator_test', {
+            loadExtraState: function() {
+              return 'loadExtraState';
+            },
+            compose: function() {
+              return 'composeFn';
+            },
+            decompose: function() {
+              return 'decomposeFn';
+            },
+          });
         }, /saveExtraState/);
       });
 
       test('No loadExtraState', function() {
         this.extensionsCleanup_.push('mutator_test');
         chai.assert.throws(function() {
-          Blockly.Extensions.registerMutator('mutator_test',
-              {
-                saveExtraState: function() {
-                  return 'saveExtraState';
-                },
-                compose: function() {
-                  return 'composeFn';
-                },
-                decompose: function() {
-                  return 'decomposeFn';
-                },
-              });
+          Blockly.Extensions.registerMutator('mutator_test', {
+            saveExtraState: function() {
+              return 'saveExtraState';
+            },
+            compose: function() {
+              return 'composeFn';
+            },
+            decompose: function() {
+              return 'decomposeFn';
+            },
+          });
         }, /loadExtraState/);
       });
 
       test('No serialization hooks', function() {
         this.extensionsCleanup_.push('mutator_test');
         chai.assert.throws(function() {
-          Blockly.Extensions.registerMutator('mutator_test',
-              {
-                compose: function() {
-                  return 'composeFn';
-                },
-                decompose: function() {
-                  return 'decomposeFn';
-                },
-              });
+          Blockly.Extensions.registerMutator('mutator_test', {
+            compose: function() {
+              return 'composeFn';
+            },
+            decompose: function() {
+              return 'decomposeFn';
+            },
+          });
         }, 'Mutations must contain either XML hooks, or JSON hooks, or both');
       });
 
       test('Has decompose but no compose', function() {
         this.extensionsCleanup_.push('mutator_test');
         chai.assert.throws(function() {
-          Blockly.Extensions.registerMutator('mutator_test',
-              {
-                domToMutation: function() {
-                  return 'domToMutationFn';
-                },
-                mutationToDom: function() {
-                  return 'mutationToDomFn';
-                },
-                decompose: function() {
-                  return 'decomposeFn';
-                },
-              });
+          Blockly.Extensions.registerMutator('mutator_test', {
+            domToMutation: function() {
+              return 'domToMutationFn';
+            },
+            mutationToDom: function() {
+              return 'mutationToDomFn';
+            },
+            decompose: function() {
+              return 'decomposeFn';
+            },
+          });
         }, /compose/);
       });
 
       test('Has compose but no decompose', function() {
         this.extensionsCleanup_.push('mutator_test');
         chai.assert.throws(function() {
-          Blockly.Extensions.registerMutator('mutator_test',
-              {
-                domToMutation: function() {
-                  return 'domToMutationFn';
-                },
-                mutationToDom: function() {
-                  return 'mutationToDomFn';
-                },
-                compose: function() {
-                  return 'composeFn';
-                },
-              });
+          Blockly.Extensions.registerMutator('mutator_test', {
+            domToMutation: function() {
+              return 'domToMutationFn';
+            },
+            mutationToDom: function() {
+              return 'mutationToDomFn';
+            },
+            compose: function() {
+              return 'composeFn';
+            },
+          });
         }, /decompose/);
       });
     });

--- a/tests/mocha/field_angle_test.js
+++ b/tests/mocha/field_angle_test.js
@@ -34,7 +34,7 @@ suite('Angle Fields', function() {
     {
       title: 'Negative Infinity String',
       value: '-Infinity',
-      expectedValue: -Infinity
+      expectedValue: -Infinity,
     },
   ];
   /**
@@ -130,7 +130,7 @@ suite('Angle Fields', function() {
           return null;
         },
         value: 2,
-        expectedValue: '1'
+        expectedValue: '1',
       },
       {
         title: 'Force Mult of 30 Validator',
@@ -138,13 +138,13 @@ suite('Angle Fields', function() {
           return Math.round(newValue / 30) * 30;
         },
         value: 25,
-        expectedValue: 30
+        expectedValue: 30,
       },
       {
         title: 'Returns Undefined Validator',
         validator: function() {},
         value: 2,
-        expectedValue: 2
+        expectedValue: 2,
       },
     ];
     testSuites.forEach(function(suiteInfo) {

--- a/tests/mocha/field_angle_test.js
+++ b/tests/mocha/field_angle_test.js
@@ -31,8 +31,11 @@ suite('Angle Fields', function() {
     {title: 'Infinity', value: Infinity, expectedValue: Infinity},
     {title: 'Negative Infinity', value: -Infinity, expectedValue: -Infinity},
     {title: 'Infinity String', value: 'Infinity', expectedValue: Infinity},
-    {title: 'Negative Infinity String', value: '-Infinity',
-      expectedValue: -Infinity},
+    {
+      title: 'Negative Infinity String',
+      value: '-Infinity',
+      expectedValue: -Infinity
+    },
   ];
   /**
    * Configuration for field tests with valid values.
@@ -121,20 +124,28 @@ suite('Angle Fields', function() {
       sinon.restore();
     });
     const testSuites = [
-      {title: 'Null Validator',
-        validator:
-            function() {
-              return null;
-            },
-        value: 2, expectedValue: '1'},
-      {title: 'Force Mult of 30 Validator',
-        validator:
-            function(newValue) {
-              return Math.round(newValue / 30) * 30;
-            },
-        value: 25, expectedValue: 30},
-      {title: 'Returns Undefined Validator', validator: function() {}, value: 2,
-        expectedValue: 2},
+      {
+        title: 'Null Validator',
+        validator: function() {
+          return null;
+        },
+        value: 2,
+        expectedValue: '1'
+      },
+      {
+        title: 'Force Mult of 30 Validator',
+        validator: function(newValue) {
+          return Math.round(newValue / 30) * 30;
+        },
+        value: 25,
+        expectedValue: 30
+      },
+      {
+        title: 'Returns Undefined Validator',
+        validator: function() {},
+        value: 2,
+        expectedValue: 2
+      },
     ];
     testSuites.forEach(function(suiteInfo) {
       suite(suiteInfo.title, function() {

--- a/tests/mocha/field_checkbox_test.js
+++ b/tests/mocha/field_checkbox_test.js
@@ -42,25 +42,25 @@ suite('Checkbox Fields', function() {
       title: 'Boolean true',
       value: true,
       expectedValue: 'TRUE',
-      expectedText: 'true'
+      expectedText: 'true',
     },
     {
       title: 'Boolean false',
       value: false,
       expectedValue: 'FALSE',
-      expectedText: 'false'
+      expectedText: 'false',
     },
     {
       title: 'String TRUE',
       value: 'TRUE',
       expectedValue: 'TRUE',
-      expectedText: 'true'
+      expectedText: 'true',
     },
     {
       title: 'String FALSE',
       value: 'FALSE',
       expectedValue: 'FALSE',
-      expectedText: 'false'
+      expectedText: 'false',
     },
   ];
   const addArgsAndJson = function(testCase) {
@@ -127,7 +127,7 @@ suite('Checkbox Fields', function() {
           return null;
         },
         value: 'FALSE',
-        expectedValue: 'TRUE'
+        expectedValue: 'TRUE',
       },
       {
         title: 'Always True Validator',
@@ -135,7 +135,7 @@ suite('Checkbox Fields', function() {
           return 'TRUE';
         },
         value: 'FALSE',
-        expectedValue: 'TRUE'
+        expectedValue: 'TRUE',
       },
       {
         title: 'Always False Validator',
@@ -143,13 +143,13 @@ suite('Checkbox Fields', function() {
           return 'TRUE';
         },
         value: 'FALSE',
-        expectedValue: 'TRUE'
+        expectedValue: 'TRUE',
       },
       {
         title: 'Returns Undefined Validator',
         validator: function() {},
         value: 'FALSE',
-        expectedValue: 'FALSE'
+        expectedValue: 'FALSE',
       },
     ];
     testSuites.forEach(function(suiteInfo) {

--- a/tests/mocha/field_checkbox_test.js
+++ b/tests/mocha/field_checkbox_test.js
@@ -38,14 +38,30 @@ suite('Checkbox Fields', function() {
    * @type {!Array<!FieldCreationTestCase>}
    */
   const validValueTestCases = [
-    {title: 'Boolean true', value: true, expectedValue: 'TRUE',
-      expectedText: 'true'},
-    {title: 'Boolean false', value: false, expectedValue: 'FALSE',
-      expectedText: 'false'},
-    {title: 'String TRUE', value: 'TRUE', expectedValue: 'TRUE',
-      expectedText: 'true'},
-    {title: 'String FALSE', value: 'FALSE', expectedValue: 'FALSE',
-      expectedText: 'false'},
+    {
+      title: 'Boolean true',
+      value: true,
+      expectedValue: 'TRUE',
+      expectedText: 'true'
+    },
+    {
+      title: 'Boolean false',
+      value: false,
+      expectedValue: 'FALSE',
+      expectedText: 'false'
+    },
+    {
+      title: 'String TRUE',
+      value: 'TRUE',
+      expectedValue: 'TRUE',
+      expectedText: 'true'
+    },
+    {
+      title: 'String FALSE',
+      value: 'FALSE',
+      expectedValue: 'FALSE',
+      expectedText: 'false'
+    },
   ];
   const addArgsAndJson = function(testCase) {
     testCase.args = [testCase.value];
@@ -64,8 +80,7 @@ suite('Checkbox Fields', function() {
    * @param {!Blockly.FieldCheckbox} field The field to check.
    */
   const assertFieldDefault = function(field) {
-    assertFieldValue(
-        field, defaultFieldValue, defaultFieldValue.toLowerCase());
+    assertFieldValue(field, defaultFieldValue, defaultFieldValue.toLowerCase());
   };
   /**
    * Asserts that the field properties are correct based on the test case.
@@ -106,26 +121,36 @@ suite('Checkbox Fields', function() {
       this.field = new Blockly.FieldCheckbox(true);
     });
     const testSuites = [
-      {title: 'Null Validator',
-        validator:
-            function() {
-              return null;
-            },
-        value: 'FALSE', expectedValue: 'TRUE'},
-      {title: 'Always True Validator',
-        validator:
-            function() {
-              return 'TRUE';
-            },
-        value: 'FALSE', expectedValue: 'TRUE'},
-      {title: 'Always False Validator',
-        validator:
-            function() {
-              return 'TRUE';
-            },
-        value: 'FALSE', expectedValue: 'TRUE'},
-      {title: 'Returns Undefined Validator', validator: function() {},
-        value: 'FALSE', expectedValue: 'FALSE'},
+      {
+        title: 'Null Validator',
+        validator: function() {
+          return null;
+        },
+        value: 'FALSE',
+        expectedValue: 'TRUE'
+      },
+      {
+        title: 'Always True Validator',
+        validator: function() {
+          return 'TRUE';
+        },
+        value: 'FALSE',
+        expectedValue: 'TRUE'
+      },
+      {
+        title: 'Always False Validator',
+        validator: function() {
+          return 'TRUE';
+        },
+        value: 'FALSE',
+        expectedValue: 'TRUE'
+      },
+      {
+        title: 'Returns Undefined Validator',
+        validator: function() {},
+        value: 'FALSE',
+        expectedValue: 'FALSE'
+      },
     ];
     testSuites.forEach(function(suiteInfo) {
       suite(suiteInfo.title, function() {
@@ -144,15 +169,17 @@ suite('Checkbox Fields', function() {
   suite('Customizations', function() {
     suite('Check Character', function() {
       function assertCharacter(field, char) {
-        field.fieldGroup_ = Blockly.utils.dom.createSvgElement(
-            Blockly.utils.Svg.G, {}, null);
+        field.fieldGroup_ =
+            Blockly.utils.dom.createSvgElement(Blockly.utils.Svg.G, {}, null);
         field.sourceBlock_ = {
           RTL: false,
           rendered: true,
           workspace: {
             keyboardAccessibilityMode: false,
           },
-          queueRender: function() {field.render_();},
+          queueRender: function() {
+            field.render_();
+          },
           bumpNeighbours: function() {},
         };
         field.constants_ = {
@@ -207,8 +234,8 @@ suite('Checkbox Fields', function() {
         });
         assertCharacter(field, '\u2661');
         field.setCheckCharacter(null);
-        chai.assert(field.textContent_.nodeValue,
-            Blockly.FieldCheckbox.CHECK_CHAR);
+        chai.assert(
+            field.textContent_.nodeValue, Blockly.FieldCheckbox.CHECK_CHAR);
       });
     });
   });

--- a/tests/mocha/field_colour_test.js
+++ b/tests/mocha/field_colour_test.js
@@ -43,61 +43,61 @@ suite('Colour Fields', function() {
       title: '#AAAAAA',
       value: '#AAAAAA',
       expectedValue: '#aaaaaa',
-      expectedText: '#aaa'
+      expectedText: '#aaa',
     },
     {
       title: '#aaaaaa',
       value: '#aaaaaa',
       expectedValue: '#aaaaaa',
-      expectedText: '#aaa'
+      expectedText: '#aaa',
     },
     {
       title: '#AAAA00',
       value: '#AAAA00',
       expectedValue: '#aaaa00',
-      expectedText: '#aa0'
+      expectedText: '#aa0',
     },
     {
       title: '#aaaA00',
       value: '#aaaA00',
       expectedValue: '#aaaa00',
-      expectedText: '#aa0'
+      expectedText: '#aa0',
     },
     {
       title: '#BCBCBC',
       value: '#BCBCBC',
       expectedValue: '#bcbcbc',
-      expectedText: '#bcbcbc'
+      expectedText: '#bcbcbc',
     },
     {
       title: '#bcbcbc',
       value: '#bcbcbc',
       expectedValue: '#bcbcbc',
-      expectedText: '#bcbcbc'
+      expectedText: '#bcbcbc',
     },
     {
       title: '#AA0',
       value: '#AA0',
       expectedValue: '#aaaa00',
-      expectedText: '#aa0'
+      expectedText: '#aa0',
     },
     {
       title: '#aa0',
       value: '#aa0',
       expectedValue: '#aaaa00',
-      expectedText: '#aa0'
+      expectedText: '#aa0',
     },
     {
       title: 'rgb(170, 170, 0)',
       value: 'rgb(170, 170, 0)',
       expectedValue: '#aaaa00',
-      expectedText: '#aa0'
+      expectedText: '#aa0',
     },
     {
       title: 'red',
       value: 'red',
       expectedValue: '#ff0000',
-      expectedText: '#f00'
+      expectedText: '#f00',
     },
   ];
   const addArgsAndJson = function(testCase) {
@@ -187,7 +187,7 @@ suite('Colour Fields', function() {
         },
         value: '#000000',
         expectedValue: '#aaaaaa',
-        expectedText: '#aaa'
+        expectedText: '#aaa',
       },
       {
         title: 'Force Full Red Validator',
@@ -196,14 +196,14 @@ suite('Colour Fields', function() {
         },
         value: '#000000',
         expectedValue: '#ff0000',
-        expectedText: '#f00'
+        expectedText: '#f00',
       },
       {
         title: 'Returns Undefined Validator',
         validator: function() {},
         value: '#000000',
         expectedValue: '#000000',
-        expectedText: '#000'
+        expectedText: '#000',
       },
     ];
     testSuites.forEach(function(suiteInfo) {

--- a/tests/mocha/field_colour_test.js
+++ b/tests/mocha/field_colour_test.js
@@ -39,26 +39,66 @@ suite('Colour Fields', function() {
    */
 
   const validValueTestCases = [
-    {title: '#AAAAAA', value: '#AAAAAA', expectedValue: '#aaaaaa',
-      expectedText: '#aaa'},
-    {title: '#aaaaaa', value: '#aaaaaa', expectedValue: '#aaaaaa',
-      expectedText: '#aaa'},
-    {title: '#AAAA00', value: '#AAAA00', expectedValue: '#aaaa00',
-      expectedText: '#aa0'},
-    {title: '#aaaA00', value: '#aaaA00', expectedValue: '#aaaa00',
-      expectedText: '#aa0'},
-    {title: '#BCBCBC', value: '#BCBCBC', expectedValue: '#bcbcbc',
-      expectedText: '#bcbcbc'},
-    {title: '#bcbcbc', value: '#bcbcbc', expectedValue: '#bcbcbc',
-      expectedText: '#bcbcbc'},
-    {title: '#AA0', value: '#AA0', expectedValue: '#aaaa00',
-      expectedText: '#aa0'},
-    {title: '#aa0', value: '#aa0', expectedValue: '#aaaa00',
-      expectedText: '#aa0'},
-    {title: 'rgb(170, 170, 0)', value: 'rgb(170, 170, 0)',
-      expectedValue: '#aaaa00', expectedText: '#aa0'},
-    {title: 'red', value: 'red', expectedValue: '#ff0000',
-      expectedText: '#f00'},
+    {
+      title: '#AAAAAA',
+      value: '#AAAAAA',
+      expectedValue: '#aaaaaa',
+      expectedText: '#aaa'
+    },
+    {
+      title: '#aaaaaa',
+      value: '#aaaaaa',
+      expectedValue: '#aaaaaa',
+      expectedText: '#aaa'
+    },
+    {
+      title: '#AAAA00',
+      value: '#AAAA00',
+      expectedValue: '#aaaa00',
+      expectedText: '#aa0'
+    },
+    {
+      title: '#aaaA00',
+      value: '#aaaA00',
+      expectedValue: '#aaaa00',
+      expectedText: '#aa0'
+    },
+    {
+      title: '#BCBCBC',
+      value: '#BCBCBC',
+      expectedValue: '#bcbcbc',
+      expectedText: '#bcbcbc'
+    },
+    {
+      title: '#bcbcbc',
+      value: '#bcbcbc',
+      expectedValue: '#bcbcbc',
+      expectedText: '#bcbcbc'
+    },
+    {
+      title: '#AA0',
+      value: '#AA0',
+      expectedValue: '#aaaa00',
+      expectedText: '#aa0'
+    },
+    {
+      title: '#aa0',
+      value: '#aa0',
+      expectedValue: '#aaaa00',
+      expectedText: '#aa0'
+    },
+    {
+      title: 'rgb(170, 170, 0)',
+      value: 'rgb(170, 170, 0)',
+      expectedValue: '#aaaa00',
+      expectedText: '#aa0'
+    },
+    {
+      title: 'red',
+      value: 'red',
+      expectedValue: '#ff0000',
+      expectedText: '#f00'
+    },
   ];
   const addArgsAndJson = function(testCase) {
     testCase.args = [testCase.value];
@@ -76,15 +116,14 @@ suite('Colour Fields', function() {
    * The expected default text for the field being tested.
    * @type {*}
    */
-  const defaultTextValue = (
-    function() {
-      let expectedText = defaultFieldValue;
-      const m = defaultFieldValue.match(/^#(.)\1(.)\2(.)\3$/);
-      if (m) {
-        expectedText = '#' + m[1] + m[2] + m[3];
-      }
-      return expectedText;
-    })();
+  const defaultTextValue = (function() {
+    let expectedText = defaultFieldValue;
+    const m = defaultFieldValue.match(/^#(.)\1(.)\2(.)\3$/);
+    if (m) {
+      expectedText = '#' + m[1] + m[2] + m[3];
+    }
+    return expectedText;
+  })();
   /**
    * Asserts that the field property values are set to default.
    * @param {FieldTemplate} field The field to check.
@@ -98,8 +137,7 @@ suite('Colour Fields', function() {
    * @param {!FieldValueTestCase} testCase The test case.
    */
   const validTestCaseAssertField = function(field, testCase) {
-    assertFieldValue(
-        field, testCase.expectedValue, testCase.expectedText);
+    assertFieldValue(field, testCase.expectedValue, testCase.expectedText);
   };
 
   runConstructorSuiteTests(
@@ -142,20 +180,31 @@ suite('Colour Fields', function() {
       this.field = new Blockly.FieldColour('#aaaaaa');
     });
     const testSuites = [
-      {title: 'Null Validator',
-        validator:
-            function() {
-              return null;
-            },
-        value: '#000000', expectedValue: '#aaaaaa', expectedText: '#aaa'},
-      {title: 'Force Full Red Validator',
-        validator:
-            function(newValue) {
-              return '#ff' + newValue.substr(3, 4);
-            },
-        value: '#000000', expectedValue: '#ff0000', expectedText: '#f00'},
-      {title: 'Returns Undefined Validator', validator: function() {},
-        value: '#000000', expectedValue: '#000000', expectedText: '#000'},
+      {
+        title: 'Null Validator',
+        validator: function() {
+          return null;
+        },
+        value: '#000000',
+        expectedValue: '#aaaaaa',
+        expectedText: '#aaa'
+      },
+      {
+        title: 'Force Full Red Validator',
+        validator: function(newValue) {
+          return '#ff' + newValue.substr(3, 4);
+        },
+        value: '#000000',
+        expectedValue: '#ff0000',
+        expectedText: '#f00'
+      },
+      {
+        title: 'Returns Undefined Validator',
+        validator: function() {},
+        value: '#000000',
+        expectedValue: '#000000',
+        expectedText: '#000'
+      },
     ];
     testSuites.forEach(function(suiteInfo) {
       suite(suiteInfo.title, function() {
@@ -179,8 +228,7 @@ suite('Colour Fields', function() {
         while (node) {
           chai.assert.equal(node.getAttribute('title'), titles[index]);
           chai.assert.equal(
-              Blockly.utils.colour.parse(
-                  node.style.backgroundColor),
+              Blockly.utils.colour.parse(node.style.backgroundColor),
               colours[index]);
 
           let nextNode = node.nextSibling;
@@ -238,8 +286,8 @@ suite('Colour Fields', function() {
       test('Some Titles Undefined', function() {
         const field = new Blockly.FieldColour();
         field.setColours(['#aaaaaa', '#ff0000'], ['grey']);
-        assertColoursAndTitles(field,
-            ['#aaaaaa', '#ff0000'], ['grey', '#ff0000']);
+        assertColoursAndTitles(
+            field, ['#aaaaaa', '#ff0000'], ['grey', '#ff0000']);
       });
       // This is kinda derpy behavior, but I wanted to document it.
       test('Overwriting Colours While Leaving Titles', function() {

--- a/tests/mocha/field_dropdown_test.js
+++ b/tests/mocha/field_dropdown_test.js
@@ -38,11 +38,11 @@ suite('Dropdown Fields', function() {
     {title: 'Array Items not Arrays', args: [undefined]},
     {
       title: 'Array Items with Invalid IDs',
-      args: [[['1', 1], ['2', 2], ['3', 3]]]
+      args: [[['1', 1], ['2', 2], ['3', 3]]],
     },
     {
       title: 'Array Items with Invalid Content',
-      args: [[[1, '1'], [2, '2'], [3, '3']]]
+      args: [[[1, '1'], [2, '2'], [3, '3']]],
     },
   ];
   /**
@@ -55,7 +55,7 @@ suite('Dropdown Fields', function() {
       value: 'A',
       expectedValue: 'A',
       expectedText: 'a',
-      args: [[['a', 'A'], ['b', 'B'], ['c', 'C']]]
+      args: [[['a', 'A'], ['b', 'B'], ['c', 'C']]],
     },
     {
       title: 'Image Dropdown',
@@ -63,9 +63,10 @@ suite('Dropdown Fields', function() {
       expectedValue: 'A',
       expectedText: 'a',
       args: [[
-        [{src: 'scrA', alt: 'a'}, 'A'], [{src: 'scrB', alt: 'b'}, 'B'],
-        [{src: 'scrC', alt: 'c'}, 'C']
-      ]]
+        [{src: 'scrA', alt: 'a'}, 'A'],
+        [{src: 'scrB', alt: 'b'}, 'B'],
+        [{src: 'scrC', alt: 'c'}, 'C'],
+      ]],
     },
     {
       title: 'Dynamic Text Dropdown',
@@ -74,7 +75,7 @@ suite('Dropdown Fields', function() {
       expectedText: 'a',
       args: [() => {
         return [['a', 'A'], ['b', 'B'], ['c', 'C']];
-      }]
+      }],
     },
     {
       title: 'Dynamic Image Dropdown',
@@ -83,10 +84,11 @@ suite('Dropdown Fields', function() {
       expectedText: 'a',
       args: [() => {
         return [
-          [{src: 'scrA', alt: 'a'}, 'A'], [{src: 'scrB', alt: 'b'}, 'B'],
-          [{src: 'scrC', alt: 'c'}, 'C']
+          [{src: 'scrA', alt: 'a'}, 'A'],
+          [{src: 'scrB', alt: 'b'}, 'B'],
+          [{src: 'scrC', alt: 'c'}, 'C'],
         ];
-      }]
+      }],
     },
   ];
   const addJson = function(testCase) {
@@ -146,8 +148,12 @@ suite('Dropdown Fields', function() {
   suite('Validators', function() {
     setup(function() {
       this.dropdownField = new Blockly.FieldDropdown([
-        ["1a", "1A"], ["1b", "1B"], ["1c", "1C"], ["2a", "2A"], ["2b", "2B"],
-        ["2c", "2C"]
+        ["1a", "1A"],
+        ["1b", "1B"],
+        ["1c", "1C"],
+        ["2a", "2A"],
+        ["2b", "2B"],
+        ["2c", "2C"],
       ]);
     });
     teardown(function() {

--- a/tests/mocha/field_dropdown_test.js
+++ b/tests/mocha/field_dropdown_test.js
@@ -36,34 +36,58 @@ suite('Dropdown Fields', function() {
   const invalidValueCreationTestCases = [
     {title: 'Undefined', args: [undefined]},
     {title: 'Array Items not Arrays', args: [undefined]},
-    {title: 'Array Items with Invalid IDs',
-      args: [[['1', 1], ['2', 2], ['3', 3]]]},
-    {title: 'Array Items with Invalid Content',
-      args: [[[1, '1'], [2, '2'], [3, '3']]]},
+    {
+      title: 'Array Items with Invalid IDs',
+      args: [[['1', 1], ['2', 2], ['3', 3]]]
+    },
+    {
+      title: 'Array Items with Invalid Content',
+      args: [[[1, '1'], [2, '2'], [3, '3']]]
+    },
   ];
   /**
    * Configuration for field tests with valid values.
    * @type {!Array<!FieldCreationTestCase>}
    */
   const validValueCreationTestCases = [
-    {title: 'Text Dropdown', value: 'A', expectedValue: 'A', expectedText: 'a',
-      args: [[['a', 'A'], ['b', 'B'], ['c', 'C']]]},
-    {title: 'Image Dropdown', value: 'A', expectedValue: 'A', expectedText: 'a',
+    {
+      title: 'Text Dropdown',
+      value: 'A',
+      expectedValue: 'A',
+      expectedText: 'a',
+      args: [[['a', 'A'], ['b', 'B'], ['c', 'C']]]
+    },
+    {
+      title: 'Image Dropdown',
+      value: 'A',
+      expectedValue: 'A',
+      expectedText: 'a',
       args: [[
-        [{src: 'scrA', alt: 'a'}, 'A'],
-        [{src: 'scrB', alt: 'b'}, 'B'],
-        [{src: 'scrC', alt: 'c'}, 'C']]]},
-    {title: 'Dynamic Text Dropdown', value: 'A', expectedValue: 'A', expectedText: 'a',
+        [{src: 'scrA', alt: 'a'}, 'A'], [{src: 'scrB', alt: 'b'}, 'B'],
+        [{src: 'scrC', alt: 'c'}, 'C']
+      ]]
+    },
+    {
+      title: 'Dynamic Text Dropdown',
+      value: 'A',
+      expectedValue: 'A',
+      expectedText: 'a',
       args: [() => {
         return [['a', 'A'], ['b', 'B'], ['c', 'C']];
-      }]},
-    {title: 'Dynamic Image Dropdown', value: 'A', expectedValue: 'A', expectedText: 'a',
+      }]
+    },
+    {
+      title: 'Dynamic Image Dropdown',
+      value: 'A',
+      expectedValue: 'A',
+      expectedText: 'a',
       args: [() => {
         return [
-          [{src: 'scrA', alt: 'a'}, 'A'],
-          [{src: 'scrB', alt: 'b'}, 'B'],
-          [{src: 'scrC', alt: 'c'}, 'C']];
-      }]},
+          [{src: 'scrA', alt: 'a'}, 'A'], [{src: 'scrB', alt: 'b'}, 'B'],
+          [{src: 'scrC', alt: 'c'}, 'C']
+        ];
+      }]
+    },
   ];
   const addJson = function(testCase) {
     testCase.json = {'options': testCase.args[0]};
@@ -107,8 +131,8 @@ suite('Dropdown Fields', function() {
 
   suite('setValue', function() {
     setup(function() {
-      this.field = new Blockly.FieldDropdown(
-          [['a', 'A'], ['b', 'B'], ['c', 'C']]);
+      this.field =
+          new Blockly.FieldDropdown([['a', 'A'], ['b', 'B'], ['c', 'C']]);
     });
     runSetValueTests(
         validValueSetValueTestCases, invalidValueSetValueTestCases, 'A', 'a');
@@ -122,8 +146,9 @@ suite('Dropdown Fields', function() {
   suite('Validators', function() {
     setup(function() {
       this.dropdownField = new Blockly.FieldDropdown([
-        ["1a", "1A"], ["1b", "1B"], ["1c", "1C"],
-        ["2a", "2A"], ["2b", "2B"], ["2c", "2C"]]);
+        ["1a", "1A"], ["1b", "1B"], ["1c", "1C"], ["2a", "2A"], ["2b", "2B"],
+        ["2c", "2C"]
+      ]);
     });
     teardown(function() {
       this.dropdownField.setValidator(null);

--- a/tests/mocha/field_image_test.js
+++ b/tests/mocha/field_image_test.js
@@ -26,13 +26,13 @@ suite('Image Fields', function() {
     {
       title: 'Undefined Size',
       value: 'src',
-      args: ['src', undefined, undefined]
+      args: ['src', undefined, undefined],
     },
     {title: 'Zero Size', value: 'src', args: ['src', 0, 0]},
     {
       title: 'Non-Parsable String for Size',
       value: 'src',
-      args: ['src', 'bad', 'bad']
+      args: ['src', 'bad', 'bad'],
     },
   ];
   /**
@@ -45,14 +45,14 @@ suite('Image Fields', function() {
       value: 'src',
       expectedValue: 'src',
       args: ['src', 1, 1, 'alt'],
-      expectedText: 'alt'
+      expectedText: 'alt',
     },
     {
       title: 'Without Alt',
       value: 'src',
       expectedValue: 'src',
       args: ['src', 1, 1],
-      expectedText: ''
+      expectedText: '',
     },
   ];
   /**
@@ -63,7 +63,7 @@ suite('Image Fields', function() {
     testCase.json = {
       'src': testCase.args[0],
       'width': testCase.args[1],
-      'height': testCase.args[2]
+      'height': testCase.args[2],
     };
     if (testCase.args[3]) {
       testCase.json['alt'] = testCase.args[3];
@@ -98,7 +98,7 @@ suite('Image Fields', function() {
       title: 'Good src',
       value: 'newSrc',
       expectedValue: 'newSrc',
-      expectedText: 'alt'
+      expectedText: 'alt',
     },
   ];
 

--- a/tests/mocha/field_image_test.js
+++ b/tests/mocha/field_image_test.js
@@ -23,27 +23,48 @@ suite('Image Fields', function() {
    * @type {!Array<!FieldCreationTestCase>}
    */
   const invalidValueTestCases = [
-    {title: 'Undefined Size', value: 'src', args: ['src', undefined, undefined]},
+    {
+      title: 'Undefined Size',
+      value: 'src',
+      args: ['src', undefined, undefined]
+    },
     {title: 'Zero Size', value: 'src', args: ['src', 0, 0]},
-    {title: 'Non-Parsable String for Size', value: 'src', args: ['src', 'bad', 'bad']},
+    {
+      title: 'Non-Parsable String for Size',
+      value: 'src',
+      args: ['src', 'bad', 'bad']
+    },
   ];
   /**
    * Configuration for field tests with valid values.
    * @type {!Array<!FieldCreationTestCase>}
    */
   const validValueCreationTestCases = [
-    {title: 'With Alt', value: 'src', expectedValue: 'src',
-      args: ['src', 1, 1, 'alt'], expectedText: 'alt'},
-    {title: 'Without Alt', value: 'src', expectedValue: 'src',
-      args: ['src', 1, 1], expectedText: ''},
+    {
+      title: 'With Alt',
+      value: 'src',
+      expectedValue: 'src',
+      args: ['src', 1, 1, 'alt'],
+      expectedText: 'alt'
+    },
+    {
+      title: 'Without Alt',
+      value: 'src',
+      expectedValue: 'src',
+      args: ['src', 1, 1],
+      expectedText: ''
+    },
   ];
   /**
    * Adds json property to test cases based on args property.
    * @param {!Array<!FieldCreationTestCase>} testCase The test case to modify.
    */
   const addJson = function(testCase) {
-    testCase.json = {'src': testCase.args[0], 'width': testCase.args[1],
-      'height': testCase.args[2]};
+    testCase.json = {
+      'src': testCase.args[0],
+      'width': testCase.args[1],
+      'height': testCase.args[2]
+    };
     if (testCase.args[3]) {
       testCase.json['alt'] = testCase.args[3];
     }
@@ -73,8 +94,12 @@ suite('Image Fields', function() {
    * @type {!Array<!FieldValueTestCase>}
    */
   const validValueSetValueTestCases = [
-    {title: 'Good src', value: 'newSrc', expectedValue: 'newSrc',
-      expectedText: 'alt'},
+    {
+      title: 'Good src',
+      value: 'newSrc',
+      expectedValue: 'newSrc',
+      expectedText: 'alt'
+    },
   ];
 
   suite('setValue', function() {

--- a/tests/mocha/field_label_serializable_test.js
+++ b/tests/mocha/field_label_serializable_test.js
@@ -72,8 +72,8 @@ suite('Label Serializable Fields', function() {
       invalidValueTestCases, validTestCaseAssertField, assertFieldDefault);
 
   runFromJsonSuiteTests(
-      Blockly.FieldLabelSerializable, validValueTestCases, invalidValueTestCases,
-      validTestCaseAssertField, assertFieldDefault);
+      Blockly.FieldLabelSerializable, validValueTestCases,
+      invalidValueTestCases, validTestCaseAssertField, assertFieldDefault);
 
   suite('setValue', function() {
     suite('Empty -> New Value', function() {
@@ -105,24 +105,24 @@ suite('Label Serializable Fields', function() {
 
   suite('Customizations', function() {
     function assertHasClass(labelField, cssClass) {
-      labelField.fieldGroup_ = Blockly.utils.dom.createSvgElement(
-          Blockly.utils.Svg.G, {}, null);
+      labelField.fieldGroup_ =
+          Blockly.utils.dom.createSvgElement(Blockly.utils.Svg.G, {}, null);
       labelField.constants_ = {
         FIELD_TEXT_BASELINE_Y: 13,
       };
       labelField.initView();
-      chai.assert.isTrue(Blockly.utils.dom.hasClass(
-          labelField.textElement_, cssClass));
+      chai.assert.isTrue(
+          Blockly.utils.dom.hasClass(labelField.textElement_, cssClass));
     }
     function assertDoesNotHaveClass(labelField, cssClass) {
-      labelField.fieldGroup_ = Blockly.utils.dom.createSvgElement(
-          Blockly.utils.Svg.G, {}, null);
+      labelField.fieldGroup_ =
+          Blockly.utils.dom.createSvgElement(Blockly.utils.Svg.G, {}, null);
       labelField.constants_ = {
         FIELD_TEXT_BASELINE_Y: 13,
       };
       labelField.initView();
-      chai.assert.isFalse(Blockly.utils.dom.hasClass(
-          labelField.textElement_, cssClass));
+      chai.assert.isFalse(
+          Blockly.utils.dom.hasClass(labelField.textElement_, cssClass));
     }
     test('JS Constructor', function() {
       const field = new Blockly.FieldLabelSerializable('text', 'testClass');
@@ -162,16 +162,16 @@ suite('Label Serializable Fields', function() {
     suite('setClass', function() {
       test('setClass', function() {
         const field = new Blockly.FieldLabelSerializable();
-        field.fieldGroup_ = Blockly.utils.dom.createSvgElement(
-            Blockly.utils.Svg.G, {}, null);
+        field.fieldGroup_ =
+            Blockly.utils.dom.createSvgElement(Blockly.utils.Svg.G, {}, null);
         field.constants_ = {
           FIELD_TEXT_BASELINE_Y: 13,
         };
         field.initView();
         field.setClass('testClass');
         // Don't call assertHasClass b/c we don't want to re-initialize.
-        chai.assert.isTrue(Blockly.utils.dom.hasClass(
-            field.textElement_, 'testClass'));
+        chai.assert.isTrue(
+            Blockly.utils.dom.hasClass(field.textElement_, 'testClass'));
       });
       test('setClass Before Initialization', function() {
         const field = new Blockly.FieldLabelSerializable();
@@ -184,8 +184,8 @@ suite('Label Serializable Fields', function() {
         });
         assertHasClass(field, 'testClass');
         field.setClass(null);
-        chai.assert.isFalse(Blockly.utils.dom.hasClass(
-            field.textElement_, 'testClass'));
+        chai.assert.isFalse(
+            Blockly.utils.dom.hasClass(field.textElement_, 'testClass'));
       });
     });
   });

--- a/tests/mocha/field_label_test.js
+++ b/tests/mocha/field_label_test.js
@@ -105,24 +105,24 @@ suite('Label Fields', function() {
 
   suite('Customizations', function() {
     function assertHasClass(labelField, cssClass) {
-      labelField.fieldGroup_ = Blockly.utils.dom.createSvgElement(
-          Blockly.utils.Svg.G, {}, null);
+      labelField.fieldGroup_ =
+          Blockly.utils.dom.createSvgElement(Blockly.utils.Svg.G, {}, null);
       labelField.constants_ = {
         FIELD_TEXT_BASELINE_Y: 13,
       };
       labelField.initView();
-      chai.assert.isTrue(Blockly.utils.dom.hasClass(
-          labelField.textElement_, cssClass));
+      chai.assert.isTrue(
+          Blockly.utils.dom.hasClass(labelField.textElement_, cssClass));
     }
     function assertDoesNotHaveClass(labelField, cssClass) {
-      labelField.fieldGroup_ = Blockly.utils.dom.createSvgElement(
-          Blockly.utils.Svg.G, {}, null);
+      labelField.fieldGroup_ =
+          Blockly.utils.dom.createSvgElement(Blockly.utils.Svg.G, {}, null);
       labelField.constants_ = {
         FIELD_TEXT_BASELINE_Y: 13,
       };
       labelField.initView();
-      chai.assert.isFalse(Blockly.utils.dom.hasClass(
-          labelField.textElement_, cssClass));
+      chai.assert.isFalse(
+          Blockly.utils.dom.hasClass(labelField.textElement_, cssClass));
     }
 
     test('JS Constructor', function() {
@@ -163,16 +163,16 @@ suite('Label Fields', function() {
     suite('setClass', function() {
       test('setClass', function() {
         const field = new Blockly.FieldLabel();
-        field.fieldGroup_ = Blockly.utils.dom.createSvgElement(
-            Blockly.utils.Svg.G, {}, null);
+        field.fieldGroup_ =
+            Blockly.utils.dom.createSvgElement(Blockly.utils.Svg.G, {}, null);
         field.constants_ = {
           FIELD_TEXT_BASELINE_Y: 13,
         };
         field.initView();
         field.setClass('testClass');
         // Don't call assertHasClass b/c we don't want to re-initialize.
-        chai.assert.isTrue(Blockly.utils.dom.hasClass(
-            field.textElement_, 'testClass'));
+        chai.assert.isTrue(
+            Blockly.utils.dom.hasClass(field.textElement_, 'testClass'));
       });
       test('setClass Before Initialization', function() {
         const field = new Blockly.FieldLabel();
@@ -185,8 +185,8 @@ suite('Label Fields', function() {
         });
         assertHasClass(field, 'testClass');
         field.setClass(null);
-        chai.assert.isFalse(Blockly.utils.dom.hasClass(
-            field.textElement_, 'testClass'));
+        chai.assert.isFalse(
+            Blockly.utils.dom.hasClass(field.textElement_, 'testClass'));
       });
     });
   });

--- a/tests/mocha/field_multilineinput_test.js
+++ b/tests/mocha/field_multilineinput_test.js
@@ -43,7 +43,7 @@ suite('Multiline Input Fields', function() {
     {
       title: 'String with newline',
       value: 'bark bark\n bark bark bark\n bark bar bark bark\n',
-      expectedValue: 'bark bark\n bark bark bark\n bark bar bark bark\n'
+      expectedValue: 'bark bark\n bark bark bark\n bark bar bark bark\n',
     },
     {title: 'Boolean true', value: true, expectedValue: 'true'},
     {title: 'Boolean false', value: false, expectedValue: 'false'},
@@ -140,16 +140,16 @@ suite('Multiline Input Fields', function() {
           {
             title: 'Empty string',
             expectedCode: '\'\'',
-            createBlock: createBlockFn('')
+            createBlock: createBlockFn(''),
           },
           {
             title: 'String with newline',
             expectedCode:
                 '\'bark bark\' + \'\\n\' + \n\' bark bark bark\' + \'\\n\' + \n\' bark bar bark bark\' + \'\\n\' + \n\'\'',
             createBlock: createBlockFn(
-                'bark bark\n bark bark bark\n bark bar bark bark\n')
+                'bark bark\n bark bark bark\n bark bar bark bark\n'),
           },
-        ]
+        ],
       },
       {
         title: 'JavaScript',
@@ -158,16 +158,16 @@ suite('Multiline Input Fields', function() {
           {
             title: 'Empty string',
             expectedCode: '\'\'',
-            createBlock: createBlockFn('')
+            createBlock: createBlockFn(''),
           },
           {
             title: 'String with newline',
             expectedCode:
                 '\'bark bark\' + \'\\n\' +\n\' bark bark bark\' + \'\\n\' +\n\' bark bar bark bark\' + \'\\n\' +\n\'\'',
             createBlock: createBlockFn(
-                'bark bark\n bark bark bark\n bark bar bark bark\n')
+                'bark bark\n bark bark bark\n bark bar bark bark\n'),
           },
-        ]
+        ],
       },
       {
         title: 'Lua',
@@ -176,16 +176,16 @@ suite('Multiline Input Fields', function() {
           {
             title: 'Empty string',
             expectedCode: '\'\'',
-            createBlock: createBlockFn('')
+            createBlock: createBlockFn(''),
           },
           {
             title: 'String with newline',
             expectedCode:
                 '\'bark bark\' .. \'\\n\' ..\n\' bark bark bark\' .. \'\\n\' ..\n\' bark bar bark bark\' .. \'\\n\' ..\n\'\'',
             createBlock: createBlockFn(
-                'bark bark\n bark bark bark\n bark bar bark bark\n')
+                'bark bark\n bark bark bark\n bark bar bark bark\n'),
           },
-        ]
+        ],
       },
       {
         title: 'PHP',
@@ -194,16 +194,16 @@ suite('Multiline Input Fields', function() {
           {
             title: 'Empty string',
             expectedCode: '\'\'',
-            createBlock: createBlockFn('')
+            createBlock: createBlockFn(''),
           },
           {
             title: 'String with newline',
             expectedCode:
                 '\'bark bark\' . "\\n" .\n\' bark bark bark\' . "\\n" .\n\' bark bar bark bark\' . "\\n" .\n\'\'',
             createBlock: createBlockFn(
-                'bark bark\n bark bark bark\n bark bar bark bark\n')
+                'bark bark\n bark bark bark\n bark bar bark bark\n'),
           },
-        ]
+        ],
       },
       {
         title: 'Python',
@@ -212,16 +212,16 @@ suite('Multiline Input Fields', function() {
           {
             title: 'Empty string',
             expectedCode: '\'\'',
-            createBlock: createBlockFn('')
+            createBlock: createBlockFn(''),
           },
           {
             title: 'String with newline',
             expectedCode:
                 '\'bark bark\' + \'\\n\' + \n\' bark bark bark\' + \'\\n\' + \n\' bark bar bark bark\' + \'\\n\' + \n\'\'',
             createBlock: createBlockFn(
-                'bark bark\n bark bark bark\n bark bar bark bark\n')
+                'bark bark\n bark bark bark\n bark bar bark bark\n'),
           },
-        ]
+        ],
       },
     ];
     runCodeGenerationTestSuites(testSuites);

--- a/tests/mocha/field_multilineinput_test.js
+++ b/tests/mocha/field_multilineinput_test.js
@@ -40,7 +40,11 @@ suite('Multiline Input Fields', function() {
   const validValueTestCases = [
     {title: 'Empty string', value: '', expectedValue: ''},
     {title: 'String no newline', value: 'value', expectedValue: 'value'},
-    {title: 'String with newline', value: 'bark bark\n bark bark bark\n bark bar bark bark\n', expectedValue: 'bark bark\n bark bark bark\n bark bar bark bark\n'},
+    {
+      title: 'String with newline',
+      value: 'bark bark\n bark bark bark\n bark bar bark bark\n',
+      expectedValue: 'bark bark\n bark bark bark\n bark bar bark bark\n'
+    },
     {title: 'Boolean true', value: true, expectedValue: 'true'},
     {title: 'Boolean false', value: false, expectedValue: 'false'},
     {title: 'Number (Truthy)', value: 1, expectedValue: '1'},
@@ -129,41 +133,96 @@ suite('Multiline Input Fields', function() {
      * @type {Array<CodeGenerationTestSuite>}
      */
     const testSuites = [
-      {title: 'Dart', generator: dartGenerator,
+      {
+        title: 'Dart',
+        generator: dartGenerator,
         testCases: [
-          {title: 'Empty string', expectedCode: '\'\'',
-            createBlock: createBlockFn('')},
-          {title: 'String with newline', expectedCode: '\'bark bark\' + \'\\n\' + \n\' bark bark bark\' + \'\\n\' + \n\' bark bar bark bark\' + \'\\n\' + \n\'\'',
-            createBlock: createBlockFn('bark bark\n bark bark bark\n bark bar bark bark\n')},
-        ]},
-      {title: 'JavaScript', generator: javascriptGenerator,
+          {
+            title: 'Empty string',
+            expectedCode: '\'\'',
+            createBlock: createBlockFn('')
+          },
+          {
+            title: 'String with newline',
+            expectedCode:
+                '\'bark bark\' + \'\\n\' + \n\' bark bark bark\' + \'\\n\' + \n\' bark bar bark bark\' + \'\\n\' + \n\'\'',
+            createBlock: createBlockFn(
+                'bark bark\n bark bark bark\n bark bar bark bark\n')
+          },
+        ]
+      },
+      {
+        title: 'JavaScript',
+        generator: javascriptGenerator,
         testCases: [
-          {title: 'Empty string', expectedCode: '\'\'',
-            createBlock: createBlockFn('')},
-          {title: 'String with newline', expectedCode: '\'bark bark\' + \'\\n\' +\n\' bark bark bark\' + \'\\n\' +\n\' bark bar bark bark\' + \'\\n\' +\n\'\'',
-            createBlock: createBlockFn('bark bark\n bark bark bark\n bark bar bark bark\n')},
-        ]},
-      {title: 'Lua', generator: luaGenerator,
+          {
+            title: 'Empty string',
+            expectedCode: '\'\'',
+            createBlock: createBlockFn('')
+          },
+          {
+            title: 'String with newline',
+            expectedCode:
+                '\'bark bark\' + \'\\n\' +\n\' bark bark bark\' + \'\\n\' +\n\' bark bar bark bark\' + \'\\n\' +\n\'\'',
+            createBlock: createBlockFn(
+                'bark bark\n bark bark bark\n bark bar bark bark\n')
+          },
+        ]
+      },
+      {
+        title: 'Lua',
+        generator: luaGenerator,
         testCases: [
-          {title: 'Empty string', expectedCode: '\'\'',
-            createBlock: createBlockFn('')},
-          {title: 'String with newline', expectedCode: '\'bark bark\' .. \'\\n\' ..\n\' bark bark bark\' .. \'\\n\' ..\n\' bark bar bark bark\' .. \'\\n\' ..\n\'\'',
-            createBlock: createBlockFn('bark bark\n bark bark bark\n bark bar bark bark\n')},
-        ]},
-      {title: 'PHP', generator: phpGenerator,
+          {
+            title: 'Empty string',
+            expectedCode: '\'\'',
+            createBlock: createBlockFn('')
+          },
+          {
+            title: 'String with newline',
+            expectedCode:
+                '\'bark bark\' .. \'\\n\' ..\n\' bark bark bark\' .. \'\\n\' ..\n\' bark bar bark bark\' .. \'\\n\' ..\n\'\'',
+            createBlock: createBlockFn(
+                'bark bark\n bark bark bark\n bark bar bark bark\n')
+          },
+        ]
+      },
+      {
+        title: 'PHP',
+        generator: phpGenerator,
         testCases: [
-          {title: 'Empty string', expectedCode: '\'\'',
-            createBlock: createBlockFn('')},
-          {title: 'String with newline', expectedCode: '\'bark bark\' . "\\n" .\n\' bark bark bark\' . "\\n" .\n\' bark bar bark bark\' . "\\n" .\n\'\'',
-            createBlock: createBlockFn('bark bark\n bark bark bark\n bark bar bark bark\n')},
-        ]},
-      {title: 'Python', generator: pythonGenerator,
+          {
+            title: 'Empty string',
+            expectedCode: '\'\'',
+            createBlock: createBlockFn('')
+          },
+          {
+            title: 'String with newline',
+            expectedCode:
+                '\'bark bark\' . "\\n" .\n\' bark bark bark\' . "\\n" .\n\' bark bar bark bark\' . "\\n" .\n\'\'',
+            createBlock: createBlockFn(
+                'bark bark\n bark bark bark\n bark bar bark bark\n')
+          },
+        ]
+      },
+      {
+        title: 'Python',
+        generator: pythonGenerator,
         testCases: [
-          {title: 'Empty string', expectedCode: '\'\'',
-            createBlock: createBlockFn('')},
-          {title: 'String with newline', expectedCode: '\'bark bark\' + \'\\n\' + \n\' bark bark bark\' + \'\\n\' + \n\' bark bar bark bark\' + \'\\n\' + \n\'\'',
-            createBlock: createBlockFn('bark bark\n bark bark bark\n bark bar bark bark\n')},
-        ]},
+          {
+            title: 'Empty string',
+            expectedCode: '\'\'',
+            createBlock: createBlockFn('')
+          },
+          {
+            title: 'String with newline',
+            expectedCode:
+                '\'bark bark\' + \'\\n\' + \n\' bark bark bark\' + \'\\n\' + \n\' bark bar bark bark\' + \'\\n\' + \n\'\'',
+            createBlock: createBlockFn(
+                'bark bark\n bark bark bark\n bark bar bark bark\n')
+          },
+        ]
+      },
     ];
     runCodeGenerationTestSuites(testSuites);
   });

--- a/tests/mocha/field_number_test.js
+++ b/tests/mocha/field_number_test.js
@@ -45,7 +45,7 @@ suite('Number Fields', function() {
     {
       title: 'Negative Infinity String',
       value: '-Infinity',
-      expectedValue: -Infinity
+      expectedValue: -Infinity,
     },
   ];
   const addArgsAndJson = function(testCase) {
@@ -54,7 +54,7 @@ suite('Number Fields', function() {
       'value': testCase.value,
       'min': testCase.value,
       'max': testCase.value,
-      'precision': testCase.value
+      'precision': testCase.value,
     };
   };
   invalidValueTestCases.forEach(addArgsAndJson);
@@ -129,26 +129,26 @@ suite('Number Fields', function() {
           title: '0.01',
           json: {precision: .01},
           value: 123.456,
-          expectedValue: 123.46
+          expectedValue: 123.46,
         },
         {
           title: '1e-7',
           json: {precision: .0000001},
           value: 123.00000456,
-          expectedValue: 123.0000046
+          expectedValue: 123.0000046,
         },
         {
           title: '0.5',
           json: {precision: .5},
           value: 123.456,
-          expectedValue: 123.5
+          expectedValue: 123.5,
         },
         {title: '1', json: {precision: 1}, value: 123.456, expectedValue: 123},
         {
           title: '1.5',
           json: {precision: 1.5},
           value: 123.456,
-          expectedValue: 123
+          expectedValue: 123,
         },
       ];
       suite('Precision', function() {
@@ -179,19 +179,19 @@ suite('Number Fields', function() {
             title: '-10',
             json: {min: -10},
             values: [-20, 0, 20],
-            expectedValues: [-10, 0, 20]
+            expectedValues: [-10, 0, 20],
           },
           {
             title: '0',
             json: {min: 0},
             values: [-20, 0, 20],
-            expectedValues: [0, 0, 20]
+            expectedValues: [0, 0, 20],
           },
           {
             title: '+10',
             json: {min: 10},
             values: [-20, 0, 20],
-            expectedValues: [10, 10, 20]
+            expectedValues: [10, 10, 20],
           },
         ];
         runTestCases(testCases, setValueBoundsTestFn);
@@ -206,19 +206,19 @@ suite('Number Fields', function() {
             title: '-10',
             json: {max: -10},
             values: [-20, 0, 20],
-            expectedValues: [-20, -10, -10]
+            expectedValues: [-20, -10, -10],
           },
           {
             title: '0',
             json: {max: 0},
             values: [-20, 0, 20],
-            expectedValues: [-20, 0, 0]
+            expectedValues: [-20, 0, 0],
           },
           {
             title: '+10',
             json: {max: 10},
             values: [-20, 0, 20],
-            expectedValues: [-20, 0, 10]
+            expectedValues: [-20, 0, 10],
           },
         ];
         runTestCases(testCases, setValueBoundsTestFn);
@@ -247,7 +247,7 @@ suite('Number Fields', function() {
           return null;
         },
         value: 2,
-        expectedValue: '1'
+        expectedValue: '1',
       },
       {
         title: 'Force End with 6 Validator',
@@ -255,13 +255,13 @@ suite('Number Fields', function() {
           return +String(newValue).replace(/.$/, '6');
         },
         value: 25,
-        expectedValue: 26
+        expectedValue: 26,
       },
       {
         title: 'Returns Undefined Validator',
         validator: function() {},
         value: 2,
-        expectedValue: 2
+        expectedValue: 2,
       },
     ];
     testSuites.forEach(function(suiteInfo) {

--- a/tests/mocha/field_number_test.js
+++ b/tests/mocha/field_number_test.js
@@ -42,13 +42,20 @@ suite('Number Fields', function() {
     {title: 'Infinity', value: Infinity, expectedValue: Infinity},
     {title: 'Negative Infinity', value: -Infinity, expectedValue: -Infinity},
     {title: 'Infinity String', value: 'Infinity', expectedValue: Infinity},
-    {title: 'Negative Infinity String', value: '-Infinity',
-      expectedValue: -Infinity},
+    {
+      title: 'Negative Infinity String',
+      value: '-Infinity',
+      expectedValue: -Infinity
+    },
   ];
   const addArgsAndJson = function(testCase) {
     testCase.args = Array(4).fill(testCase.value);
-    testCase.json = {'value': testCase.value, 'min': testCase.value,
-      'max': testCase.value, 'precision': testCase.value};
+    testCase.json = {
+      'value': testCase.value,
+      'min': testCase.value,
+      'max': testCase.value,
+      'precision': testCase.value
+    };
   };
   invalidValueTestCases.forEach(addArgsAndJson);
   validValueTestCases.forEach(addArgsAndJson);
@@ -66,13 +73,12 @@ suite('Number Fields', function() {
    * @param {!number} expectedPrecision The expected precision.
    * @param {!number} expectedValue The expected value.
    */
-  function assertNumberField(field, expectedMin, expectedMax,
-      expectedPrecision, expectedValue) {
+  function assertNumberField(
+      field, expectedMin, expectedMax, expectedPrecision, expectedValue) {
     assertFieldValue(field, expectedValue);
     chai.assert.equal(field.getMin(), expectedMin, 'Min');
     chai.assert.equal(field.getMax(), expectedMax, 'Max');
-    chai.assert.equal(
-        field.getPrecision(), expectedPrecision, 'Precision');
+    chai.assert.equal(field.getPrecision(), expectedPrecision, 'Precision');
   }
   /**
    * Asserts that the field property values are set to default.
@@ -119,16 +125,31 @@ suite('Number Fields', function() {
     suite('Constraints', function() {
       const testCases = [
         {title: 'Float', json: {}, value: 123.456, expectedValue: 123.456},
-        {title: '0.01', json: {precision: .01}, value: 123.456,
-          expectedValue: 123.46},
-        {title: '1e-7', json: {precision: .0000001}, value: 123.00000456,
-          expectedValue: 123.0000046},
-        {title: '0.5', json: {precision: .5}, value: 123.456,
-          expectedValue: 123.5},
-        {title: '1', json: {precision: 1}, value: 123.456,
-          expectedValue: 123},
-        {title: '1.5', json: {precision: 1.5}, value: 123.456,
-          expectedValue: 123},
+        {
+          title: '0.01',
+          json: {precision: .01},
+          value: 123.456,
+          expectedValue: 123.46
+        },
+        {
+          title: '1e-7',
+          json: {precision: .0000001},
+          value: 123.00000456,
+          expectedValue: 123.0000046
+        },
+        {
+          title: '0.5',
+          json: {precision: .5},
+          value: 123.456,
+          expectedValue: 123.5
+        },
+        {title: '1', json: {precision: 1}, value: 123.456, expectedValue: 123},
+        {
+          title: '1.5',
+          json: {precision: 1.5},
+          value: 123.456,
+          expectedValue: 123
+        },
       ];
       suite('Precision', function() {
         runTestCases(testCases, function(testCase) {
@@ -148,19 +169,30 @@ suite('Number Fields', function() {
           const field = Blockly.FieldNumber.fromJson(testCase.json);
           testCase.values.forEach(function(value, i) {
             field.setValue(value);
-            assertFieldValue(
-                field, testCase.expectedValues[i]);
+            assertFieldValue(field, testCase.expectedValues[i]);
           });
         };
       };
       suite('Min', function() {
         const testCases = [
-          {title: '-10', json: {min: -10}, values: [-20, 0, 20],
-            expectedValues: [-10, 0, 20]},
-          {title: '0', json: {min: 0}, values: [-20, 0, 20],
-            expectedValues: [0, 0, 20]},
-          {title: '+10', json: {min: 10}, values: [-20, 0, 20],
-            expectedValues: [10, 10, 20]},
+          {
+            title: '-10',
+            json: {min: -10},
+            values: [-20, 0, 20],
+            expectedValues: [-10, 0, 20]
+          },
+          {
+            title: '0',
+            json: {min: 0},
+            values: [-20, 0, 20],
+            expectedValues: [0, 0, 20]
+          },
+          {
+            title: '+10',
+            json: {min: 10},
+            values: [-20, 0, 20],
+            expectedValues: [10, 10, 20]
+          },
         ];
         runTestCases(testCases, setValueBoundsTestFn);
         test('Null', function() {
@@ -170,12 +202,24 @@ suite('Number Fields', function() {
       });
       suite('Max', function() {
         const testCases = [
-          {title: '-10', json: {max: -10}, values: [-20, 0, 20],
-            expectedValues: [-20, -10, -10]},
-          {title: '0', json: {max: 0}, values: [-20, 0, 20],
-            expectedValues: [-20, 0, 0]},
-          {title: '+10', json: {max: 10}, values: [-20, 0, 20],
-            expectedValues: [-20, 0, 10]},
+          {
+            title: '-10',
+            json: {max: -10},
+            values: [-20, 0, 20],
+            expectedValues: [-20, -10, -10]
+          },
+          {
+            title: '0',
+            json: {max: 0},
+            values: [-20, 0, 20],
+            expectedValues: [-20, 0, 0]
+          },
+          {
+            title: '+10',
+            json: {max: 10},
+            values: [-20, 0, 20],
+            expectedValues: [-20, 0, 10]
+          },
         ];
         runTestCases(testCases, setValueBoundsTestFn);
         test('Null', function() {
@@ -197,20 +241,28 @@ suite('Number Fields', function() {
       sinon.restore();
     });
     const testSuites = [
-      {title: 'Null Validator',
-        validator:
-            function() {
-              return null;
-            },
-        value: 2, expectedValue: '1'},
-      {title: 'Force End with 6 Validator',
-        validator:
-            function(newValue) {
-              return +String(newValue).replace(/.$/, '6');
-            },
-        value: 25, expectedValue: 26},
-      {title: 'Returns Undefined Validator', validator: function() {}, value: 2,
-        expectedValue: 2},
+      {
+        title: 'Null Validator',
+        validator: function() {
+          return null;
+        },
+        value: 2,
+        expectedValue: '1'
+      },
+      {
+        title: 'Force End with 6 Validator',
+        validator: function(newValue) {
+          return +String(newValue).replace(/.$/, '6');
+        },
+        value: 25,
+        expectedValue: 26
+      },
+      {
+        title: 'Returns Undefined Validator',
+        validator: function() {},
+        value: 2,
+        expectedValue: 2
+      },
     ];
     testSuites.forEach(function(suiteInfo) {
       suite(suiteInfo.title, function() {

--- a/tests/mocha/field_test.js
+++ b/tests/mocha/field_test.js
@@ -243,8 +243,7 @@ suite('Abstract Fields', function() {
           const value = Blockly.Xml.domToText(field.toXml(element));
           chai.assert.equal(
               value,
-              '<field xmlns="http://www.w3.org/1999/xhtml">custom value</field>'
-          );
+              '<field xmlns="http://www.w3.org/1999/xhtml">custom value</field>');
         });
 
         test('Xml super implementation', function() {
@@ -254,7 +253,7 @@ suite('Abstract Fields', function() {
           chai.assert.equal(
               value,
               '<field xmlns="http://www.w3.org/1999/xhtml" ' +
-              'attribute="custom value">test value</field>');
+                  'attribute="custom value">test value</field>');
         });
 
         test('Xml and JSO implementations', function() {
@@ -263,8 +262,7 @@ suite('Abstract Fields', function() {
           const value = Blockly.Xml.domToText(field.toXml(element));
           chai.assert.equal(
               value,
-              '<field xmlns="http://www.w3.org/1999/xhtml">custom value</field>'
-          );
+              '<field xmlns="http://www.w3.org/1999/xhtml">custom value</field>');
         });
       });
     });
@@ -321,26 +319,23 @@ suite('Abstract Fields', function() {
 
         test('Xml implementations', function() {
           const field = new CustomXmlField('');
-          field.fromXml(
-              Blockly.utils.xml.textToDom('<field name="">custom value</field>'));
+          field.fromXml(Blockly.utils.xml.textToDom(
+              '<field name="">custom value</field>'));
           chai.assert.equal(field.someProperty, 'custom value');
         });
 
         test('Xml super implementation', function() {
           const field = new CustomXmlCallSuperField('');
-          field.fromXml(
-              Blockly.utils.xml.textToDom(
-                  '<field attribute="custom value" name="">test value</field>'
-              )
-          );
+          field.fromXml(Blockly.utils.xml.textToDom(
+              '<field attribute="custom value" name="">test value</field>'));
           chai.assert.equal(field.getValue(), 'test value');
           chai.assert.equal(field.someProperty, 'custom value');
         });
 
         test('XML andd JSO implementations', function() {
           const field = new CustomXmlAndJsoField('');
-          field.fromXml(
-              Blockly.utils.xml.textToDom('<field name="">custom value</field>'));
+          field.fromXml(Blockly.utils.xml.textToDom(
+              '<field name="">custom value</field>'));
           chai.assert.equal(field.someProperty, 'custom value');
         });
       });
@@ -539,8 +534,8 @@ suite('Abstract Fields', function() {
       sinon.assert.notCalled(this.field.doValueUpdate_);
     });
     test('Class Validator Returns Same', function() {
-      sinon.stub(this.field, 'doClassValidation_').callsFake(
-          function(newValue) {
+      sinon.stub(this.field, 'doClassValidation_')
+          .callsFake(function(newValue) {
             return newValue;
           });
       addSpies(this.field);
@@ -662,15 +657,17 @@ suite('Abstract Fields', function() {
             init: function() {
               const field = new Blockly.FieldTextInput('default');
               field.setTooltip('tooltip');
-              this.appendDummyInput()
-                  .appendField(field, 'TOOLTIP');
+              this.appendDummyInput().appendField(field, 'TOOLTIP');
             },
           };
-          const block = Blockly.Xml.domToBlock(Blockly.utils.xml.textToDom(
-              '<xml xmlns="https://developers.google.com/blockly/xml">' +
-              '  <block type="tooltip"></block>' +
-              '</xml>'
-          ).children[0], this.workspace);
+          const block = Blockly.Xml.domToBlock(
+              Blockly.utils.xml
+                  .textToDom(
+                      '<xml xmlns="https://developers.google.com/blockly/xml">' +
+                      '  <block type="tooltip"></block>' +
+                      '</xml>')
+                  .children[0],
+              this.workspace);
           const field = block.getField('TOOLTIP');
           chai.assert.equal(field.getClickTarget_().tooltip, 'tooltip');
         });
@@ -679,16 +676,18 @@ suite('Abstract Fields', function() {
           Blockly.Blocks['tooltip'] = {
             init: function() {
               const field = new Blockly.FieldTextInput('default');
-              this.appendDummyInput()
-                  .appendField(field, 'TOOLTIP');
+              this.appendDummyInput().appendField(field, 'TOOLTIP');
               field.setTooltip('tooltip');
             },
           };
-          const block = Blockly.Xml.domToBlock(Blockly.utils.xml.textToDom(
-              '<xml xmlns="https://developers.google.com/blockly/xml">' +
-              '  <block type="tooltip"></block>' +
-              '</xml>'
-          ).children[0], this.workspace);
+          const block = Blockly.Xml.domToBlock(
+              Blockly.utils.xml
+                  .textToDom(
+                      '<xml xmlns="https://developers.google.com/blockly/xml">' +
+                      '  <block type="tooltip"></block>' +
+                      '</xml>')
+                  .children[0],
+              this.workspace);
           const field = block.getField('TOOLTIP');
           chai.assert.equal(field.getClickTarget_().tooltip, 'tooltip');
         });
@@ -697,15 +696,17 @@ suite('Abstract Fields', function() {
           Blockly.Blocks['tooltip'] = {
             init: function() {
               const field = new Blockly.FieldTextInput('default');
-              this.appendDummyInput()
-                  .appendField(field, 'TOOLTIP');
+              this.appendDummyInput().appendField(field, 'TOOLTIP');
             },
           };
-          const block = Blockly.Xml.domToBlock(Blockly.utils.xml.textToDom(
-              '<xml xmlns="https://developers.google.com/blockly/xml">' +
-              '  <block type="tooltip"></block>' +
-              '</xml>'
-          ).children[0], this.workspace);
+          const block = Blockly.Xml.domToBlock(
+              Blockly.utils.xml
+                  .textToDom(
+                      '<xml xmlns="https://developers.google.com/blockly/xml">' +
+                      '  <block type="tooltip"></block>' +
+                      '</xml>')
+                  .children[0],
+              this.workspace);
           const field = block.getField('TOOLTIP');
           field.setTooltip('tooltip');
           chai.assert.equal(field.getClickTarget_().tooltip, 'tooltip');
@@ -716,19 +717,21 @@ suite('Abstract Fields', function() {
             init: function() {
               const field = new Blockly.FieldTextInput('default');
               field.setTooltip(this.tooltipFunc);
-              this.appendDummyInput()
-                  .appendField(field, 'TOOLTIP');
+              this.appendDummyInput().appendField(field, 'TOOLTIP');
             },
 
             tooltipFunc: function() {
               return this.getFieldValue('TOOLTIP');
             },
           };
-          const block = Blockly.Xml.domToBlock(Blockly.utils.xml.textToDom(
-              '<xml xmlns="https://developers.google.com/blockly/xml">' +
-              '  <block type="tooltip"></block>' +
-              '</xml>'
-          ).children[0], this.workspace);
+          const block = Blockly.Xml.domToBlock(
+              Blockly.utils.xml
+                  .textToDom(
+                      '<xml xmlns="https://developers.google.com/blockly/xml">' +
+                      '  <block type="tooltip"></block>' +
+                      '</xml>')
+                  .children[0],
+              this.workspace);
           const field = block.getField('TOOLTIP');
           chai.assert.equal(field.getClickTarget_().tooltip, block.tooltipFunc);
         });
@@ -738,18 +741,20 @@ suite('Abstract Fields', function() {
             init: function() {
               const field = new Blockly.FieldTextInput('default');
               field.setTooltip(this.element);
-              this.appendDummyInput()
-                  .appendField(field, 'TOOLTIP');
+              this.appendDummyInput().appendField(field, 'TOOLTIP');
             },
             element: {
               tooltip: 'tooltip',
             },
           };
-          const block = Blockly.Xml.domToBlock(Blockly.utils.xml.textToDom(
-              '<xml xmlns="https://developers.google.com/blockly/xml">' +
-              '  <block type="tooltip"></block>' +
-              '</xml>'
-          ).children[0], this.workspace);
+          const block = Blockly.Xml.domToBlock(
+              Blockly.utils.xml
+                  .textToDom(
+                      '<xml xmlns="https://developers.google.com/blockly/xml">' +
+                      '  <block type="tooltip"></block>' +
+                      '</xml>')
+                  .children[0],
+              this.workspace);
           const field = block.getField('TOOLTIP');
           chai.assert.equal(field.getClickTarget_().tooltip, block.element);
         });
@@ -759,15 +764,17 @@ suite('Abstract Fields', function() {
             init: function() {
               const field = new Blockly.FieldTextInput('default');
               field.setTooltip(null);
-              this.appendDummyInput()
-                  .appendField(field, 'TOOLTIP');
+              this.appendDummyInput().appendField(field, 'TOOLTIP');
             },
           };
-          const block = Blockly.Xml.domToBlock(Blockly.utils.xml.textToDom(
-              '<xml xmlns="https://developers.google.com/blockly/xml">' +
-              '  <block type="tooltip"></block>' +
-              '</xml>'
-          ).children[0], this.workspace);
+          const block = Blockly.Xml.domToBlock(
+              Blockly.utils.xml
+                  .textToDom(
+                      '<xml xmlns="https://developers.google.com/blockly/xml">' +
+                      '  <block type="tooltip"></block>' +
+                      '</xml>')
+                  .children[0],
+              this.workspace);
           const field = block.getField('TOOLTIP');
           chai.assert.equal(field.getClickTarget_().tooltip, block);
         });
@@ -776,15 +783,17 @@ suite('Abstract Fields', function() {
           Blockly.Blocks['tooltip'] = {
             init: function() {
               const field = new Blockly.FieldTextInput('default');
-              this.appendDummyInput()
-                  .appendField(field, 'TOOLTIP');
+              this.appendDummyInput().appendField(field, 'TOOLTIP');
             },
           };
-          const block = Blockly.Xml.domToBlock(Blockly.utils.xml.textToDom(
-              '<xml xmlns="https://developers.google.com/blockly/xml">' +
-              '  <block type="tooltip"></block>' +
-              '</xml>'
-          ).children[0], this.workspace);
+          const block = Blockly.Xml.domToBlock(
+              Blockly.utils.xml
+                  .textToDom(
+                      '<xml xmlns="https://developers.google.com/blockly/xml">' +
+                      '  <block type="tooltip"></block>' +
+                      '</xml>')
+                  .children[0],
+              this.workspace);
           const field = block.getField('TOOLTIP');
           chai.assert.equal(field.getClickTarget_().tooltip, block);
         });

--- a/tests/mocha/field_textinput_test.js
+++ b/tests/mocha/field_textinput_test.js
@@ -121,7 +121,7 @@ suite('Text Input Fields', function() {
           return null;
         },
         value: 'newValue',
-        expectedValue: 'value'
+        expectedValue: 'value',
       },
       {
         title: 'Remove \'a\' Validator',
@@ -129,14 +129,14 @@ suite('Text Input Fields', function() {
           return newValue.replace(/a/g, '');
         },
         value: 'bbbaaa',
-        expectedValue: 'bbb'
+        expectedValue: 'bbb',
       },
       {
         title: 'Returns Undefined Validator',
         validator: function() {},
         value: 'newValue',
         expectedValue: 'newValue',
-        expectedText: 'newValue'
+        expectedText: 'newValue',
       },
     ];
     testSuites.forEach(function(suiteInfo) {

--- a/tests/mocha/field_textinput_test.js
+++ b/tests/mocha/field_textinput_test.js
@@ -115,20 +115,29 @@ suite('Text Input Fields', function() {
       sinon.restore();
     });
     const testSuites = [
-      {title: 'Null Validator',
-        validator:
-            function() {
-              return null;
-            },
-        value: 'newValue', expectedValue: 'value'},
-      {title: 'Remove \'a\' Validator',
-        validator:
-            function(newValue) {
-              return newValue.replace(/a/g, '');
-            },
-        value: 'bbbaaa', expectedValue: 'bbb'},
-      {title: 'Returns Undefined Validator', validator: function() {},
-        value: 'newValue', expectedValue: 'newValue', expectedText: 'newValue'},
+      {
+        title: 'Null Validator',
+        validator: function() {
+          return null;
+        },
+        value: 'newValue',
+        expectedValue: 'value'
+      },
+      {
+        title: 'Remove \'a\' Validator',
+        validator: function(newValue) {
+          return newValue.replace(/a/g, '');
+        },
+        value: 'bbbaaa',
+        expectedValue: 'bbb'
+      },
+      {
+        title: 'Returns Undefined Validator',
+        validator: function() {},
+        value: 'newValue',
+        expectedValue: 'newValue',
+        expectedText: 'newValue'
+      },
     ];
     testSuites.forEach(function(suiteInfo) {
       suite(suiteInfo.title, function() {
@@ -192,8 +201,8 @@ suite('Text Input Fields', function() {
         this.assertSpellcheck = function(field, value) {
           this.prepField(field);
           field.showEditor_();
-          chai.assert.equal(field.htmlInput_.getAttribute('spellcheck'),
-              value.toString());
+          chai.assert.equal(
+              field.htmlInput_.getAttribute('spellcheck'), value.toString());
         };
       });
       teardown(function() {

--- a/tests/mocha/field_variable_test.js
+++ b/tests/mocha/field_variable_test.js
@@ -48,7 +48,7 @@ suite('Variable Fields', function() {
       value: 'id2',
       args: ['name2'],
       expectedValue: 'id2',
-      expectedText: 'name2'
+      expectedText: 'name2',
     },
   ];
   const addJson = function(testCase) {
@@ -133,7 +133,7 @@ suite('Variable Fields', function() {
       value: 'id3',
       args: ['name2'],
       expectedValue: 'id2',
-      expectedText: 'name2'
+      expectedText: 'name2',
     },
   ];
   /**
@@ -146,7 +146,7 @@ suite('Variable Fields', function() {
       value: 'id2',
       args: ['name2'],
       expectedValue: 'id2',
-      expectedText: 'name2'
+      expectedText: 'name2',
     },
   ];
 

--- a/tests/mocha/field_variable_test.js
+++ b/tests/mocha/field_variable_test.js
@@ -19,8 +19,8 @@ suite('Variable Fields', function() {
     sharedTestSetup.call(this);
     this.workspace = new Blockly.Workspace();
     // Stub for default variable name.
-    sinon.stub(Blockly.Variables.TEST_ONLY, 'generateUniqueNameInternal').returns(
-      FAKE_VARIABLE_NAME);
+    sinon.stub(Blockly.Variables.TEST_ONLY, 'generateUniqueNameInternal')
+        .returns(FAKE_VARIABLE_NAME);
   });
   teardown(function() {
     sharedTestTeardown.call(this);
@@ -43,8 +43,13 @@ suite('Variable Fields', function() {
    * @type {!Array<!FieldCreationTestCase>}
    */
   const validValueCreationTestCases = [
-    {title: 'String', value: 'id2', args: ['name2'],
-      expectedValue: 'id2', expectedText: 'name2'},
+    {
+      title: 'String',
+      value: 'id2',
+      args: ['name2'],
+      expectedValue: 'id2',
+      expectedText: 'name2'
+    },
   ];
   const addJson = function(testCase) {
     testCase.json = {'variable': testCase.args[0]};
@@ -65,7 +70,8 @@ suite('Variable Fields', function() {
     return fieldVariable;
   };
   const customCreateWithJs = function(testCase) {
-    const fieldVariable = testCase ? new Blockly.FieldVariable(...testCase.args) :
+    const fieldVariable = testCase ?
+        new Blockly.FieldVariable(...testCase.args) :
         new Blockly.FieldVariable();
     return initVariableField(this.workspace, fieldVariable);
   };
@@ -99,13 +105,13 @@ suite('Variable Fields', function() {
 
   runConstructorSuiteTests(
       Blockly.FieldVariable, validValueCreationTestCases,
-      invalidValueCreationTestCases,
-      validTestCaseAssertField, assertFieldDefault, customCreateWithJs);
+      invalidValueCreationTestCases, validTestCaseAssertField,
+      assertFieldDefault, customCreateWithJs);
 
   runFromJsonSuiteTests(
       Blockly.FieldVariable, validValueCreationTestCases,
-      invalidValueCreationTestCases,
-      validTestCaseAssertField, assertFieldDefault, customCreateWithJson);
+      invalidValueCreationTestCases, validTestCaseAssertField,
+      assertFieldDefault, customCreateWithJson);
 
   suite('initModel', function() {
     test('No Value Before InitModel', function() {
@@ -122,16 +128,26 @@ suite('Variable Fields', function() {
    */
   const invalidValueTestCases = [
     ...invalidValueCreationTestCases,
-    {title: 'Variable does not exist', value: 'id3', args: ['name2'],
-      expectedValue: 'id2', expectedText: 'name2'},
+    {
+      title: 'Variable does not exist',
+      value: 'id3',
+      args: ['name2'],
+      expectedValue: 'id2',
+      expectedText: 'name2'
+    },
   ];
   /**
    * Configuration for field tests with valid values.
    * @type {!Array<!FieldCreationTestCase>}
    */
   const validValueTestCases = [
-    {title: 'New variable ID', value: 'id2', args: ['name2'],
-      expectedValue: 'id2', expectedText: 'name2'},
+    {
+      title: 'New variable ID',
+      value: 'id2',
+      args: ['name2'],
+      expectedValue: 'id2',
+      expectedText: 'name2'
+    },
   ];
 
   suite('setValue', function() {
@@ -152,14 +168,14 @@ suite('Variable Fields', function() {
     teardown(function() {
       console.warn = this.nativeConsoleWarn;
     });
-    runSetValueTests(validValueTestCases, invalidValueTestCases,
-        FAKE_ID, defaultFieldName);
+    runSetValueTests(
+        validValueTestCases, invalidValueTestCases, FAKE_ID, defaultFieldName);
   });
 
   suite('Dropdown options', function() {
     const assertDropdownContents = (fieldVariable, expectedVarOptions) => {
-      const dropdownOptions = Blockly.FieldVariable.dropdownCreate.call(
-          fieldVariable);
+      const dropdownOptions =
+          Blockly.FieldVariable.dropdownCreate.call(fieldVariable);
       // Expect variable options, a rename option, and a delete option.
       chai.assert.lengthOf(dropdownOptions, expectedVarOptions.length + 2);
       for (let i = 0, option; (option = expectedVarOptions[i]); i++) {
@@ -175,29 +191,30 @@ suite('Variable Fields', function() {
       this.workspace.createVariable('name1', '', 'id1');
       this.workspace.createVariable('name2', '', 'id2');
       // Expect that the dropdown options will contain the variables that exist
-      const fieldVariable = initVariableField(
-          this.workspace, new Blockly.FieldVariable('name2'));
-      assertDropdownContents(fieldVariable,
-          [['name1', 'id1'], ['name2', 'id2']]);
+      const fieldVariable =
+          initVariableField(this.workspace, new Blockly.FieldVariable('name2'));
+      assertDropdownContents(
+          fieldVariable, [['name1', 'id1'], ['name2', 'id2']]);
     });
     test('Contains variables created after field', function() {
       // Expect that the dropdown options will contain the variables that exist
-      const fieldVariable = initVariableField(
-          this.workspace, new Blockly.FieldVariable('name1'));
+      const fieldVariable =
+          initVariableField(this.workspace, new Blockly.FieldVariable('name1'));
       // Expect that variables created after field creation will show up too.
       this.workspace.createVariable('name2', '', 'id2');
-      assertDropdownContents(fieldVariable,
-          [['name1', 'id1'], ['name2', 'id2']]);
+      assertDropdownContents(
+          fieldVariable, [['name1', 'id1'], ['name2', 'id2']]);
     });
     test('Contains variables created before and after field', function() {
       this.workspace.createVariable('name1', '', 'id1');
       this.workspace.createVariable('name2', '', 'id2');
       // Expect that the dropdown options will contain the variables that exist
-      const fieldVariable = initVariableField(
-          this.workspace, new Blockly.FieldVariable('name1'));
+      const fieldVariable =
+          initVariableField(this.workspace, new Blockly.FieldVariable('name1'));
       // Expect that variables created after field creation will show up too.
       this.workspace.createVariable('name3', '', 'id3');
-      assertDropdownContents(fieldVariable,
+      assertDropdownContents(
+          fieldVariable,
           [['name1', 'id1'], ['name2', 'id2'], ['name3', 'id3']]);
     });
   });
@@ -207,8 +224,8 @@ suite('Variable Fields', function() {
       this.workspace.createVariable('name1', null, 'id1');
       this.workspace.createVariable('name2', null, 'id2');
       this.workspace.createVariable('name3', null, 'id3');
-      this.variableField = initVariableField(
-          this.workspace, new Blockly.FieldVariable('name1'));
+      this.variableField =
+          initVariableField(this.workspace, new Blockly.FieldVariable('name1'));
     });
     suite('Null Validator', function() {
       setup(function() {
@@ -248,8 +265,8 @@ suite('Variable Fields', function() {
   suite('Customizations', function() {
     suite('Types and Default Types', function() {
       test('JS Constructor', function() {
-        const field = new Blockly.FieldVariable(
-            'test', undefined, ['Type1'], 'Type1');
+        const field =
+            new Blockly.FieldVariable('test', undefined, ['Type1'], 'Type1');
         chai.assert.deepEqual(field.variableTypes, ['Type1']);
         chai.assert.equal(field.defaultType_, 'Type1');
       });
@@ -263,8 +280,8 @@ suite('Variable Fields', function() {
         chai.assert.equal(field.defaultType_, 'Type1');
       });
       test('JS Configuration - Simple', function() {
-        const field = new Blockly.FieldVariable(
-            'test', undefined, undefined, undefined, {
+        const field =
+            new Blockly.FieldVariable('test', undefined, undefined, undefined, {
               variableTypes: ['Type1'],
               defaultType: 'Type1',
             });
@@ -272,8 +289,8 @@ suite('Variable Fields', function() {
         chai.assert.equal(field.defaultType_, 'Type1');
       });
       test('JS Configuration - Ignore', function() {
-        const field = new Blockly.FieldVariable(
-            'test', undefined, ['Type2'], 'Type2', {
+        const field =
+            new Blockly.FieldVariable('test', undefined, ['Type2'], 'Type2', {
               variableTypes: ['Type1'],
               defaultType: 'Type1',
             });
@@ -289,7 +306,8 @@ suite('Variable Fields', function() {
     });
     test('variableTypes is undefined', function() {
       // Expect that since variableTypes is undefined, only type empty string
-      // will be returned (regardless of what types are available on the workspace).
+      // will be returned (regardless of what types are available on the
+      // workspace).
       const fieldVariable = new Blockly.FieldVariable('name1');
       const resultTypes = fieldVariable.getVariableTypes_();
       chai.assert.deepEqual(resultTypes, ['']);
@@ -297,12 +315,12 @@ suite('Variable Fields', function() {
     test('variableTypes is explicit', function() {
       // Expect that since variableTypes is defined, it will be the return
       // value, regardless of what types are available on the workspace.
-      const fieldVariable = new Blockly.FieldVariable(
-          'name1', null, ['type1', 'type2'], 'type1');
+      const fieldVariable =
+          new Blockly.FieldVariable('name1', null, ['type1', 'type2'], 'type1');
       const resultTypes = fieldVariable.getVariableTypes_();
       chai.assert.deepEqual(resultTypes, ['type1', 'type2']);
-      chai.assert.equal(fieldVariable.defaultType_, 'type1',
-          'Default type was wrong');
+      chai.assert.equal(
+          fieldVariable.defaultType_, 'type1', 'Default type was wrong');
     });
     test('variableTypes is null', function() {
       // Expect all variable types to be returned.
@@ -333,13 +351,17 @@ suite('Variable Fields', function() {
   suite('Default types', function() {
     test('Default type exists', function() {
       const fieldVariable = new Blockly.FieldVariable(null, null, ['b'], 'b');
-      chai.assert.equal(fieldVariable.defaultType_, 'b',
+      chai.assert.equal(
+          fieldVariable.defaultType_, 'b',
           'The variable field\'s default type should be "b"');
     });
     test('No default type', function() {
       const fieldVariable = new Blockly.FieldVariable(null);
-      chai.assert.equal(fieldVariable.defaultType_, '', 'The variable field\'s default type should be the empty string');
-      chai.assert.isNull(fieldVariable.variableTypes,
+      chai.assert.equal(
+          fieldVariable.defaultType_, '',
+          'The variable field\'s default type should be the empty string');
+      chai.assert.isNull(
+          fieldVariable.variableTypes,
           'The variable field\'s allowed types should be null');
     });
     test('Default type mismatch', function() {
@@ -369,8 +391,8 @@ suite('Variable Fields', function() {
           },
         ],
       }]);
-      this.variableBlock = new Blockly.Block(this.workspace,
-          'field_variable_test_block');
+      this.variableBlock =
+          new Blockly.Block(this.workspace, 'field_variable_test_block');
       this.variableField = this.variableBlock.getField('VAR');
     });
     test('Rename & Keep Old ID', function() {
@@ -414,7 +436,8 @@ suite('Variable Fields', function() {
         block.getInput('INPUT').appendField(field, 'VAR');
         const jso = Blockly.serialization.blocks.save(block);
         chai.assert.deepEqual(
-            jso['fields'], {'VAR': {'id': 'id2', 'name': 'x', 'type': 'String'}});
+            jso['fields'],
+            {'VAR': {'id': 'id2', 'name': 'x', 'type': 'String'}});
       });
     });
 
@@ -457,15 +480,16 @@ suite('Variable Fields', function() {
 
     test('ID', function() {
       this.workspace.createVariable('test', '', 'id1');
-      const block = Blockly.serialization.blocks.append({
-        'type': 'variables_get',
-        'fields': {
-          'VAR': {
-            'id': 'id1',
+      const block = Blockly.serialization.blocks.append(
+          {
+            'type': 'variables_get',
+            'fields': {
+              'VAR': {
+                'id': 'id1',
+              },
+            },
           },
-        },
-      },
-      this.workspace);
+          this.workspace);
       const variable = block.getField('VAR').getVariable();
       chai.assert.equal(variable.name, 'test');
       chai.assert.equal(variable.type, '');
@@ -473,15 +497,16 @@ suite('Variable Fields', function() {
     });
 
     test('Name, untyped', function() {
-      const block = Blockly.serialization.blocks.append({
-        'type': 'variables_get',
-        'fields': {
-          'VAR': {
-            'name': 'test',
+      const block = Blockly.serialization.blocks.append(
+          {
+            'type': 'variables_get',
+            'fields': {
+              'VAR': {
+                'name': 'test',
+              },
+            },
           },
-        },
-      },
-      this.workspace);
+          this.workspace);
       const variable = block.getField('VAR').getVariable();
       chai.assert.equal(variable.name, 'test');
       chai.assert.equal(variable.type, '');
@@ -489,16 +514,17 @@ suite('Variable Fields', function() {
     });
 
     test('Name, typed', function() {
-      const block = Blockly.serialization.blocks.append({
-        'type': 'variables_get',
-        'fields': {
-          'VAR': {
-            'name': 'test',
-            'type': 'string',
+      const block = Blockly.serialization.blocks.append(
+          {
+            'type': 'variables_get',
+            'fields': {
+              'VAR': {
+                'name': 'test',
+                'type': 'string',
+              },
+            },
           },
-        },
-      },
-      this.workspace);
+          this.workspace);
       const variable = block.getField('VAR').getVariable();
       chai.assert.equal(variable.name, 'test');
       chai.assert.equal(variable.type, 'string');

--- a/tests/mocha/flyout_test.js
+++ b/tests/mocha/flyout_test.js
@@ -26,10 +26,9 @@ suite('Flyout', function() {
       ],
     }]);
     this.toolboxXml = document.getElementById('toolbox-simple');
-    this.workspace = Blockly.inject('blocklyDiv',
-        {
-          toolbox: this.toolboxXml,
-        });
+    this.workspace = Blockly.inject('blocklyDiv', {
+      toolbox: this.toolboxXml,
+    });
   });
 
   teardown(function() {
@@ -41,10 +40,13 @@ suite('Flyout', function() {
       suite('simple flyout', function() {
         setup(function() {
           this.flyout = this.workspace.getFlyout();
-          this.targetMetricsManager = this.flyout.targetWorkspace.getMetricsManager();
+          this.targetMetricsManager =
+              this.flyout.targetWorkspace.getMetricsManager();
         });
         test('y is always 0', function() {
-          chai.assert.equal(this.flyout.getY(), 0, 'y coordinate in vertical flyout should be 0');
+          chai.assert.equal(
+              this.flyout.getY(), 0,
+              'y coordinate in vertical flyout should be 0');
         });
         test('x is right of workspace if flyout at right', function() {
           sinon.stub(this.targetMetricsManager, 'getViewMetrics').returns({
@@ -53,24 +55,27 @@ suite('Flyout', function() {
           this.flyout.targetWorkspace.toolboxPosition =
               Blockly.utils.toolbox.Position.RIGHT;
           this.flyout.toolboxPosition_ = Blockly.utils.toolbox.Position.RIGHT;
-          chai.assert.equal(this.flyout.getX(), 100, 'x should be right of workspace');
+          chai.assert.equal(
+              this.flyout.getX(), 100, 'x should be right of workspace');
         });
         test('x is 0 if flyout at left', function() {
           this.flyout.targetWorkspace.toolboxPosition =
               Blockly.utils.toolbox.Position.LEFT;
           this.flyout.toolboxPosition_ = Blockly.utils.toolbox.Position.LEFT;
-          chai.assert.equal(this.flyout.getX(), 0, 'x should be 0 if the flyout is on the left');
+          chai.assert.equal(
+              this.flyout.getX(), 0,
+              'x should be 0 if the flyout is on the left');
         });
       });
       suite('toolbox flyout', function() {
         setup(function() {
           const toolbox = document.getElementById('toolbox-categories');
-          this.workspace = Blockly.inject('blocklyDiv',
-              {
-                toolbox: toolbox,
-              });
+          this.workspace = Blockly.inject('blocklyDiv', {
+            toolbox: toolbox,
+          });
           this.flyout = this.workspace.getToolbox().getFlyout();
-          this.targetMetricsManager = this.flyout.targetWorkspace.getMetricsManager();
+          this.targetMetricsManager =
+              this.flyout.targetWorkspace.getMetricsManager();
         });
         teardown(function() {
           workspaceTeardown.call(this, this.workspace);
@@ -83,7 +88,8 @@ suite('Flyout', function() {
           this.flyout.targetWorkspace.toolboxPosition =
               Blockly.utils.toolbox.Position.LEFT;
           this.flyout.toolboxPosition_ = Blockly.utils.toolbox.Position.LEFT;
-          chai.assert.equal(this.flyout.getX(), 20, 'x should be aligned with toolbox');
+          chai.assert.equal(
+              this.flyout.getX(), 20, 'x should be aligned with toolbox');
         });
         test('x is aligned with toolbox at right', function() {
           sinon.stub(this.targetMetricsManager, 'getToolboxMetrics').returns({
@@ -97,15 +103,18 @@ suite('Flyout', function() {
           this.flyout.targetWorkspace.toolboxPosition =
               Blockly.utils.toolbox.Position.RIGHT;
           this.flyout.toolboxPosition_ = Blockly.utils.toolbox.Position.RIGHT;
-          chai.assert.equal(this.flyout.getX(), 90, 'x + width should be aligned with toolbox');
+          chai.assert.equal(
+              this.flyout.getX(), 90,
+              'x + width should be aligned with toolbox');
         });
       });
-      // These tests simulate a trashcan flyout, i.e. the flyout under test is on the
-      // opposite side of the workspace toolbox setting.
+      // These tests simulate a trashcan flyout, i.e. the flyout under test is
+      // on the opposite side of the workspace toolbox setting.
       suite('trashcan flyout', function() {
         setup(function() {
           this.flyout = this.workspace.getFlyout();
-          this.targetMetricsManager = this.flyout.targetWorkspace.getMetricsManager();
+          this.targetMetricsManager =
+              this.flyout.targetWorkspace.getMetricsManager();
         });
         test('x is 0 if trashcan on left', function() {
           sinon.stub(this.flyout.targetWorkspace, 'getMetrics').returns({
@@ -114,7 +123,8 @@ suite('Flyout', function() {
           this.flyout.targetWorkspace.toolboxPosition =
               Blockly.utils.toolbox.Position.RIGHT;
           this.flyout.toolboxPosition_ = Blockly.utils.toolbox.Position.LEFT;
-          chai.assert.equal(this.flyout.getX(), 0, 'x should be aligned with left edge');
+          chai.assert.equal(
+              this.flyout.getX(), 0, 'x should be aligned with left edge');
         });
         test('trashcan on right covers right edge of workspace', function() {
           this.flyout.width_ = 20;
@@ -129,18 +139,19 @@ suite('Flyout', function() {
           this.flyout.targetWorkspace.toolboxPosition =
               Blockly.utils.toolbox.Position.LEFT;
           this.flyout.toolboxPosition_ = Blockly.utils.toolbox.Position.RIGHT;
-          chai.assert.equal(this.flyout.getX(), 90, 'x + width should be aligned with right edge');
+          chai.assert.equal(
+              this.flyout.getX(), 90,
+              'x + width should be aligned with right edge');
         });
       });
     });
 
     suite('horizontal flyout', function() {
       setup(function() {
-        this.workspace = Blockly.inject('blocklyDiv',
-            {
-              toolbox: this.toolboxXml,
-              horizontalLayout: true,
-            });
+        this.workspace = Blockly.inject('blocklyDiv', {
+          toolbox: this.toolboxXml,
+          horizontalLayout: true,
+        });
       });
       teardown(function() {
         workspaceTeardown.call(this, this.workspace);
@@ -148,16 +159,20 @@ suite('Flyout', function() {
       suite('simple flyout', function() {
         setup(function() {
           this.flyout = this.workspace.getFlyout();
-          this.targetMetricsManager = this.flyout.targetWorkspace.getMetricsManager();
+          this.targetMetricsManager =
+              this.flyout.targetWorkspace.getMetricsManager();
         });
         test('x is always 0', function() {
-          chai.assert.equal(this.flyout.getX(), 0, 'x coordinate in horizontal flyout should be 0');
+          chai.assert.equal(
+              this.flyout.getX(), 0,
+              'x coordinate in horizontal flyout should be 0');
         });
         test('y is 0 if flyout at top', function() {
           this.flyout.targetWorkspace.toolboxPosition =
               Blockly.utils.toolbox.Position.TOP;
           this.flyout.toolboxPosition_ = Blockly.utils.toolbox.Position.TOP;
-          chai.assert.equal(this.flyout.getY(), 0, 'y should be 0 if flyout is at the top');
+          chai.assert.equal(
+              this.flyout.getY(), 0, 'y should be 0 if flyout is at the top');
         });
         test('y is below workspace if flyout at bottom', function() {
           this.flyout.targetWorkspace.toolboxPosition =
@@ -166,17 +181,17 @@ suite('Flyout', function() {
           sinon.stub(this.targetMetricsManager, 'getViewMetrics').returns({
             height: 50,
           });
-          chai.assert.equal(this.flyout.getY(), 50, 'y should be below the workspace');
+          chai.assert.equal(
+              this.flyout.getY(), 50, 'y should be below the workspace');
         });
       });
       suite('toolbox flyout', function() {
         setup(function() {
           const toolbox = document.getElementById('toolbox-categories');
-          this.workspace = Blockly.inject('blocklyDiv',
-              {
-                toolbox: toolbox,
-                horizontalLayout: true,
-              });
+          this.workspace = Blockly.inject('blocklyDiv', {
+            toolbox: toolbox,
+            horizontalLayout: true,
+          });
           this.flyout = this.workspace.getToolbox().getFlyout();
           this.targetMetricsManager =
               this.flyout.targetWorkspace.getMetricsManager();
@@ -192,7 +207,8 @@ suite('Flyout', function() {
           this.flyout.targetWorkspace.toolboxPosition =
               Blockly.utils.toolbox.Position.TOP;
           this.flyout.toolboxPosition_ = Blockly.utils.toolbox.Position.TOP;
-          chai.assert.equal(this.flyout.getY(), 20, 'y should be aligned with toolbox');
+          chai.assert.equal(
+              this.flyout.getY(), 20, 'y should be aligned with toolbox');
         });
         test('y is aligned with toolbox at bottom', function() {
           sinon.stub(this.targetMetricsManager, 'getToolboxMetrics').returns({
@@ -206,11 +222,13 @@ suite('Flyout', function() {
           this.flyout.targetWorkspace.toolboxPosition =
               Blockly.utils.toolbox.Position.BOTTOM;
           this.flyout.toolboxPosition_ = Blockly.utils.toolbox.Position.BOTTOM;
-          chai.assert.equal(this.flyout.getY(), 70, 'y + height should be aligned with toolbox');
+          chai.assert.equal(
+              this.flyout.getY(), 70,
+              'y + height should be aligned with toolbox');
         });
       });
-      // These tests simulate a trashcan flyout, i.e. the flyout under test is on the
-      // opposite side of the workspace toolbox setting.
+      // These tests simulate a trashcan flyout, i.e. the flyout under test is
+      // on the opposite side of the workspace toolbox setting.
       suite('trashcan flyout', function() {
         setup(function() {
           this.flyout = this.workspace.getFlyout();
@@ -221,7 +239,8 @@ suite('Flyout', function() {
           this.flyout.targetWorkspace.toolboxPosition =
               Blockly.utils.toolbox.Position.BOTTOM;
           this.flyout.toolboxPosition_ = Blockly.utils.toolbox.Position.TOP;
-          chai.assert.equal(this.flyout.getY(), 0, 'y should be aligned with top');
+          chai.assert.equal(
+              this.flyout.getY(), 0, 'y should be aligned with top');
         });
         test('trashcan on bottom covers bottom of workspace', function() {
           this.flyout.targetWorkspace.toolboxPosition =
@@ -235,7 +254,9 @@ suite('Flyout', function() {
           });
           this.flyout.setVisible(true);
           this.flyout.height_ = 20;
-          chai.assert.equal(this.flyout.getY(), 40, 'y + height should be aligned with bottom');
+          chai.assert.equal(
+              this.flyout.getY(), 40,
+              'y + height should be aligned with bottom');
         });
       });
     });
@@ -306,10 +327,13 @@ suite('Flyout', function() {
     suite('Dynamic category', function() {
       setup(function() {
         this.stubAndAssert = function(val) {
-          sinon.stub(
-              this.flyout.workspace_.targetWorkspace,
-              'getToolboxCategoryCallback')
-              .returns(function() {return val;});
+          sinon
+              .stub(
+                  this.flyout.workspace_.targetWorkspace,
+                  'getToolboxCategoryCallback')
+              .returns(function() {
+                return val;
+              });
           this.flyout.show('someString');
           checkFlyoutInfo(this.createFlyoutSpy);
         };
@@ -321,7 +345,7 @@ suite('Flyout', function() {
               this.flyout.show('someString');
             }.bind(this),
             'Couldn\'t find a callback function when opening ' +
-            'a toolbox category.');
+                'a toolbox category.');
       });
 
       test('Node', function() {
@@ -363,8 +387,7 @@ suite('Flyout', function() {
           const xml = Blockly.utils.xml.textToDom(
               '<xml>' +
               '<block type="text_print" disabled="true"></block>' +
-              '</xml>'
-          );
+              '</xml>');
           this.flyout.show(xml);
           this.assertDisabled(true);
         });
@@ -373,8 +396,7 @@ suite('Flyout', function() {
           const xml = Blockly.utils.xml.textToDom(
               '<xml>' +
               '<block type="text_print" disabled="false"></block>' +
-              '</xml>'
-          );
+              '</xml>');
           this.flyout.show(xml);
           this.assertDisabled(false);
         });
@@ -384,8 +406,7 @@ suite('Flyout', function() {
           const xml = Blockly.utils.xml.textToDom(
               '<xml>' +
               '<block type="text_print" disabled="disabled"></block>' +
-              '</xml>'
-          );
+              '</xml>');
           this.flyout.show(xml);
           this.assertDisabled(true);
         });
@@ -394,8 +415,7 @@ suite('Flyout', function() {
           const xml = Blockly.utils.xml.textToDom(
               '<xml>' +
               '<block type="text_print" disabled="random"></block>' +
-              '</xml>'
-          );
+              '</xml>');
           this.flyout.show(xml);
           this.assertDisabled(false);
         });
@@ -557,7 +577,9 @@ suite('Flyout', function() {
     });
 
     test('Recycling enabled', function() {
-      this.flyout.blockIsRecyclable_ = function() {return true;};
+      this.flyout.blockIsRecyclable_ = function() {
+        return true;
+      };
       this.flyout.show({
         'contents': [
           {

--- a/tests/mocha/generator_test.js
+++ b/tests/mocha/generator_test.js
@@ -39,42 +39,50 @@ suite('Generator', function() {
     });
 
     test('One line', function() {
-      chai.assert.equal(this.generator.prefixLines('Hello\n', '12'), '12Hello\n');
+      chai.assert.equal(
+          this.generator.prefixLines('Hello\n', '12'), '12Hello\n');
     });
 
     test('Two lines', function() {
-      chai.assert.equal(this.generator.prefixLines('Hello\nWorld\n', '***'), '***Hello\n***World\n');
+      chai.assert.equal(
+          this.generator.prefixLines('Hello\nWorld\n', '***'),
+          '***Hello\n***World\n');
     });
   });
 
   suite('blockToCode', function() {
     setup(function() {
-      Blockly.defineBlocksWithJsonArray([{
-        "type": "stack_block",
-        "message0": "",
-        "previousStatement": null,
-        "nextStatement": null,
-      },
-      {
-        "type": "row_block",
-        "message0": "%1",
-        "args0": [
-          {
-            "type": "input_value",
-            "name": "INPUT",
-          },
-        ],
-        "output": null,
-        "nextStatement": null,
-      }]);
+      Blockly.defineBlocksWithJsonArray([
+        {
+          "type": "stack_block",
+          "message0": "",
+          "previousStatement": null,
+          "nextStatement": null,
+        },
+        {
+          "type": "row_block",
+          "message0": "%1",
+          "args0": [
+            {
+              "type": "input_value",
+              "name": "INPUT",
+            },
+          ],
+          "output": null,
+          "nextStatement": null,
+        }
+      ]);
       const rowBlock = this.workspace.newBlock('row_block');
       const stackBlock = this.workspace.newBlock('stack_block');
 
       this.blockToCodeTest = function(
-          generator, blockDisabled, opt_thisOnly,
-          expectedCode, opt_message) {
-        generator.row_block = function(_) {return 'row_block';};
-        generator.stack_block = function(_) {return 'stack_block';};
+          generator, blockDisabled, opt_thisOnly, expectedCode, opt_message) {
+        generator.row_block = function(_) {
+          return 'row_block';
+        };
+        generator.stack_block = function(_) {
+          return 'stack_block';
+        };
         rowBlock.nextConnection.connect(stackBlock.previousConnection);
         rowBlock.disabled = blockDisabled;
 
@@ -84,11 +92,9 @@ suite('Generator', function() {
     });
 
     const testCase = [
-      [dartGenerator, 'Dart'],
-      [javascriptGenerator, 'JavaScript'],
-      [luaGenerator, 'Lua'],
-      [phpGenerator, 'PHP'],
-      [pythonGenerator, 'Python']];
+      [dartGenerator, 'Dart'], [javascriptGenerator, 'JavaScript'],
+      [luaGenerator, 'Lua'], [phpGenerator, 'PHP'], [pythonGenerator, 'Python']
+    ];
 
     suite('Trivial', function() {
       testCase.forEach(function(testCase) {
@@ -98,7 +104,8 @@ suite('Generator', function() {
           generator.init(this.workspace);
           this.blockToCodeTest(generator, false, true, 'row_block');
           this.blockToCodeTest(
-              generator, false, false, 'row_blockstack_block', 'thisOnly=false');
+              generator, false, false, 'row_blockstack_block',
+              'thisOnly=false');
         });
       });
     });
@@ -109,7 +116,8 @@ suite('Generator', function() {
         const name = testCase[1];
         test(name, function() {
           this.blockToCodeTest(generator, true, true, '');
-          this.blockToCodeTest(generator, true, false, 'stack_block', 'thisOnly=false');
+          this.blockToCodeTest(
+              generator, true, false, 'stack_block', 'thisOnly=false');
         });
       });
     });

--- a/tests/mocha/generator_test.js
+++ b/tests/mocha/generator_test.js
@@ -70,7 +70,7 @@ suite('Generator', function() {
           ],
           "output": null,
           "nextStatement": null,
-        }
+        },
       ]);
       const rowBlock = this.workspace.newBlock('row_block');
       const stackBlock = this.workspace.newBlock('stack_block');
@@ -92,8 +92,11 @@ suite('Generator', function() {
     });
 
     const testCase = [
-      [dartGenerator, 'Dart'], [javascriptGenerator, 'JavaScript'],
-      [luaGenerator, 'Lua'], [phpGenerator, 'PHP'], [pythonGenerator, 'Python']
+      [dartGenerator, 'Dart'],
+      [javascriptGenerator, 'JavaScript'],
+      [luaGenerator, 'Lua'],
+      [phpGenerator, 'PHP'],
+      [pythonGenerator, 'Python'],
     ];
 
     suite('Trivial', function() {

--- a/tests/mocha/gesture_test.js
+++ b/tests/mocha/gesture_test.js
@@ -17,8 +17,8 @@ suite('Gesture', function() {
   function testGestureIsFieldClick(block, isFieldClick, eventsFireStub) {
     const field = block.getField('NAME');
     const eventTarget = field.getClickTarget_();
-    chai.assert.exists(eventTarget,
-        'Precondition: missing click target for field');
+    chai.assert.exists(
+        eventTarget, 'Precondition: missing click target for field');
 
     eventsFireStub.resetHistory();
     dispatchPointerEvent(eventTarget, 'pointerdown');
@@ -37,9 +37,11 @@ suite('Gesture', function() {
     chai.assert.isTrue(isFieldClickSpy.alwaysReturned(isFieldClick));
 
 
-    assertEventFired(eventsFireStub, Blockly.Events.Selected,
+    assertEventFired(
+        eventsFireStub, Blockly.Events.Selected,
         {newElementId: block.id, type: eventUtils.SELECTED}, fieldWorkspace.id);
-    assertEventNotFired(eventsFireStub, Blockly.Events.Click, {type: eventUtils.CLICK});
+    assertEventNotFired(
+        eventsFireStub, Blockly.Events.Click, {type: eventUtils.CLICK});
   }
 
   function getTopFlyoutBlock(flyout) {
@@ -74,8 +76,7 @@ suite('Gesture', function() {
 
   test('Field click - Auto close flyout', function() {
     const flyout = this.workspace.getFlyout(true);
-    chai.assert.exists(flyout,
-        'Precondition: missing flyout');
+    chai.assert.exists(flyout, 'Precondition: missing flyout');
     flyout.autoClose = true;
 
     const block = getTopFlyoutBlock(flyout);
@@ -84,8 +85,7 @@ suite('Gesture', function() {
 
   test('Field click - Always open flyout', function() {
     const flyout = this.workspace.getFlyout(true);
-    chai.assert.exists(flyout,
-        'Precondition: missing flyout');
+    chai.assert.exists(flyout, 'Precondition: missing flyout');
     flyout.autoClose = false;
 
     const block = getTopFlyoutBlock(flyout);

--- a/tests/mocha/input_test.js
+++ b/tests/mocha/input_test.js
@@ -19,9 +19,9 @@ suite('Inputs', function() {
     }]);
 
     this.workspace = Blockly.inject('blocklyDiv');
-    this.block = Blockly.Xml.domToBlock(Blockly.utils.xml.textToDom(
-        '<block type="empty_block"/>'
-    ), this.workspace);
+    this.block = Blockly.Xml.domToBlock(
+        Blockly.utils.xml.textToDom('<block type="empty_block"/>'),
+        this.workspace);
 
     this.renderStub = sinon.stub(this.block, 'queueRender');
     this.bumpNeighboursStub = sinon.stub(this.block, 'bumpNeighbours');
@@ -117,34 +117,28 @@ suite('Inputs', function() {
         chai.assert.deepEqual(this.dummy.fieldRow, [prefix, field, suffix]);
       });
       test('Dropdown - Prefix', function() {
-        const field = new Blockly.FieldDropdown(
-            [
-              ['prefix option1', 'OPTION1'],
-              ['prefix option2', 'OPTION2'],
-            ]
-        );
+        const field = new Blockly.FieldDropdown([
+          ['prefix option1', 'OPTION1'],
+          ['prefix option2', 'OPTION2'],
+        ]);
 
         this.dummy.appendField(field);
         chai.assert.equal(this.dummy.fieldRow.length, 2);
       });
       test('Dropdown - Suffix', function() {
-        const field = new Blockly.FieldDropdown(
-            [
-              ['option1 suffix', 'OPTION1'],
-              ['option2 suffix', 'OPTION2'],
-            ]
-        );
+        const field = new Blockly.FieldDropdown([
+          ['option1 suffix', 'OPTION1'],
+          ['option2 suffix', 'OPTION2'],
+        ]);
 
         this.dummy.appendField(field);
         chai.assert.equal(this.dummy.fieldRow.length, 2);
       });
       test('Dropdown - Prefix and Suffix', function() {
-        const field = new Blockly.FieldDropdown(
-            [
-              ['prefix option1 suffix', 'OPTION1'],
-              ['prefix option2 suffix', 'OPTION2'],
-            ]
-        );
+        const field = new Blockly.FieldDropdown([
+          ['prefix option1 suffix', 'OPTION1'],
+          ['prefix option2 suffix', 'OPTION2'],
+        ]);
 
         this.dummy.appendField(field);
         chai.assert.equal(this.dummy.fieldRow.length, 3);

--- a/tests/mocha/insertion_marker_test.js
+++ b/tests/mocha/insertion_marker_test.js
@@ -42,7 +42,7 @@ suite('InsertionMarkers', function() {
         ],
         "previousStatement": null,
         "nextStatement": null,
-      }
+      },
     ]);
   });
   teardown(function() {

--- a/tests/mocha/insertion_marker_test.js
+++ b/tests/mocha/insertion_marker_test.js
@@ -42,7 +42,8 @@ suite('InsertionMarkers', function() {
         ],
         "previousStatement": null,
         "nextStatement": null,
-      }]);
+      }
+    ]);
   });
   teardown(function() {
     sharedTestTeardown.call(this);
@@ -53,14 +54,14 @@ suite('InsertionMarkers', function() {
         return 'stack[' + block.id + '];\n';
       };
       javascriptGenerator['row_block'] = function(block) {
-        const value = javascriptGenerator
-            .valueToCode(block, 'INPUT', javascriptGenerator.ORDER_NONE);
+        const value = javascriptGenerator.valueToCode(
+            block, 'INPUT', javascriptGenerator.ORDER_NONE);
         const code = 'row[' + block.id + '](' + value + ')';
         return [code, javascriptGenerator.ORDER_NONE];
       };
       javascriptGenerator['statement_block'] = function(block) {
-        return 'statement[' + block.id + ']{\n' + javascriptGenerator
-            .statementToCode(block, 'STATEMENT') + '};\n';
+        return 'statement[' + block.id + ']{\n' +
+            javascriptGenerator.statementToCode(block, 'STATEMENT') + '};\n';
       };
 
       this.assertGen = function(xml, expectedCode) {
@@ -111,11 +112,12 @@ suite('InsertionMarkers', function() {
           '    </statement>' +
           '  </block>' +
           '</xml>');
-      this.assertGen(xml,
+      this.assertGen(
+          xml,
           'statement[a]{\n' +
-          '  statement[b]{\n' +
-          '  };\n' +
-          '};\n');
+              '  statement[b]{\n' +
+              '  };\n' +
+              '};\n');
     });
     test('Marker Prev', function() {
       const xml = Blockly.utils.xml.textToDom(
@@ -152,9 +154,10 @@ suite('InsertionMarkers', function() {
           '    </next>' +
           '  </block>' +
           '</xml>');
-      this.assertGen(xml,
+      this.assertGen(
+          xml,
           'stack[a];\n' +
-          'stack[b];\n');
+              'stack[b];\n');
     });
     test('Marker On Output', function() {
       const xml = Blockly.utils.xml.textToDom(
@@ -225,10 +228,11 @@ suite('InsertionMarkers', function() {
           '</xml>');
       // Note how the x and y are not 20, they are slightly lower and end-er
       // because these are the coords of the wrapped block.
-      this.assertXml(xml,
+      this.assertXml(
+          xml,
           '<xml xmlns="https://developers.google.com/blockly/xml">' +
-          '<block type="statement_block" id="a" x="41" y="31"></block>' +
-          '</xml>');
+              '<block type="statement_block" id="a" x="41" y="31"></block>' +
+              '</xml>');
     });
     test('Marker Enclosed', function() {
       const xml = Blockly.utils.xml.textToDom(
@@ -239,10 +243,11 @@ suite('InsertionMarkers', function() {
           '    </statement>' +
           '  </block>' +
           '</xml>');
-      this.assertXml(xml,
+      this.assertXml(
+          xml,
           '<xml xmlns="https://developers.google.com/blockly/xml">' +
-          '<block type="statement_block" id="a" x="20" y="20"></block>' +
-          '</xml>');
+              '<block type="statement_block" id="a" x="20" y="20"></block>' +
+              '</xml>');
     });
     test('Marker Enclosed and Surrounds', function() {
       const xml = Blockly.utils.xml.textToDom(
@@ -257,14 +262,15 @@ suite('InsertionMarkers', function() {
           '    </statement>' +
           '  </block>' +
           '</xml>');
-      this.assertXml(xml,
+      this.assertXml(
+          xml,
           '<xml xmlns="https://developers.google.com/blockly/xml">' +
-          '<block type="statement_block" id="a" x="20" y="20">' +
-          '<statement name="STATEMENT">' +
-          '<block type="statement_block" id="b"></block>' +
-          '</statement>' +
-          '</block>' +
-          '</xml>');
+              '<block type="statement_block" id="a" x="20" y="20">' +
+              '<statement name="STATEMENT">' +
+              '<block type="statement_block" id="b"></block>' +
+              '</statement>' +
+              '</block>' +
+              '</xml>');
     });
     test('Marker Prev', function() {
       const xml = Blockly.utils.xml.textToDom(
@@ -277,10 +283,11 @@ suite('InsertionMarkers', function() {
           '</xml>');
       // Note how the y coord is not at 20, it is lower. This is because these
       // are the coords of the next block.
-      this.assertXml(xml,
+      this.assertXml(
+          xml,
           '<xml xmlns="https://developers.google.com/blockly/xml">' +
-          '<block type="stack_block" id="a" x="20" y="46"></block>' +
-          '</xml>');
+              '<block type="stack_block" id="a" x="20" y="46"></block>' +
+              '</xml>');
     });
     test('Marker Next', function() {
       const xml = Blockly.utils.xml.textToDom(
@@ -291,10 +298,11 @@ suite('InsertionMarkers', function() {
           '    </next>' +
           '  </block>' +
           '</xml>');
-      this.assertXml(xml,
+      this.assertXml(
+          xml,
           '<xml xmlns="https://developers.google.com/blockly/xml">' +
-          '<block type="stack_block" id="a" x="20" y="20"></block>' +
-          '</xml>');
+              '<block type="stack_block" id="a" x="20" y="20"></block>' +
+              '</xml>');
     });
     test('Marker Middle of Stack', function() {
       const xml = Blockly.utils.xml.textToDom(
@@ -309,14 +317,15 @@ suite('InsertionMarkers', function() {
           '    </next>' +
           '  </block>' +
           '</xml>');
-      this.assertXml(xml,
+      this.assertXml(
+          xml,
           '<xml xmlns="https://developers.google.com/blockly/xml">' +
-          '<block type="stack_block" id="a" x="20" y="20">' +
-          '<next>' +
-          '<block type="stack_block" id="b"></block>' +
-          '</next>' +
-          '</block>' +
-          '</xml>');
+              '<block type="stack_block" id="a" x="20" y="20">' +
+              '<next>' +
+              '<block type="stack_block" id="b"></block>' +
+              '</next>' +
+              '</block>' +
+              '</xml>');
     });
     test('Marker On Output', function() {
       const xml = Blockly.utils.xml.textToDom(
@@ -329,10 +338,11 @@ suite('InsertionMarkers', function() {
           '</xml>');
       // Note how the x value is not at 20. This is because these are the coords
       // of the wrapped block.
-      this.assertXml(xml,
+      this.assertXml(
+          xml,
           '<xml xmlns="https://developers.google.com/blockly/xml">' +
-          '<block type="row_block" id="a" x="41" y="20"></block>' +
-          '</xml>');
+              '<block type="row_block" id="a" x="41" y="20"></block>' +
+              '</xml>');
     });
     test('Marker On Input', function() {
       const xml = Blockly.utils.xml.textToDom(
@@ -343,10 +353,11 @@ suite('InsertionMarkers', function() {
           '    </value>' +
           '  </block>' +
           '</xml>');
-      this.assertXml(xml,
+      this.assertXml(
+          xml,
           '<xml xmlns="https://developers.google.com/blockly/xml">' +
-          '<block type="row_block" id="a" x="20" y="20"></block>' +
-          '</xml>');
+              '<block type="row_block" id="a" x="20" y="20"></block>' +
+              '</xml>');
     });
     test('Marker Middle of Row', function() {
       const xml = Blockly.utils.xml.textToDom(
@@ -361,14 +372,15 @@ suite('InsertionMarkers', function() {
           '    </value>' +
           '  </block>' +
           '</xml>');
-      this.assertXml(xml,
+      this.assertXml(
+          xml,
           '<xml xmlns="https://developers.google.com/blockly/xml">' +
-          '<block type="row_block" id="a" x="20" y="20">' +
-          '<value name="INPUT">' +
-          '<block type="row_block" id="b"></block>' +
-          '</value>' +
-          '</block>' +
-          '</xml>');
+              '<block type="row_block" id="a" x="20" y="20">' +
+              '<value name="INPUT">' +
+              '<block type="row_block" id="b"></block>' +
+              '</value>' +
+              '</block>' +
+              '</xml>');
     });
     test('Marker Detatched', function() {
       const xml = Blockly.utils.xml.textToDom(
@@ -376,10 +388,11 @@ suite('InsertionMarkers', function() {
           '  <block type="stack_block" id="insertion"/>' +
           '  <block type="stack_block" id="a" x="20" y="20"/>' +
           '</xml>');
-      this.assertXml(xml,
+      this.assertXml(
+          xml,
           '<xml xmlns="https://developers.google.com/blockly/xml">' +
-          '<block type="stack_block" id="a" x="20" y="20"></block>' +
-          '</xml>');
+              '<block type="stack_block" id="a" x="20" y="20"></block>' +
+              '</xml>');
     });
   });
 });

--- a/tests/mocha/jso_deserialization_test.js
+++ b/tests/mocha/jso_deserialization_test.js
@@ -38,10 +38,8 @@ suite('JSO Deserialization', function() {
         };
         Blockly.serialization.workspaces.load(state, this.workspace);
         assertEventFired(
-            this.eventsFireStub,
-            Blockly.Events.FinishedLoading,
-            {type: eventUtils.FINISHED_LOADING},
-            this.workspace.id);
+            this.eventsFireStub, Blockly.Events.FinishedLoading,
+            {type: eventUtils.FINISHED_LOADING}, this.workspace.id);
       });
 
       test('Explicit group', function() {
@@ -127,7 +125,8 @@ suite('JSO Deserialization', function() {
             },
           ],
         };
-        Blockly.serialization.workspaces.load(state, this.workspace, {recordUndo: true});
+        Blockly.serialization.workspaces.load(
+            state, this.workspace, {recordUndo: true});
         assertEventFired(
             this.eventsFireStub, Blockly.Events.VarCreate, {
               'varName': 'test',
@@ -241,11 +240,9 @@ suite('JSO Deserialization', function() {
           };
           Blockly.serialization.workspaces.load(state, this.workspace);
           assertEventFired(
-              this.eventsFireStub,
-              Blockly.Events.BlockCreate,
+              this.eventsFireStub, Blockly.Events.BlockCreate,
               {'recordUndo': false, "type": eventUtils.BLOCK_CREATE},
-              this.workspace.id,
-              'testId');
+              this.workspace.id, 'testId');
         });
 
         test('Record undo', function() {
@@ -261,13 +258,12 @@ suite('JSO Deserialization', function() {
               ],
             },
           };
-          Blockly.serialization.workspaces.load(state, this.workspace, {'recordUndo': true});
+          Blockly.serialization.workspaces.load(
+              state, this.workspace, {'recordUndo': true});
           assertEventFired(
-              this.eventsFireStub,
-              Blockly.Events.BlockCreate,
+              this.eventsFireStub, Blockly.Events.BlockCreate,
               {'recordUndo': true, "type": eventUtils.BLOCK_CREATE},
-              this.workspace.id,
-              'testId');
+              this.workspace.id, 'testId');
         });
 
         test('Grouping', function() {
@@ -286,11 +282,9 @@ suite('JSO Deserialization', function() {
           Blockly.Events.setGroup('my group');
           Blockly.serialization.workspaces.load(state, this.workspace);
           assertEventFired(
-              this.eventsFireStub,
-              Blockly.Events.BlockCreate,
+              this.eventsFireStub, Blockly.Events.BlockCreate,
               {'group': 'my group', "type": eventUtils.BLOCK_CREATE},
-              this.workspace.id,
-              'testId');
+              this.workspace.id, 'testId');
         });
 
         test('Multiple blocks grouped', function() {
@@ -315,7 +309,8 @@ suite('JSO Deserialization', function() {
           Blockly.serialization.workspaces.load(state, this.workspace);
           const calls = this.eventsFireStub.getCalls();
           const group = calls[0].args[0].group;
-          chai.assert.isTrue(calls.every((call) => call.args[0].group == group));
+          chai.assert.isTrue(
+              calls.every((call) => call.args[0].group == group));
         });
 
         test('With children', function() {
@@ -347,11 +342,8 @@ suite('JSO Deserialization', function() {
           };
           Blockly.serialization.workspaces.load(state, this.workspace);
           assertEventFired(
-              this.eventsFireStub,
-              Blockly.Events.BlockCreate,
-              {type: eventUtils.BLOCK_CREATE},
-              this.workspace.id,
-              'id1');
+              this.eventsFireStub, Blockly.Events.BlockCreate,
+              {type: eventUtils.BLOCK_CREATE}, this.workspace.id, 'id1');
         });
       });
 
@@ -365,11 +357,8 @@ suite('JSO Deserialization', function() {
           };
           Blockly.serialization.blocks.append(state, this.workspace);
           assertEventFired(
-              this.eventsFireStub,
-              Blockly.Events.BlockCreate,
-              {'recordUndo': false},
-              this.workspace.id,
-              'testId');
+              this.eventsFireStub, Blockly.Events.BlockCreate,
+              {'recordUndo': false}, this.workspace.id, 'testId');
         });
 
         test('Record undo', function() {
@@ -382,11 +371,9 @@ suite('JSO Deserialization', function() {
           Blockly.serialization.blocks.append(
               state, this.workspace, {'recordUndo': true});
           assertEventFired(
-              this.eventsFireStub,
-              Blockly.Events.BlockCreate,
+              this.eventsFireStub, Blockly.Events.BlockCreate,
               {'recordUndo': true, "type": eventUtils.BLOCK_CREATE},
-              this.workspace.id,
-              'testId');
+              this.workspace.id, 'testId');
         });
 
         test('Grouping', function() {
@@ -399,11 +386,9 @@ suite('JSO Deserialization', function() {
           Blockly.Events.setGroup('my group');
           Blockly.serialization.blocks.append(state, this.workspace);
           assertEventFired(
-              this.eventsFireStub,
-              Blockly.Events.BlockCreate,
+              this.eventsFireStub, Blockly.Events.BlockCreate,
               {'group': 'my group', "type": eventUtils.BLOCK_CREATE},
-              this.workspace.id,
-              'testId');
+              this.workspace.id, 'testId');
         });
       });
     });
@@ -628,8 +613,8 @@ suite('JSO Deserialization', function() {
   });
 
   test('Priority', function() {
-    const blocksSerializer = Blockly.registry.getClass(
-        Blockly.registry.Type.SERIALIZER, 'blocks');
+    const blocksSerializer =
+        Blockly.registry.getClass(Blockly.registry.Type.SERIALIZER, 'blocks');
     const variablesSerializer = Blockly.registry.getClass(
         Blockly.registry.Type.SERIALIZER, 'variables');
 
@@ -671,16 +656,14 @@ suite('JSO Deserialization', function() {
     Blockly.serialization.registry.register('blocks', blocksSerializer);
     Blockly.serialization.registry.register('variables', variablesSerializer);
 
-    chai.assert.deepEqual(
-        calls,
-        [
-          'third-clear',
-          'second-clear',
-          'first-clear',
-          'first-load',
-          'second-load',
-          'third-load',
-        ]);
+    chai.assert.deepEqual(calls, [
+      'third-clear',
+      'second-clear',
+      'first-clear',
+      'first-load',
+      'second-load',
+      'third-load',
+    ]);
   });
 
   suite('Extra state', function() {
@@ -688,7 +671,7 @@ suite('JSO Deserialization', function() {
     // for old xml hooks.
     test('Xml hooks', function() {
       Blockly.Blocks['test_block'] = {
-        init: function() { },
+        init: function() {},
 
         mutationToDom: function() {
           const container = Blockly.utils.xml.createElement('mutation');
@@ -805,9 +788,9 @@ suite('JSO Deserialization', function() {
     }
 
     setup(function() {
-      this.procedureSerializer = new
-          Blockly.serialization.procedures.ProcedureSerializer(
-            MockProcedureModel, MockParameterModel);
+      this.procedureSerializer =
+          new Blockly.serialization.procedures.ProcedureSerializer(
+              MockProcedureModel, MockParameterModel);
       this.procedureMap = this.workspace.getProcedureMap();
     });
 
@@ -830,8 +813,7 @@ suite('JSO Deserialization', function() {
         chai.assert.isNotNull(
             procedureModel, 'Expected a procedure model to exist');
         chai.assert.equal(
-            procedureModel.getId(),
-            'test id',
+            procedureModel.getId(), 'test id',
             'Expected the procedure model ID to match the serialized ID');
       });
 
@@ -848,8 +830,7 @@ suite('JSO Deserialization', function() {
         chai.assert.isNotNull(
             procedureModel, 'Expected a procedure model to exist');
         chai.assert.equal(
-            procedureModel.getName(),
-            'test name',
+            procedureModel.getName(), 'test name',
             'Expected the procedure model name to match the serialized name');
       });
     });
@@ -872,47 +853,50 @@ suite('JSO Deserialization', function() {
             'Expected the procedure model types to be null');
       });
 
-      test('if the return type property is an empty array it is assigned', function() {
-        const jso = {
-          'id': 'test id',
-          'name': 'test name',
-          'returnTypes': [],
-        };
+      test(
+          'if the return type property is an empty array it is assigned',
+          function() {
+            const jso = {
+              'id': 'test id',
+              'name': 'test name',
+              'returnTypes': [],
+            };
 
-        this.procedureSerializer.load([jso], this.workspace);
+            this.procedureSerializer.load([jso], this.workspace);
 
-        const procedureModel = this.procedureMap.getProcedures()[0];
-        chai.assert.isNotNull(
-            procedureModel, 'Expected a procedure model to exist');
-        chai.assert.isArray(
-            procedureModel.getReturnTypes(),
-            'Expected the procedure model types to be an array');
-        chai.assert.isEmpty(
-            procedureModel.getReturnTypes(),
-            'Expected the procedure model types array to be empty');
-      });
+            const procedureModel = this.procedureMap.getProcedures()[0];
+            chai.assert.isNotNull(
+                procedureModel, 'Expected a procedure model to exist');
+            chai.assert.isArray(
+                procedureModel.getReturnTypes(),
+                'Expected the procedure model types to be an array');
+            chai.assert.isEmpty(
+                procedureModel.getReturnTypes(),
+                'Expected the procedure model types array to be empty');
+          });
 
-      test('if the return type property is a string array it is assigned', function() {
-        const jso = {
-          'id': 'test id',
-          'name': 'test name',
-          'returnTypes': ['test type 1', 'test type 2'],
-        };
+      test(
+          'if the return type property is a string array it is assigned',
+          function() {
+            const jso = {
+              'id': 'test id',
+              'name': 'test name',
+              'returnTypes': ['test type 1', 'test type 2'],
+            };
 
-        this.procedureSerializer.load([jso], this.workspace);
+            this.procedureSerializer.load([jso], this.workspace);
 
-        const procedureModel = this.procedureMap.getProcedures()[0];
-        chai.assert.isNotNull(
-            procedureModel, 'Expected a procedure model to exist');
-        chai.assert.isArray(
-            procedureModel.getReturnTypes(),
-            'Expected the procedure model types to be an array');
-        chai.assert.deepEqual(
-            procedureModel.getReturnTypes(),
-            ['test type 1', 'test type 2'],
-            'Expected the procedure model types array to be match the ' +
-            'serialized array');
-      });
+            const procedureModel = this.procedureMap.getProcedures()[0];
+            chai.assert.isNotNull(
+                procedureModel, 'Expected a procedure model to exist');
+            chai.assert.isArray(
+                procedureModel.getReturnTypes(),
+                'Expected the procedure model types to be an array');
+            chai.assert.deepEqual(
+                procedureModel.getReturnTypes(), ['test type 1', 'test type 2'],
+                'Expected the procedure model types array to be match the ' +
+                    'serialized array');
+          });
     });
 
     suite('parameters', function() {
@@ -937,8 +921,7 @@ suite('JSO Deserialization', function() {
           chai.assert.isNotNull(
               parameterModel, 'Expected a parameter model to exist');
           chai.assert.equal(
-              parameterModel.getId(),
-              'test id',
+              parameterModel.getId(), 'test id',
               'Expected the parameter model ID to match the serialized ID');
         });
 
@@ -962,8 +945,7 @@ suite('JSO Deserialization', function() {
           chai.assert.isNotNull(
               parameterModel, 'Expected a parameter model to exist');
           chai.assert.equal(
-              parameterModel.getName(),
-              'test name',
+              parameterModel.getName(), 'test name',
               'Expected the parameter model name to match the serialized name');
         });
       });
@@ -982,11 +964,9 @@ suite('JSO Deserialization', function() {
             ],
           };
 
-          chai.assert.doesNotThrow(
-            () => {
-              this.procedureMap.getProcedures()[0].getParameters()[0];
-            },
-            'Expected the deserializer to skip the non-existant type property');
+          chai.assert.doesNotThrow(() => {
+            this.procedureMap.getProcedures()[0].getParameters()[0];
+          }, 'Expected the deserializer to skip the non-existant type property');
         });
 
         test('if the type property exists, it is assigned', function() {
@@ -1010,8 +990,7 @@ suite('JSO Deserialization', function() {
           chai.assert.isNotNull(
               parameterModel, 'Expected a parameter model to exist');
           chai.assert.deepEqual(
-              parameterModel.getTypes(),
-              ['test type 1', 'test type 2'],
+              parameterModel.getTypes(), ['test type 1', 'test type 2'],
               'Expected the parameter model types to match the serialized types');
         });
       });

--- a/tests/mocha/jso_serialization_test.js
+++ b/tests/mocha/jso_serialization_test.js
@@ -342,11 +342,13 @@ suite('JSO Serialization', function() {
         const block = this.workspace.newBlock('row_block');
         block.getInput('INPUT').appendField(new ObjectStateField(''), 'FIELD');
         const jso = Blockly.serialization.blocks.save(block);
-        assertProperty(jso, 'fields', {'FIELD': {
-          'prop1': 'state1',
-          'prop2': 42,
-          'prop3': true,
-        }});
+        assertProperty(jso, 'fields', {
+          'FIELD': {
+            'prop1': 'state1',
+            'prop2': 42,
+            'prop3': true,
+          }
+        });
       });
 
       test('Array', function() {
@@ -408,19 +410,16 @@ suite('JSO Serialization', function() {
           const block =
               this.createBlockWithShadowAndChild(blockType, inputName);
           const jso = Blockly.serialization.blocks.save(block);
-          this.assertInput(
-              jso,
-              inputName,
-              {
-                'block': {
-                  'type': blockType,
-                  'id': 'id2',
-                },
-                'shadow': {
-                  'type': blockType,
-                  'id': 'test',
-                },
-              });
+          this.assertInput(jso, inputName, {
+            'block': {
+              'type': blockType,
+              'id': 'id2',
+            },
+            'shadow': {
+              'type': blockType,
+              'id': 'test',
+            },
+          });
         };
 
         this.assertNoChild = function(blockType, inputName) {
@@ -455,18 +454,15 @@ suite('JSO Serialization', function() {
           });
           block.getInputTargetBlock('TEXT').setFieldValue('new value', 'TEXT');
           const jso = Blockly.serialization.blocks.save(block);
-          this.assertInput(
-              jso,
-              'TEXT',
-              {
-                'shadow': {
-                  'type': 'text',
-                  'id': 'id',
-                  'fields': {
-                    'TEXT': 'new value',
-                  },
-                },
-              });
+          this.assertInput(jso, 'TEXT', {
+            'shadow': {
+              'type': 'text',
+              'id': 'id',
+              'fields': {
+                'TEXT': 'new value',
+              },
+            },
+          });
         });
 
         test('Overwritten', function() {
@@ -480,25 +476,22 @@ suite('JSO Serialization', function() {
           block.getInput('TEXT').connection.connect(
               childBlock.outputConnection);
           const jso = Blockly.serialization.blocks.save(block);
-          this.assertInput(
-              jso,
-              'TEXT',
-              {
-                'shadow': {
-                  'type': 'text',
-                  'id': 'id',
-                  'fields': {
-                    'TEXT': 'new value',
-                  },
-                },
-                'block': {
-                  'type': 'text',
-                  'id': 'id3',
-                  'fields': {
-                    'TEXT': '',
-                  },
-                },
-              });
+          this.assertInput(jso, 'TEXT', {
+            'shadow': {
+              'type': 'text',
+              'id': 'id',
+              'fields': {
+                'TEXT': 'new value',
+              },
+            },
+            'block': {
+              'type': 'text',
+              'id': 'id3',
+              'fields': {
+                'TEXT': '',
+              },
+            },
+          });
         });
       });
 
@@ -550,27 +543,23 @@ suite('JSO Serialization', function() {
             const block = this.workspace.newBlock('statement_block');
             const childBlock = this.workspace.newBlock('stack_block');
             const grandChildBlock = this.workspace.newBlock('stack_block');
-            block.getInput('NAME').connection
-                .connect(childBlock.previousConnection);
-            childBlock.nextConnection
-                .connect(grandChildBlock.previousConnection);
+            block.getInput('NAME').connection.connect(
+                childBlock.previousConnection);
+            childBlock.nextConnection.connect(
+                grandChildBlock.previousConnection);
             const jso = Blockly.serialization.blocks.save(block);
-            this.assertInput(
-                jso,
-                'NAME',
-                {
+            this.assertInput(jso, 'NAME', {
+              'block': {
+                'type': 'stack_block',
+                'id': 'id2',
+                'next': {
                   'block': {
                     'type': 'stack_block',
-                    'id': 'id2',
-                    'next': {
-                      'block': {
-                        'type': 'stack_block',
-                        'id': 'id4',
-                      },
-                    },
+                    'id': 'id4',
                   },
-                }
-            );
+                },
+              },
+            });
           });
         });
 
@@ -600,9 +589,8 @@ suite('JSO Serialization', function() {
 
           this.createNextWithShadow = function() {
             const block = this.workspace.newBlock('stack_block');
-            block.nextConnection.setShadowDom(
-                Blockly.utils.xml.textToDom(
-                    '<shadow type="stack_block" id="test"></shadow>'));
+            block.nextConnection.setShadowDom(Blockly.utils.xml.textToDom(
+                '<shadow type="stack_block" id="test"></shadow>'));
             return block;
           };
 
@@ -610,9 +598,8 @@ suite('JSO Serialization', function() {
             const block = this.workspace.newBlock('stack_block');
             const childBlock = this.workspace.newBlock('stack_block');
             block.nextConnection.connect(childBlock.previousConnection);
-            block.nextConnection.setShadowDom(
-                Blockly.utils.xml.textToDom(
-                    '<shadow type="stack_block" id="test"></shadow>'));
+            block.nextConnection.setShadowDom(Blockly.utils.xml.textToDom(
+                '<shadow type="stack_block" id="test"></shadow>'));
             return block;
           };
         });
@@ -620,8 +607,7 @@ suite('JSO Serialization', function() {
         suite('With serialization', function() {
           test('Child', function() {
             const block = this.createNextWithChild();
-            const jso =
-                Blockly.serialization.blocks.save(block);
+            const jso = Blockly.serialization.blocks.save(block);
             chai.assert.deepInclude(
                 jso['next'], {'block': {'type': 'stack_block', 'id': 'id2'}});
           });
@@ -636,18 +622,16 @@ suite('JSO Serialization', function() {
           test('Overwritten shadow', function() {
             const block = this.createNextWithShadowAndChild();
             const jso = Blockly.serialization.blocks.save(block);
-            chai.assert.deepInclude(
-                jso['next'],
-                {
-                  'block': {
-                    'type': 'stack_block',
-                    'id': 'id2',
-                  },
-                  'shadow': {
-                    'type': 'stack_block',
-                    'id': 'test',
-                  },
-                });
+            chai.assert.deepInclude(jso['next'], {
+              'block': {
+                'type': 'stack_block',
+                'id': 'id2',
+              },
+              'shadow': {
+                'type': 'stack_block',
+                'id': 'test',
+              },
+            });
           });
 
           test('Next block with inputs', function() {
@@ -655,26 +639,23 @@ suite('JSO Serialization', function() {
             const childBlock = this.workspace.newBlock('statement_block');
             const grandChildBlock = this.workspace.newBlock('stack_block');
             block.nextConnection.connect(childBlock.previousConnection);
-            childBlock.getInput('NAME').connection
-                .connect(grandChildBlock.previousConnection);
+            childBlock.getInput('NAME').connection.connect(
+                grandChildBlock.previousConnection);
             const jso = Blockly.serialization.blocks.save(block);
-            chai.assert.deepInclude(
-                jso['next'],
-                {
-                  'block': {
-                    'type': 'statement_block',
-                    'id': 'id2',
-                    'inputs': {
-                      'NAME': {
-                        'block': {
-                          'type': 'stack_block',
-                          'id': 'id4',
-                        },
-                      },
+            chai.assert.deepInclude(jso['next'], {
+              'block': {
+                'type': 'statement_block',
+                'id': 'id2',
+                'inputs': {
+                  'NAME': {
+                    'block': {
+                      'type': 'stack_block',
+                      'id': 'id4',
                     },
                   },
-                }
-            );
+                },
+              },
+            });
           });
         });
 
@@ -857,8 +838,8 @@ suite('JSO Serialization', function() {
       test(
           'if the procedure has return types, returnTypes is the array',
           function() {
-            const procedureModel = new MockProcedureModel()
-                .setReturnTypes(['a type']);
+            const procedureModel =
+                new MockProcedureModel().setReturnTypes(['a type']);
             this.procedureMap.add(procedureModel);
             const jso = this.serializer.save(this.workspace);
             const procedure = jso[0];
@@ -897,7 +878,7 @@ suite('JSO Serialization', function() {
               const jso = this.serializer.save(this.workspace);
               const parameter = jso[0]['parameters'][0];
               assertNoProperty(parameter, 'types');
-             });
+            });
 
         test('if the parameter has types, types is an array', function() {
           const parameterModel =

--- a/tests/mocha/jso_serialization_test.js
+++ b/tests/mocha/jso_serialization_test.js
@@ -347,7 +347,7 @@ suite('JSO Serialization', function() {
             'prop1': 'state1',
             'prop2': 42,
             'prop3': true,
-          }
+          },
         });
       });
 

--- a/tests/mocha/json_test.js
+++ b/tests/mocha/json_test.js
@@ -46,8 +46,10 @@ suite('JSON Block Definitions', function() {
 
       assertWarnings(() => {
         Blockly.defineBlocksWithJsonArray([
-          {"type": BLOCK_TYPE1}, {"type": undefined}, {"type": null},
-          {"type": BLOCK_TYPE2}
+          {"type": BLOCK_TYPE1},
+          {"type": undefined},
+          {"type": null},
+          {"type": BLOCK_TYPE2},
         ]);
       }, [/missing a type attribute/, /missing a type attribute/]);
       chai.assert.isNotNull(
@@ -73,10 +75,11 @@ suite('JSON Block Definitions', function() {
             "type": BLOCK_TYPE1,
             "message0": 'before',
           },
-          null, {
+          null,
+          {
             "type": BLOCK_TYPE2,
             "message0": 'after',
-          }
+          },
         ]);
       }, /is null/);
       chai.assert.isNotNull(
@@ -101,10 +104,11 @@ suite('JSON Block Definitions', function() {
             "type": BLOCK_TYPE1,
             "message0": 'before',
           },
-          undefined, {
+          undefined,
+          {
             "type": BLOCK_TYPE2,
             "message0": 'after',
-          }
+          },
         ]);
       }, /is undefined/);
       chai.assert.isNotNull(

--- a/tests/mocha/json_test.js
+++ b/tests/mocha/json_test.js
@@ -46,14 +46,15 @@ suite('JSON Block Definitions', function() {
 
       assertWarnings(() => {
         Blockly.defineBlocksWithJsonArray([
-          {"type": BLOCK_TYPE1},
-          {"type": undefined},
-          {"type": null},
-          {"type": BLOCK_TYPE2}]);
+          {"type": BLOCK_TYPE1}, {"type": undefined}, {"type": null},
+          {"type": BLOCK_TYPE2}
+        ]);
       }, [/missing a type attribute/, /missing a type attribute/]);
-      chai.assert.isNotNull(Blockly.Blocks[BLOCK_TYPE1],
+      chai.assert.isNotNull(
+          Blockly.Blocks[BLOCK_TYPE1],
           'Block before bad blocks should be defined.');
-      chai.assert.isNotNull(Blockly.Blocks[BLOCK_TYPE2],
+      chai.assert.isNotNull(
+          Blockly.Blocks[BLOCK_TYPE2],
           'Block after bad blocks should be defined.');
       chai.assert.equal(Object.keys(Blockly.Blocks).length, blockTypeCount + 2);
     });
@@ -72,15 +73,17 @@ suite('JSON Block Definitions', function() {
             "type": BLOCK_TYPE1,
             "message0": 'before',
           },
-          null,
-          {
+          null, {
             "type": BLOCK_TYPE2,
             "message0": 'after',
-          }]);
+          }
+        ]);
       }, /is null/);
-      chai.assert.isNotNull(Blockly.Blocks[BLOCK_TYPE1],
+      chai.assert.isNotNull(
+          Blockly.Blocks[BLOCK_TYPE1],
           'Block before null in array should be defined.');
-      chai.assert.isNotNull(Blockly.Blocks[BLOCK_TYPE2],
+      chai.assert.isNotNull(
+          Blockly.Blocks[BLOCK_TYPE2],
           'Block after null in array should be defined.');
       chai.assert.equal(Object.keys(Blockly.Blocks).length, blockTypeCount + 2);
     });
@@ -98,15 +101,17 @@ suite('JSON Block Definitions', function() {
             "type": BLOCK_TYPE1,
             "message0": 'before',
           },
-          undefined,
-          {
+          undefined, {
             "type": BLOCK_TYPE2,
             "message0": 'after',
-          }]);
+          }
+        ]);
       }, /is undefined/);
-      chai.assert.isNotNull(Blockly.Blocks[BLOCK_TYPE1],
+      chai.assert.isNotNull(
+          Blockly.Blocks[BLOCK_TYPE1],
           'Block before undefined in array should be defined.');
-      chai.assert.isNotNull(Blockly.Blocks[BLOCK_TYPE2],
+      chai.assert.isNotNull(
+          Blockly.Blocks[BLOCK_TYPE2],
           'Block after undefined in array should be defined.');
       chai.assert.equal(Object.keys(Blockly.Blocks).length, blockTypeCount + 2);
     });

--- a/tests/mocha/keydown_test.js
+++ b/tests/mocha/keydown_test.js
@@ -23,7 +23,8 @@ suite('Key Down', function() {
 
   /**
    * Creates a block and sets it as Blockly.selected.
-   * @param {Blockly.Workspace} workspace The workspace to create a new block on.
+   * @param {Blockly.Workspace} workspace The workspace to create a new block
+   *     on.
    */
   function setSelectedBlock(workspace) {
     defineStackBlock();
@@ -31,7 +32,8 @@ suite('Key Down', function() {
   }
 
   /**
-   * Creates a test for not running keyDown events when the workspace is in read only mode.
+   * Creates a test for not running keyDown events when the workspace is in read
+   * only mode.
    * @param {Object} keyEvent Mocked key down event. Use createKeyDownEvent.
    * @param {string=} opt_name An optional name for the test case.
    */
@@ -47,8 +49,8 @@ suite('Key Down', function() {
   suite('Escape', function() {
     setup(function() {
       this.event = createKeyDownEvent(Blockly.utils.KeyCodes.ESC);
-      this.hideChaffSpy = sinon.spy(
-        Blockly.WorkspaceSvg.prototype, 'hideChaff');
+      this.hideChaffSpy =
+          sinon.spy(Blockly.WorkspaceSvg.prototype, 'hideChaff');
     });
     test('Simple', function() {
       document.dispatchEvent(this.event);
@@ -70,8 +72,8 @@ suite('Key Down', function() {
 
   suite('Delete Block', function() {
     setup(function() {
-      this.hideChaffSpy = sinon.spy(
-        Blockly.WorkspaceSvg.prototype, 'hideChaff');
+      this.hideChaffSpy =
+          sinon.spy(Blockly.WorkspaceSvg.prototype, 'hideChaff');
       setSelectedBlock(this.workspace);
       this.deleteSpy = sinon.spy(Blockly.common.getSelected(), 'dispose');
     });
@@ -105,13 +107,25 @@ suite('Key Down', function() {
     setup(function() {
       setSelectedBlock(this.workspace);
       this.copySpy = sinon.spy(Blockly.clipboard.TEST_ONLY, 'copyInternal');
-      this.hideChaffSpy = sinon.spy(
-        Blockly.WorkspaceSvg.prototype, 'hideChaff');
+      this.hideChaffSpy =
+          sinon.spy(Blockly.WorkspaceSvg.prototype, 'hideChaff');
     });
     const testCases = [
-      ['Control C', createKeyDownEvent(Blockly.utils.KeyCodes.C, [Blockly.utils.KeyCodes.CTRL])],
-      ['Meta C', createKeyDownEvent(Blockly.utils.KeyCodes.C, [Blockly.utils.KeyCodes.META])],
-      ['Alt C', createKeyDownEvent(Blockly.utils.KeyCodes.C, [Blockly.utils.KeyCodes.ALT])],
+      [
+        'Control C',
+        createKeyDownEvent(
+            Blockly.utils.KeyCodes.C, [Blockly.utils.KeyCodes.CTRL])
+      ],
+      [
+        'Meta C',
+        createKeyDownEvent(
+            Blockly.utils.KeyCodes.C, [Blockly.utils.KeyCodes.META])
+      ],
+      [
+        'Alt C',
+        createKeyDownEvent(
+            Blockly.utils.KeyCodes.C, [Blockly.utils.KeyCodes.ALT])
+      ],
     ];
     // Copy a block.
     suite('Simple', function() {
@@ -152,7 +166,8 @@ suite('Key Down', function() {
         const testCaseName = testCase[0];
         const keyEvent = testCase[1];
         test(testCaseName, function() {
-          sinon.stub(Blockly.common.getSelected(), 'isDeletable').returns(false);
+          sinon.stub(Blockly.common.getSelected(), 'isDeletable')
+              .returns(false);
           document.dispatchEvent(keyEvent);
           sinon.assert.notCalled(this.copySpy);
           sinon.assert.notCalled(this.hideChaffSpy);
@@ -177,13 +192,25 @@ suite('Key Down', function() {
   suite('Undo', function() {
     setup(function() {
       this.undoSpy = sinon.spy(this.workspace, 'undo');
-      this.hideChaffSpy = sinon.spy(
-        Blockly.WorkspaceSvg.prototype, 'hideChaff');
+      this.hideChaffSpy =
+          sinon.spy(Blockly.WorkspaceSvg.prototype, 'hideChaff');
     });
     const testCases = [
-      ['Control Z', createKeyDownEvent(Blockly.utils.KeyCodes.Z, [Blockly.utils.KeyCodes.CTRL])],
-      ['Meta Z', createKeyDownEvent(Blockly.utils.KeyCodes.Z, [Blockly.utils.KeyCodes.META])],
-      ['Alt Z', createKeyDownEvent(Blockly.utils.KeyCodes.Z, [Blockly.utils.KeyCodes.ALT])],
+      [
+        'Control Z',
+        createKeyDownEvent(
+            Blockly.utils.KeyCodes.Z, [Blockly.utils.KeyCodes.CTRL])
+      ],
+      [
+        'Meta Z',
+        createKeyDownEvent(
+            Blockly.utils.KeyCodes.Z, [Blockly.utils.KeyCodes.META])
+      ],
+      [
+        'Alt Z',
+        createKeyDownEvent(
+            Blockly.utils.KeyCodes.Z, [Blockly.utils.KeyCodes.ALT])
+      ],
     ];
     // Undo.
     suite('Simple', function() {
@@ -224,13 +251,28 @@ suite('Key Down', function() {
   suite('Redo', function() {
     setup(function() {
       this.redoSpy = sinon.spy(this.workspace, 'undo');
-      this.hideChaffSpy = sinon.spy(
-        Blockly.WorkspaceSvg.prototype, 'hideChaff');
+      this.hideChaffSpy =
+          sinon.spy(Blockly.WorkspaceSvg.prototype, 'hideChaff');
     });
     const testCases = [
-      ['Control Shift Z', createKeyDownEvent(Blockly.utils.KeyCodes.Z, [Blockly.utils.KeyCodes.CTRL, Blockly.utils.KeyCodes.SHIFT])],
-      ['Meta Shift Z', createKeyDownEvent(Blockly.utils.KeyCodes.Z, [Blockly.utils.KeyCodes.META, Blockly.utils.KeyCodes.SHIFT])],
-      ['Alt Shift Z', createKeyDownEvent(Blockly.utils.KeyCodes.Z, [Blockly.utils.KeyCodes.ALT, Blockly.utils.KeyCodes.SHIFT])],
+      [
+        'Control Shift Z',
+        createKeyDownEvent(
+            Blockly.utils.KeyCodes.Z,
+            [Blockly.utils.KeyCodes.CTRL, Blockly.utils.KeyCodes.SHIFT])
+      ],
+      [
+        'Meta Shift Z',
+        createKeyDownEvent(
+            Blockly.utils.KeyCodes.Z,
+            [Blockly.utils.KeyCodes.META, Blockly.utils.KeyCodes.SHIFT])
+      ],
+      [
+        'Alt Shift Z',
+        createKeyDownEvent(
+            Blockly.utils.KeyCodes.Z,
+            [Blockly.utils.KeyCodes.ALT, Blockly.utils.KeyCodes.SHIFT])
+      ],
     ];
     // Undo.
     suite('Simple', function() {
@@ -270,10 +312,11 @@ suite('Key Down', function() {
 
   suite('UndoWindows', function() {
     setup(function() {
-      this.ctrlYEvent = createKeyDownEvent(Blockly.utils.KeyCodes.Y, [Blockly.utils.KeyCodes.CTRL]);
+      this.ctrlYEvent = createKeyDownEvent(
+          Blockly.utils.KeyCodes.Y, [Blockly.utils.KeyCodes.CTRL]);
       this.undoSpy = sinon.spy(this.workspace, 'undo');
-      this.hideChaffSpy = sinon.spy(
-        Blockly.WorkspaceSvg.prototype, 'hideChaff');
+      this.hideChaffSpy =
+          sinon.spy(Blockly.WorkspaceSvg.prototype, 'hideChaff');
     });
     test('Simple', function() {
       document.dispatchEvent(this.ctrlYEvent);
@@ -287,6 +330,7 @@ suite('Key Down', function() {
       sinon.assert.notCalled(this.undoSpy);
       sinon.assert.notCalled(this.hideChaffSpy);
     });
-    runReadOnlyTest(createKeyDownEvent(Blockly.utils.KeyCodes.Y, [Blockly.utils.KeyCodes.CTRL]));
+    runReadOnlyTest(createKeyDownEvent(
+        Blockly.utils.KeyCodes.Y, [Blockly.utils.KeyCodes.CTRL]));
   });
 });

--- a/tests/mocha/keydown_test.js
+++ b/tests/mocha/keydown_test.js
@@ -114,17 +114,17 @@ suite('Key Down', function() {
       [
         'Control C',
         createKeyDownEvent(
-            Blockly.utils.KeyCodes.C, [Blockly.utils.KeyCodes.CTRL])
+            Blockly.utils.KeyCodes.C, [Blockly.utils.KeyCodes.CTRL]),
       ],
       [
         'Meta C',
         createKeyDownEvent(
-            Blockly.utils.KeyCodes.C, [Blockly.utils.KeyCodes.META])
+            Blockly.utils.KeyCodes.C, [Blockly.utils.KeyCodes.META]),
       ],
       [
         'Alt C',
         createKeyDownEvent(
-            Blockly.utils.KeyCodes.C, [Blockly.utils.KeyCodes.ALT])
+            Blockly.utils.KeyCodes.C, [Blockly.utils.KeyCodes.ALT]),
       ],
     ];
     // Copy a block.
@@ -199,17 +199,17 @@ suite('Key Down', function() {
       [
         'Control Z',
         createKeyDownEvent(
-            Blockly.utils.KeyCodes.Z, [Blockly.utils.KeyCodes.CTRL])
+            Blockly.utils.KeyCodes.Z, [Blockly.utils.KeyCodes.CTRL]),
       ],
       [
         'Meta Z',
         createKeyDownEvent(
-            Blockly.utils.KeyCodes.Z, [Blockly.utils.KeyCodes.META])
+            Blockly.utils.KeyCodes.Z, [Blockly.utils.KeyCodes.META]),
       ],
       [
         'Alt Z',
         createKeyDownEvent(
-            Blockly.utils.KeyCodes.Z, [Blockly.utils.KeyCodes.ALT])
+            Blockly.utils.KeyCodes.Z, [Blockly.utils.KeyCodes.ALT]),
       ],
     ];
     // Undo.
@@ -259,19 +259,19 @@ suite('Key Down', function() {
         'Control Shift Z',
         createKeyDownEvent(
             Blockly.utils.KeyCodes.Z,
-            [Blockly.utils.KeyCodes.CTRL, Blockly.utils.KeyCodes.SHIFT])
+            [Blockly.utils.KeyCodes.CTRL, Blockly.utils.KeyCodes.SHIFT]),
       ],
       [
         'Meta Shift Z',
         createKeyDownEvent(
             Blockly.utils.KeyCodes.Z,
-            [Blockly.utils.KeyCodes.META, Blockly.utils.KeyCodes.SHIFT])
+            [Blockly.utils.KeyCodes.META, Blockly.utils.KeyCodes.SHIFT]),
       ],
       [
         'Alt Shift Z',
         createKeyDownEvent(
             Blockly.utils.KeyCodes.Z,
-            [Blockly.utils.KeyCodes.ALT, Blockly.utils.KeyCodes.SHIFT])
+            [Blockly.utils.KeyCodes.ALT, Blockly.utils.KeyCodes.SHIFT]),
       ],
     ];
     // Undo.

--- a/tests/mocha/metrics_test.js
+++ b/tests/mocha/metrics_test.js
@@ -31,8 +31,12 @@ suite('Metrics', function() {
       scale: scale,
       scrollX: SCROLL_X,
       scrollY: SCROLL_Y,
-      isMovableHorizontally: function() {return true;},
-      isMovableVertically: function() {return true;},
+      isMovableHorizontally: function() {
+        return true;
+      },
+      isMovableVertically: function() {
+        return true;
+      },
     };
   }
 
@@ -344,8 +348,8 @@ suite('Metrics', function() {
       // The bounding box around the blocks on the screen.
       const mockContentMetrics = {top: 0, left: 0, width: 0, height: 0};
 
-      const contentMetrics =
-          metricsManager.getScrollMetrics(true, mockViewMetrics, mockContentMetrics);
+      const contentMetrics = metricsManager.getScrollMetrics(
+          true, mockViewMetrics, mockContentMetrics);
 
       // Should add half the view width to all sides.
       assertDimensionsMatch(contentMetrics, -200, -200, 400, 400);
@@ -358,8 +362,8 @@ suite('Metrics', function() {
       // The bounding box around the blocks on the screen.
       const mockContentMetrics = {top: 0, left: 0, width: 0, height: 0};
 
-      const contentMetrics =
-          metricsManager.getScrollMetrics(true, mockViewMetrics, mockContentMetrics);
+      const contentMetrics = metricsManager.getScrollMetrics(
+          true, mockViewMetrics, mockContentMetrics);
 
       // Should add half the view width to all sides.
       assertDimensionsMatch(contentMetrics, -100, -100, 200, 200);
@@ -372,8 +376,8 @@ suite('Metrics', function() {
       // The bounding box around the blocks on the screen.
       const mockContentMetrics = {top: 0, left: 0, width: 0, height: 0};
 
-      const contentMetrics =
-          metricsManager.getScrollMetrics(true, mockViewMetrics, mockContentMetrics);
+      const contentMetrics = metricsManager.getScrollMetrics(
+          true, mockViewMetrics, mockContentMetrics);
 
       // Should add half the view width to all sides.
       assertDimensionsMatch(contentMetrics, -400, -400, 800, 800);
@@ -386,8 +390,8 @@ suite('Metrics', function() {
       // The bounding box around the blocks on the screen.
       const mockContentMetrics = {top: 100, left: 100, width: 50, height: 50};
 
-      const contentMetrics =
-          metricsManager.getScrollMetrics(true, mockViewMetrics, mockContentMetrics);
+      const contentMetrics = metricsManager.getScrollMetrics(
+          true, mockViewMetrics, mockContentMetrics);
 
       // Should add half of the view width to all sides.
       assertDimensionsMatch(contentMetrics, -50, -50, 350, 350);
@@ -400,8 +404,8 @@ suite('Metrics', function() {
       // The bounding box around the blocks on the screen.
       const mockContentMetrics = {top: 100, left: 100, width: 50, height: 50};
 
-      const contentMetrics =
-          metricsManager.getScrollMetrics(true, mockViewMetrics, mockContentMetrics);
+      const contentMetrics = metricsManager.getScrollMetrics(
+          true, mockViewMetrics, mockContentMetrics);
 
       // Should add half of the view width to all sides.
       assertDimensionsMatch(contentMetrics, -25, -25, 175, 175);
@@ -414,8 +418,8 @@ suite('Metrics', function() {
       // The bounding box around the blocks on the screen.
       const mockContentMetrics = {top: 100, left: 100, width: 50, height: 50};
 
-      const contentMetrics =
-          metricsManager.getScrollMetrics(true, mockViewMetrics, mockContentMetrics);
+      const contentMetrics = metricsManager.getScrollMetrics(
+          true, mockViewMetrics, mockContentMetrics);
 
       // Should add half of the view width to all sides.
       assertDimensionsMatch(contentMetrics, -100, -100, 700, 700);
@@ -428,8 +432,8 @@ suite('Metrics', function() {
       // The bounding box around the blocks on the screen.
       const mockContentMetrics = {top: 0, left: 0, width: 0, height: 0};
 
-      const contentMetrics =
-          metricsManager.getScrollMetrics(false, mockViewMetrics, mockContentMetrics);
+      const contentMetrics = metricsManager.getScrollMetrics(
+          false, mockViewMetrics, mockContentMetrics);
 
       // Should add half the view width to all sides.
       assertDimensionsMatch(contentMetrics, -200, -200, 400, 400);
@@ -442,8 +446,8 @@ suite('Metrics', function() {
       // The bounding box around the blocks on the screen.
       const mockContentMetrics = {top: 0, left: 0, width: 0, height: 0};
 
-      const contentMetrics =
-          metricsManager.getScrollMetrics(false, mockViewMetrics, mockContentMetrics);
+      const contentMetrics = metricsManager.getScrollMetrics(
+          false, mockViewMetrics, mockContentMetrics);
 
       // Should add half the view width to all sides.
       assertDimensionsMatch(contentMetrics, -200, -200, 400, 400);
@@ -456,8 +460,8 @@ suite('Metrics', function() {
       // The bounding box around the blocks on the screen.
       const mockContentMetrics = {top: 0, left: 0, width: 0, height: 0};
 
-      const contentMetrics =
-          metricsManager.getScrollMetrics(false, mockViewMetrics, mockContentMetrics);
+      const contentMetrics = metricsManager.getScrollMetrics(
+          false, mockViewMetrics, mockContentMetrics);
 
       // Should add half the view width to all sides.
       assertDimensionsMatch(contentMetrics, -200, -200, 400, 400);
@@ -470,8 +474,8 @@ suite('Metrics', function() {
       // The bounding box around the blocks on the screen.
       const mockContentMetrics = {top: 100, left: 100, width: 50, height: 50};
 
-      const contentMetrics =
-          metricsManager.getScrollMetrics(false, mockViewMetrics, mockContentMetrics);
+      const contentMetrics = metricsManager.getScrollMetrics(
+          false, mockViewMetrics, mockContentMetrics);
 
       // Should add half of the view width to all sides.
       assertDimensionsMatch(contentMetrics, -50, -50, 350, 350);
@@ -484,8 +488,8 @@ suite('Metrics', function() {
       // The bounding box around the blocks on the screen.
       const mockContentMetrics = {top: 100, left: 100, width: 50, height: 50};
 
-      const contentMetrics =
-          metricsManager.getScrollMetrics(false, mockViewMetrics, mockContentMetrics);
+      const contentMetrics = metricsManager.getScrollMetrics(
+          false, mockViewMetrics, mockContentMetrics);
 
       // Should add half of the view width to all sides.
       assertDimensionsMatch(contentMetrics, -50, -50, 350, 350);
@@ -498,8 +502,8 @@ suite('Metrics', function() {
       // The bounding box around the blocks on the screen.
       const mockContentMetrics = {top: 100, left: 100, width: 50, height: 50};
 
-      const contentMetrics =
-          metricsManager.getScrollMetrics(false, mockViewMetrics, mockContentMetrics);
+      const contentMetrics = metricsManager.getScrollMetrics(
+          false, mockViewMetrics, mockContentMetrics);
 
       // Should add half of the view width to all sides.
       assertDimensionsMatch(contentMetrics, -50, -50, 350, 350);

--- a/tests/mocha/mutator_test.js
+++ b/tests/mocha/mutator_test.js
@@ -35,8 +35,9 @@ suite('Mutator', function() {
       const mutatorWorkspace = block.mutator.getWorkspace();
       // Trigger mutator change listener.
       createRenderedBlock(mutatorWorkspace, 'checkbox_block');
-      assertEventNotFired(this.eventsFireStub, Blockly.Events.BlockChange,
-        {element: 'mutation'});
+      assertEventNotFired(
+          this.eventsFireStub, Blockly.Events.BlockChange,
+          {element: 'mutation'});
     });
 
     test('XML', function() {
@@ -45,12 +46,10 @@ suite('Mutator', function() {
       const mutatorWorkspace = block.mutator.getWorkspace();
       mutatorWorkspace.getBlockById('check_block')
           .setFieldValue('TRUE', 'CHECK');
-      chai.assert.isTrue(
-          this.eventsFireStub.getCalls().some(
-              ({args}) =>
-                args[0].type === Blockly.Events.BLOCK_CHANGE &&
-                args[0].element === 'mutation' &&
-                /<mutation.*><\/mutation>/.test(args[0].newValue)));
+      chai.assert.isTrue(this.eventsFireStub.getCalls().some(
+          ({args}) => args[0].type === Blockly.Events.BLOCK_CHANGE &&
+              args[0].element === 'mutation' &&
+              /<mutation.*><\/mutation>/.test(args[0].newValue)));
     });
 
     test('JSO', function() {
@@ -59,11 +58,12 @@ suite('Mutator', function() {
       const mutatorWorkspace = block.mutator.getWorkspace();
       mutatorWorkspace.getBlockById('check_block')
           .setFieldValue('TRUE', 'CHECK');
-      assertEventFired(this.eventsFireStub, Blockly.Events.BlockChange,
-        {
-          element: 'mutation',
-          newValue: '{"hasInput":true}',
-        }, this.workspace.id, block.id);
+      assertEventFired(
+          this.eventsFireStub, Blockly.Events.BlockChange, {
+            element: 'mutation',
+            newValue: '{"hasInput":true}',
+          },
+          this.workspace.id, block.id);
     });
   });
 });

--- a/tests/mocha/names_test.js
+++ b/tests/mocha/names_test.js
@@ -21,43 +21,63 @@ suite('Names', function() {
     const varDB = new Blockly.Names('window,door');
     chai.assert.equal(varDB.safeName(''), 'unnamed', 'SafeName empty.');
     chai.assert.equal(varDB.safeName('foobar'), 'foobar', 'SafeName ok.');
-    chai.assert.equal(varDB.safeName('9lives'), 'my_9lives', 'SafeName number start.');
-    chai.assert.equal(varDB.safeName('lives9'), 'lives9', 'SafeName number end.');
-    chai.assert.equal(varDB.safeName('!@#$'), '____', 'SafeName special chars.');
+    chai.assert.equal(
+        varDB.safeName('9lives'), 'my_9lives', 'SafeName number start.');
+    chai.assert.equal(
+        varDB.safeName('lives9'), 'lives9', 'SafeName number end.');
+    chai.assert.equal(
+        varDB.safeName('!@#$'), '____', 'SafeName special chars.');
     chai.assert.equal(varDB.safeName('door'), 'door', 'SafeName reserved.');
   });
 
   test('Get name', function() {
     const varDB = new Blockly.Names('window,door');
-    chai.assert.equal(varDB.getName('Foo.bar', 'var'), 'Foo_bar', 'Name add #1.');
-    chai.assert.equal(varDB.getName('Foo.bar', 'var'), 'Foo_bar', 'Name get #1.');
-    chai.assert.equal(varDB.getName('Foo bar', 'var'), 'Foo_bar2', 'Name add #2.');
-    chai.assert.equal(varDB.getName('foo BAR', 'var'), 'Foo_bar2', 'Name get #2.');
+    chai.assert.equal(
+        varDB.getName('Foo.bar', 'var'), 'Foo_bar', 'Name add #1.');
+    chai.assert.equal(
+        varDB.getName('Foo.bar', 'var'), 'Foo_bar', 'Name get #1.');
+    chai.assert.equal(
+        varDB.getName('Foo bar', 'var'), 'Foo_bar2', 'Name add #2.');
+    chai.assert.equal(
+        varDB.getName('foo BAR', 'var'), 'Foo_bar2', 'Name get #2.');
     chai.assert.equal(varDB.getName('door', 'var'), 'door2', 'Name add #3.');
-    chai.assert.equal(varDB.getName('Foo.bar', 'proc'), 'Foo_bar3', 'Name add #4.');
-    chai.assert.equal(varDB.getName('Foo.bar', 'var'), 'Foo_bar', 'Name get #1b.');
-    chai.assert.equal(varDB.getName('Foo.bar', 'proc'), 'Foo_bar3', 'Name get #4.');
+    chai.assert.equal(
+        varDB.getName('Foo.bar', 'proc'), 'Foo_bar3', 'Name add #4.');
+    chai.assert.equal(
+        varDB.getName('Foo.bar', 'var'), 'Foo_bar', 'Name get #1b.');
+    chai.assert.equal(
+        varDB.getName('Foo.bar', 'proc'), 'Foo_bar3', 'Name get #4.');
 
-    chai.assert.equal(String(varDB.getUserNames('var')), 'foo.bar,foo bar,door', 'Get var names.');
-    chai.assert.equal(String(varDB.getUserNames('proc')), 'foo.bar', 'Get proc names.');
+    chai.assert.equal(
+        String(varDB.getUserNames('var')), 'foo.bar,foo bar,door',
+        'Get var names.');
+    chai.assert.equal(
+        String(varDB.getUserNames('proc')), 'foo.bar', 'Get proc names.');
   });
 
   test('Get distinct name', function() {
     const varDB = new Blockly.Names('window,door');
-    chai.assert.equal(varDB.getDistinctName('Foo.bar', 'var'), 'Foo_bar',
+    chai.assert.equal(
+        varDB.getDistinctName('Foo.bar', 'var'), 'Foo_bar',
         'Name distinct #1.');
-    chai.assert.equal(varDB.getDistinctName('Foo.bar', 'var'), 'Foo_bar2',
+    chai.assert.equal(
+        varDB.getDistinctName('Foo.bar', 'var'), 'Foo_bar2',
         'Name distinct #2.');
-    chai.assert.equal(varDB.getDistinctName('Foo.bar', 'proc'), 'Foo_bar3',
+    chai.assert.equal(
+        varDB.getDistinctName('Foo.bar', 'proc'), 'Foo_bar3',
         'Name distinct #3.');
     varDB.reset();
-    chai.assert.equal(varDB.getDistinctName('Foo.bar', 'var'), 'Foo_bar',
+    chai.assert.equal(
+        varDB.getDistinctName('Foo.bar', 'var'), 'Foo_bar',
         'Name distinct #4.');
   });
 
   test('name equals', function() {
-    chai.assert.isTrue(Blockly.Names.equals('Foo.bar', 'Foo.bar'), 'Name equals #1.');
-    chai.assert.isFalse(Blockly.Names.equals('Foo.bar', 'Foo_bar'), 'Name equals #2.');
-    chai.assert.isTrue(Blockly.Names.equals('Foo.bar', 'FOO.BAR'), 'Name equals #3.');
+    chai.assert.isTrue(
+        Blockly.Names.equals('Foo.bar', 'Foo.bar'), 'Name equals #1.');
+    chai.assert.isFalse(
+        Blockly.Names.equals('Foo.bar', 'Foo_bar'), 'Name equals #2.');
+    chai.assert.isTrue(
+        Blockly.Names.equals('Foo.bar', 'FOO.BAR'), 'Name equals #3.');
   });
 });

--- a/tests/mocha/procedure_map_test.js
+++ b/tests/mocha/procedure_map_test.js
@@ -4,9 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {sharedTestSetup, sharedTestTeardown} from './test_helpers/setup_teardown.js';
 import {assertEventFiredShallow, assertEventNotFired, createChangeListenerSpy} from './test_helpers/events.js';
 import {MockProcedureModel} from './test_helpers/procedures.js';
+import {sharedTestSetup, sharedTestTeardown} from './test_helpers/setup_teardown.js';
 
 goog.declareModuleId('Blockly.test.procedureMap');
 
@@ -27,8 +27,7 @@ suite('Procedure Map', function() {
       const spy = sinon.spy(procedureModel, 'startPublishing');
       this.procedureMap.set(procedureModel.getId(), procedureModel);
 
-      chai.assert.isTrue(
-          spy.called, 'Expected the model to start publishing');
+      chai.assert.isTrue(spy.called, 'Expected the model to start publishing');
     });
 
     test('adding a procedure tells it to start publishing', function() {
@@ -36,8 +35,7 @@ suite('Procedure Map', function() {
       const spy = sinon.spy(procedureModel, 'startPublishing');
       this.procedureMap.add(procedureModel);
 
-      chai.assert.isTrue(
-          spy.called, 'Expected the model to start publishing');
+      chai.assert.isTrue(spy.called, 'Expected the model to start publishing');
     });
 
     test('deleting a procedure tells it to stop publishing', function() {
@@ -47,8 +45,7 @@ suite('Procedure Map', function() {
 
       this.procedureMap.delete(procedureModel.getId());
 
-      chai.assert.isTrue(
-          spy.calledOnce, 'Expected the model stop publishing');
+      chai.assert.isTrue(spy.calledOnce, 'Expected the model stop publishing');
     });
   });
 });

--- a/tests/mocha/registry_test.js
+++ b/tests/mocha/registry_test.js
@@ -100,7 +100,8 @@ suite('Registry', function() {
     suite('Does not have', function() {
       test('Type', function() {
         assertWarnings(() => {
-          chai.assert.isNull(Blockly.registry.getClass('bad_type', 'test_name'));
+          chai.assert.isNull(
+              Blockly.registry.getClass('bad_type', 'test_name'));
         }, /Unable to find/);
       });
 
@@ -140,7 +141,8 @@ suite('Registry', function() {
     suite('Does not have', function() {
       test('Type', function() {
         assertWarnings(() => {
-          chai.assert.isNull(Blockly.registry.getObject('bad_type', 'test_name'));
+          chai.assert.isNull(
+              Blockly.registry.getObject('bad_type', 'test_name'));
         }, /Unable to find/);
       });
 
@@ -199,22 +201,18 @@ suite('Registry', function() {
     });
 
     test('Respect name case', function() {
-      chai.assert.deepEqual(
-          Blockly.registry.getAllItems('test', true),
-          {
-            'test_name': {},
-            'casedNAME': {},
-          });
+      chai.assert.deepEqual(Blockly.registry.getAllItems('test', true), {
+        'test_name': {},
+        'casedNAME': {},
+      });
     });
 
     test('Respect overwriting name case', function() {
       Blockly.registry.register('test', 'CASEDname', {}, true);
-      chai.assert.deepEqual(
-          Blockly.registry.getAllItems('test', true),
-          {
-            'test_name': {},
-            'CASEDname': {},
-          });
+      chai.assert.deepEqual(Blockly.registry.getAllItems('test', true), {
+        'test_name': {},
+        'CASEDname': {},
+      });
     });
   });
 
@@ -238,19 +236,22 @@ suite('Registry', function() {
     });
 
     test('Simple - Plugin name given', function() {
-      const testClass = Blockly.registry.getClassFromOptions('test', this.options);
+      const testClass =
+          Blockly.registry.getClassFromOptions('test', this.options);
       chai.assert.instanceOf(new testClass(), TestClass);
     });
 
     test('Simple - Plugin class given', function() {
       this.options.plugins['test'] = TestClass;
-      const testClass = Blockly.registry.getClassFromOptions('test', this.options);
+      const testClass =
+          Blockly.registry.getClassFromOptions('test', this.options);
       chai.assert.instanceOf(new testClass(), TestClass);
     });
 
     test('No Plugin Name Given', function() {
       delete this.options['plugins']['test'];
-      const testClass = Blockly.registry.getClassFromOptions('test', this.options);
+      const testClass =
+          Blockly.registry.getClassFromOptions('test', this.options);
       chai.assert.instanceOf(new testClass(), this.defaultClass);
     });
 

--- a/tests/mocha/render_management_test.js
+++ b/tests/mocha/render_management_test.js
@@ -22,7 +22,9 @@ suite('Render Management', function() {
     function createMockBlock() {
       return {
         hasRendered: false,
-        renderEfficiently: function() {this.hasRendered = true;},
+        renderEfficiently: function() {
+          this.hasRendered = true;
+        },
 
         // All of the APIs the render management system needs.
         getParent: () => null,
@@ -36,14 +38,15 @@ suite('Render Management', function() {
       };
     }
 
-    test('the queueRender promise is properly resolved after rendering',
+    test(
+        'the queueRender promise is properly resolved after rendering',
         function() {
           const block = createMockBlock();
-          const promise = Blockly.renderManagement.queueRender(block)
-            .then(() => {
-              chai.assert.isTrue(
-                  block.hasRendered, 'Expected block to be rendered');
-             });
+          const promise =
+              Blockly.renderManagement.queueRender(block).then(() => {
+                chai.assert.isTrue(
+                    block.hasRendered, 'Expected block to be rendered');
+              });
           this.clock.runAll();
           return promise;
         });
@@ -54,9 +57,9 @@ suite('Render Management', function() {
           const block = createMockBlock();
           Blockly.renderManagement.queueRender(block);
           const promise = Blockly.renderManagement.finishQueuedRenders(() => {
-              chai.assert.isTrue(
-                  block.hasRendered, 'Expected block to be rendered');
-             });
+            chai.assert.isTrue(
+                block.hasRendered, 'Expected block to be rendered');
+          });
           this.clock.runAll();
           return promise;
         });

--- a/tests/mocha/serializer_test.js
+++ b/tests/mocha/serializer_test.js
@@ -46,45 +46,51 @@ SerializerTestSuite.prototype = new TestSuite();
 const Serializer = new SerializerTestSuite('Serializer');
 
 // TODO: Make sure all of these properties are documented ad exported properly.
-Serializer.Empty = new SerializerTestCase('Empty',
-    '<xml xmlns="https://developers.google.com/blockly/xml"></xml>'
-);
-Serializer.Data = new SerializerTestCase('Data',
+Serializer.Empty = new SerializerTestCase(
+    'Empty', '<xml xmlns="https://developers.google.com/blockly/xml"></xml>');
+Serializer.Data = new SerializerTestCase(
+    'Data',
     '<xml xmlns="https://developers.google.com/blockly/xml">' +
-    '<block type="logic_negate" id="id******************" x="42" y="42">' +
-    '<data>test data</data>' +
-    '</block>' +
-    '</xml>');
+        '<block type="logic_negate" id="id******************" x="42" y="42">' +
+        '<data>test data</data>' +
+        '</block>' +
+        '</xml>');
 Serializer.testCases = [
   Serializer.Empty,
   Serializer.Data,
 ];
 
 Serializer.Attributes = new SerializerTestSuite('Attributes');
-Serializer.Attributes.Basic = new SerializerTestCase('Basic',
+Serializer.Attributes.Basic = new SerializerTestCase(
+    'Basic',
     '<xml xmlns="https://developers.google.com/blockly/xml">' +
-    '<block type="logic_negate" id="id******************" x="42" y="42"></block>' +
-    '</xml>');
-Serializer.Attributes.Collapsed = new SerializerTestCase('Collapsed',
+        '<block type="logic_negate" id="id******************" x="42" y="42"></block>' +
+        '</xml>');
+Serializer.Attributes.Collapsed = new SerializerTestCase(
+    'Collapsed',
     '<xml xmlns="https://developers.google.com/blockly/xml">' +
-    '<block type="logic_negate" id="id******************" collapsed="true" x="42" y="42"></block>' +
-    '</xml>');
-Serializer.Attributes.Disabled = new SerializerTestCase('Disabled',
+        '<block type="logic_negate" id="id******************" collapsed="true" x="42" y="42"></block>' +
+        '</xml>');
+Serializer.Attributes.Disabled = new SerializerTestCase(
+    'Disabled',
     '<xml xmlns="https://developers.google.com/blockly/xml">' +
-    '<block type="logic_negate" id="id******************" disabled="true" x="42" y="42"></block>' +
-    '</xml>');
-Serializer.Attributes.NotDeletable = new SerializerTestCase('Deletable',
+        '<block type="logic_negate" id="id******************" disabled="true" x="42" y="42"></block>' +
+        '</xml>');
+Serializer.Attributes.NotDeletable = new SerializerTestCase(
+    'Deletable',
     '<xml xmlns="https://developers.google.com/blockly/xml">' +
-    '<block type="logic_negate" id="id******************" deletable="false" x="42" y="42"></block>' +
-    '</xml>');
-Serializer.Attributes.NotMovable = new SerializerTestCase('Movable',
+        '<block type="logic_negate" id="id******************" deletable="false" x="42" y="42"></block>' +
+        '</xml>');
+Serializer.Attributes.NotMovable = new SerializerTestCase(
+    'Movable',
     '<xml xmlns="https://developers.google.com/blockly/xml">' +
-    '<block type="logic_negate" id="id******************" movable="false" x="42" y="42"></block>' +
-    '</xml>');
-Serializer.Attributes.NotEditable = new SerializerTestCase('Editable',
+        '<block type="logic_negate" id="id******************" movable="false" x="42" y="42"></block>' +
+        '</xml>');
+Serializer.Attributes.NotEditable = new SerializerTestCase(
+    'Editable',
     '<xml xmlns="https://developers.google.com/blockly/xml">' +
-    '<block type="logic_negate" id="id******************" editable="false" x="42" y="42"></block>' +
-    '</xml>');
+        '<block type="logic_negate" id="id******************" editable="false" x="42" y="42"></block>' +
+        '</xml>');
 Serializer.Attributes.testCases = [
   Serializer.Attributes.Basic,
   Serializer.Attributes.Collapsed,
@@ -95,32 +101,37 @@ Serializer.Attributes.testCases = [
 ];
 
 Serializer.Attributes.Inline = new SerializerTestSuite('Inline');
-Serializer.Attributes.Inline.True = new SerializerTestCase('True',
+Serializer.Attributes.Inline.True = new SerializerTestCase(
+    'True',
     '<xml xmlns="https://developers.google.com/blockly/xml">' +
-    '<block type="logic_negate" id="id******************" inline="true" x="42" y="42"></block>' +
-    '</xml>');
-Serializer.Attributes.Inline.False = new SerializerTestCase('False',
+        '<block type="logic_negate" id="id******************" inline="true" x="42" y="42"></block>' +
+        '</xml>');
+Serializer.Attributes.Inline.False = new SerializerTestCase(
+    'False',
     '<xml xmlns="https://developers.google.com/blockly/xml">' +
-    '<block type="logic_negate" id="id******************" inline="false" x="42" y="42"></block>' +
-    '</xml>');
+        '<block type="logic_negate" id="id******************" inline="false" x="42" y="42"></block>' +
+        '</xml>');
 Serializer.Attributes.Inline.testCases = [
   Serializer.Attributes.Inline.True,
   Serializer.Attributes.Inline.False,
 ];
 
 Serializer.Attributes.Coordinates = new SerializerTestSuite('Coordinates');
-Serializer.Attributes.Coordinates.Simple = new SerializerTestCase('Simple',
+Serializer.Attributes.Coordinates.Simple = new SerializerTestCase(
+    'Simple',
     '<xml xmlns="https://developers.google.com/blockly/xml">' +
-    '<block type="logic_negate" id="id******************" x="42" y="42"></block>' +
-    '</xml>');
-Serializer.Attributes.Coordinates.Negative = new SerializerTestCase('Negative',
+        '<block type="logic_negate" id="id******************" x="42" y="42"></block>' +
+        '</xml>');
+Serializer.Attributes.Coordinates.Negative = new SerializerTestCase(
+    'Negative',
     '<xml xmlns="https://developers.google.com/blockly/xml">' +
-    '<block type="logic_negate" id="id******************" x="-42" y="-42"></block>' +
-    '</xml>');
-Serializer.Attributes.Coordinates.Zero = new SerializerTestCase('Zero',
+        '<block type="logic_negate" id="id******************" x="-42" y="-42"></block>' +
+        '</xml>');
+Serializer.Attributes.Coordinates.Zero = new SerializerTestCase(
+    'Zero',
     '<xml xmlns="https://developers.google.com/blockly/xml">' +
-    '<block type="logic_negate" id="id******************" x="0" y="0"></block>' +
-    '</xml>');
+        '<block type="logic_negate" id="id******************" x="0" y="0"></block>' +
+        '</xml>');
 Serializer.Attributes.Coordinates.testCases = [
   Serializer.Attributes.Coordinates.Simple,
   Serializer.Attributes.Coordinates.Negative,
@@ -130,40 +141,46 @@ Serializer.Attributes.Coordinates.testCases = [
 Serializer.Attributes.Id = new SerializerTestSuite('Ids');
 
 Serializer.Attributes.Id.Length = new SerializerTestSuite('Length');
-Serializer.Attributes.Id.Length.Short = new SerializerTestCase('Short',
+Serializer.Attributes.Id.Length.Short = new SerializerTestCase(
+    'Short',
     '<xml xmlns="https://developers.google.com/blockly/xml">' +
-    '<block type="logic_negate" id="id******************" x="42" y="42"></block>' +
-    '</xml>');
-Serializer.Attributes.Id.Length.Long = new SerializerTestCase('Long',
+        '<block type="logic_negate" id="id******************" x="42" y="42"></block>' +
+        '</xml>');
+Serializer.Attributes.Id.Length.Long = new SerializerTestCase(
+    'Long',
     '<xml xmlns="https://developers.google.com/blockly/xml">' +
-    '<block type="logic_negate" id="id***********************" x="42" y="42">' +
-    '</block>' +
-    '</xml>');
+        '<block type="logic_negate" id="id***********************" x="42" y="42">' +
+        '</block>' +
+        '</xml>');
 Serializer.Attributes.Id.Length.testCases = [
   Serializer.Attributes.Id.Length.Short,
   Serializer.Attributes.Id.Length.Long,
 ];
 
 Serializer.Attributes.Id.Chars = new SerializerTestSuite('Chars');
-Serializer.Attributes.Id.Chars.Symbols = new SerializerTestCase('Symbols',
+Serializer.Attributes.Id.Chars.Symbols = new SerializerTestCase(
+    'Symbols',
     '<xml xmlns="https://developers.google.com/blockly/xml">' +
-    '<block type="logic_negate" id="!#$%()*+,-./:;=?@[]^" x="42" y="42"></block>' +
-    '<block type="logic_negate" id="_`{|}~!!!!!!!!!!!!!!" x="42" y="42"></block>' +
-    '</xml>');
-Serializer.Attributes.Id.Chars.Uppercase = new SerializerTestCase('Uppercase',
+        '<block type="logic_negate" id="!#$%()*+,-./:;=?@[]^" x="42" y="42"></block>' +
+        '<block type="logic_negate" id="_`{|}~!!!!!!!!!!!!!!" x="42" y="42"></block>' +
+        '</xml>');
+Serializer.Attributes.Id.Chars.Uppercase = new SerializerTestCase(
+    'Uppercase',
     '<xml xmlns="https://developers.google.com/blockly/xml">' +
-    '<block type="logic_negate" id="ABCDEFGHIJKLMNOPQRST" x="42" y="42"></block>' +
-    '<block type="logic_negate" id="TUVWXYZAAAAAAAAAAAAA" x="42" y="42"></block>' +
-    '</xml>');
-Serializer.Attributes.Id.Chars.Lowercase = new SerializerTestCase('Lowercase',
+        '<block type="logic_negate" id="ABCDEFGHIJKLMNOPQRST" x="42" y="42"></block>' +
+        '<block type="logic_negate" id="TUVWXYZAAAAAAAAAAAAA" x="42" y="42"></block>' +
+        '</xml>');
+Serializer.Attributes.Id.Chars.Lowercase = new SerializerTestCase(
+    'Lowercase',
     '<xml xmlns="https://developers.google.com/blockly/xml">' +
-    '<block type="logic_negate" id="abcdefghijklmnopqrst" x="42" y="42"></block>' +
-    '<block type="logic_negate" id="tuvwxyzaaaaaaaaaaaaa" x="42" y="42"></block>' +
-    '</xml>');
-Serializer.Attributes.Id.Chars.Numbers = new SerializerTestCase('Numbers',
+        '<block type="logic_negate" id="abcdefghijklmnopqrst" x="42" y="42"></block>' +
+        '<block type="logic_negate" id="tuvwxyzaaaaaaaaaaaaa" x="42" y="42"></block>' +
+        '</xml>');
+Serializer.Attributes.Id.Chars.Numbers = new SerializerTestCase(
+    'Numbers',
     '<xml xmlns="https://developers.google.com/blockly/xml">' +
-    '<block type="logic_negate" id="01234567890000000000" x="42" y="42"></block>' +
-    '</xml>');
+        '<block type="logic_negate" id="01234567890000000000" x="42" y="42"></block>' +
+        '</xml>');
 Serializer.Attributes.Id.Chars.testCases = [
   Serializer.Attributes.Id.Chars.Symbols,
   Serializer.Attributes.Id.Chars.Uppercase,
@@ -185,39 +202,41 @@ Serializer.Attributes.testSuites = [
 Serializer.Fields = new SerializerTestSuite('Fields');
 
 Serializer.Fields.Angle = new SerializerTestSuite('Angle');
-Serializer.Fields.Angle.Simple = new SerializerTestCase('Simple',
+Serializer.Fields.Angle.Simple = new SerializerTestCase(
+    'Simple',
     '<xml xmlns="https://developers.google.com/blockly/xml">' +
-    '<block type="test_fields_angle" id="id******************" x="42" y="42">' +
-    '<field name="FIELDNAME">90</field>' +
-    '</block>' +
-    '</xml>');
+        '<block type="test_fields_angle" id="id******************" x="42" y="42">' +
+        '<field name="FIELDNAME">90</field>' +
+        '</block>' +
+        '</xml>');
 Serializer.Fields.Angle.Negative = new SerializerTestCase(
     'Negative',
     '<xml xmlns="https://developers.google.com/blockly/xml">' +
-    '<block type="test_angles_wrap" id="id******************" x="42" y="42">' +
-    '<field name="FIELDNAME">-90</field>' +
-    '</block>' +
-    '</xml>');
-Serializer.Fields.Angle.Decimals = new SerializerTestCase('Decimals',
+        '<block type="test_angles_wrap" id="id******************" x="42" y="42">' +
+        '<field name="FIELDNAME">-90</field>' +
+        '</block>' +
+        '</xml>');
+Serializer.Fields.Angle.Decimals = new SerializerTestCase(
+    'Decimals',
     '<xml xmlns="https://developers.google.com/blockly/xml">' +
-    '<block type="test_fields_angle" id="id******************" x="42" y="42">' +
-    '<field name="FIELDNAME">1.5</field>' +
-    '</block>' +
-    '</xml>');
+        '<block type="test_fields_angle" id="id******************" x="42" y="42">' +
+        '<field name="FIELDNAME">1.5</field>' +
+        '</block>' +
+        '</xml>');
 Serializer.Fields.Angle.MaxPrecision = new SerializerTestCase(
     'MaxPrecision',
     '<xml xmlns="https://developers.google.com/blockly/xml">' +
-    '<block type="test_fields_angle" id="id******************" x="42" y="42">' +
-    '<field name="FIELDNAME">1.000000000000001</field>' +
-    '</block>' +
-    '</xml>');
+        '<block type="test_fields_angle" id="id******************" x="42" y="42">' +
+        '<field name="FIELDNAME">1.000000000000001</field>' +
+        '</block>' +
+        '</xml>');
 Serializer.Fields.Angle.SmallestNumber = new SerializerTestCase(
     'SmallestNumber',
     '<xml xmlns="https://developers.google.com/blockly/xml">' +
-    '<block type="test_fields_angle" id="id******************" x="42" y="42">' +
-    '<field name="FIELDNAME">5e-324</field>' +
-    '</block>' +
-    '</xml>');
+        '<block type="test_fields_angle" id="id******************" x="42" y="42">' +
+        '<field name="FIELDNAME">5e-324</field>' +
+        '</block>' +
+        '</xml>');
 Serializer.Fields.Angle.testCases = [
   Serializer.Fields.Angle.Simple,
   Serializer.Fields.Angle.Negative,
@@ -227,42 +246,47 @@ Serializer.Fields.Angle.testCases = [
 ];
 
 Serializer.Fields.Checkbox = new SerializerTestSuite('Checkbox');
-Serializer.Fields.Checkbox.True = new SerializerTestCase('True',
+Serializer.Fields.Checkbox.True = new SerializerTestCase(
+    'True',
     '<xml xmlns="https://developers.google.com/blockly/xml">' +
-    '<block type="test_fields_checkbox" id="id******************" x="42" y="42">' +
-    '<field name="CHECKBOX">TRUE</field>' +
-    '</block>' +
-    '</xml>');
-Serializer.Fields.Checkbox.False = new SerializerTestCase('False',
+        '<block type="test_fields_checkbox" id="id******************" x="42" y="42">' +
+        '<field name="CHECKBOX">TRUE</field>' +
+        '</block>' +
+        '</xml>');
+Serializer.Fields.Checkbox.False = new SerializerTestCase(
+    'False',
     '<xml xmlns="https://developers.google.com/blockly/xml">' +
-    '<block type="test_fields_checkbox" id="id******************" x="42" y="42">' +
-    '<field name="CHECKBOX">FALSE</field>' +
-    '</block>' +
-    '</xml>');
+        '<block type="test_fields_checkbox" id="id******************" x="42" y="42">' +
+        '<field name="CHECKBOX">FALSE</field>' +
+        '</block>' +
+        '</xml>');
 Serializer.Fields.Checkbox.testCases = [
   Serializer.Fields.Checkbox.True,
   Serializer.Fields.Checkbox.False,
 ];
 
 Serializer.Fields.Colour = new SerializerTestSuite('Colour');
-Serializer.Fields.Colour.ThreeChar = new SerializerTestCase('ThreeChar',
+Serializer.Fields.Colour.ThreeChar = new SerializerTestCase(
+    'ThreeChar',
     '<xml xmlns="https://developers.google.com/blockly/xml">' +
-    '<block type="test_fields_colour" id="id******************" x="42" y="42">' +
-    '<field name="COLOUR">#ffcc00</field>' +  // Could use a 3 char code.
-    '</block>' +
-    '</xml>');
-Serializer.Fields.Colour.SixChar = new SerializerTestCase('SixChar',
+        '<block type="test_fields_colour" id="id******************" x="42" y="42">' +
+        '<field name="COLOUR">#ffcc00</field>' +  // Could use a 3 char code.
+        '</block>' +
+        '</xml>');
+Serializer.Fields.Colour.SixChar = new SerializerTestCase(
+    'SixChar',
     '<xml xmlns="https://developers.google.com/blockly/xml">' +
-    '<block type="test_fields_colour" id="id******************" x="42" y="42">' +
-    '<field name="COLOUR">#f1c101</field>' +
-    '</block>' +
-    '</xml>');
-Serializer.Fields.Colour.Black = new SerializerTestCase('Black',
+        '<block type="test_fields_colour" id="id******************" x="42" y="42">' +
+        '<field name="COLOUR">#f1c101</field>' +
+        '</block>' +
+        '</xml>');
+Serializer.Fields.Colour.Black = new SerializerTestCase(
+    'Black',
     '<xml xmlns="https://developers.google.com/blockly/xml">' +
-    '<block type="test_fields_colour" id="id******************" x="42" y="42">' +
-    '<field name="COLOUR">#000000</field>' +
-    '</block>' +
-    '</xml>');
+        '<block type="test_fields_colour" id="id******************" x="42" y="42">' +
+        '<field name="COLOUR">#000000</field>' +
+        '</block>' +
+        '</xml>');
 Serializer.Fields.Colour.testCases = [
   Serializer.Fields.Colour.ThreeChar,
   Serializer.Fields.Colour.SixChar,
@@ -270,25 +294,27 @@ Serializer.Fields.Colour.testCases = [
 ];
 
 Serializer.Fields.Dropdown = new SerializerTestSuite('Dropdown');
-Serializer.Fields.Dropdown.Default = new SerializerTestCase('Default',
+Serializer.Fields.Dropdown.Default = new SerializerTestCase(
+    'Default',
     '<xml xmlns="https://developers.google.com/blockly/xml">' +
-    '<block type="test_dropdowns_long" id="id******************" x="42" y="42">' +
-    '<field name="FIELDNAME">ITEM1</field>' +
-    '</block>' +
-    '</xml>');
-Serializer.Fields.Dropdown.NotDefault = new SerializerTestCase('NotDefault',
+        '<block type="test_dropdowns_long" id="id******************" x="42" y="42">' +
+        '<field name="FIELDNAME">ITEM1</field>' +
+        '</block>' +
+        '</xml>');
+Serializer.Fields.Dropdown.NotDefault = new SerializerTestCase(
+    'NotDefault',
     '<xml xmlns="https://developers.google.com/blockly/xml">' +
-    '<block type="test_dropdowns_long" id="id******************" x="42" y="42">' +
-    '<field name="FIELDNAME">ITEM32</field>' +
-    '</block>' +
-    '</xml>');
+        '<block type="test_dropdowns_long" id="id******************" x="42" y="42">' +
+        '<field name="FIELDNAME">ITEM32</field>' +
+        '</block>' +
+        '</xml>');
 Serializer.Fields.Dropdown.Dynamic = new SerializerTestCase(
     'Dynamic',
     '<xml xmlns="https://developers.google.com/blockly/xml">' +
-    '<block type="test_dropdowns_dynamic_random" id="id******************" x="42" y="42">' +
-    '<field name="OPTIONS">0</field>' +
-    '</block>' +
-    '</xml>');
+        '<block type="test_dropdowns_dynamic_random" id="id******************" x="42" y="42">' +
+        '<field name="OPTIONS">0</field>' +
+        '</block>' +
+        '</xml>');
 Serializer.Fields.Dropdown.testCases = [
   Serializer.Fields.Dropdown.Default,
   Serializer.Fields.Dropdown.NotDefault,
@@ -296,83 +322,85 @@ Serializer.Fields.Dropdown.testCases = [
 ];
 
 
-Serializer.Fields.LabelSerializable = new SerializerTestSuite(
-    'LabelSerializable');
-Serializer.Fields.LabelSerializable.Simple = new SerializerTestCase('Simple',
+Serializer.Fields.LabelSerializable =
+    new SerializerTestSuite('LabelSerializable');
+Serializer.Fields.LabelSerializable.Simple = new SerializerTestCase(
+    'Simple',
     '<xml xmlns="https://developers.google.com/blockly/xml">' +
-    '<block type="test_fields_label_serializable" id="id******************" x="42" y="42">' +
-    '<field name="LABEL">test</field>' +
-    '</block>' +
-    '</xml>');
-Serializer.Fields.LabelSerializable.Symbols = new SerializerTestCase('Symbols',
+        '<block type="test_fields_label_serializable" id="id******************" x="42" y="42">' +
+        '<field name="LABEL">test</field>' +
+        '</block>' +
+        '</xml>');
+Serializer.Fields.LabelSerializable.Symbols = new SerializerTestCase(
+    'Symbols',
     '<xml xmlns="https://developers.google.com/blockly/xml">' +
-    '<block type="test_fields_label_serializable" id="id******************" x="42" y="42">' +
-    '<field name="LABEL">~`!@#$%^*()_+-={[}]|\\:;,.?/</field>' +
-    '</block>' +
-    '</xml>');
+        '<block type="test_fields_label_serializable" id="id******************" x="42" y="42">' +
+        '<field name="LABEL">~`!@#$%^*()_+-={[}]|\\:;,.?/</field>' +
+        '</block>' +
+        '</xml>');
 Serializer.Fields.LabelSerializable.EscapedSymbols = new SerializerTestCase(
     'EscapedSymbols',
     '<xml xmlns="https://developers.google.com/blockly/xml">' +
-    '<block type="test_fields_label_serializable" id="id******************" x="42" y="42">' +
-    '<field name="LABEL">&amp;&lt;&gt;</field>' +
-    '</block>' +
-    '</xml>');
+        '<block type="test_fields_label_serializable" id="id******************" x="42" y="42">' +
+        '<field name="LABEL">&amp;&lt;&gt;</field>' +
+        '</block>' +
+        '</xml>');
 Serializer.Fields.LabelSerializable.SingleQuotes = new SerializerTestCase(
     'SingleQuotes',
     '<xml xmlns="https://developers.google.com/blockly/xml">' +
-    '<block type="test_fields_label_serializable" id="id******************" x="42" y="42">' +
-    '<field name="LABEL">\'test\'</field>' +
-    '</block>' +
-    '</xml>');
+        '<block type="test_fields_label_serializable" id="id******************" x="42" y="42">' +
+        '<field name="LABEL">\'test\'</field>' +
+        '</block>' +
+        '</xml>');
 Serializer.Fields.LabelSerializable.DoubleQuotes = new SerializerTestCase(
     'DoubleQuotes',
     '<xml xmlns="https://developers.google.com/blockly/xml">' +
-    '<block type="test_fields_label_serializable" id="id******************" x="42" y="42">' +
-    '<field name="LABEL">"test"</field>' +
-    '</block>' +
-    '</xml>');
+        '<block type="test_fields_label_serializable" id="id******************" x="42" y="42">' +
+        '<field name="LABEL">"test"</field>' +
+        '</block>' +
+        '</xml>');
 Serializer.Fields.LabelSerializable.Numbers = new SerializerTestCase(
     'Numbers',
     '<xml xmlns="https://developers.google.com/blockly/xml">' +
-    '<block type="test_fields_label_serializable" id="id******************" x="42" y="42">' +
-    '<field name="LABEL">1234567890a123a123a</field>' +
-    '</block>' +
-    '</xml>');
+        '<block type="test_fields_label_serializable" id="id******************" x="42" y="42">' +
+        '<field name="LABEL">1234567890a123a123a</field>' +
+        '</block>' +
+        '</xml>');
 Serializer.Fields.LabelSerializable.Emoji = new SerializerTestCase(
     'Emoji',
     '<xml xmlns="https://developers.google.com/blockly/xml">' +
-    '<block type="test_fields_label_serializable" id="id******************" x="42" y="42">' +
-    '<field name="LABEL">😀👋🏿👋🏾👋🏽👋🏼👋🏻😀❤❤❤</field>' +
-    '</block>' +
-    '</xml>');
+        '<block type="test_fields_label_serializable" id="id******************" x="42" y="42">' +
+        '<field name="LABEL">😀👋🏿👋🏾👋🏽👋🏼👋🏻😀❤❤❤</field>' +
+        '</block>' +
+        '</xml>');
 Serializer.Fields.LabelSerializable.Russian = new SerializerTestCase(
     'Russian',
     '<xml xmlns="https://developers.google.com/blockly/xml">' +
-    '<block type="test_fields_label_serializable" id="id******************" x="42" y="42">' +
-    '<field name="LABEL">ты любопытный кот</field>' +
-    '</block>' +
-    '</xml>');
+        '<block type="test_fields_label_serializable" id="id******************" x="42" y="42">' +
+        '<field name="LABEL">ты любопытный кот</field>' +
+        '</block>' +
+        '</xml>');
 Serializer.Fields.LabelSerializable.Japanese = new SerializerTestCase(
     'Japanese',
     '<xml xmlns="https://developers.google.com/blockly/xml">' +
-    '<block type="test_fields_label_serializable" id="id******************" x="42" y="42">' +
-    '<field name="LABEL">あなたは好奇心旺盛な猫です</field>' +
-    '</block>' +
-    '</xml>');
+        '<block type="test_fields_label_serializable" id="id******************" x="42" y="42">' +
+        '<field name="LABEL">あなたは好奇心旺盛な猫です</field>' +
+        '</block>' +
+        '</xml>');
 Serializer.Fields.LabelSerializable.Zalgo = new SerializerTestCase(
     'Zalgo',
     '<xml xmlns="https://developers.google.com/blockly/xml">' +
-    '<block type="test_fields_label_serializable" id="id******************" x="42" y="42">' +
-    '<field name="LABEL">z̴̪͈̲̜͕̽̈̀͒͂̓̋̉̍a̸̧̧̜̻̘̤̫̱̲͎̞̻͆̋ļ̸̛̖̜̳͚̖͔̟̈́͂̉̀͑̑͑̎ǵ̸̫̳̽̐̃̑̚̕o̶͇̫͔̮̼̭͕̹̘̬͋̀͆̂̇̋͊̒̽</field>' +
-    '</block>' +
-    '</xml>');
+        '<block type="test_fields_label_serializable" id="id******************" x="42" y="42">' +
+        '<field name="LABEL">z̴̪͈̲̜͕̽̈̀͒͂̓̋̉̍a̸̧̧̜̻̘̤̫̱̲͎̞̻͆̋ļ̸̛̖̜̳͚̖͔̟̈́͂̉̀͑̑͑̎ǵ̸̫̳̽̐̃̑̚̕o̶͇̫͔̮̼̭͕̹̘̬͋̀͆̂̇̋͊̒̽</field>' +
+        '</block>' +
+        '</xml>');
 Serializer.Fields.LabelSerializable.ControlChars = new SerializerTestCase(
     'ControlChars',
     '<xml xmlns="https://developers.google.com/blockly/xml">' +
-    '<block type="test_fields_label_serializable" id="id******************" x="42" y="42">' +
-    '<field name="LABEL">&#01;&#a1;</field>' +
-    '</block>' +
-    '</xml>');
+        '<block type="test_fields_label_serializable" id="id******************" x="42" y="42">' +
+        '<field name="LABEL">&#01;&#a1;</field>' +
+        '</block>' +
+        '</xml>');
 Serializer.Fields.LabelSerializable.testCases = [
   Serializer.Fields.LabelSerializable.Simple,
   Serializer.Fields.LabelSerializable.Symbols,
@@ -392,104 +420,105 @@ Serializer.Fields.MultilineInput = new SerializerTestSuite('MultilineInput');
 Serializer.Fields.MultilineInput.SingleLine = new SerializerTestCase(
     'SingleLine',
     '<xml xmlns="https://developers.google.com/blockly/xml">' +
-    '<block type="test_fields_multilinetext" id="id******************" x="42" y="42">' +
-    '<field name="CODE">test</field>' +
-    '</block>' +
-    '</xml>');
+        '<block type="test_fields_multilinetext" id="id******************" x="42" y="42">' +
+        '<field name="CODE">test</field>' +
+        '</block>' +
+        '</xml>');
 Serializer.Fields.MultilineInput.MultipleLines = new SerializerTestCase(
     'MultipleLines',
     '<xml xmlns="https://developers.google.com/blockly/xml">' +
-    '<block type="test_fields_multilinetext" id="id******************" x="42" y="42">' +
-    '<field name="CODE">line1&amp;#10;line2&amp;#10;line3</field>' +
-    '</block>' +
-    '</xml>');
+        '<block type="test_fields_multilinetext" id="id******************" x="42" y="42">' +
+        '<field name="CODE">line1&amp;#10;line2&amp;#10;line3</field>' +
+        '</block>' +
+        '</xml>');
 Serializer.Fields.MultilineInput.Indentation = new SerializerTestCase(
     'Indentation',
     '<xml xmlns="https://developers.google.com/blockly/xml">' +
-    '<block type="test_fields_multilinetext" id="id******************" x="42" y="42">' +
-    '<field name="CODE">line1&amp;#10;  line2&amp;#10;  line3</field>' +
-    '</block>' +
-    '</xml>');
+        '<block type="test_fields_multilinetext" id="id******************" x="42" y="42">' +
+        '<field name="CODE">line1&amp;#10;  line2&amp;#10;  line3</field>' +
+        '</block>' +
+        '</xml>');
 /* eslint-disable no-tabs */
 Serializer.Fields.MultilineInput.Tabs = new SerializerTestCase(
     'Tabs',
     '<xml xmlns="https://developers.google.com/blockly/xml">' +
-    '<block type="test_fields_multilinetext" id="id******************" x="42" y="42">' +
-    '<field name="CODE">' +
-    'line1&amp;#10;&amp;#x9line2&amp;#10;&amp;#x9line3' +
-    '</field>' +
-    '</block>' +
-    '</xml>');
+        '<block type="test_fields_multilinetext" id="id******************" x="42" y="42">' +
+        '<field name="CODE">' +
+        'line1&amp;#10;&amp;#x9line2&amp;#10;&amp;#x9line3' +
+        '</field>' +
+        '</block>' +
+        '</xml>');
 /* eslint-enable no-tabs */
-Serializer.Fields.MultilineInput.Symbols = new SerializerTestCase('Symbols',
+Serializer.Fields.MultilineInput.Symbols = new SerializerTestCase(
+    'Symbols',
     '<xml xmlns="https://developers.google.com/blockly/xml">' +
-    '<block type="test_fields_multilinetext" id="id******************" x="42" y="42">' +
-    '<field name="CODE">~`!@#$%^*()_+-={[}]|\\:;,.?/</field>' +
-    '</block>' +
-    '</xml>');
+        '<block type="test_fields_multilinetext" id="id******************" x="42" y="42">' +
+        '<field name="CODE">~`!@#$%^*()_+-={[}]|\\:;,.?/</field>' +
+        '</block>' +
+        '</xml>');
 Serializer.Fields.MultilineInput.EscapedSymbols = new SerializerTestCase(
     'EscapedSymbols',
     '<xml xmlns="https://developers.google.com/blockly/xml">' +
-    '<block type="test_fields_multilinetext" id="id******************" x="42" y="42">' +
-    '<field name="CODE">&amp;&lt;&gt;</field>' +
-    '</block>' +
-    '</xml>');
+        '<block type="test_fields_multilinetext" id="id******************" x="42" y="42">' +
+        '<field name="CODE">&amp;&lt;&gt;</field>' +
+        '</block>' +
+        '</xml>');
 Serializer.Fields.MultilineInput.SingleQuotes = new SerializerTestCase(
     'SingleQuotes',
     '<xml xmlns="https://developers.google.com/blockly/xml">' +
-    '<block type="test_fields_multilinetext" id="id******************" x="42" y="42">' +
-    '<field name="CODE">\'test\'</field>' +
-    '</block>' +
-    '</xml>');
+        '<block type="test_fields_multilinetext" id="id******************" x="42" y="42">' +
+        '<field name="CODE">\'test\'</field>' +
+        '</block>' +
+        '</xml>');
 Serializer.Fields.MultilineInput.DoubleQuotes = new SerializerTestCase(
     'DoubleQuotes',
     '<xml xmlns="https://developers.google.com/blockly/xml">' +
-    '<block type="test_fields_multilinetext" id="id******************" x="42" y="42">' +
-    '<field name="CODE">"test"</field>' +
-    '</block>' +
-    '</xml>');
+        '<block type="test_fields_multilinetext" id="id******************" x="42" y="42">' +
+        '<field name="CODE">"test"</field>' +
+        '</block>' +
+        '</xml>');
 Serializer.Fields.MultilineInput.Numbers = new SerializerTestCase(
     'Numbers',
     '<xml xmlns="https://developers.google.com/blockly/xml">' +
-    '<block type="test_fields_multilinetext" id="id******************" x="42" y="42">' +
-    '<field name="CODE">1234567890a123a123a</field>' +
-    '</block>' +
-    '</xml>');
+        '<block type="test_fields_multilinetext" id="id******************" x="42" y="42">' +
+        '<field name="CODE">1234567890a123a123a</field>' +
+        '</block>' +
+        '</xml>');
 Serializer.Fields.MultilineInput.Emoji = new SerializerTestCase(
     'Emoji',
     '<xml xmlns="https://developers.google.com/blockly/xml">' +
-    '<block type="test_fields_multilinetext" id="id******************" x="42" y="42">' +
-    '<field name="CODE">😀👋🏿👋🏾👋🏽👋🏼👋🏻😀❤❤❤</field>' +
-    '</block>' +
-    '</xml>');
+        '<block type="test_fields_multilinetext" id="id******************" x="42" y="42">' +
+        '<field name="CODE">😀👋🏿👋🏾👋🏽👋🏼👋🏻😀❤❤❤</field>' +
+        '</block>' +
+        '</xml>');
 Serializer.Fields.MultilineInput.Russian = new SerializerTestCase(
     'Russian',
     '<xml xmlns="https://developers.google.com/blockly/xml">' +
-    '<block type="test_fields_multilinetext" id="id******************" x="42" y="42">' +
-    '<field name="CODE">ты любопытный кот</field>' +
-    '</block>' +
-    '</xml>');
+        '<block type="test_fields_multilinetext" id="id******************" x="42" y="42">' +
+        '<field name="CODE">ты любопытный кот</field>' +
+        '</block>' +
+        '</xml>');
 Serializer.Fields.MultilineInput.Japanese = new SerializerTestCase(
     'Japanese',
     '<xml xmlns="https://developers.google.com/blockly/xml">' +
-    '<block type="test_fields_multilinetext" id="id******************" x="42" y="42">' +
-    '<field name="CODE">あなたは好奇心旺盛な猫です</field>' +
-    '</block>' +
-    '</xml>');
+        '<block type="test_fields_multilinetext" id="id******************" x="42" y="42">' +
+        '<field name="CODE">あなたは好奇心旺盛な猫です</field>' +
+        '</block>' +
+        '</xml>');
 Serializer.Fields.MultilineInput.Zalgo = new SerializerTestCase(
     'Zalgo',
     '<xml xmlns="https://developers.google.com/blockly/xml">' +
-    '<block type="test_fields_multilinetext" id="id******************" x="42" y="42">' +
-    '<field name="CODE">z̴̪͈̲̜͕̽̈̀͒͂̓̋̉̍a̸̧̧̜̻̘̤̫̱̲͎̞̻͆̋ļ̸̛̖̜̳͚̖͔̟̈́͂̉̀͑̑͑̎ǵ̸̫̳̽̐̃̑̚̕o̶͇̫͔̮̼̭͕̹̘̬͋̀͆̂̇̋͊̒̽</field>' +
-    '</block>' +
-    '</xml>');
+        '<block type="test_fields_multilinetext" id="id******************" x="42" y="42">' +
+        '<field name="CODE">z̴̪͈̲̜͕̽̈̀͒͂̓̋̉̍a̸̧̧̜̻̘̤̫̱̲͎̞̻͆̋ļ̸̛̖̜̳͚̖͔̟̈́͂̉̀͑̑͑̎ǵ̸̫̳̽̐̃̑̚̕o̶͇̫͔̮̼̭͕̹̘̬͋̀͆̂̇̋͊̒̽</field>' +
+        '</block>' +
+        '</xml>');
 Serializer.Fields.MultilineInput.ControlChars = new SerializerTestCase(
     'ControlChars',
     '<xml xmlns="https://developers.google.com/blockly/xml">' +
-    '<block type="test_fields_multilinetext" id="id******************" x="42" y="42">' +
-    '<field name="CODE">&#01;&#a1;</field>' +
-    '</block>' +
-    '</xml>');
+        '<block type="test_fields_multilinetext" id="id******************" x="42" y="42">' +
+        '<field name="CODE">&#01;&#a1;</field>' +
+        '</block>' +
+        '</xml>');
 Serializer.Fields.MultilineInput.testCases = [
   Serializer.Fields.MultilineInput.SingleLine,
   Serializer.Fields.MultilineInput.MultipleLines,
@@ -509,62 +538,69 @@ Serializer.Fields.MultilineInput.testCases = [
 ];
 
 Serializer.Fields.Number = new SerializerTestSuite('Number');
-Serializer.Fields.Number.Simple = new SerializerTestCase('Simple',
+Serializer.Fields.Number.Simple = new SerializerTestCase(
+    'Simple',
     '<xml xmlns="https://developers.google.com/blockly/xml">' +
-    '<block type="test_numbers_float" id="id******************" x="42" y="42">' +
-    '<field name="NUM">123</field>' +
-    '</block>' +
-    '</xml>');
-Serializer.Fields.Number.Negative = new SerializerTestCase('Negative',
+        '<block type="test_numbers_float" id="id******************" x="42" y="42">' +
+        '<field name="NUM">123</field>' +
+        '</block>' +
+        '</xml>');
+Serializer.Fields.Number.Negative = new SerializerTestCase(
+    'Negative',
     '<xml xmlns="https://developers.google.com/blockly/xml">' +
-    '<block type="test_numbers_float" id="id******************" x="42" y="42">' +
-    '<field name="NUM">-123</field>' +
-    '</block>' +
-    '</xml>');
-Serializer.Fields.Number.PosInfinity = new SerializerTestCase('PosInfinity',
+        '<block type="test_numbers_float" id="id******************" x="42" y="42">' +
+        '<field name="NUM">-123</field>' +
+        '</block>' +
+        '</xml>');
+Serializer.Fields.Number.PosInfinity = new SerializerTestCase(
+    'PosInfinity',
     '<xml xmlns="https://developers.google.com/blockly/xml">' +
-    '<block type="test_numbers_float" id="id******************" x="42" y="42">' +
-    '<field name="NUM">Infinity</field>' +
-    '</block>' +
-    '</xml>');
-Serializer.Fields.Number.NegInfinity = new SerializerTestCase('NegInfinity',
+        '<block type="test_numbers_float" id="id******************" x="42" y="42">' +
+        '<field name="NUM">Infinity</field>' +
+        '</block>' +
+        '</xml>');
+Serializer.Fields.Number.NegInfinity = new SerializerTestCase(
+    'NegInfinity',
     '<xml xmlns="https://developers.google.com/blockly/xml">' +
-    '<block type="test_numbers_float" id="id******************" x="42" y="42">' +
-    '<field name="NUM">-Infinity</field>' +
-    '</block>' +
-    '</xml>');
-Serializer.Fields.Number.Decimals = new SerializerTestCase('Decimals',
+        '<block type="test_numbers_float" id="id******************" x="42" y="42">' +
+        '<field name="NUM">-Infinity</field>' +
+        '</block>' +
+        '</xml>');
+Serializer.Fields.Number.Decimals = new SerializerTestCase(
+    'Decimals',
     '<xml xmlns="https://developers.google.com/blockly/xml">' +
-    '<block type="test_numbers_float" id="id******************" x="42" y="42">' +
-    '<field name="NUM">1.5</field>' +
-    '</block>' +
-    '</xml>');
-Serializer.Fields.Number.Smallest = new SerializerTestCase('Smallest',
+        '<block type="test_numbers_float" id="id******************" x="42" y="42">' +
+        '<field name="NUM">1.5</field>' +
+        '</block>' +
+        '</xml>');
+Serializer.Fields.Number.Smallest = new SerializerTestCase(
+    'Smallest',
     '<xml xmlns="https://developers.google.com/blockly/xml">' +
-    '<block type="test_numbers_float" id="id******************" x="42" y="42">' +
-    '<field name="NUM">5e-324</field>' +
-    '</block>' +
-    '</xml>');
-Serializer.Fields.Number.Largest = new SerializerTestCase('Largest',
+        '<block type="test_numbers_float" id="id******************" x="42" y="42">' +
+        '<field name="NUM">5e-324</field>' +
+        '</block>' +
+        '</xml>');
+Serializer.Fields.Number.Largest = new SerializerTestCase(
+    'Largest',
     '<xml xmlns="https://developers.google.com/blockly/xml">' +
-    '<block type="test_numbers_float" id="id******************" x="42" y="42">' +
-    '<field name="NUM">1.7976931348623157e+308</field>' +
-    '</block>' +
-    '</xml>');
+        '<block type="test_numbers_float" id="id******************" x="42" y="42">' +
+        '<field name="NUM">1.7976931348623157e+308</field>' +
+        '</block>' +
+        '</xml>');
 Serializer.Fields.Number.MaxPrecisionSmall = new SerializerTestCase(
     'MaxPrecisionSmall',
     '<xml xmlns="https://developers.google.com/blockly/xml">' +
-    '<block type="test_numbers_float" id="id******************" x="42" y="42">' +
-    '<field name="NUM">1.000000000000001</field>' +
-    '</block>' +
-    '</xml>');
+        '<block type="test_numbers_float" id="id******************" x="42" y="42">' +
+        '<field name="NUM">1.000000000000001</field>' +
+        '</block>' +
+        '</xml>');
 Serializer.Fields.Number.MaxPrecisionLarge = new SerializerTestCase(
     'MaxPrecisionLarge',
     '<xml xmlns="https://developers.google.com/blockly/xml">' +
-    '<block type="test_numbers_float" id="id******************" x="42" y="42">' +
-    '<field name="NUM">1000000000000001</field>' +
-    '</block>' +
-    '</xml>');
+        '<block type="test_numbers_float" id="id******************" x="42" y="42">' +
+        '<field name="NUM">1000000000000001</field>' +
+        '</block>' +
+        '</xml>');
 Serializer.Fields.Number.testCases = [
   Serializer.Fields.Number.Simple,
   Serializer.Fields.Number.Negative,
@@ -578,255 +614,253 @@ Serializer.Fields.Number.testCases = [
 ];
 
 Serializer.Fields.TextInput = new SerializerTestSuite('TextInput');
-Serializer.Fields.TextInput.Simple = new SerializerTestCase('Simple',
+Serializer.Fields.TextInput.Simple = new SerializerTestCase(
+    'Simple',
     '<xml xmlns="https://developers.google.com/blockly/xml">' +
-    '<block type="test_fields_text_input" id="id******************" x="42" y="42">' +
-    '<field name="TEXT_INPUT">test</field>' +
-    '</block>' +
-    '</xml>');
+        '<block type="test_fields_text_input" id="id******************" x="42" y="42">' +
+        '<field name="TEXT_INPUT">test</field>' +
+        '</block>' +
+        '</xml>');
 /* eslint-disable no-tabs */
-Serializer.Fields.TextInput.Tabs = new SerializerTestCase('Tabs',
+Serializer.Fields.TextInput.Tabs = new SerializerTestCase(
+    'Tabs',
     '<xml xmlns="https://developers.google.com/blockly/xml">' +
-    '<block type="test_fields_text_input" id="id******************" x="42" y="42">' +
-    '<field name="TEXT_INPUT">line1&amp;#x9line2&amp;#x9line3</field>' +
-    '</block>' +
-    '</xml>');
+        '<block type="test_fields_text_input" id="id******************" x="42" y="42">' +
+        '<field name="TEXT_INPUT">line1&amp;#x9line2&amp;#x9line3</field>' +
+        '</block>' +
+        '</xml>');
 /* eslint-enable no-tabs */
-Serializer.Fields.TextInput.Symbols = new SerializerTestCase('Symbols',
+Serializer.Fields.TextInput.Symbols = new SerializerTestCase(
+    'Symbols',
     '<xml xmlns="https://developers.google.com/blockly/xml">' +
-    '<block type="test_fields_text_input" id="id******************" x="42" y="42">' +
-    '<field name="TEXT_INPUT">~`!@#$%^*()_+-={[}]|\\:;,.?/</field>' +
-    '</block>' +
-    '</xml>');
+        '<block type="test_fields_text_input" id="id******************" x="42" y="42">' +
+        '<field name="TEXT_INPUT">~`!@#$%^*()_+-={[}]|\\:;,.?/</field>' +
+        '</block>' +
+        '</xml>');
 Serializer.Fields.TextInput.EscapedSymbols = new SerializerTestCase(
     'EscapedSymbols',
     '<xml xmlns="https://developers.google.com/blockly/xml">' +
-    '<block type="test_fields_text_input" id="id******************" x="42" y="42">' +
-    '<field name="TEXT_INPUT">&amp;&lt;&gt;</field>' +
-    '</block>' +
-    '</xml>');
+        '<block type="test_fields_text_input" id="id******************" x="42" y="42">' +
+        '<field name="TEXT_INPUT">&amp;&lt;&gt;</field>' +
+        '</block>' +
+        '</xml>');
 Serializer.Fields.TextInput.SingleQuotes = new SerializerTestCase(
     'SingleQuotes',
     '<xml xmlns="https://developers.google.com/blockly/xml">' +
-    '<block type="test_fields_text_input" id="id******************" x="42" y="42">' +
-    '<field name="TEXT_INPUT">\'test\'</field>' +
-    '</block>' +
-    '</xml>');
+        '<block type="test_fields_text_input" id="id******************" x="42" y="42">' +
+        '<field name="TEXT_INPUT">\'test\'</field>' +
+        '</block>' +
+        '</xml>');
 Serializer.Fields.TextInput.DoubleQuotes = new SerializerTestCase(
     'DoubleQuotes',
     '<xml xmlns="https://developers.google.com/blockly/xml">' +
-    '<block type="test_fields_text_input" id="id******************" x="42" y="42">' +
-    '<field name="TEXT_INPUT">"test"</field>' +
-    '</block>' +
-    '</xml>');
+        '<block type="test_fields_text_input" id="id******************" x="42" y="42">' +
+        '<field name="TEXT_INPUT">"test"</field>' +
+        '</block>' +
+        '</xml>');
 Serializer.Fields.TextInput.Numbers = new SerializerTestCase(
     'Numbers',
     '<xml xmlns="https://developers.google.com/blockly/xml">' +
-    '<block type="test_fields_text_input" id="id******************" x="42" y="42">' +
-    '<field name="TEXT_INPUT">1234567890a123a123a</field>' +
-    '</block>' +
-    '</xml>');
+        '<block type="test_fields_text_input" id="id******************" x="42" y="42">' +
+        '<field name="TEXT_INPUT">1234567890a123a123a</field>' +
+        '</block>' +
+        '</xml>');
 Serializer.Fields.TextInput.Emoji = new SerializerTestCase(
     'Emoji',
     '<xml xmlns="https://developers.google.com/blockly/xml">' +
-    '<block type="test_fields_text_input" id="id******************" x="42" y="42">' +
-    '<field name="TEXT_INPUT">😀👋🏿👋🏾👋🏽👋🏼👋🏻😀❤❤❤</field>' +
-    '</block>' +
-    '</xml>');
+        '<block type="test_fields_text_input" id="id******************" x="42" y="42">' +
+        '<field name="TEXT_INPUT">😀👋🏿👋🏾👋🏽👋🏼👋🏻😀❤❤❤</field>' +
+        '</block>' +
+        '</xml>');
 Serializer.Fields.TextInput.Russian = new SerializerTestCase(
     'Russian',
     '<xml xmlns="https://developers.google.com/blockly/xml">' +
-    '<block type="test_fields_text_input" id="id******************" x="42" y="42">' +
-    '<field name="TEXT_INPUT">ты любопытный кот</field>' +
-    '</block>' +
-    '</xml>');
+        '<block type="test_fields_text_input" id="id******************" x="42" y="42">' +
+        '<field name="TEXT_INPUT">ты любопытный кот</field>' +
+        '</block>' +
+        '</xml>');
 Serializer.Fields.TextInput.Japanese = new SerializerTestCase(
     'Japanese',
     '<xml xmlns="https://developers.google.com/blockly/xml">' +
-    '<block type="test_fields_text_input" id="id******************" x="42" y="42">' +
-    '<field name="TEXT_INPUT">あなたは好奇心旺盛な猫です</field>' +
-    '</block>' +
-    '</xml>');
+        '<block type="test_fields_text_input" id="id******************" x="42" y="42">' +
+        '<field name="TEXT_INPUT">あなたは好奇心旺盛な猫です</field>' +
+        '</block>' +
+        '</xml>');
 Serializer.Fields.TextInput.Zalgo = new SerializerTestCase(
     'Zalgo',
     '<xml xmlns="https://developers.google.com/blockly/xml">' +
-    '<block type="test_fields_text_input" id="id******************" x="42" y="42">' +
-    '<field name="TEXT_INPUT">z̴̪͈̲̜͕̽̈̀͒͂̓̋̉̍a̸̧̧̜̻̘̤̫̱̲͎̞̻͆̋ļ̸̛̖̜̳͚̖͔̟̈́͂̉̀͑̑͑̎ǵ̸̫̳̽̐̃̑̚̕o̶͇̫͔̮̼̭͕̹̘̬͋̀͆̂̇̋͊̒̽</field>' +
-    '</block>' +
-    '</xml>');
+        '<block type="test_fields_text_input" id="id******************" x="42" y="42">' +
+        '<field name="TEXT_INPUT">z̴̪͈̲̜͕̽̈̀͒͂̓̋̉̍a̸̧̧̜̻̘̤̫̱̲͎̞̻͆̋ļ̸̛̖̜̳͚̖͔̟̈́͂̉̀͑̑͑̎ǵ̸̫̳̽̐̃̑̚̕o̶͇̫͔̮̼̭͕̹̘̬͋̀͆̂̇̋͊̒̽</field>' +
+        '</block>' +
+        '</xml>');
 Serializer.Fields.TextInput.ControlChars = new SerializerTestCase(
     'ControlChars',
     '<xml xmlns="https://developers.google.com/blockly/xml">' +
-    '<block type="test_fields_text_input" id="id******************" x="42" y="42">' +
-    '<field name="TEXT_INPUT">&#01;&#a1;</field>' +
-    '</block>' +
-    '</xml>');
+        '<block type="test_fields_text_input" id="id******************" x="42" y="42">' +
+        '<field name="TEXT_INPUT">&#01;&#a1;</field>' +
+        '</block>' +
+        '</xml>');
 Serializer.Fields.TextInput.testCases = [
-  Serializer.Fields.TextInput.Simple,
-  Serializer.Fields.TextInput.Tabs,
+  Serializer.Fields.TextInput.Simple, Serializer.Fields.TextInput.Tabs,
   Serializer.Fields.TextInput.Symbols,
   Serializer.Fields.TextInput.EscapedSymbols,
   Serializer.Fields.TextInput.SingleQuotes,
-  Serializer.Fields.TextInput.DoubleQuotes,
-  Serializer.Fields.TextInput.Numbers,
-  Serializer.Fields.TextInput.Emoji,
-  Serializer.Fields.TextInput.Russian,
-  Serializer.Fields.TextInput.Japanese,
-  Serializer.Fields.TextInput.Zalgo,
+  Serializer.Fields.TextInput.DoubleQuotes, Serializer.Fields.TextInput.Numbers,
+  Serializer.Fields.TextInput.Emoji, Serializer.Fields.TextInput.Russian,
+  Serializer.Fields.TextInput.Japanese, Serializer.Fields.TextInput.Zalgo,
   // TODO: Uncoment once #4945 is merged.
   // Serializer.Fields.TextInput.ControlChars,
 ];
 
 Serializer.Fields.Variable = new SerializerTestSuite('Variable');
-Serializer.Fields.Variable.Simple = new SerializerTestCase('Simple',
+Serializer.Fields.Variable.Simple = new SerializerTestCase(
+    'Simple',
     '<xml xmlns="https://developers.google.com/blockly/xml">' +
-    '<variables>' +
-    '<variable id="aaaaaaaaaaaaaaaaaaaa">test</variable>' +
-    '</variables>' +
-    '<block type="variables_get" id="id******************" x="42" y="42">' +
-    '<field name="VAR" id="aaaaaaaaaaaaaaaaaaaa">test</field>' +
-    '</block>' +
-    '</xml>');
-Serializer.Fields.Variable.Types = new SerializerTestCase('Types',
+        '<variables>' +
+        '<variable id="aaaaaaaaaaaaaaaaaaaa">test</variable>' +
+        '</variables>' +
+        '<block type="variables_get" id="id******************" x="42" y="42">' +
+        '<field name="VAR" id="aaaaaaaaaaaaaaaaaaaa">test</field>' +
+        '</block>' +
+        '</xml>');
+Serializer.Fields.Variable.Types = new SerializerTestCase(
+    'Types',
     '<xml xmlns="https://developers.google.com/blockly/xml">' +
-    '<variables>' +
-    '<variable type="String" id="aaaaaaaaaaaaaaaaaaaa">test</variable>' +
-    '<variable type="Number" id="bbbbbbbbbbbbbbbbbbbb">test2</variable>' +
-    '<variable type="Colour" id="cccccccccccccccccccc">test3</variable>' +
-    '</variables>' +
-    '<block type="variables_get_dynamic" id="id******************" x="42" y="42">' +
-    '<field name="VAR" id="aaaaaaaaaaaaaaaaaaaa" variabletype="String">test</field>' +
-    '</block>' +
-    '<block type="variables_get_dynamic" id="id2*****************" x="42" y="84">' +
-    '<field name="VAR" id="bbbbbbbbbbbbbbbbbbbb" variabletype="Number">test2</field>' +
-    '</block>' +
-    '<block type="variables_get_dynamic" id="id3*****************" x="42" y="106">' +
-    '<field name="VAR" id="cccccccccccccccccccc" variabletype="Colour">test3</field>' +
-    '</block>' +
-    '</xml>');
+        '<variables>' +
+        '<variable type="String" id="aaaaaaaaaaaaaaaaaaaa">test</variable>' +
+        '<variable type="Number" id="bbbbbbbbbbbbbbbbbbbb">test2</variable>' +
+        '<variable type="Colour" id="cccccccccccccccccccc">test3</variable>' +
+        '</variables>' +
+        '<block type="variables_get_dynamic" id="id******************" x="42" y="42">' +
+        '<field name="VAR" id="aaaaaaaaaaaaaaaaaaaa" variabletype="String">test</field>' +
+        '</block>' +
+        '<block type="variables_get_dynamic" id="id2*****************" x="42" y="84">' +
+        '<field name="VAR" id="bbbbbbbbbbbbbbbbbbbb" variabletype="Number">test2</field>' +
+        '</block>' +
+        '<block type="variables_get_dynamic" id="id3*****************" x="42" y="106">' +
+        '<field name="VAR" id="cccccccccccccccccccc" variabletype="Colour">test3</field>' +
+        '</block>' +
+        '</xml>');
 /* eslint-disable no-tabs */
-Serializer.Fields.Variable.Tabs = new SerializerTestCase('Tabs',
+Serializer.Fields.Variable.Tabs = new SerializerTestCase(
+    'Tabs',
     '<xml xmlns="https://developers.google.com/blockly/xml">' +
-    '<variables>' +
-    '<variable id="aaaaaaaaaaaaaaaaaaaa">line1&amp;#x9line2&amp;#x9line3</variable>' +
-    '</variables>' +
-    '<block type="variables_get" id="id******************" x="42" y="42">' +
-    '<field name="VAR" id="aaaaaaaaaaaaaaaaaaaa">line1&amp;#x9line2&amp;#x9line3</field>' +
-    '</block>' +
-    '</xml>');
+        '<variables>' +
+        '<variable id="aaaaaaaaaaaaaaaaaaaa">line1&amp;#x9line2&amp;#x9line3</variable>' +
+        '</variables>' +
+        '<block type="variables_get" id="id******************" x="42" y="42">' +
+        '<field name="VAR" id="aaaaaaaaaaaaaaaaaaaa">line1&amp;#x9line2&amp;#x9line3</field>' +
+        '</block>' +
+        '</xml>');
 /* eslint-enable no-tabs */
-Serializer.Fields.Variable.Symbols = new SerializerTestCase('Symbols',
+Serializer.Fields.Variable.Symbols = new SerializerTestCase(
+    'Symbols',
     '<xml xmlns="https://developers.google.com/blockly/xml">' +
-    '<variables>' +
-    '<variable id="aaaaaaaaaaaaaaaaaaaa">~`!@#$%^*()_+-={[}]|\\:;,.?/</variable>' +
-    '</variables>' +
-    '<block type="variables_get" id="id******************" x="42" y="42">' +
-    '<field name="VAR" id="aaaaaaaaaaaaaaaaaaaa">~`!@#$%^*()_+-={[}]|\\:;,.?/</field>' +
-    '</block>' +
-    '</xml>');
+        '<variables>' +
+        '<variable id="aaaaaaaaaaaaaaaaaaaa">~`!@#$%^*()_+-={[}]|\\:;,.?/</variable>' +
+        '</variables>' +
+        '<block type="variables_get" id="id******************" x="42" y="42">' +
+        '<field name="VAR" id="aaaaaaaaaaaaaaaaaaaa">~`!@#$%^*()_+-={[}]|\\:;,.?/</field>' +
+        '</block>' +
+        '</xml>');
 Serializer.Fields.Variable.EscapedSymbols = new SerializerTestCase(
     'EscapedSymbols',
     '<xml xmlns="https://developers.google.com/blockly/xml">' +
-    '<variables>' +
-    '<variable id="aaaaaaaaaaaaaaaaaaaa">&amp;&lt;&gt;</variable>' +
-    '</variables>' +
-    '<block type="variables_get" id="id******************" x="42" y="42">' +
-    '<field name="VAR" id="aaaaaaaaaaaaaaaaaaaa">&amp;&lt;&gt;</field>' +
-    '</block>' +
-    '</xml>');
+        '<variables>' +
+        '<variable id="aaaaaaaaaaaaaaaaaaaa">&amp;&lt;&gt;</variable>' +
+        '</variables>' +
+        '<block type="variables_get" id="id******************" x="42" y="42">' +
+        '<field name="VAR" id="aaaaaaaaaaaaaaaaaaaa">&amp;&lt;&gt;</field>' +
+        '</block>' +
+        '</xml>');
 Serializer.Fields.Variable.SingleQuotes = new SerializerTestCase(
     'SingleQuotes',
     '<xml xmlns="https://developers.google.com/blockly/xml">' +
-    '<variables>' +
-    '<variable id="aaaaaaaaaaaaaaaaaaaa">\'test\'</variable>' +
-    '</variables>' +
-    '<block type="variables_get" id="id******************" x="42" y="42">' +
-    '<field name="VAR" id="aaaaaaaaaaaaaaaaaaaa">\'test\'</field>' +
-    '</block>' +
-    '</xml>');
+        '<variables>' +
+        '<variable id="aaaaaaaaaaaaaaaaaaaa">\'test\'</variable>' +
+        '</variables>' +
+        '<block type="variables_get" id="id******************" x="42" y="42">' +
+        '<field name="VAR" id="aaaaaaaaaaaaaaaaaaaa">\'test\'</field>' +
+        '</block>' +
+        '</xml>');
 Serializer.Fields.Variable.DoubleQuotes = new SerializerTestCase(
     'DoubleQuotes',
     '<xml xmlns="https://developers.google.com/blockly/xml">' +
-    '<variables>' +
-    '<variable id="aaaaaaaaaaaaaaaaaaaa">"test"</variable>' +
-    '</variables>' +
-    '<block type="variables_get" id="id******************" x="42" y="42">' +
-    '<field name="VAR" id="aaaaaaaaaaaaaaaaaaaa">"test"</field>' +
-    '</block>' +
-    '</xml>');
+        '<variables>' +
+        '<variable id="aaaaaaaaaaaaaaaaaaaa">"test"</variable>' +
+        '</variables>' +
+        '<block type="variables_get" id="id******************" x="42" y="42">' +
+        '<field name="VAR" id="aaaaaaaaaaaaaaaaaaaa">"test"</field>' +
+        '</block>' +
+        '</xml>');
 Serializer.Fields.Variable.Numbers = new SerializerTestCase(
     'Numbers',
     '<xml xmlns="https://developers.google.com/blockly/xml">' +
-    '<variables>' +
-    '<variable id="aaaaaaaaaaaaaaaaaaaa">1234567890a123a123a</variable>' +
-    '</variables>' +
-    '<block type="variables_get" id="id******************" x="42" y="42">' +
-    '<field name="VAR" id="aaaaaaaaaaaaaaaaaaaa">1234567890a123a123a</field>' +
-    '</block>' +
-    '</xml>');
+        '<variables>' +
+        '<variable id="aaaaaaaaaaaaaaaaaaaa">1234567890a123a123a</variable>' +
+        '</variables>' +
+        '<block type="variables_get" id="id******************" x="42" y="42">' +
+        '<field name="VAR" id="aaaaaaaaaaaaaaaaaaaa">1234567890a123a123a</field>' +
+        '</block>' +
+        '</xml>');
 Serializer.Fields.Variable.Emoji = new SerializerTestCase(
     'Emoji',
     '<xml xmlns="https://developers.google.com/blockly/xml">' +
-    '<variables>' +
-    '<variable id="aaaaaaaaaaaaaaaaaaaa">😀👋🏿👋🏾👋🏽👋🏼👋🏻😀❤❤❤</variable>' +
-    '</variables>' +
-    '<block type="variables_get" id="id******************" x="42" y="42">' +
-    '<field name="VAR" id="aaaaaaaaaaaaaaaaaaaa">😀👋🏿👋🏾👋🏽👋🏼👋🏻😀❤❤❤</field>' +
-    '</block>' +
-    '</xml>');
+        '<variables>' +
+        '<variable id="aaaaaaaaaaaaaaaaaaaa">😀👋🏿👋🏾👋🏽👋🏼👋🏻😀❤❤❤</variable>' +
+        '</variables>' +
+        '<block type="variables_get" id="id******************" x="42" y="42">' +
+        '<field name="VAR" id="aaaaaaaaaaaaaaaaaaaa">😀👋🏿👋🏾👋🏽👋🏼👋🏻😀❤❤❤</field>' +
+        '</block>' +
+        '</xml>');
 Serializer.Fields.Variable.Russian = new SerializerTestCase(
     'Russian',
     '<xml xmlns="https://developers.google.com/blockly/xml">' +
-    '<variables>' +
-    '<variable id="aaaaaaaaaaaaaaaaaaaa">ты любопытный кот</variable>' +
-    '</variables>' +
-    '<block type="variables_get" id="id******************" x="42" y="42">' +
-    '<field name="VAR" id="aaaaaaaaaaaaaaaaaaaa">ты любопытный кот</field>' +
-    '</block>' +
-    '</xml>');
+        '<variables>' +
+        '<variable id="aaaaaaaaaaaaaaaaaaaa">ты любопытный кот</variable>' +
+        '</variables>' +
+        '<block type="variables_get" id="id******************" x="42" y="42">' +
+        '<field name="VAR" id="aaaaaaaaaaaaaaaaaaaa">ты любопытный кот</field>' +
+        '</block>' +
+        '</xml>');
 Serializer.Fields.Variable.Japanese = new SerializerTestCase(
     'Japanese',
     '<xml xmlns="https://developers.google.com/blockly/xml">' +
-    '<variables>' +
-    '<variable id="aaaaaaaaaaaaaaaaaaaa">あなたは好奇心旺盛な猫です</variable>' +
-    '</variables>' +
-    '<block type="variables_get" id="id******************" x="42" y="42">' +
-    '<field name="VAR" id="aaaaaaaaaaaaaaaaaaaa">あなたは好奇心旺盛な猫です</field>' +
-    '</block>' +
-    '</xml>');
+        '<variables>' +
+        '<variable id="aaaaaaaaaaaaaaaaaaaa">あなたは好奇心旺盛な猫です</variable>' +
+        '</variables>' +
+        '<block type="variables_get" id="id******************" x="42" y="42">' +
+        '<field name="VAR" id="aaaaaaaaaaaaaaaaaaaa">あなたは好奇心旺盛な猫です</field>' +
+        '</block>' +
+        '</xml>');
 Serializer.Fields.Variable.Zalgo = new SerializerTestCase(
     'Zalgo',
     '<xml xmlns="https://developers.google.com/blockly/xml">' +
-    '<variables>' +
-    '<variable id="aaaaaaaaaaaaaaaaaaaa">z̴̪͈̲̜͕̽̈̀͒͂̓̋̉̍a̸̧̧̜̻̘̤̫̱̲͎̞̻͆̋ļ̸̛̖̜̳͚̖͔̟̈́͂̉̀͑̑͑̎ǵ̸̫̳̽̐̃̑̚̕o̶͇̫͔̮̼̭͕̹̘̬͋̀͆̂̇̋͊̒̽</variable>' +
-    '</variables>' +
-    '<block type="variables_get" id="id******************" x="42" y="42">' +
-    '<field name="VAR" id="aaaaaaaaaaaaaaaaaaaa">z̴̪͈̲̜͕̽̈̀͒͂̓̋̉̍a̸̧̧̜̻̘̤̫̱̲͎̞̻͆̋ļ̸̛̖̜̳͚̖͔̟̈́͂̉̀͑̑͑̎ǵ̸̫̳̽̐̃̑̚̕o̶͇̫͔̮̼̭͕̹̘̬͋̀͆̂̇̋͊̒̽</field>' +
-    '</block>' +
-    '</xml>');
+        '<variables>' +
+        '<variable id="aaaaaaaaaaaaaaaaaaaa">z̴̪͈̲̜͕̽̈̀͒͂̓̋̉̍a̸̧̧̜̻̘̤̫̱̲͎̞̻͆̋ļ̸̛̖̜̳͚̖͔̟̈́͂̉̀͑̑͑̎ǵ̸̫̳̽̐̃̑̚̕o̶͇̫͔̮̼̭͕̹̘̬͋̀͆̂̇̋͊̒̽</variable>' +
+        '</variables>' +
+        '<block type="variables_get" id="id******************" x="42" y="42">' +
+        '<field name="VAR" id="aaaaaaaaaaaaaaaaaaaa">z̴̪͈̲̜͕̽̈̀͒͂̓̋̉̍a̸̧̧̜̻̘̤̫̱̲͎̞̻͆̋ļ̸̛̖̜̳͚̖͔̟̈́͂̉̀͑̑͑̎ǵ̸̫̳̽̐̃̑̚̕o̶͇̫͔̮̼̭͕̹̘̬͋̀͆̂̇̋͊̒̽</field>' +
+        '</block>' +
+        '</xml>');
 Serializer.Fields.Variable.ControlChars = new SerializerTestCase(
     'ControlChars',
     '<xml xmlns="https://developers.google.com/blockly/xml">' +
-    '<variables>' +
-    '<variable id="aaaaaaaaaaaaaaaaaaaa">&#01;&#a1;</variable>' +
-    '</variables>' +
-    '<block type="variables_get" id="id******************" x="42" y="42">' +
-    '<field name="VAR" id="aaaaaaaaaaaaaaaaaaaa">&#01;&#a1;</field>' +
-    '</block>' +
-    '</xml>');
+        '<variables>' +
+        '<variable id="aaaaaaaaaaaaaaaaaaaa">&#01;&#a1;</variable>' +
+        '</variables>' +
+        '<block type="variables_get" id="id******************" x="42" y="42">' +
+        '<field name="VAR" id="aaaaaaaaaaaaaaaaaaaa">&#01;&#a1;</field>' +
+        '</block>' +
+        '</xml>');
 Serializer.Fields.Variable.testCases = [
-  Serializer.Fields.Variable.Simple,
-  Serializer.Fields.Variable.Types,
-  Serializer.Fields.Variable.Tabs,
-  Serializer.Fields.Variable.Symbols,
+  Serializer.Fields.Variable.Simple, Serializer.Fields.Variable.Types,
+  Serializer.Fields.Variable.Tabs, Serializer.Fields.Variable.Symbols,
   Serializer.Fields.Variable.EscapedSymbols,
   Serializer.Fields.Variable.SingleQuotes,
-  Serializer.Fields.Variable.DoubleQuotes,
-  Serializer.Fields.Variable.Numbers,
-  Serializer.Fields.Variable.Emoji,
-  Serializer.Fields.Variable.Russian,
-  Serializer.Fields.Variable.Japanese,
-  Serializer.Fields.Variable.Zalgo,
+  Serializer.Fields.Variable.DoubleQuotes, Serializer.Fields.Variable.Numbers,
+  Serializer.Fields.Variable.Emoji, Serializer.Fields.Variable.Russian,
+  Serializer.Fields.Variable.Japanese, Serializer.Fields.Variable.Zalgo,
   // TODO: Uncoment once #4945 is merged.
   // Serializer.Fields.Variable.ControlChars,
 ];
@@ -834,78 +868,84 @@ Serializer.Fields.Variable.testCases = [
 Serializer.Fields.Variable.Id = new SerializerTestSuite('Id');
 
 Serializer.Fields.Variable.Id.Length = new SerializerTestSuite('Length');
-Serializer.Fields.Variable.Id.Length.Short = new SerializerTestCase('Short',
+Serializer.Fields.Variable.Id.Length.Short = new SerializerTestCase(
+    'Short',
     '<xml xmlns="https://developers.google.com/blockly/xml">' +
-    '<variables>' +
-    '<variable id="id">test</variable>' +
-    '</variables>' +
-    '<block type="variables_get" id="id******************" x="42" y="42">' +
-    '<field name="VAR" id="id">test</field>' +
-    '</block>' +
-    '</xml>');
-Serializer.Fields.Variable.Id.Length.Long = new SerializerTestCase('Long',
+        '<variables>' +
+        '<variable id="id">test</variable>' +
+        '</variables>' +
+        '<block type="variables_get" id="id******************" x="42" y="42">' +
+        '<field name="VAR" id="id">test</field>' +
+        '</block>' +
+        '</xml>');
+Serializer.Fields.Variable.Id.Length.Long = new SerializerTestCase(
+    'Long',
     '<xml xmlns="https://developers.google.com/blockly/xml">' +
-    '<variables>' +
-    '<variable id="id***********************">test</variable>' +
-    '</variables>' +
-    '<block type="variables_get" id="id******************" x="42" y="42">' +
-    '<field name="VAR" id="id***********************">test</field>' +
-    '</block>' +
-    '</xml>');
+        '<variables>' +
+        '<variable id="id***********************">test</variable>' +
+        '</variables>' +
+        '<block type="variables_get" id="id******************" x="42" y="42">' +
+        '<field name="VAR" id="id***********************">test</field>' +
+        '</block>' +
+        '</xml>');
 Serializer.Fields.Variable.Id.Length.testCases = [
   Serializer.Fields.Variable.Id.Length.Short,
   Serializer.Fields.Variable.Id.Length.Long,
 ];
 
 Serializer.Fields.Variable.Id.Chars = new SerializerTestSuite('Chars');
-Serializer.Fields.Variable.Id.Chars.Symbols = new SerializerTestCase('Symbols',
+Serializer.Fields.Variable.Id.Chars.Symbols = new SerializerTestCase(
+    'Symbols',
     '<xml xmlns="https://developers.google.com/blockly/xml">' +
-    '<variables>' +
-    '<variable id="!#$%()*+,-./:;=?@[]^">test</variable>' +
-    '<variable id="_`{|}~!!!!!!!!!!!!!!">test2</variable>' +
-    '</variables>' +
-    '<block type="variables_get" id="id******************" x="42" y="42">' +
-    '<field name="VAR" id="!#$%()*+,-./:;=?@[]^">test</field>' +
-    '</block>' +
-    '<block type="variables_get" id="id1*****************" x="42" y="42">' +
-    '<field name="VAR" id="_`{|}~!!!!!!!!!!!!!!">test2</field>' +
-    '</block>' +
-    '</xml>');
-Serializer.Fields.Variable.Id.Chars.Uppercase = new SerializerTestCase('Uppercase',
+        '<variables>' +
+        '<variable id="!#$%()*+,-./:;=?@[]^">test</variable>' +
+        '<variable id="_`{|}~!!!!!!!!!!!!!!">test2</variable>' +
+        '</variables>' +
+        '<block type="variables_get" id="id******************" x="42" y="42">' +
+        '<field name="VAR" id="!#$%()*+,-./:;=?@[]^">test</field>' +
+        '</block>' +
+        '<block type="variables_get" id="id1*****************" x="42" y="42">' +
+        '<field name="VAR" id="_`{|}~!!!!!!!!!!!!!!">test2</field>' +
+        '</block>' +
+        '</xml>');
+Serializer.Fields.Variable.Id.Chars.Uppercase = new SerializerTestCase(
+    'Uppercase',
     '<xml xmlns="https://developers.google.com/blockly/xml">' +
-    '<variables>' +
-    '<variable id="ABCDEFGHIJKLMNOPQRST">test</variable>' +
-    '<variable id="TUVWXYZAAAAAAAAAAAAA">test2</variable>' +
-    '</variables>' +
-    '<block type="variables_get" id="id******************" x="42" y="42">' +
-    '<field name="VAR" id="ABCDEFGHIJKLMNOPQRST">test</field>' +
-    '</block>' +
-    '<block type="variables_get" id="id1*****************" x="42" y="42">' +
-    '<field name="VAR" id="TUVWXYZAAAAAAAAAAAAA">test2</field>' +
-    '</block>' +
-    '</xml>');
-Serializer.Fields.Variable.Id.Chars.Lowercase = new SerializerTestCase('Lowercase',
+        '<variables>' +
+        '<variable id="ABCDEFGHIJKLMNOPQRST">test</variable>' +
+        '<variable id="TUVWXYZAAAAAAAAAAAAA">test2</variable>' +
+        '</variables>' +
+        '<block type="variables_get" id="id******************" x="42" y="42">' +
+        '<field name="VAR" id="ABCDEFGHIJKLMNOPQRST">test</field>' +
+        '</block>' +
+        '<block type="variables_get" id="id1*****************" x="42" y="42">' +
+        '<field name="VAR" id="TUVWXYZAAAAAAAAAAAAA">test2</field>' +
+        '</block>' +
+        '</xml>');
+Serializer.Fields.Variable.Id.Chars.Lowercase = new SerializerTestCase(
+    'Lowercase',
     '<xml xmlns="https://developers.google.com/blockly/xml">' +
-    '<variables>' +
-    '<variable id="abcdefghijklmnopqrst">test</variable>' +
-    '<variable id="tuvwxyzaaaaaaaaaaaaa">test2</variable>' +
-    '</variables>' +
-    '<block type="variables_get" id="id******************" x="42" y="42">' +
-    '<field name="VAR" id="abcdefghijklmnopqrst">test</field>' +
-    '</block>' +
-    '<block type="variables_get" id="id1*****************" x="42" y="42">' +
-    '<field name="VAR" id="tuvwxyzaaaaaaaaaaaaa">test2</field>' +
-    '</block>' +
-    '</xml>');
-Serializer.Fields.Variable.Id.Chars.Numbers = new SerializerTestCase('Numbers',
+        '<variables>' +
+        '<variable id="abcdefghijklmnopqrst">test</variable>' +
+        '<variable id="tuvwxyzaaaaaaaaaaaaa">test2</variable>' +
+        '</variables>' +
+        '<block type="variables_get" id="id******************" x="42" y="42">' +
+        '<field name="VAR" id="abcdefghijklmnopqrst">test</field>' +
+        '</block>' +
+        '<block type="variables_get" id="id1*****************" x="42" y="42">' +
+        '<field name="VAR" id="tuvwxyzaaaaaaaaaaaaa">test2</field>' +
+        '</block>' +
+        '</xml>');
+Serializer.Fields.Variable.Id.Chars.Numbers = new SerializerTestCase(
+    'Numbers',
     '<xml xmlns="https://developers.google.com/blockly/xml">' +
-    '<variables>' +
-    '<variable id="01234567890000000000">test</variable>' +
-    '</variables>' +
-    '<block type="variables_get" id="id******************" x="42" y="42">' +
-    '<field name="VAR" id="01234567890000000000">test</field>' +
-    '</block>' +
-    '</xml>');
+        '<variables>' +
+        '<variable id="01234567890000000000">test</variable>' +
+        '</variables>' +
+        '<block type="variables_get" id="id******************" x="42" y="42">' +
+        '<field name="VAR" id="01234567890000000000">test</field>' +
+        '</block>' +
+        '</xml>');
 Serializer.Fields.Variable.Id.Chars.testCases = [
   Serializer.Fields.Variable.Id.Chars.Symbols,
   Serializer.Fields.Variable.Id.Chars.Uppercase,
@@ -937,128 +977,132 @@ Serializer.Fields.testSuites = [
 Serializer.Icons = new SerializerTestSuite('Icons');
 
 Serializer.Icons.Comment = new SerializerTestSuite('Comment');
-Serializer.Icons.Comment.Basic = new SerializerTestCase('Basic',
+Serializer.Icons.Comment.Basic = new SerializerTestCase(
+    'Basic',
     '<xml xmlns="https://developers.google.com/blockly/xml">' +
-    '<block type="logic_negate" id="id******************" x="42" y="42">' +
-    '<comment pinned="false" h="80" w="160">test</comment>' +
-    '</block>' +
-    '</xml>');
+        '<block type="logic_negate" id="id******************" x="42" y="42">' +
+        '<comment pinned="false" h="80" w="160">test</comment>' +
+        '</block>' +
+        '</xml>');
 
 Serializer.Icons.Comment.Size = new SerializerTestSuite('Size');
-Serializer.Icons.Comment.Size.Different = new SerializerTestCase('Different',
+Serializer.Icons.Comment.Size.Different = new SerializerTestCase(
+    'Different',
     '<xml xmlns="https://developers.google.com/blockly/xml">' +
-    '<block type="logic_negate" id="id******************" x="42" y="42">' +
-    '<comment pinned="false" h="160" w="80">test</comment>' +
-    '</block>' +
-    '</xml>');
-Serializer.Icons.Comment.Size.Large = new SerializerTestCase('Large',
+        '<block type="logic_negate" id="id******************" x="42" y="42">' +
+        '<comment pinned="false" h="160" w="80">test</comment>' +
+        '</block>' +
+        '</xml>');
+Serializer.Icons.Comment.Size.Large = new SerializerTestCase(
+    'Large',
     '<xml xmlns="https://developers.google.com/blockly/xml">' +
-    '<block type="logic_negate" id="id******************" x="42" y="42">' +
-    '<comment pinned="false" h="10000" w="10000">test</comment>' +
-    '</block>' +
-    '</xml>');
+        '<block type="logic_negate" id="id******************" x="42" y="42">' +
+        '<comment pinned="false" h="10000" w="10000">test</comment>' +
+        '</block>' +
+        '</xml>');
 Serializer.Icons.Comment.Size.testCases = [
   Serializer.Icons.Comment.Size.Different,
   Serializer.Icons.Comment.Size.Large,
 ];
 
 Serializer.Icons.Comment.Pinned = new SerializerTestSuite('Pinned');
-Serializer.Icons.Comment.Pinned.True = new SerializerTestCase('True',
+Serializer.Icons.Comment.Pinned.True = new SerializerTestCase(
+    'True',
     '<xml xmlns="https://developers.google.com/blockly/xml">' +
-    '<block type="logic_negate" id="id******************" x="42" y="42">' +
-    '<comment pinned="true" h="80" w="160">test</comment>' +
-    '</block>' +
-    '</xml>');
-Serializer.Icons.Comment.Pinned.False = new SerializerTestCase('False',
+        '<block type="logic_negate" id="id******************" x="42" y="42">' +
+        '<comment pinned="true" h="80" w="160">test</comment>' +
+        '</block>' +
+        '</xml>');
+Serializer.Icons.Comment.Pinned.False = new SerializerTestCase(
+    'False',
     '<xml xmlns="https://developers.google.com/blockly/xml">' +
-    '<block type="logic_negate" id="id******************" x="42" y="42">' +
-    '<comment pinned="false" h="80" w="160">test</comment>' +
-    '</block>' +
-    '</xml>');
+        '<block type="logic_negate" id="id******************" x="42" y="42">' +
+        '<comment pinned="false" h="80" w="160">test</comment>' +
+        '</block>' +
+        '</xml>');
 Serializer.Icons.Comment.Pinned.testCases = [
   Serializer.Icons.Comment.Pinned.True,
   Serializer.Icons.Comment.Pinned.False,
 ];
 
 Serializer.Icons.Comment.Text = new SerializerTestSuite('Text');
-Serializer.Icons.Comment.Text.Symbols = new SerializerTestCase('Symbols',
+Serializer.Icons.Comment.Text.Symbols = new SerializerTestCase(
+    'Symbols',
     '<xml xmlns="https://developers.google.com/blockly/xml">' +
-    '<block type="logic_negate" id="id******************" x="42" y="42">' +
-    '<comment pinned="false" h="80" w="160">~`!@#$%^*()_+-={[}]|\\:;,.?/</comment>' +
-    '</block>' +
-    '</xml>');
+        '<block type="logic_negate" id="id******************" x="42" y="42">' +
+        '<comment pinned="false" h="80" w="160">~`!@#$%^*()_+-={[}]|\\:;,.?/</comment>' +
+        '</block>' +
+        '</xml>');
 Serializer.Icons.Comment.Text.EscapedSymbols = new SerializerTestCase(
     'EscapedSymbols',
     '<xml xmlns="https://developers.google.com/blockly/xml">' +
-    '<block type="logic_negate" id="id******************" x="42" y="42">' +
-    '<comment pinned="false" h="80" w="160">&amp;&lt;&gt;</comment>' +
-    '</block>' +
-    '</xml>');
+        '<block type="logic_negate" id="id******************" x="42" y="42">' +
+        '<comment pinned="false" h="80" w="160">&amp;&lt;&gt;</comment>' +
+        '</block>' +
+        '</xml>');
 Serializer.Icons.Comment.Text.SingleQuotes = new SerializerTestCase(
     'SingleQuotes',
     '<xml xmlns="https://developers.google.com/blockly/xml">' +
-    '<block type="logic_negate" id="id******************" x="42" y="42">' +
-    '<comment pinned="false" h="80" w="160">\'test\'</comment>' +
-    '</block>' +
-    '</xml>');
+        '<block type="logic_negate" id="id******************" x="42" y="42">' +
+        '<comment pinned="false" h="80" w="160">\'test\'</comment>' +
+        '</block>' +
+        '</xml>');
 Serializer.Icons.Comment.Text.DoubleQuotes = new SerializerTestCase(
     'DoubleQuotes',
     '<xml xmlns="https://developers.google.com/blockly/xml">' +
-    '<block type="logic_negate" id="id******************" x="42" y="42">' +
-    '<comment pinned="false" h="80" w="160">"test"</comment>' +
-    '</block>' +
-    '</xml>');
+        '<block type="logic_negate" id="id******************" x="42" y="42">' +
+        '<comment pinned="false" h="80" w="160">"test"</comment>' +
+        '</block>' +
+        '</xml>');
 Serializer.Icons.Comment.Text.Numbers = new SerializerTestCase(
     'Numbers',
     '<xml xmlns="https://developers.google.com/blockly/xml">' +
-    '<block type="logic_negate" id="id******************" x="42" y="42">' +
-    '<comment pinned="false" h="80" w="160">1234567890a123a123a</comment>' +
-    '</block>' +
-    '</xml>');
+        '<block type="logic_negate" id="id******************" x="42" y="42">' +
+        '<comment pinned="false" h="80" w="160">1234567890a123a123a</comment>' +
+        '</block>' +
+        '</xml>');
 Serializer.Icons.Comment.Text.Emoji = new SerializerTestCase(
     'Emoji',
     '<xml xmlns="https://developers.google.com/blockly/xml">' +
-    '<block type="logic_negate" id="id******************" x="42" y="42">' +
-    '<comment pinned="false" h="80" w="160">😀👋🏿👋🏾👋🏽👋🏼👋🏻😀❤❤❤</comment>' +
-    '</block>' +
-    '</xml>');
+        '<block type="logic_negate" id="id******************" x="42" y="42">' +
+        '<comment pinned="false" h="80" w="160">😀👋🏿👋🏾👋🏽👋🏼👋🏻😀❤❤❤</comment>' +
+        '</block>' +
+        '</xml>');
 Serializer.Icons.Comment.Text.Russian = new SerializerTestCase(
     'Russian',
     '<xml xmlns="https://developers.google.com/blockly/xml">' +
-    '<block type="logic_negate" id="id******************" x="42" y="42">' +
-    '<comment pinned="false" h="80" w="160">ты любопытный кот</comment>' +
-    '</block>' +
-    '</xml>');
+        '<block type="logic_negate" id="id******************" x="42" y="42">' +
+        '<comment pinned="false" h="80" w="160">ты любопытный кот</comment>' +
+        '</block>' +
+        '</xml>');
 Serializer.Icons.Comment.Text.Japanese = new SerializerTestCase(
     'Japanese',
     '<xml xmlns="https://developers.google.com/blockly/xml">' +
-    '<block type="logic_negate" id="id******************" x="42" y="42">' +
-    '<comment pinned="false" h="80" w="160">あなたは好奇心旺盛な猫です</comment>' +
-    '</block>' +
-    '</xml>');
+        '<block type="logic_negate" id="id******************" x="42" y="42">' +
+        '<comment pinned="false" h="80" w="160">あなたは好奇心旺盛な猫です</comment>' +
+        '</block>' +
+        '</xml>');
 Serializer.Icons.Comment.Text.Zalgo = new SerializerTestCase(
     'Zalgo',
     '<xml xmlns="https://developers.google.com/blockly/xml">' +
-    '<block type="logic_negate" id="id******************" x="42" y="42">' +
-    '<comment pinned="false" h="80" w="160">z̴̪͈̲̜͕̽̈̀͒͂̓̋̉̍a̸̧̧̜̻̘̤̫̱̲͎̞̻͆̋ļ̸̛̖̜̳͚̖͔̟̈́͂̉̀͑̑͑̎ǵ̸̫̳̽̐̃̑̚̕o̶͇̫͔̮̼̭͕̹̘̬͋̀͆̂̇̋͊̒̽</comment>' +
-    '</block>' +
-    '</xml>');
+        '<block type="logic_negate" id="id******************" x="42" y="42">' +
+        '<comment pinned="false" h="80" w="160">z̴̪͈̲̜͕̽̈̀͒͂̓̋̉̍a̸̧̧̜̻̘̤̫̱̲͎̞̻͆̋ļ̸̛̖̜̳͚̖͔̟̈́͂̉̀͑̑͑̎ǵ̸̫̳̽̐̃̑̚̕o̶͇̫͔̮̼̭͕̹̘̬͋̀͆̂̇̋͊̒̽</comment>' +
+        '</block>' +
+        '</xml>');
 Serializer.Icons.Comment.Text.ControlChars = new SerializerTestCase(
     'ControlChars',
     '<xml xmlns="https://developers.google.com/blockly/xml">' +
-    '<block type="logic_negate" id="id******************" x="42" y="42">' +
-    '<comment pinned="false" h="80" w="160">&#01;&#a1;</comment>' +
-    '</block>' +
-    '</xml>');
+        '<block type="logic_negate" id="id******************" x="42" y="42">' +
+        '<comment pinned="false" h="80" w="160">&#01;&#a1;</comment>' +
+        '</block>' +
+        '</xml>');
 Serializer.Icons.Comment.Text.testCases = [
   Serializer.Icons.Comment.Text.Symbols,
   Serializer.Icons.Comment.Text.EscapedSymbols,
   Serializer.Icons.Comment.Text.SingleQuotes,
   Serializer.Icons.Comment.Text.DoubleQuotes,
-  Serializer.Icons.Comment.Text.Numbers,
-  Serializer.Icons.Comment.Text.Emoji,
-  Serializer.Icons.Comment.Text.Russian,
-  Serializer.Icons.Comment.Text.Japanese,
+  Serializer.Icons.Comment.Text.Numbers, Serializer.Icons.Comment.Text.Emoji,
+  Serializer.Icons.Comment.Text.Russian, Serializer.Icons.Comment.Text.Japanese,
   Serializer.Icons.Comment.Text.Zalgo,
   // TODO: Uncoment once #4945 is merged.
   // Serializer.Icons.Comment.Text.ControlChars,
@@ -1079,70 +1123,76 @@ Serializer.Icons.testSuites = [Serializer.Icons.Comment];
 Serializer.Connections = new SerializerTestSuite('Connections');
 
 Serializer.Connections.Child = new SerializerTestSuite('Child');
-Serializer.Connections.Child.Value = new SerializerTestCase('Value',
+Serializer.Connections.Child.Value = new SerializerTestCase(
+    'Value',
     '<xml xmlns="https://developers.google.com/blockly/xml">' +
-    '<block type="logic_negate" id="id******************" x="42" y="42">' +
-    '<value name="BOOL">' +
-    '<block type="logic_boolean" id="id2*****************">' +
-    '<field name="BOOL">TRUE</field>' +
-    '</block>' +
-    '</value>' +
-    '</block>' +
-    '</xml>');
-Serializer.Connections.Child.Statement = new SerializerTestCase('Statement',
+        '<block type="logic_negate" id="id******************" x="42" y="42">' +
+        '<value name="BOOL">' +
+        '<block type="logic_boolean" id="id2*****************">' +
+        '<field name="BOOL">TRUE</field>' +
+        '</block>' +
+        '</value>' +
+        '</block>' +
+        '</xml>');
+Serializer.Connections.Child.Statement = new SerializerTestCase(
+    'Statement',
     '<xml xmlns="https://developers.google.com/blockly/xml">' +
-    '<block type="controls_repeat_ext" id="id******************" x="42" y="42">' +
-    '<statement name="DO">' +
-    '<block type="text_print" id="id2*****************"></block>' +
-    '</statement>' +
-    '</block>' +
-    '</xml>');
-Serializer.Connections.Child.Next = new SerializerTestCase('Next',
+        '<block type="controls_repeat_ext" id="id******************" x="42" y="42">' +
+        '<statement name="DO">' +
+        '<block type="text_print" id="id2*****************"></block>' +
+        '</statement>' +
+        '</block>' +
+        '</xml>');
+Serializer.Connections.Child.Next = new SerializerTestCase(
+    'Next',
     '<xml xmlns="https://developers.google.com/blockly/xml">' +
-    '<block type="text_print" id="id******************" x="42" y="42">' +
-    '<next>' +
-    '<block type="text_print" id="id2*****************"></block>' +
-    '</next>' +
-    '</block>' +
-    '</xml>');
-Serializer.Connections.Child.Row = new SerializerTestCase('Row',
+        '<block type="text_print" id="id******************" x="42" y="42">' +
+        '<next>' +
+        '<block type="text_print" id="id2*****************"></block>' +
+        '</next>' +
+        '</block>' +
+        '</xml>');
+Serializer.Connections.Child.Row = new SerializerTestCase(
+    'Row',
     '<xml xmlns="https://developers.google.com/blockly/xml">' +
-    '<block type="logic_negate" id="id******************" x="42" y="42">' +
-    '<value name="BOOL">' +
-    '<block type="logic_negate" id="id2*****************">' +
-    '<value name="BOOL">' +
-    '<block type="logic_boolean" id="id3*****************">' +
-    '<field name="BOOL">TRUE</field>' +
-    '</block>' +
-    '</value>' +
-    '</block>' +
-    '</value>' +
-    '</block>' +
-    '</xml>');
-Serializer.Connections.Child.Nested = new SerializerTestCase('Nested',
+        '<block type="logic_negate" id="id******************" x="42" y="42">' +
+        '<value name="BOOL">' +
+        '<block type="logic_negate" id="id2*****************">' +
+        '<value name="BOOL">' +
+        '<block type="logic_boolean" id="id3*****************">' +
+        '<field name="BOOL">TRUE</field>' +
+        '</block>' +
+        '</value>' +
+        '</block>' +
+        '</value>' +
+        '</block>' +
+        '</xml>');
+Serializer.Connections.Child.Nested = new SerializerTestCase(
+    'Nested',
     '<xml xmlns="https://developers.google.com/blockly/xml">' +
-    '<block type="controls_repeat_ext" id="id******************" x="42" y="42">' +
-    '<statement name="DO">' +
-    '<block type="controls_repeat_ext" id="id2*****************">' +
-    '<statement name="DO">' +
-    '<block type="text_print" id="id3*****************"></block>' +
-    '</statement>' +
-    '</block>' +
-    '</statement>' +
-    '</block>' +
-    '</xml>');
-Serializer.Connections.Child.Stack = new SerializerTestCase('Stack',
+        '<block type="controls_repeat_ext" id="id******************" x="42" y="42">' +
+        '<statement name="DO">' +
+        '<block type="controls_repeat_ext" id="id2*****************">' +
+        '<statement name="DO">' +
+        '<block type="text_print" id="id3*****************"></block>' +
+        '</statement>' +
+        '</block>' +
+        '</statement>' +
+        '</block>' +
+        '</xml>');
+Serializer.Connections.Child.Stack = new SerializerTestCase(
+    'Stack',
     '<xml xmlns="https://developers.google.com/blockly/xml">' +
-    '<block type="text_print" id="id******************" x="42" y="42">' +
-    '<next>' +
-    '<block type="text_print" id="id2*****************">' +
-    '<next>' +
-    '<block type="text_print" id="id3*****************"></block>' +
-    '</next>' +
-    '</block>' +
-    '</next>' +
-    '</block>' +
-    '</xml>');
+        '<block type="text_print" id="id******************" x="42" y="42">' +
+        '<next>' +
+        '<block type="text_print" id="id2*****************">' +
+        '<next>' +
+        '<block type="text_print" id="id3*****************"></block>' +
+        '</next>' +
+        '</block>' +
+        '</next>' +
+        '</block>' +
+        '</xml>');
 Serializer.Connections.Child.testCases = [
   Serializer.Connections.Child.Value,
   Serializer.Connections.Child.Statement,
@@ -1153,70 +1203,76 @@ Serializer.Connections.Child.testCases = [
 ];
 
 Serializer.Connections.Shadow = new SerializerTestSuite('Shadow');
-Serializer.Connections.Shadow.Value = new SerializerTestCase('Value',
+Serializer.Connections.Shadow.Value = new SerializerTestCase(
+    'Value',
     '<xml xmlns="https://developers.google.com/blockly/xml">' +
-    '<block type="logic_negate" id="id******************" x="42" y="42">' +
-    '<value name="BOOL">' +
-    '<shadow type="logic_boolean" id="id2*****************">' +
-    '<field name="BOOL">TRUE</field>' +
-    '</shadow>' +
-    '</value>' +
-    '</block>' +
-    '</xml>');
-Serializer.Connections.Shadow.Statement = new SerializerTestCase('Statement',
+        '<block type="logic_negate" id="id******************" x="42" y="42">' +
+        '<value name="BOOL">' +
+        '<shadow type="logic_boolean" id="id2*****************">' +
+        '<field name="BOOL">TRUE</field>' +
+        '</shadow>' +
+        '</value>' +
+        '</block>' +
+        '</xml>');
+Serializer.Connections.Shadow.Statement = new SerializerTestCase(
+    'Statement',
     '<xml xmlns="https://developers.google.com/blockly/xml">' +
-    '<block type="controls_repeat_ext" id="id******************" x="42" y="42">' +
-    '<statement name="DO">' +
-    '<shadow type="text_print" id="id2*****************"></shadow>' +
-    '</statement>' +
-    '</block>' +
-    '</xml>');
-Serializer.Connections.Shadow.Next = new SerializerTestCase('Next',
+        '<block type="controls_repeat_ext" id="id******************" x="42" y="42">' +
+        '<statement name="DO">' +
+        '<shadow type="text_print" id="id2*****************"></shadow>' +
+        '</statement>' +
+        '</block>' +
+        '</xml>');
+Serializer.Connections.Shadow.Next = new SerializerTestCase(
+    'Next',
     '<xml xmlns="https://developers.google.com/blockly/xml">' +
-    '<block type="text_print" id="id******************" x="42" y="42">' +
-    '<next>' +
-    '<shadow type="text_print" id="id2*****************"></shadow>' +
-    '</next>' +
-    '</block>' +
-    '</xml>');
-Serializer.Connections.Shadow.Row = new SerializerTestCase('Row',
+        '<block type="text_print" id="id******************" x="42" y="42">' +
+        '<next>' +
+        '<shadow type="text_print" id="id2*****************"></shadow>' +
+        '</next>' +
+        '</block>' +
+        '</xml>');
+Serializer.Connections.Shadow.Row = new SerializerTestCase(
+    'Row',
     '<xml xmlns="https://developers.google.com/blockly/xml">' +
-    '<block type="logic_negate" id="id******************" x="42" y="42">' +
-    '<value name="BOOL">' +
-    '<shadow type="logic_negate" id="id2*****************">' +
-    '<value name="BOOL">' +
-    '<shadow type="logic_boolean" id="id3*****************">' +
-    '<field name="BOOL">TRUE</field>' +
-    '</shadow>' +
-    '</value>' +
-    '</shadow>' +
-    '</value>' +
-    '</block>' +
-    '</xml>');
-Serializer.Connections.Shadow.Nested = new SerializerTestCase('Nested',
+        '<block type="logic_negate" id="id******************" x="42" y="42">' +
+        '<value name="BOOL">' +
+        '<shadow type="logic_negate" id="id2*****************">' +
+        '<value name="BOOL">' +
+        '<shadow type="logic_boolean" id="id3*****************">' +
+        '<field name="BOOL">TRUE</field>' +
+        '</shadow>' +
+        '</value>' +
+        '</shadow>' +
+        '</value>' +
+        '</block>' +
+        '</xml>');
+Serializer.Connections.Shadow.Nested = new SerializerTestCase(
+    'Nested',
     '<xml xmlns="https://developers.google.com/blockly/xml">' +
-    '<block type="controls_repeat_ext" id="id******************" x="42" y="42">' +
-    '<statement name="DO">' +
-    '<shadow type="controls_repeat_ext" id="id2*****************">' +
-    '<statement name="DO">' +
-    '<shadow type="text_print" id="id3*****************"></shadow>' +
-    '</statement>' +
-    '</shadow>' +
-    '</statement>' +
-    '</block>' +
-    '</xml>');
-Serializer.Connections.Shadow.Stack = new SerializerTestCase('Stack',
+        '<block type="controls_repeat_ext" id="id******************" x="42" y="42">' +
+        '<statement name="DO">' +
+        '<shadow type="controls_repeat_ext" id="id2*****************">' +
+        '<statement name="DO">' +
+        '<shadow type="text_print" id="id3*****************"></shadow>' +
+        '</statement>' +
+        '</shadow>' +
+        '</statement>' +
+        '</block>' +
+        '</xml>');
+Serializer.Connections.Shadow.Stack = new SerializerTestCase(
+    'Stack',
     '<xml xmlns="https://developers.google.com/blockly/xml">' +
-    '<block type="text_print" id="id******************" x="42" y="42">' +
-    '<next>' +
-    '<shadow type="text_print" id="id2*****************">' +
-    '<next>' +
-    '<shadow type="text_print" id="id3*****************"></shadow>' +
-    '</next>' +
-    '</shadow>' +
-    '</next>' +
-    '</block>' +
-    '</xml>');
+        '<block type="text_print" id="id******************" x="42" y="42">' +
+        '<next>' +
+        '<shadow type="text_print" id="id2*****************">' +
+        '<next>' +
+        '<shadow type="text_print" id="id3*****************"></shadow>' +
+        '</next>' +
+        '</shadow>' +
+        '</next>' +
+        '</block>' +
+        '</xml>');
 Serializer.Connections.Shadow.testCases = [
   Serializer.Connections.Shadow.Value,
   Serializer.Connections.Shadow.Statement,
@@ -1231,80 +1287,83 @@ Serializer.Connections.OverwrittenShadow =
 Serializer.Connections.OverwrittenShadow.Value = new SerializerTestCase(
     'Value',
     '<xml xmlns="https://developers.google.com/blockly/xml">' +
-    '<block type="logic_negate" id="id******************" x="42" y="42">' +
-    '<value name="BOOL">' +
-    '<shadow type="logic_boolean" id="id2*****************">' +
-    '<field name="BOOL">TRUE</field>' +
-    '</shadow>' +
-    '<block type="logic_boolean" id="id3*****************">' +
-    '<field name="BOOL">TRUE</field>' +
-    '</block>' +
-    '</value>' +
-    '</block>' +
-    '</xml>');
+        '<block type="logic_negate" id="id******************" x="42" y="42">' +
+        '<value name="BOOL">' +
+        '<shadow type="logic_boolean" id="id2*****************">' +
+        '<field name="BOOL">TRUE</field>' +
+        '</shadow>' +
+        '<block type="logic_boolean" id="id3*****************">' +
+        '<field name="BOOL">TRUE</field>' +
+        '</block>' +
+        '</value>' +
+        '</block>' +
+        '</xml>');
 Serializer.Connections.OverwrittenShadow.Statement = new SerializerTestCase(
     'Statement',
     '<xml xmlns="https://developers.google.com/blockly/xml">' +
-    '<block type="controls_repeat_ext" id="id******************" x="42" y="42">' +
-    '<statement name="DO">' +
-    '<shadow type="text_print" id="id2*****************"></shadow>' +
-    '<block type="text_print" id="id3*****************"></block>' +
-    '</statement>' +
-    '</block>' +
-    '</xml>');
-Serializer.Connections.OverwrittenShadow.Next = new SerializerTestCase('Next',
+        '<block type="controls_repeat_ext" id="id******************" x="42" y="42">' +
+        '<statement name="DO">' +
+        '<shadow type="text_print" id="id2*****************"></shadow>' +
+        '<block type="text_print" id="id3*****************"></block>' +
+        '</statement>' +
+        '</block>' +
+        '</xml>');
+Serializer.Connections.OverwrittenShadow.Next = new SerializerTestCase(
+    'Next',
     '<xml xmlns="https://developers.google.com/blockly/xml">' +
-    '<block type="text_print" id="id******************" x="42" y="42">' +
-    '<next>' +
-    '<block type="text_print" id="id2*****************"></block>' +
-    '<shadow type="text_print" id="id3*****************"></shadow>' +
-    '</next>' +
-    '</block>' +
-    '</xml>');
-Serializer.Connections.OverwrittenShadow.Row = new SerializerTestCase('Row',
+        '<block type="text_print" id="id******************" x="42" y="42">' +
+        '<next>' +
+        '<block type="text_print" id="id2*****************"></block>' +
+        '<shadow type="text_print" id="id3*****************"></shadow>' +
+        '</next>' +
+        '</block>' +
+        '</xml>');
+Serializer.Connections.OverwrittenShadow.Row = new SerializerTestCase(
+    'Row',
     '<xml xmlns="https://developers.google.com/blockly/xml">' +
-    '<block type="logic_negate" id="id******************" x="42" y="42">' +
-    '<value name="BOOL">' +
-    '<shadow type="logic_negate" id="id2*****************">' +
-    '<value name="BOOL">' +
-    '<shadow type="logic_boolean" id="id3*****************">' +
-    '<field name="BOOL">TRUE</field>' +
-    '</shadow>' +
-    '</value>' +
-    '</shadow>' +
-    '<block type="logic_boolean" id="id4*****************">' +
-    '<field name="BOOL">TRUE</field>' +
-    '</block>' +
-    '</value>' +
-    '</block>' +
-    '</xml>');
+        '<block type="logic_negate" id="id******************" x="42" y="42">' +
+        '<value name="BOOL">' +
+        '<shadow type="logic_negate" id="id2*****************">' +
+        '<value name="BOOL">' +
+        '<shadow type="logic_boolean" id="id3*****************">' +
+        '<field name="BOOL">TRUE</field>' +
+        '</shadow>' +
+        '</value>' +
+        '</shadow>' +
+        '<block type="logic_boolean" id="id4*****************">' +
+        '<field name="BOOL">TRUE</field>' +
+        '</block>' +
+        '</value>' +
+        '</block>' +
+        '</xml>');
 Serializer.Connections.OverwrittenShadow.Nested = new SerializerTestCase(
     'Nested',
     '<xml xmlns="https://developers.google.com/blockly/xml">' +
-    '<block type="controls_repeat_ext" id="id******************" x="42" y="42">' +
-    '<statement name="DO">' +
-    '<shadow type="controls_repeat_ext" id="id2*****************">' +
-    '<statement name="DO">' +
-    '<shadow type="text_print" id="id3*****************"></shadow>' +
-    '</statement>' +
-    '</shadow>' +
-    '<block type="text_print" id="id4*****************"></block>' +
-    '</statement>' +
-    '</block>' +
-    '</xml>');
-Serializer.Connections.OverwrittenShadow.Stack = new SerializerTestCase('Stack',
+        '<block type="controls_repeat_ext" id="id******************" x="42" y="42">' +
+        '<statement name="DO">' +
+        '<shadow type="controls_repeat_ext" id="id2*****************">' +
+        '<statement name="DO">' +
+        '<shadow type="text_print" id="id3*****************"></shadow>' +
+        '</statement>' +
+        '</shadow>' +
+        '<block type="text_print" id="id4*****************"></block>' +
+        '</statement>' +
+        '</block>' +
+        '</xml>');
+Serializer.Connections.OverwrittenShadow.Stack = new SerializerTestCase(
+    'Stack',
     '<xml xmlns="https://developers.google.com/blockly/xml">' +
-    '<block type="text_print" id="id******************" x="42" y="42">' +
-    '<next>' +
-    '<block type="text_print" id="id2*****************"></block>' +
-    '<shadow type="text_print" id="id3*****************">' +
-    '<next>' +
-    '<shadow type="text_print" id="id4*****************"></shadow>' +
-    '</next>' +
-    '</shadow>' +
-    '</next>' +
-    '</block>' +
-    '</xml>');
+        '<block type="text_print" id="id******************" x="42" y="42">' +
+        '<next>' +
+        '<block type="text_print" id="id2*****************"></block>' +
+        '<shadow type="text_print" id="id3*****************">' +
+        '<next>' +
+        '<shadow type="text_print" id="id4*****************"></shadow>' +
+        '</next>' +
+        '</shadow>' +
+        '</next>' +
+        '</block>' +
+        '</xml>');
 Serializer.Connections.OverwrittenShadow.testCases = [
   Serializer.Connections.OverwrittenShadow.Value,
   Serializer.Connections.OverwrittenShadow.Statement,
@@ -1321,87 +1380,90 @@ Serializer.Connections.testSuites = [
 ];
 
 Serializer.Mutations = new SerializerTestSuite('Mutations');
-Serializer.Mutations.ListGetIndex = new SerializerTestCase('ListGetIndex',
+Serializer.Mutations.ListGetIndex = new SerializerTestCase(
+    'ListGetIndex',
     '<xml xmlns="https://developers.google.com/blockly/xml">' +
-    '<block type="lists_getIndex" id="id" x="42" y="42">' +
-    '<mutation statement="true" at="false"></mutation>' +
-    '<field name="MODE">REMOVE</field>' +
-    '<field name="WHERE">LAST</field>' +
-    '</block>' +
-    '</xml>');
-Serializer.Mutations.ListSetIndex = new SerializerTestCase('ListSetIndex',
+        '<block type="lists_getIndex" id="id" x="42" y="42">' +
+        '<mutation statement="true" at="false"></mutation>' +
+        '<field name="MODE">REMOVE</field>' +
+        '<field name="WHERE">LAST</field>' +
+        '</block>' +
+        '</xml>');
+Serializer.Mutations.ListSetIndex = new SerializerTestCase(
+    'ListSetIndex',
     '<xml xmlns="https://developers.google.com/blockly/xml">' +
-    '<block type="lists_setIndex" id="id" x="42" y="42">' +
-    '<mutation at="false"></mutation>' +
-    '<field name="MODE">SET</field>' +
-    '<field name="WHERE">LAST</field>' +
-    '</block>' +
-    '</xml>');
-Serializer.Mutations.ListGetSublist = new SerializerTestCase('ListGetSublist',
+        '<block type="lists_setIndex" id="id" x="42" y="42">' +
+        '<mutation at="false"></mutation>' +
+        '<field name="MODE">SET</field>' +
+        '<field name="WHERE">LAST</field>' +
+        '</block>' +
+        '</xml>');
+Serializer.Mutations.ListGetSublist = new SerializerTestCase(
+    'ListGetSublist',
     '<xml xmlns="https://developers.google.com/blockly/xml">' +
-    '<block type="lists_getSublist" id="id" x="42" y="42">' +
-    '<mutation at1="false" at2="false"></mutation>' +
-    '<field name="WHERE1">FIRST</field>' +
-    '<field name="WHERE2">LAST</field>' +
-    '</block>' +
-    '</xml>');
+        '<block type="lists_getSublist" id="id" x="42" y="42">' +
+        '<mutation at1="false" at2="false"></mutation>' +
+        '<field name="WHERE1">FIRST</field>' +
+        '<field name="WHERE2">LAST</field>' +
+        '</block>' +
+        '</xml>');
 Serializer.Mutations.MathNumberProperty = new SerializerTestCase(
     'MathNumberProperty',
     '<xml xmlns="https://developers.google.com/blockly/xml">' +
-    '<block type="math_number_property" id="id" x="42" y="42">' +
-    '<mutation divisor_input="true"></mutation>' +
-    '<field name="PROPERTY">DIVISIBLE_BY</field>' +
-    '</block>' +
-    '</xml>');
+        '<block type="math_number_property" id="id" x="42" y="42">' +
+        '<mutation divisor_input="true"></mutation>' +
+        '<field name="PROPERTY">DIVISIBLE_BY</field>' +
+        '</block>' +
+        '</xml>');
 Serializer.Mutations.MathOnList = new SerializerTestCase(
     'MathOnList',
     '<xml xmlns="https://developers.google.com/blockly/xml">' +
-    '<block type="math_on_list" id="id" x="42" y="42">' +
-    '<mutation op="MODE"></mutation>' +
-    '<field name="OP">MODE</field>' +
-    '</block>' +
-    '</xml>');
+        '<block type="math_on_list" id="id" x="42" y="42">' +
+        '<mutation op="MODE"></mutation>' +
+        '<field name="OP">MODE</field>' +
+        '</block>' +
+        '</xml>');
 Serializer.Mutations.TextJoin = new SerializerTestCase(
     'TextJoin',
     '<xml xmlns="https://developers.google.com/blockly/xml">' +
-    '<block type="text_join" id="id" x="42" y="42">' +
-    '<mutation items="10"></mutation>' +
-    '</block>' +
-    '</xml>');
+        '<block type="text_join" id="id" x="42" y="42">' +
+        '<mutation items="10"></mutation>' +
+        '</block>' +
+        '</xml>');
 Serializer.Mutations.TextCharAt = new SerializerTestCase(
     'TextCharAt',
     '<xml xmlns="https://developers.google.com/blockly/xml">' +
-    '<block type="text_charAt" id="id" x="42" y="42">' +
-    '<mutation at="false"></mutation>' +
-    '<field name="WHERE">FIRST</field>' +
-    '</block>' +
-    '</xml>');
+        '<block type="text_charAt" id="id" x="42" y="42">' +
+        '<mutation at="false"></mutation>' +
+        '<field name="WHERE">FIRST</field>' +
+        '</block>' +
+        '</xml>');
 Serializer.Mutations.TextGetSubstring = new SerializerTestCase(
     'TextGetSubstring',
     '<xml xmlns="https://developers.google.com/blockly/xml">' +
-    '<block type="text_getSubstring" id="id" x="42" y="42">' +
-    '<mutation at1="true" at2="false"></mutation>' +
-    '<field name="WHERE1">FROM_START</field>' +
-    '<field name="WHERE2">LAST</field>' +
-    '</block>' +
-    '</xml>');
+        '<block type="text_getSubstring" id="id" x="42" y="42">' +
+        '<mutation at1="true" at2="false"></mutation>' +
+        '<field name="WHERE1">FROM_START</field>' +
+        '<field name="WHERE2">LAST</field>' +
+        '</block>' +
+        '</xml>');
 Serializer.Mutations.TextPromptExt = new SerializerTestCase(
     'TextPromptExt',
     '<xml xmlns="https://developers.google.com/blockly/xml">' +
-    '<block type="text_prompt_ext" id="id" x="42" y="42">' +
-    '<mutation type="NUMBER"></mutation>' +
-    '<field name="TYPE">NUMBER</field>' +
-    '</block>' +
-    '</xml>');
+        '<block type="text_prompt_ext" id="id" x="42" y="42">' +
+        '<mutation type="NUMBER"></mutation>' +
+        '<field name="TYPE">NUMBER</field>' +
+        '</block>' +
+        '</xml>');
 Serializer.Mutations.TextPrompt = new SerializerTestCase(
     'TextPrompt',
     '<xml xmlns="https://developers.google.com/blockly/xml">' +
-    '<block type="text_prompt" id="id" x="42" y="42">' +
-    '<mutation type="NUMBER"></mutation>' +
-    '<field name="TYPE">NUMBER</field>' +
-    '<field name="TEXT"></field>' +
-    '</block>' +
-    '</xml>');
+        '<block type="text_prompt" id="id" x="42" y="42">' +
+        '<mutation type="NUMBER"></mutation>' +
+        '<field name="TYPE">NUMBER</field>' +
+        '<field name="TEXT"></field>' +
+        '</block>' +
+        '</xml>');
 Serializer.Mutations.testCases = [
   Serializer.Mutations.ListGetIndex,
   Serializer.Mutations.ListSetIndex,
@@ -1419,29 +1481,29 @@ Serializer.Mutations.ControlsIf = new SerializerTestSuite('ControlsIf');
 Serializer.Mutations.ControlsIf.NoMutation = new SerializerTestCase(
     'NoMutation',
     '<xml xmlns="https://developers.google.com/blockly/xml">' +
-    '<block type="controls_if" id="id******************" x="42" y="42"></block>' +
-    '</xml>');
+        '<block type="controls_if" id="id******************" x="42" y="42"></block>' +
+        '</xml>');
 Serializer.Mutations.ControlsIf.ElseIfAndElse = new SerializerTestCase(
     'ElseIfAndElse',
     '<xml xmlns="https://developers.google.com/blockly/xml">' +
-    '<block type="controls_if" id="id******************" x="42" y="42">' +
-    '<mutation elseif="1" else="1"></mutation>' +
-    '</block>' +
-    '</xml>');
+        '<block type="controls_if" id="id******************" x="42" y="42">' +
+        '<mutation elseif="1" else="1"></mutation>' +
+        '</block>' +
+        '</xml>');
 Serializer.Mutations.ControlsIf.MultipleElseIfs = new SerializerTestCase(
     'MultipleElseIfs',
     '<xml xmlns="https://developers.google.com/blockly/xml">' +
-    '<block type="controls_if" id="id******************" x="42" y="42">' +
-    '<mutation elseif="3"></mutation>' +
-    '</block>' +
-    '</xml>');
+        '<block type="controls_if" id="id******************" x="42" y="42">' +
+        '<mutation elseif="3"></mutation>' +
+        '</block>' +
+        '</xml>');
 Serializer.Mutations.ControlsIf.MutlipleElseIfsAndElse = new SerializerTestCase(
     'MutlipleElseIfsAndElse',
     '<xml xmlns="https://developers.google.com/blockly/xml">' +
-    '<block type="controls_if" id="id******************" x="42" y="42">' +
-    '<mutation elseif="3" else="1"></mutation>' +
-    '</block>' +
-    '</xml>');
+        '<block type="controls_if" id="id******************" x="42" y="42">' +
+        '<mutation elseif="3" else="1"></mutation>' +
+        '</block>' +
+        '</xml>');
 Serializer.Mutations.ControlsIf.testCases = [
   Serializer.Mutations.ControlsIf.NoMutation,
   Serializer.Mutations.ControlsIf.ElseIfAndElse,
@@ -1453,41 +1515,42 @@ Serializer.Mutations.ControlsIf.ElseIf = new SerializerTestSuite('ElseIf');
 Serializer.Mutations.ControlsIf.ElseIf.NoChild = new SerializerTestCase(
     'NoChild',
     '<xml xmlns="https://developers.google.com/blockly/xml">' +
-    '<block type="controls_if" id="id******************" x="42" y="42">' +
-    '<mutation elseif="1"></mutation>' +
-    '</block>' +
-    '</xml>');
+        '<block type="controls_if" id="id******************" x="42" y="42">' +
+        '<mutation elseif="1"></mutation>' +
+        '</block>' +
+        '</xml>');
 Serializer.Mutations.ControlsIf.ElseIf.Child = new SerializerTestCase(
     'Child',
     '<xml xmlns="https://developers.google.com/blockly/xml">' +
-    '<block type="controls_if" id="id******************" x="42" y="42">' +
-    '<mutation elseif="1"></mutation>' +
-    '<statement name="DO1">' +
-    '<block type="text_print" id="id2*****************"></block>' +
-    '</statement>' +
-    '</block>' +
-    '</xml>');
+        '<block type="controls_if" id="id******************" x="42" y="42">' +
+        '<mutation elseif="1"></mutation>' +
+        '<statement name="DO1">' +
+        '<block type="text_print" id="id2*****************"></block>' +
+        '</statement>' +
+        '</block>' +
+        '</xml>');
 Serializer.Mutations.ControlsIf.ElseIf.Shadow = new SerializerTestCase(
     'Shadow',
     '<xml xmlns="https://developers.google.com/blockly/xml">' +
-    '<block type="controls_if" id="id******************" x="42" y="42">' +
-    '<mutation elseif="1"></mutation>' +
-    '<statement name="DO1">' +
-    '<shadow type="text_print" id="id2*****************"></shadow>' +
-    '</statement>' +
-    '</block>' +
-    '</xml>');
-Serializer.Mutations.ControlsIf.ElseIf.OverwrittenShadow = new SerializerTestCase(
+        '<block type="controls_if" id="id******************" x="42" y="42">' +
+        '<mutation elseif="1"></mutation>' +
+        '<statement name="DO1">' +
+        '<shadow type="text_print" id="id2*****************"></shadow>' +
+        '</statement>' +
+        '</block>' +
+        '</xml>');
+Serializer.Mutations.ControlsIf.ElseIf
+    .OverwrittenShadow = new SerializerTestCase(
     'OverwrittenShadow',
     '<xml xmlns="https://developers.google.com/blockly/xml">' +
-    '<block type="controls_if" id="id******************" x="42" y="42">' +
-    '<mutation elseif="1"></mutation>' +
-    '<statement name="DO1">' +
-    '<shadow type="text_print" id="id2*****************"></shadow>' +
-    '<block type="text_print" id="id3*****************"></block>' +
-    '</statement>' +
-    '</block>' +
-    '</xml>');
+        '<block type="controls_if" id="id******************" x="42" y="42">' +
+        '<mutation elseif="1"></mutation>' +
+        '<statement name="DO1">' +
+        '<shadow type="text_print" id="id2*****************"></shadow>' +
+        '<block type="text_print" id="id3*****************"></block>' +
+        '</statement>' +
+        '</block>' +
+        '</xml>');
 Serializer.Mutations.ControlsIf.ElseIf.testCases = [
   Serializer.Mutations.ControlsIf.ElseIf.NoChild,
   Serializer.Mutations.ControlsIf.ElseIf.Child,
@@ -1499,41 +1562,41 @@ Serializer.Mutations.ControlsIf.Else = new SerializerTestSuite('Else');
 Serializer.Mutations.ControlsIf.Else.NoChild = new SerializerTestCase(
     'NoChild',
     '<xml xmlns="https://developers.google.com/blockly/xml">' +
-    '<block type="controls_if" id="id******************" x="42" y="42">' +
-    '<mutation else="1"></mutation>' +
-    '</block>' +
-    '</xml>');
+        '<block type="controls_if" id="id******************" x="42" y="42">' +
+        '<mutation else="1"></mutation>' +
+        '</block>' +
+        '</xml>');
 Serializer.Mutations.ControlsIf.Else.Child = new SerializerTestCase(
     'Child',
     '<xml xmlns="https://developers.google.com/blockly/xml">' +
-    '<block type="controls_if" id="id******************" x="42" y="42">' +
-    '<mutation else="1"></mutation>' +
-    '<statement name="ELSE">' +
-    '<block type="text_print" id="id2*****************"></block>' +
-    '</statement>' +
-    '</block>' +
-    '</xml>');
+        '<block type="controls_if" id="id******************" x="42" y="42">' +
+        '<mutation else="1"></mutation>' +
+        '<statement name="ELSE">' +
+        '<block type="text_print" id="id2*****************"></block>' +
+        '</statement>' +
+        '</block>' +
+        '</xml>');
 Serializer.Mutations.ControlsIf.Else.Shadow = new SerializerTestCase(
     'Shadow',
     '<xml xmlns="https://developers.google.com/blockly/xml">' +
-    '<block type="controls_if" id="id******************" x="42" y="42">' +
-    '<mutation else="1"></mutation>' +
-    '<statement name="ELSE">' +
-    '<shadow type="text_print" id="id2*****************"></shadow>' +
-    '</statement>' +
-    '</block>' +
-    '</xml>');
+        '<block type="controls_if" id="id******************" x="42" y="42">' +
+        '<mutation else="1"></mutation>' +
+        '<statement name="ELSE">' +
+        '<shadow type="text_print" id="id2*****************"></shadow>' +
+        '</statement>' +
+        '</block>' +
+        '</xml>');
 Serializer.Mutations.ControlsIf.Else.OverwrittenShadow = new SerializerTestCase(
     'OverwrittenShadow',
     '<xml xmlns="https://developers.google.com/blockly/xml">' +
-    '<block type="controls_if" id="id******************" x="42" y="42">' +
-    '<mutation else="1"></mutation>' +
-    '<statement name="ELSE">' +
-    '<shadow type="text_print" id="id2*****************"></shadow>' +
-    '<block type="text_print" id="id3*****************"></block>' +
-    '</statement>' +
-    '</block>' +
-    '</xml>');
+        '<block type="controls_if" id="id******************" x="42" y="42">' +
+        '<mutation else="1"></mutation>' +
+        '<statement name="ELSE">' +
+        '<shadow type="text_print" id="id2*****************"></shadow>' +
+        '<block type="text_print" id="id3*****************"></block>' +
+        '</statement>' +
+        '</block>' +
+        '</xml>');
 Serializer.Mutations.ControlsIf.Else.testCases = [
   Serializer.Mutations.ControlsIf.Else.NoChild,
   Serializer.Mutations.ControlsIf.Else.Child,
@@ -1550,24 +1613,24 @@ Serializer.Mutations.ListCreate = new SerializerTestSuite('ListCreate');
 Serializer.Mutations.ListCreate.Default = new SerializerTestCase(
     'Default',
     '<xml xmlns="https://developers.google.com/blockly/xml">' +
-    '<block type="lists_create_with" id="id******************" x="42" y="42">' +
-    '<mutation items="3"></mutation>' +
-    '</block>' +
-    '</xml>');
+        '<block type="lists_create_with" id="id******************" x="42" y="42">' +
+        '<mutation items="3"></mutation>' +
+        '</block>' +
+        '</xml>');
 Serializer.Mutations.ListCreate.ZeroInputs = new SerializerTestCase(
     'ZeroInputs',
     '<xml xmlns="https://developers.google.com/blockly/xml">' +
-    '<block type="lists_create_with" id="id******************" x="42" y="42">' +
-    '<mutation items="0"></mutation>' +
-    '</block>' +
-    '</xml>');
+        '<block type="lists_create_with" id="id******************" x="42" y="42">' +
+        '<mutation items="0"></mutation>' +
+        '</block>' +
+        '</xml>');
 Serializer.Mutations.ListCreate.MultipleInputs = new SerializerTestCase(
     'MultipleInputs',
     '<xml xmlns="https://developers.google.com/blockly/xml">' +
-    '<block type="lists_create_with" id="id******************" x="42" y="42">' +
-    '<mutation items="10"></mutation>' +
-    '</block>' +
-    '</xml>');
+        '<block type="lists_create_with" id="id******************" x="42" y="42">' +
+        '<mutation items="10"></mutation>' +
+        '</block>' +
+        '</xml>');
 Serializer.Mutations.ListCreate.testCases = [
   Serializer.Mutations.ListCreate.Default,
   Serializer.Mutations.ListCreate.ZeroInputs,
@@ -1578,34 +1641,34 @@ Serializer.Mutations.ListCreate.OneInput = new SerializerTestSuite('OneIput');
 Serializer.Mutations.ListCreate.OneInput.NoChild = new SerializerTestCase(
     'NoChild',
     '<xml xmlns="https://developers.google.com/blockly/xml">' +
-    '<block type="lists_create_with" id="id******************" x="42" y="42">' +
-    '<mutation items="1"></mutation>' +
-    '</block>' +
-    '</xml>');
+        '<block type="lists_create_with" id="id******************" x="42" y="42">' +
+        '<mutation items="1"></mutation>' +
+        '</block>' +
+        '</xml>');
 Serializer.Mutations.ListCreate.OneInput.Child = new SerializerTestCase(
     'Child',
     '<xml xmlns="https://developers.google.com/blockly/xml">' +
-    '<block type="lists_create_with" id="id******************" x="42" y="42">' +
-    '<mutation items="1"></mutation>' +
-    '<value name="ADD0">' +
-    '<block type="math_random_float" id="id2*****************"></block>' +
-    '</value>' +
-    '</block>' +
-    '</xml>');
+        '<block type="lists_create_with" id="id******************" x="42" y="42">' +
+        '<mutation items="1"></mutation>' +
+        '<value name="ADD0">' +
+        '<block type="math_random_float" id="id2*****************"></block>' +
+        '</value>' +
+        '</block>' +
+        '</xml>');
 Serializer.Mutations.ListCreate.OneInput.Shadow = new SerializerTestCase(
     'Shadow',
     '<xml xmlns="https://developers.google.com/blockly/xml">' +
-    '<block type="lists_create_with" id="id******************" x="42" y="42">' +
-    '<mutation items="1"></mutation>' +
-    '<value name="ADD0">' +
-    '<shadow type="math_random_float" id="id2*****************"></shadow>' +
-    '</value>' +
-    '</block>' +
-    '</xml>');
-Serializer.Mutations.ListCreate.OneInput.OverwrittenShadow =
-    new SerializerTestCase(
-        'OverwrittenShadow',
-        '<xml xmlns="https://developers.google.com/blockly/xml">' +
+        '<block type="lists_create_with" id="id******************" x="42" y="42">' +
+        '<mutation items="1"></mutation>' +
+        '<value name="ADD0">' +
+        '<shadow type="math_random_float" id="id2*****************"></shadow>' +
+        '</value>' +
+        '</block>' +
+        '</xml>');
+Serializer.Mutations.ListCreate.OneInput
+    .OverwrittenShadow = new SerializerTestCase(
+    'OverwrittenShadow',
+    '<xml xmlns="https://developers.google.com/blockly/xml">' +
         '<block type="lists_create_with" id="id******************" x="42" y="42">' +
         '<mutation items="1"></mutation>' +
         '<value name="ADD0">' +
@@ -1626,107 +1689,111 @@ Serializer.Mutations.ListCreate.testSuites = [
 ];
 
 Serializer.Mutations.Procedure = new SerializerTestSuite('Procedure');
-Serializer.Mutations.Procedure.NoMutation = new SerializerTestCase('NoMutation',
+Serializer.Mutations.Procedure.NoMutation = new SerializerTestCase(
+    'NoMutation',
     '<xml xmlns="https://developers.google.com/blockly/xml">' +
-    '<block type="procedures_defreturn" id="id******************" x="42" y="42">' +
-    '<field name="NAME">do something</field>' +
-    '</block>' +
-    '</xml>');
-Serializer.Mutations.Procedure.Variables = new SerializerTestCase('Variables',
+        '<block type="procedures_defreturn" id="id******************" x="42" y="42">' +
+        '<field name="NAME">do something</field>' +
+        '</block>' +
+        '</xml>');
+Serializer.Mutations.Procedure.Variables = new SerializerTestCase(
+    'Variables',
     '<xml xmlns="https://developers.google.com/blockly/xml">' +
-    '<variables>' +
-    '<variable id="aaaaaaaaaaaaaaaaaaaa">x</variable>' +
-    '<variable id="bbbbbbbbbbbbbbbbbbbb">y</variable>' +
-    '<variable id="cccccccccccccccccccc">z</variable>' +
-    '</variables>' +
-    '<block type="procedures_defreturn" id="id******************" x="42" y="42">' +
-    '<mutation>' +
-    '<arg name="x" varid="aaaaaaaaaaaaaaaaaaaa"></arg>' +
-    '<arg name="y" varid="bbbbbbbbbbbbbbbbbbbb"></arg>' +
-    '<arg name="z" varid="cccccccccccccccccccc"></arg>' +
-    '</mutation>' +
-    '<field name="NAME">do something</field>' +
-    '</block>' +
-    '</xml>');
+        '<variables>' +
+        '<variable id="aaaaaaaaaaaaaaaaaaaa">x</variable>' +
+        '<variable id="bbbbbbbbbbbbbbbbbbbb">y</variable>' +
+        '<variable id="cccccccccccccccccccc">z</variable>' +
+        '</variables>' +
+        '<block type="procedures_defreturn" id="id******************" x="42" y="42">' +
+        '<mutation>' +
+        '<arg name="x" varid="aaaaaaaaaaaaaaaaaaaa"></arg>' +
+        '<arg name="y" varid="bbbbbbbbbbbbbbbbbbbb"></arg>' +
+        '<arg name="z" varid="cccccccccccccccccccc"></arg>' +
+        '</mutation>' +
+        '<field name="NAME">do something</field>' +
+        '</block>' +
+        '</xml>');
 Serializer.Mutations.Procedure.NoStatements = new SerializerTestCase(
     'NoStatements',
     '<xml xmlns="https://developers.google.com/blockly/xml">' +
-    '<block type="procedures_defreturn" id="id******************" x="42" y="42">' +
-    '<mutation statements="false"></mutation>' +
-    '<field name="NAME">do something</field>' +
-    '</block>' +
-    '</xml>');
+        '<block type="procedures_defreturn" id="id******************" x="42" y="42">' +
+        '<mutation statements="false"></mutation>' +
+        '<field name="NAME">do something</field>' +
+        '</block>' +
+        '</xml>');
 Serializer.Mutations.Procedure.IfReturn = new SerializerTestCase(
     'IfReturn',
     '<xml xmlns="https://developers.google.com/blockly/xml">' +
-    '<block type="procedures_defnoreturn" id="id" x="42" y="42">' +
-    '<field name="NAME">do something</field>' +
-    '<statement name="STACK">' +
-    '<block type="procedures_ifreturn" id="id2">' +
-    '<mutation value="0"></mutation>' +
-    '</block>' +
-    '</statement>' +
-    '</block>' +
-    '</xml>');
+        '<block type="procedures_defnoreturn" id="id" x="42" y="42">' +
+        '<field name="NAME">do something</field>' +
+        '<statement name="STACK">' +
+        '<block type="procedures_ifreturn" id="id2">' +
+        '<mutation value="0"></mutation>' +
+        '</block>' +
+        '</statement>' +
+        '</block>' +
+        '</xml>');
 Serializer.Mutations.Procedure.Caller = new SerializerTestCase(
     'Caller',
     '<xml xmlns="https://developers.google.com/blockly/xml">' +
-    '<variables>' +
-    '<variable id="aaaaaaaaaaaaaaaaaaaa">x</variable>' +
-    '<variable id="bbbbbbbbbbbbbbbbbbbb">y</variable>' +
-    '</variables>' +
-    '<block type="procedures_defreturn" id="id2*****************" x="42" y="42">' +
-    '<mutation>' +
-    '<arg name="x" varid="aaaaaaaaaaaaaaaaaaaa"></arg>' +
-    '<arg name="y" varid="bbbbbbbbbbbbbbbbbbbb"></arg>' +
-    '</mutation>' +
-    '<field name="NAME">do something</field>' +
-    '</block>' +
-    '<block type="procedures_callreturn" id="id******************" x="52" y="52">' +
-    '<mutation name="do something">' +
-    '<arg name="x"></arg>' +
-    '<arg name="y"></arg>' +
-    '</mutation>' +
-    '</block>' +
-    '</xml>');
-Serializer.Mutations.Procedure.CollapsedProceduresCallreturn = new SerializerTestCase(
+        '<variables>' +
+        '<variable id="aaaaaaaaaaaaaaaaaaaa">x</variable>' +
+        '<variable id="bbbbbbbbbbbbbbbbbbbb">y</variable>' +
+        '</variables>' +
+        '<block type="procedures_defreturn" id="id2*****************" x="42" y="42">' +
+        '<mutation>' +
+        '<arg name="x" varid="aaaaaaaaaaaaaaaaaaaa"></arg>' +
+        '<arg name="y" varid="bbbbbbbbbbbbbbbbbbbb"></arg>' +
+        '</mutation>' +
+        '<field name="NAME">do something</field>' +
+        '</block>' +
+        '<block type="procedures_callreturn" id="id******************" x="52" y="52">' +
+        '<mutation name="do something">' +
+        '<arg name="x"></arg>' +
+        '<arg name="y"></arg>' +
+        '</mutation>' +
+        '</block>' +
+        '</xml>');
+Serializer.Mutations.Procedure
+    .CollapsedProceduresCallreturn = new SerializerTestCase(
     'CollapsedProceduresCallreturn',
     '<xml xmlns="https://developers.google.com/blockly/xml">' +
-    '<variables>' +
-    '<variable id="aaaaaaaaaaaaaaaaaaaa">x</variable>' +
-    '</variables>' +
-    '<block type="procedures_defreturn" id="id******************" x="42" y="42">' +
-    '<mutation>' +
-    '<arg name="x" varid="aaaaaaaaaaaaaaaaaaaa"></arg>' +
-    '</mutation>' +
-    '<field name="NAME">do something</field>' +
-    '<comment pinned="false" h="80" w="160">Describe this function...</comment>' +
-    '</block>' +
-    '<block type="procedures_callreturn" id="id1*****************" collapsed="true" x="52" y="52">' +
-    '<mutation name="do something">' +
-    '<arg name="x"></arg>' +
-    '</mutation>' +
-    '</block>' +
-    '</xml>');
-Serializer.Mutations.Procedure.CollapsedProceduresCallnoreturn = new SerializerTestCase(
+        '<variables>' +
+        '<variable id="aaaaaaaaaaaaaaaaaaaa">x</variable>' +
+        '</variables>' +
+        '<block type="procedures_defreturn" id="id******************" x="42" y="42">' +
+        '<mutation>' +
+        '<arg name="x" varid="aaaaaaaaaaaaaaaaaaaa"></arg>' +
+        '</mutation>' +
+        '<field name="NAME">do something</field>' +
+        '<comment pinned="false" h="80" w="160">Describe this function...</comment>' +
+        '</block>' +
+        '<block type="procedures_callreturn" id="id1*****************" collapsed="true" x="52" y="52">' +
+        '<mutation name="do something">' +
+        '<arg name="x"></arg>' +
+        '</mutation>' +
+        '</block>' +
+        '</xml>');
+Serializer.Mutations.Procedure
+    .CollapsedProceduresCallnoreturn = new SerializerTestCase(
     'CollapsedProceduresCallnoreturn',
     '<xml xmlns="https://developers.google.com/blockly/xml">' +
-    '<variables>' +
-    '<variable id="aaaaaaaaaaaaaaaaaaaa">x</variable>' +
-    '</variables>' +
-    '<block type="procedures_defnoreturn" id="id******************" x="42" y="42">' +
-    '<mutation>' +
-    '<arg name="x" varid="aaaaaaaaaaaaaaaaaaaa"></arg>' +
-    '</mutation>' +
-    '<field name="NAME">do something</field>' +
-    '<comment pinned="false" h="80" w="160">Describe this function...</comment>' +
-    '</block>' +
-    '<block type="procedures_callnoreturn" id="id1*****************" collapsed="true" x="52" y="52">' +
-    '<mutation name="do something">' +
-    '<arg name="x"></arg>' +
-    '</mutation>' +
-    '</block>' +
-    '</xml>');
+        '<variables>' +
+        '<variable id="aaaaaaaaaaaaaaaaaaaa">x</variable>' +
+        '</variables>' +
+        '<block type="procedures_defnoreturn" id="id******************" x="42" y="42">' +
+        '<mutation>' +
+        '<arg name="x" varid="aaaaaaaaaaaaaaaaaaaa"></arg>' +
+        '</mutation>' +
+        '<field name="NAME">do something</field>' +
+        '<comment pinned="false" h="80" w="160">Describe this function...</comment>' +
+        '</block>' +
+        '<block type="procedures_callnoreturn" id="id1*****************" collapsed="true" x="52" y="52">' +
+        '<mutation name="do something">' +
+        '<arg name="x"></arg>' +
+        '</mutation>' +
+        '</block>' +
+        '</xml>');
 Serializer.Mutations.Procedure.testCases = [
   Serializer.Mutations.Procedure.NoMutation,
   Serializer.Mutations.Procedure.Variables,
@@ -1738,75 +1805,76 @@ Serializer.Mutations.Procedure.testCases = [
 ];
 
 Serializer.Mutations.Procedure.Names = new SerializerTestSuite('Names');
-Serializer.Mutations.Procedure.Names.Symbols = new SerializerTestCase('Symbols',
+Serializer.Mutations.Procedure.Names.Symbols = new SerializerTestCase(
+    'Symbols',
     '<xml xmlns="https://developers.google.com/blockly/xml">' +
-    '<block type="procedures_defreturn" id="id******************" x="42" y="42">' +
-    '<field name="NAME">~`!@#$%^*()_+-={[}]|\\:;,.?/</field>' +
-    '</block>' +
-    '</xml>');
+        '<block type="procedures_defreturn" id="id******************" x="42" y="42">' +
+        '<field name="NAME">~`!@#$%^*()_+-={[}]|\\:;,.?/</field>' +
+        '</block>' +
+        '</xml>');
 Serializer.Mutations.Procedure.Names.EscapedSymbols = new SerializerTestCase(
     'EscapedSymbols',
     '<xml xmlns="https://developers.google.com/blockly/xml">' +
-    '<block type="procedures_defreturn" id="id******************" x="42" y="42">' +
-    '<field name="NAME">&amp;&lt;&gt;</field>' +
-    '</block>' +
-    '</xml>');
+        '<block type="procedures_defreturn" id="id******************" x="42" y="42">' +
+        '<field name="NAME">&amp;&lt;&gt;</field>' +
+        '</block>' +
+        '</xml>');
 Serializer.Mutations.Procedure.Names.SingleQuotes = new SerializerTestCase(
     'SingleQuotes',
     '<xml xmlns="https://developers.google.com/blockly/xml">' +
-    '<block type="procedures_defreturn" id="id******************" x="42" y="42">' +
-    '<field name="NAME">\'test\'</field>' +
-    '</block>' +
-    '</xml>');
+        '<block type="procedures_defreturn" id="id******************" x="42" y="42">' +
+        '<field name="NAME">\'test\'</field>' +
+        '</block>' +
+        '</xml>');
 Serializer.Mutations.Procedure.Names.DoubleQuotes = new SerializerTestCase(
     'DoubleQuotes',
     '<xml xmlns="https://developers.google.com/blockly/xml">' +
-    '<block type="procedures_defreturn" id="id******************" x="42" y="42">' +
-    '<field name="NAME">"test"</field>' +
-    '</block>' +
-    '</xml>');
+        '<block type="procedures_defreturn" id="id******************" x="42" y="42">' +
+        '<field name="NAME">"test"</field>' +
+        '</block>' +
+        '</xml>');
 Serializer.Mutations.Procedure.Names.Numbers = new SerializerTestCase(
     'Numbers',
     '<xml xmlns="https://developers.google.com/blockly/xml">' +
-    '<block type="procedures_defreturn" id="id******************" x="42" y="42">' +
-    '<field name="NAME">1234567890a123a123a</field>' +
-    '</block>' +
-    '</xml>');
+        '<block type="procedures_defreturn" id="id******************" x="42" y="42">' +
+        '<field name="NAME">1234567890a123a123a</field>' +
+        '</block>' +
+        '</xml>');
 Serializer.Mutations.Procedure.Names.Emoji = new SerializerTestCase(
     'Emoji',
     '<xml xmlns="https://developers.google.com/blockly/xml">' +
-    '<block type="procedures_defreturn" id="id******************" x="42" y="42">' +
-    '<field name="NAME">😀👋🏿👋🏾👋🏽👋🏼👋🏻😀❤❤❤</field>' +
-    '</block>' +
-    '</xml>');
+        '<block type="procedures_defreturn" id="id******************" x="42" y="42">' +
+        '<field name="NAME">😀👋🏿👋🏾👋🏽👋🏼👋🏻😀❤❤❤</field>' +
+        '</block>' +
+        '</xml>');
 Serializer.Mutations.Procedure.Names.Russian = new SerializerTestCase(
     'Russian',
     '<xml xmlns="https://developers.google.com/blockly/xml">' +
-    '<block type="procedures_defreturn" id="id******************" x="42" y="42">' +
-    '<field name="NAME">ты любопытный кот</field>' +
-    '</block>' +
-    '</xml>');
+        '<block type="procedures_defreturn" id="id******************" x="42" y="42">' +
+        '<field name="NAME">ты любопытный кот</field>' +
+        '</block>' +
+        '</xml>');
 Serializer.Mutations.Procedure.Names.Japanese = new SerializerTestCase(
     'Japanese',
     '<xml xmlns="https://developers.google.com/blockly/xml">' +
-    '<block type="procedures_defreturn" id="id******************" x="42" y="42">' +
-    '<field name="NAME">あなたは好奇心旺盛な猫です</field>' +
-    '</block>' +
-    '</xml>');
+        '<block type="procedures_defreturn" id="id******************" x="42" y="42">' +
+        '<field name="NAME">あなたは好奇心旺盛な猫です</field>' +
+        '</block>' +
+        '</xml>');
 Serializer.Mutations.Procedure.Names.Zalgo = new SerializerTestCase(
     'Zalgo',
     '<xml xmlns="https://developers.google.com/blockly/xml">' +
-    '<block type="procedures_defreturn" id="id******************" x="42" y="42">' +
-    '<field name="NAME">z̴̪͈̲̜͕̽̈̀͒͂̓̋̉̍a̸̧̧̜̻̘̤̫̱̲͎̞̻͆̋ļ̸̛̖̜̳͚̖͔̟̈́͂̉̀͑̑͑̎ǵ̸̫̳̽̐̃̑̚̕o̶͇̫͔̮̼̭͕̹̘̬͋̀͆̂̇̋͊̒̽</field>' +
-    '</block>' +
-    '</xml>');
+        '<block type="procedures_defreturn" id="id******************" x="42" y="42">' +
+        '<field name="NAME">z̴̪͈̲̜͕̽̈̀͒͂̓̋̉̍a̸̧̧̜̻̘̤̫̱̲͎̞̻͆̋ļ̸̛̖̜̳͚̖͔̟̈́͂̉̀͑̑͑̎ǵ̸̫̳̽̐̃̑̚̕o̶͇̫͔̮̼̭͕̹̘̬͋̀͆̂̇̋͊̒̽</field>' +
+        '</block>' +
+        '</xml>');
 Serializer.Mutations.Procedure.Names.ControlChars = new SerializerTestCase(
     'ControlChars',
     '<xml xmlns="https://developers.google.com/blockly/xml">' +
-    '<block type="procedures_defreturn" id="id******************" x="42" y="42">' +
-    '<field name="NAME">&#01;&#a1;</field>' +
-    '</block>' +
-    '</xml>');
+        '<block type="procedures_defreturn" id="id******************" x="42" y="42">' +
+        '<field name="NAME">&#01;&#a1;</field>' +
+        '</block>' +
+        '</xml>');
 Serializer.Mutations.Procedure.Names.testCases = [
   Serializer.Mutations.Procedure.Names.Symbols,
   Serializer.Mutations.Procedure.Names.EscapedSymbols,
@@ -1875,8 +1943,7 @@ const runSerializerTestSuite = (serializer, deserializer, testSuite) => {
       sharedTestTeardown.call(this);
     });
 
-    runTestSuites(
-        testSuite.testSuites, createTestCaseFunction);
+    runTestSuites(testSuite.testSuites, createTestCaseFunction);
     runTestCases(testSuite.testCases, createTestFunction);
   });
 };

--- a/tests/mocha/shortcut_registry_test.js
+++ b/tests/mocha/shortcut_registry_test.js
@@ -38,8 +38,7 @@ suite('Keyboard Shortcut Registry Test', function() {
         registry.register(testShortcut);
       };
       chai.assert.throws(
-          shouldThrow, Error,
-          'Shortcut named "test_shortcut" already exists.');
+          shouldThrow, Error, 'Shortcut named "test_shortcut" already exists.');
     });
     test(
         'Registers shortcut with same name opt_allowOverrides=true',
@@ -104,7 +103,8 @@ suite('Keyboard Shortcut Registry Test', function() {
 
       const registry = this.registry;
       chai.assert.isFalse(registry.unregister('test'));
-      sinon.assert.calledOnceWithExactly(consoleStub, 'Keyboard shortcut named "test" not found.');
+      sinon.assert.calledOnceWithExactly(
+          consoleStub, 'Keyboard shortcut named "test" not found.');
     });
     test('Unregistering a shortcut with key mappings', function() {
       const testShortcut = {'name': 'test_shortcut'};
@@ -237,7 +237,8 @@ suite('Keyboard Shortcut Registry Test', function() {
     test('Sets the key map', function() {
       this.registry.setKeyMap({'keyCode': ['test_shortcut']});
       chai.assert.equal(Object.keys(this.registry.getKeyMap()).length, 1);
-      chai.assert.equal(this.registry.getKeyMap()['keyCode'][0], 'test_shortcut');
+      chai.assert.equal(
+          this.registry.getKeyMap()['keyCode'][0], 'test_shortcut');
     });
     test('Gets a copy of the key map', function() {
       this.registry.setKeyMap({'keyCode': ['a']});
@@ -259,7 +260,8 @@ suite('Keyboard Shortcut Registry Test', function() {
       chai.assert.equal(shortcutNames[0], 'shortcutName');
     });
     test('Gets keycodes by shortcut name', function() {
-      this.registry.setKeyMap({'keyCode': ['shortcutName'], 'keyCode1': ['shortcutName']});
+      this.registry.setKeyMap(
+          {'keyCode': ['shortcutName'], 'keyCode1': ['shortcutName']});
       const shortcutNames =
           this.registry.getKeyCodesByShortcutName('shortcutName');
       chai.assert.lengthOf(shortcutNames, 2);
@@ -285,8 +287,8 @@ suite('Keyboard Shortcut Registry Test', function() {
           return true;
         },
       };
-      this.callBackStub =
-          addShortcut(this.registry, this.testShortcut, Blockly.utils.KeyCodes.C, true);
+      this.callBackStub = addShortcut(
+          this.registry, this.testShortcut, Blockly.utils.KeyCodes.C, true);
     });
     test('Execute a shortcut from event', function() {
       const event = createKeyDownEvent(Blockly.utils.KeyCodes.C);
@@ -314,8 +316,8 @@ suite('Keyboard Shortcut Registry Test', function() {
           return false;
         },
       };
-      const testShortcut2Stub =
-          addShortcut(this.registry, testShortcut2, Blockly.utils.KeyCodes.C, false);
+      const testShortcut2Stub = addShortcut(
+          this.registry, testShortcut2, Blockly.utils.KeyCodes.C, false);
       chai.assert.isTrue(this.registry.onKeyDown(this.workspace, event));
       sinon.assert.calledOnce(testShortcut2Stub);
       sinon.assert.calledOnce(this.callBackStub);
@@ -331,8 +333,8 @@ suite('Keyboard Shortcut Registry Test', function() {
           return false;
         },
       };
-      const testShortcut2Stub =
-          addShortcut(this.registry, testShortcut2, Blockly.utils.KeyCodes.C, true);
+      const testShortcut2Stub = addShortcut(
+          this.registry, testShortcut2, Blockly.utils.KeyCodes.C, true);
       chai.assert.isTrue(this.registry.onKeyDown(this.workspace, event));
       sinon.assert.calledOnce(testShortcut2Stub);
       sinon.assert.notCalled(this.callBackStub);
@@ -384,15 +386,13 @@ suite('Keyboard Shortcut Registry Test', function() {
       chai.assert.equal(serializedKey, 'Control+65');
     });
     test('Serialize only a modifier', function() {
-      const mockEvent =
-          createKeyDownEvent(null, [Blockly.utils.KeyCodes.CTRL]);
+      const mockEvent = createKeyDownEvent(null, [Blockly.utils.KeyCodes.CTRL]);
       const serializedKey = this.registry.serializeKeyEvent_(mockEvent);
       chai.assert.equal(serializedKey, 'Control');
     });
     test('Serialize multiple modifiers', function() {
       const mockEvent = createKeyDownEvent(
-          null,
-          [Blockly.utils.KeyCodes.CTRL, Blockly.utils.KeyCodes.SHIFT]);
+          null, [Blockly.utils.KeyCodes.CTRL, Blockly.utils.KeyCodes.SHIFT]);
       const serializedKey = this.registry.serializeKeyEvent_(mockEvent);
       chai.assert.equal(serializedKey, 'Shift+Control');
     });

--- a/tests/mocha/test_helpers/code_generation.js
+++ b/tests/mocha/test_helpers/code_generation.js
@@ -55,7 +55,8 @@ export class CodeGenerationTestSuite {
    */
   constructor() {
     /**
-     * @type {!Blockly.CodeGenerator} The generator to use for running test cases.
+     * @type {!Blockly.CodeGenerator} The generator to use for running test
+     *     cases.
      */
     this.generator;
   }
@@ -86,7 +87,8 @@ const createCodeGenerationTestFn_ = (generator) => {
         }
       }
       const assertFunc = (typeof testCase.expectedCode === 'string') ?
-          chai.assert.equal : chai.assert.match;
+          chai.assert.equal :
+          chai.assert.match;
       assertFunc(code, testCase.expectedCode);
       if (!testCase.useWorkspaceToCode &&
           testCase.expectedInnerOrder !== undefined) {

--- a/tests/mocha/test_helpers/events.js
+++ b/tests/mocha/test_helpers/events.js
@@ -58,8 +58,8 @@ function assertXmlProperties_(obj, expectedXmlProperties) {
     const value = obj[key];
     const expectedValue = expectedXmlProperties[key];
     if (expectedValue === undefined) {
-      chai.assert.isUndefined(value,
-          'Expected ' + key + ' property to be undefined');
+      chai.assert.isUndefined(
+          value, 'Expected ' + key + ' property to be undefined');
       return;
     }
     chai.assert.exists(value, 'Expected ' + key + ' property to exist');
@@ -88,16 +88,16 @@ function isXmlProperty_(key) {
  * @param {boolean=} [isUiEvent=false] Whether the event is a UI event.
  * @param {string=} message Optional message to prepend assert messages.
  */
-export function assertEventEquals(event, expectedType,
-    expectedWorkspaceId, expectedBlockId, expectedProperties, isUiEvent = false, message) {
+export function assertEventEquals(
+    event, expectedType, expectedWorkspaceId, expectedBlockId,
+    expectedProperties, isUiEvent = false, message) {
   let prependMessage = message ? message + ' ' : '';
   prependMessage += 'Event fired ';
-  chai.assert.equal(event.type, expectedType,
-      prependMessage + 'type');
-  chai.assert.equal(event.workspaceId, expectedWorkspaceId,
-      prependMessage + 'workspace id');
-  chai.assert.equal(event.blockId, expectedBlockId,
-      prependMessage + 'block id');
+  chai.assert.equal(event.type, expectedType, prependMessage + 'type');
+  chai.assert.equal(
+      event.workspaceId, expectedWorkspaceId, prependMessage + 'workspace id');
+  chai.assert.equal(
+      event.blockId, expectedBlockId, prependMessage + 'block id');
   Object.keys(expectedProperties).map((key) => {
     const value = event[key];
     const expectedValue = expectedProperties[key];
@@ -107,11 +107,9 @@ export function assertEventEquals(event, expectedType,
     }
     chai.assert.exists(value, prependMessage + key);
     if (isXmlProperty_(key)) {
-      assertXmlPropertyEqual_(value, expectedValue,
-          prependMessage + key);
+      assertXmlPropertyEqual_(value, expectedValue, prependMessage + key);
     } else {
-      chai.assert.equal(value, expectedValue,
-          prependMessage + key);
+      chai.assert.equal(value, expectedValue, prependMessage + key);
     }
   });
   if (isUiEvent) {
@@ -131,12 +129,15 @@ export function assertEventEquals(event, expectedType,
  * @param {string} expectedWorkspaceId Expected workspace id of event fired.
  * @param {?string=} expectedBlockId Expected block id of event fired.
  */
-export function assertEventFired(spy, instanceType, expectedProperties,
-    expectedWorkspaceId, expectedBlockId) {
-  expectedProperties = Object.assign({
-    workspaceId: expectedWorkspaceId,
-    blockId: expectedBlockId,
-  }, expectedProperties);
+export function assertEventFired(
+    spy, instanceType, expectedProperties, expectedWorkspaceId,
+    expectedBlockId) {
+  expectedProperties = Object.assign(
+      {
+        workspaceId: expectedWorkspaceId,
+        blockId: expectedBlockId,
+      },
+      expectedProperties);
   const expectedEvent =
       sinon.match.instanceOf(instanceType).and(sinon.match(expectedProperties));
   sinon.assert.calledWith(spy, expectedEvent);
@@ -173,16 +174,15 @@ function shallowMatch(expected) {
  * @param {?string=} expectedBlockId Expected block id of event fired.
  */
 export function assertEventFiredShallow(
-    spy, instanceType, expectedProperties, expectedWorkspaceId, expectedBlockId) {
+    spy, instanceType, expectedProperties, expectedWorkspaceId,
+    expectedBlockId) {
   const properties = {
     ...expectedProperties,
     workspaceId: expectedWorkspaceId,
     blockId: expectedBlockId,
   };
   sinon.assert.calledWith(
-      spy,
-      sinon.match.instanceOf(instanceType)
-          .and(shallowMatch(properties)));
+      spy, sinon.match.instanceOf(instanceType).and(shallowMatch(properties)));
 }
 
 /**
@@ -195,8 +195,9 @@ export function assertEventFiredShallow(
  * @param {string=} expectedWorkspaceId Expected workspace id of event fired.
  * @param {?string=} expectedBlockId Expected block id of event fired.
  */
-export function assertEventNotFired(spy, instanceType, expectedProperties,
-    expectedWorkspaceId, expectedBlockId) {
+export function assertEventNotFired(
+    spy, instanceType, expectedProperties, expectedWorkspaceId,
+    expectedBlockId) {
   if (expectedWorkspaceId !== undefined) {
     expectedProperties.workspaceId = expectedWorkspaceId;
   }
@@ -241,14 +242,16 @@ function splitByXmlProperties_(properties) {
  * @param {string} expectedWorkspaceId Expected workspace id of event fired.
  * @param {?string=} expectedBlockId Expected block id of event fired.
  */
-export function assertNthCallEventArgEquals(spy, n, instanceType, expectedProperties,
-    expectedWorkspaceId, expectedBlockId) {
+export function assertNthCallEventArgEquals(
+    spy, n, instanceType, expectedProperties, expectedWorkspaceId,
+    expectedBlockId) {
   const nthCall = spy.getCall(n);
   const splitProperties = splitByXmlProperties_(expectedProperties);
   const nonXmlProperties = splitProperties[0];
   const xmlProperties = splitProperties[1];
 
-  assertEventFired(nthCall, instanceType, nonXmlProperties, expectedWorkspaceId,
+  assertEventFired(
+      nthCall, instanceType, nonXmlProperties, expectedWorkspaceId,
       expectedBlockId);
   const eventArg = nthCall.firstArg;
   assertXmlProperties_(eventArg, xmlProperties);

--- a/tests/mocha/test_helpers/fields.js
+++ b/tests/mocha/test_helpers/fields.js
@@ -67,7 +67,8 @@ export class FieldCreationTestCase {
  * @param {*} expectedValue The expected value.
  * @param {string=} expectedText The expected text.
  */
-export function assertFieldValue(field, expectedValue, expectedText = undefined) {
+export function assertFieldValue(
+    field, expectedValue, expectedText = undefined) {
   const actualValue = field.getValue();
   const actualText = field.getText();
   if (expectedText === undefined) {
@@ -142,21 +143,21 @@ function runCreationTestsAssertThrows_(testCases, creation) {
  * @param {function(!FieldCreationTestCase=)=} customCreateWithJs Custom
  *    creation function to use in tests.
  */
-export function runConstructorSuiteTests(TestedField, validValueTestCases,
-    invalidValueTestCases, validRunAssertField, assertFieldDefault,
-    customCreateWithJs) {
+export function runConstructorSuiteTests(
+    TestedField, validValueTestCases, invalidValueTestCases,
+    validRunAssertField, assertFieldDefault, customCreateWithJs) {
   suite('Constructor', function() {
     if (assertFieldDefault) {
       test('Empty', function() {
         const field = customCreateWithJs ? customCreateWithJs.call(this) :
-            new TestedField();
+                                           new TestedField();
         assertFieldDefault(field);
       });
     } else {
       test('Empty', function() {
         chai.assert.throws(function() {
           customCreateWithJs ? customCreateWithJs.call(this) :
-              new TestedField();
+                               new TestedField();
         });
       });
     }
@@ -168,7 +169,7 @@ export function runConstructorSuiteTests(TestedField, validValueTestCases,
      */
     const createWithJs = function(testCase) {
       return customCreateWithJs ? customCreateWithJs.call(this, testCase) :
-          new TestedField(...testCase.args);
+                                  new TestedField(...testCase.args);
     };
     if (assertFieldDefault) {
       runCreationTests_(
@@ -196,21 +197,21 @@ export function runConstructorSuiteTests(TestedField, validValueTestCases,
  * @param {function(!FieldCreationTestCase=)=} customCreateWithJson Custom
  *    creation function to use in tests.
  */
-export function runFromJsonSuiteTests(TestedField, validValueTestCases,
-    invalidValueTestCases, validRunAssertField, assertFieldDefault,
-    customCreateWithJson) {
+export function runFromJsonSuiteTests(
+    TestedField, validValueTestCases, invalidValueTestCases,
+    validRunAssertField, assertFieldDefault, customCreateWithJson) {
   suite('fromJson', function() {
     if (assertFieldDefault) {
       test('Empty', function() {
         const field = customCreateWithJson ? customCreateWithJson.call(this) :
-            TestedField.fromJson({});
+                                             TestedField.fromJson({});
         assertFieldDefault(field);
       });
     } else {
       test('Empty', function() {
         chai.assert.throws(function() {
           customCreateWithJson ? customCreateWithJson.call(this) :
-              TestedField.fromJson({});
+                                 TestedField.fromJson({});
         });
       });
     }
@@ -222,7 +223,7 @@ export function runFromJsonSuiteTests(TestedField, validValueTestCases,
      */
     const createWithJson = function(testCase) {
       return customCreateWithJson ? customCreateWithJson.call(this, testCase) :
-          TestedField.fromJson(testCase.json);
+                                    TestedField.fromJson(testCase.json);
     };
     if (assertFieldDefault) {
       runCreationTests_(
@@ -245,8 +246,9 @@ export function runFromJsonSuiteTests(TestedField, validValueTestCases,
  * @param {string=} invalidRunExpectedText Expected text for field after invalid
  *    call to setValue.
  */
-export function runSetValueTests(validValueTestCases, invalidValueTestCases,
-    invalidRunExpectedValue, invalidRunExpectedText) {
+export function runSetValueTests(
+    validValueTestCases, invalidValueTestCases, invalidRunExpectedValue,
+    invalidRunExpectedText) {
   /**
    * Creates test callback for invalid setValue test.
    * @param {!FieldValueTestCase} testCase The test case information.

--- a/tests/mocha/test_helpers/procedures.js
+++ b/tests/mocha/test_helpers/procedures.js
@@ -31,7 +31,8 @@ function assertBlockVarModels(block, varIds) {
  */
 function assertCallBlockArgsStructure(callBlock, args) {
   // inputList also contains "TOPROW"
-  chai.assert.equal(callBlock.inputList.length - 1, args.length,
+  chai.assert.equal(
+      callBlock.inputList.length - 1, args.length,
       'call block has the expected number of args');
 
   for (let i = 0; i < args.length; i++) {
@@ -39,7 +40,8 @@ function assertCallBlockArgsStructure(callBlock, args) {
     const callInput = callBlock.inputList[i + 1];
     chai.assert.equal(callInput.type, ConnectionType.INPUT_VALUE);
     chai.assert.equal(callInput.name, 'ARG' + i);
-    chai.assert.equal(callInput.fieldRow[0].getValue(), expectedName,
+    chai.assert.equal(
+        callInput.fieldRow[0].getValue(), expectedName,
         'Call block consts did not match expected.');
   }
   chai.assert.sameOrderedMembers(callBlock.getVars(), args);
@@ -56,27 +58,28 @@ function assertCallBlockArgsStructure(callBlock, args) {
  * @param {boolean=} hasStatements If we expect the procedure def to have a
  *     statement input or not.
  */
-export function assertDefBlockStructure(defBlock, hasReturn = false,
-    args = [], varIds = [], hasStatements = true) {
+export function assertDefBlockStructure(
+    defBlock, hasReturn = false, args = [], varIds = [], hasStatements = true) {
   if (hasStatements) {
-    chai.assert.isNotNull(defBlock.getInput('STACK'),
-        'Def block should have STACK input');
+    chai.assert.isNotNull(
+        defBlock.getInput('STACK'), 'Def block should have STACK input');
   } else {
-    chai.assert.isNull(defBlock.getInput('STACK'),
-        'Def block should not have STACK input');
+    chai.assert.isNull(
+        defBlock.getInput('STACK'), 'Def block should not have STACK input');
   }
   if (hasReturn) {
-    chai.assert.isNotNull(defBlock.getInput('RETURN'),
-        'Def block should have RETURN input');
+    chai.assert.isNotNull(
+        defBlock.getInput('RETURN'), 'Def block should have RETURN input');
   } else {
-    chai.assert.isNull(defBlock.getInput('RETURN'),
-        'Def block should not have RETURN input');
+    chai.assert.isNull(
+        defBlock.getInput('RETURN'), 'Def block should not have RETURN input');
   }
   if (args.length) {
-    chai.assert.include(defBlock.toString(), 'with',
-        'Def block string should include "with"');
+    chai.assert.include(
+        defBlock.toString(), 'with', 'Def block string should include "with"');
   } else {
-    chai.assert.notInclude(defBlock.toString(), 'with',
+    chai.assert.notInclude(
+        defBlock.toString(), 'with',
         'Def block string should not include "with"');
   }
 
@@ -93,7 +96,7 @@ export function assertDefBlockStructure(defBlock, hasReturn = false,
  * @param {string=} name The name we expect the caller to have.
  */
 export function assertCallBlockStructure(
-  callBlock, args = [], varIds = [], name = undefined) {
+    callBlock, args = [], varIds = [], name = undefined) {
   if (args.length) {
     chai.assert.include(callBlock.toString(), 'with');
   } else {
@@ -118,15 +121,12 @@ export function assertCallBlockStructure(
  */
 export function createProcDefBlock(
     workspace, hasReturn = false, args = [], name = 'proc name') {
-  const type = hasReturn ?
-      'procedures_defreturn' : 'procedures_defnoreturn';
+  const type = hasReturn ? 'procedures_defreturn' : 'procedures_defnoreturn';
   let xml = `<block type="${type}">`;
-  for (let i = 0; i < args.length; i ++) {
-    xml +=
-        `    <mutation><arg name="${args[i]}"></arg></mutation>\n`;
+  for (let i = 0; i < args.length; i++) {
+    xml += `    <mutation><arg name="${args[i]}"></arg></mutation>\n`;
   }
-  xml +=
-      `  <field name="NAME">${name}</field>` +
+  xml += `  <field name="NAME">${name}</field>` +
       '</block>';
   return Blockly.Xml.domToBlock(Blockly.utils.xml.textToDom(xml), workspace);
 }
@@ -141,13 +141,13 @@ export function createProcDefBlock(
  */
 export function createProcCallBlock(
     workspace, hasReturn = false, name = 'proc name') {
-  const type = hasReturn ?
-      'procedures_callreturn' : 'procedures_callnoreturn';
-  return Blockly.Xml.domToBlock(Blockly.utils.xml.textToDom(
-      `<block type="${type}">` +
-      `  <mutation name="${name}"/>` +
-      `</block>`
-  ), workspace);
+  const type = hasReturn ? 'procedures_callreturn' : 'procedures_callnoreturn';
+  return Blockly.Xml.domToBlock(
+      Blockly.utils.xml.textToDom(
+          `<block type="${type}">` +
+          `  <mutation name="${name}"/>` +
+          `</block>`),
+      workspace);
 }
 
 export class MockProcedureModel {
@@ -208,9 +208,9 @@ export class MockProcedureModel {
     return this.enabled;
   }
 
-  startPublishing() { }
+  startPublishing() {}
 
-  stopPublishing() { }
+  stopPublishing() {}
 }
 
 export class MockParameterModel {

--- a/tests/mocha/test_helpers/serialization.js
+++ b/tests/mocha/test_helpers/serialization.js
@@ -63,8 +63,8 @@ export const runSerializationTestSuite = (testCases) => {
         block = Blockly.serialization.blocks.append(
             testCase.json, this.workspace, {recordUndo: true});
       } else {
-        block = Blockly.Xml.domToBlock(Blockly.utils.xml.textToDom(
-            testCase.xml), this.workspace);
+        block = Blockly.Xml.domToBlock(
+            Blockly.utils.xml.textToDom(testCase.xml), this.workspace);
       }
       this.clock.runAll();
       testCase.assertBlockStructure(block);
@@ -85,12 +85,11 @@ export const runSerializationTestSuite = (testCases) => {
         const expectedJson = testCase.expectedJson || testCase.json;
         chai.assert.deepEqual(generatedJson, expectedJson);
       } else {
-        const block = Blockly.Xml.domToBlock(Blockly.utils.xml.textToDom(
-            testCase.xml), this.workspace);
+        const block = Blockly.Xml.domToBlock(
+            Blockly.utils.xml.textToDom(testCase.xml), this.workspace);
         this.clock.runAll();
         const generatedXml =
-            Blockly.Xml.domToPrettyText(
-                Blockly.Xml.blockToDom(block));
+            Blockly.Xml.domToPrettyText(Blockly.Xml.blockToDom(block));
         const expectedXml = testCase.expectedXml || testCase.xml;
         chai.assert.equal(generatedXml, expectedXml);
       }
@@ -113,8 +112,7 @@ export const runSerializationTestSuite = (testCases) => {
         //   .genUid is now a wrapper around .TEST_ONLY.genUid, which
         //   can be safely stubbed by sinon or other similar
         //   frameworks in a way that will continue to work.
-        if (Blockly.utils.idGenerator &&
-            Blockly.utils.idGenerator.TEST_ONLY) {
+        if (Blockly.utils.idGenerator && Blockly.utils.idGenerator.TEST_ONLY) {
           sinon.stub(Blockly.utils.idGenerator.TEST_ONLY, 'genUid')
               .returns('1');
         } else {

--- a/tests/mocha/test_helpers/setup_teardown.js
+++ b/tests/mocha/test_helpers/setup_teardown.js
@@ -74,7 +74,8 @@ export function addBlockTypeToCleanup(sharedCleanupObj, blockType) {
  * @private
  */
 function wrapDefineBlocksWithJsonArrayWithCleanup_(sharedCleanupObj) {
-  const stub = sinon.stub(Blockly.common.TEST_ONLY, 'defineBlocksWithJsonArrayInternal');
+  const stub =
+      sinon.stub(Blockly.common.TEST_ONLY, 'defineBlocksWithJsonArrayInternal');
   stub.callsFake(function(jsonArray) {
     if (jsonArray) {
       jsonArray.forEach((jsonBlock) => {
@@ -161,7 +162,8 @@ export function sharedTestTeardown() {
       // (i.e. a previous test added an event to the queue on a timeout that
       // did not use a stubbed clock).
       eventUtils.TEST_ONLY.FIRE_QUEUE.length = 0;
-      console.warn('"' + testRef.fullTitle() +
+      console.warn(
+          '"' + testRef.fullTitle() +
           '" needed cleanup of Blockly.Events.TEST_ONLY.FIRE_QUEUE. This may ' +
           'indicate leakage from an earlier test');
     }
@@ -184,9 +186,9 @@ export function sharedTestTeardown() {
 }
 
 /**
- * Creates stub for Blockly.utils.idGenerator.genUid that returns the provided id or ids.
- * Recommended to also assert that the stub is called the expected number of
- * times.
+ * Creates stub for Blockly.utils.idGenerator.genUid that returns the provided
+ * id or ids. Recommended to also assert that the stub is called the expected
+ * number of times.
  * @param {string|!Array<string>} returnIds The return values to use for the
  *    created stub. If a single value is passed, then the stub always returns
  *    that value.

--- a/tests/mocha/test_helpers/toolbox_definitions.js
+++ b/tests/mocha/test_helpers/toolbox_definitions.js
@@ -13,34 +13,40 @@ goog.declareModuleId('Blockly.test.helpers.toolboxDefinitions');
  *    for a toolbox.
  */
 export function getCategoryJSON() {
-  return {"contents": [
-    {
-      "kind": "CATEGORY",
-      "cssconfig": {
-        "container": "something",
+  return {
+    "contents": [
+      {
+        "kind": "CATEGORY",
+        "cssconfig": {
+          "container": "something",
+        },
+        "contents": [
+          {
+            "kind": "BLOCK",
+            "blockxml":
+                '<block type="basic_block"><field name="TEXT">FirstCategory-FirstBlock</field></block>',
+          },
+          {
+            "kind": "BLOCK",
+            "blockxml":
+                '<block type="basic_block"><field name="TEXT">FirstCategory-SecondBlock</field></block>',
+          },
+        ],
+        "name": "First",
       },
-      "contents": [
-        {
-          "kind": "BLOCK",
-          "blockxml": '<block type="basic_block"><field name="TEXT">FirstCategory-FirstBlock</field></block>',
-        },
-        {
-          "kind": "BLOCK",
-          "blockxml": '<block type="basic_block"><field name="TEXT">FirstCategory-SecondBlock</field></block>',
-        },
-      ],
-      "name": "First",
-    },
-    {
-      "kind": "CATEGORY",
-      "contents": [
-        {
-          "kind": "BLOCK",
-          "blockxml": '<block type="basic_block"><field name="TEXT">SecondCategory-FirstBlock</field></block>',
-        },
-      ],
-      "name": "Second",
-    }]};
+      {
+        "kind": "CATEGORY",
+        "contents": [
+          {
+            "kind": "BLOCK",
+            "blockxml":
+                '<block type="basic_block"><field name="TEXT">SecondCategory-FirstBlock</field></block>',
+          },
+        ],
+        "name": "Second",
+      }
+    ]
+  };
 }
 
 /**
@@ -49,11 +55,11 @@ export function getCategoryJSON() {
  *    for a simple toolbox.
  */
 export function getSimpleJson() {
-  return {"contents": [
-    {
-      "kind": "BLOCK",
-      "blockxml":
-        `<block type="logic_compare">
+  return {
+    "contents": [
+      {
+        "kind": "BLOCK",
+        "blockxml": `<block type="logic_compare">
           <field name="OP">NEQ</field>
           <value name="A">
             <shadow type="math_number">
@@ -66,21 +72,22 @@ export function getSimpleJson() {
             </block>
           </value>
         </block>`,
-    },
-    {
-      "kind": "SEP",
-      "gap": "20",
-    },
-    {
-      "kind": "BUTTON",
-      "text": "insert",
-      "callbackkey": "insertConnectionRows",
-    },
-    {
-      "kind": "LABEL",
-      "text": "tooltips",
-    },
-  ]};
+      },
+      {
+        "kind": "SEP",
+        "gap": "20",
+      },
+      {
+        "kind": "BUTTON",
+        "text": "insert",
+        "callbackkey": "insertConnectionRows",
+      },
+      {
+        "kind": "LABEL",
+        "text": "tooltips",
+      },
+    ]
+  };
 }
 
 export function getProperSimpleJson() {
@@ -124,7 +131,8 @@ export function getProperSimpleJson() {
         "kind": "LABEL",
         "text": "tooltips",
       },
-    ]};
+    ]
+  };
 }
 
 /**
@@ -133,42 +141,48 @@ export function getProperSimpleJson() {
  *    for a toolbox.
  */
 export function getDeeplyNestedJSON() {
-  return {"contents": [
-    {
-      "kind": "CATEGORY",
-      "cssconfig": {
-        "container": "something",
-      },
-      "contents": [{
+  return {
+    "contents": [
+      {
         "kind": "CATEGORY",
+        "cssconfig": {
+          "container": "something",
+        },
         "contents": [{
           "kind": "CATEGORY",
-          "contents": [
-            {
-              "kind": "BLOCK",
-              "blockxml": '<block type="basic_block"><field name="TEXT">NestedCategory-FirstBlock</field></block>',
-            },
-            {
-              "kind": "BLOCK",
-              "blockxml": '<block type="basic_block"><field name="TEXT">NestedCategory-SecondBlock</field></block>',
-            },
-          ],
-          "name": "NestedCategoryInner",
+          "contents": [{
+            "kind": "CATEGORY",
+            "contents": [
+              {
+                "kind": "BLOCK",
+                "blockxml":
+                    '<block type="basic_block"><field name="TEXT">NestedCategory-FirstBlock</field></block>',
+              },
+              {
+                "kind": "BLOCK",
+                "blockxml":
+                    '<block type="basic_block"><field name="TEXT">NestedCategory-SecondBlock</field></block>',
+              },
+            ],
+            "name": "NestedCategoryInner",
+          }],
+          "name": "NestedCategoryMiddle",
         }],
-        "name": "NestedCategoryMiddle",
-      }],
-      "name": "NestedCategoryOuter",
-    },
-    {
-      "kind": "CATEGORY",
-      "contents": [
-        {
-          "kind": "BLOCK",
-          "blockxml": '<block type="basic_block"><field name="TEXT">SecondCategory-FirstBlock</field></block>',
-        },
-      ],
-      "name": "Second",
-    }]};
+        "name": "NestedCategoryOuter",
+      },
+      {
+        "kind": "CATEGORY",
+        "contents": [
+          {
+            "kind": "BLOCK",
+            "blockxml":
+                '<block type="basic_block"><field name="TEXT">SecondCategory-FirstBlock</field></block>',
+          },
+        ],
+        "name": "Second",
+      }
+    ]
+  };
 }
 
 /**
@@ -176,8 +190,7 @@ export function getDeeplyNestedJSON() {
  * @return {Array<Node>} Array holding xml elements for a toolbox.
  */
 export function getXmlArray() {
-  const block = Blockly.utils.xml.textToDom(
-      `<block type="logic_compare">
+  const block = Blockly.utils.xml.textToDom(`<block type="logic_compare">
         <field name="OP">NEQ</field>
         <value name="A">
           <shadow type="math_number">
@@ -191,7 +204,8 @@ export function getXmlArray() {
         </value>
       </block>`);
   const separator = Blockly.utils.xml.textToDom('<sep gap="20"></sep>');
-  const button = Blockly.utils.xml.textToDom('<button text="insert" callbackkey="insertConnectionRows"></button>');
+  const button = Blockly.utils.xml.textToDom(
+      '<button text="insert" callbackkey="insertConnectionRows"></button>');
   const label = Blockly.utils.xml.textToDom('<label text="tooltips"></label>');
   return [block, separator, button, label];
 }
@@ -210,10 +224,9 @@ export function getInjectedToolbox() {
    *   Category: NestedItemOne
    */
   const toolboxXml = document.getElementById('toolbox-test');
-  const workspace = Blockly.inject('blocklyDiv',
-      {
-        toolbox: toolboxXml,
-      });
+  const workspace = Blockly.inject('blocklyDiv', {
+    toolbox: toolboxXml,
+  });
   return workspace.getToolbox();
 }
 

--- a/tests/mocha/test_helpers/toolbox_definitions.js
+++ b/tests/mocha/test_helpers/toolbox_definitions.js
@@ -44,8 +44,8 @@ export function getCategoryJSON() {
           },
         ],
         "name": "Second",
-      }
-    ]
+      },
+    ],
   };
 }
 
@@ -86,7 +86,7 @@ export function getSimpleJson() {
         "kind": "LABEL",
         "text": "tooltips",
       },
-    ]
+    ],
   };
 }
 
@@ -131,7 +131,7 @@ export function getProperSimpleJson() {
         "kind": "LABEL",
         "text": "tooltips",
       },
-    ]
+    ],
   };
 }
 
@@ -180,8 +180,8 @@ export function getDeeplyNestedJSON() {
           },
         ],
         "name": "Second",
-      }
-    ]
+      },
+    ],
   };
 }
 

--- a/tests/mocha/test_helpers/user_input.js
+++ b/tests/mocha/test_helpers/user_input.js
@@ -35,8 +35,10 @@ export function dispatchPointerEvent(target, type, properties) {
 
 /**
  * Creates a key down event used for testing.
- * @param {number} keyCode The keycode for the event. Use Blockly.utils.KeyCodes enum.
- * @param {!Array<number>=} modifiers A list of modifiers. Use Blockly.utils.KeyCodes enum.
+ * @param {number} keyCode The keycode for the event. Use Blockly.utils.KeyCodes
+ *     enum.
+ * @param {!Array<number>=} modifiers A list of modifiers. Use
+ *     Blockly.utils.KeyCodes enum.
  * @return {!KeyboardEvent} The mocked keydown event.
  */
 export function createKeyDownEvent(keyCode, modifiers) {

--- a/tests/mocha/test_helpers/workspace.js
+++ b/tests/mocha/test_helpers/workspace.js
@@ -40,10 +40,11 @@ export function testAWorkspace() {
     const block = workspace.getTopBlocks(false)[blockIndex];
     chai.assert.exists(block, 'Block at topBlocks[' + blockIndex + ']');
     const varModel = block.getVarModels()[0];
-    chai.assert.exists(varModel,
-        'VariableModel for block at topBlocks[' + blockIndex + ']');
+    chai.assert.exists(
+        varModel, 'VariableModel for block at topBlocks[' + blockIndex + ']');
     const blockVarName = varModel.name;
-    chai.assert.equal(blockVarName, name,
+    chai.assert.equal(
+        blockVarName, name,
         'VariableModel name for block at topBlocks[' + blockIndex + ']');
   }
 
@@ -95,8 +96,8 @@ export function testAWorkspace() {
 
     test('deleteVariableById(id2) one usage', function() {
       // Deleting variable one usage should not trigger confirm dialog.
-      const stub =
-          sinon.stub(Blockly.dialog.TEST_ONLY, "confirmInternal").callsArgWith(1, true);
+      const stub = sinon.stub(Blockly.dialog.TEST_ONLY, "confirmInternal")
+                       .callsArgWith(1, true);
       this.workspace.deleteVariableById('id2');
 
       sinon.assert.notCalled(stub);
@@ -108,8 +109,8 @@ export function testAWorkspace() {
 
     test('deleteVariableById(id1) multiple usages confirm', function() {
       // Deleting variable with multiple usages triggers confirm dialog.
-      const stub =
-          sinon.stub(Blockly.dialog.TEST_ONLY, "confirmInternal").callsArgWith(1, true);
+      const stub = sinon.stub(Blockly.dialog.TEST_ONLY, "confirmInternal")
+                       .callsArgWith(1, true);
       this.workspace.deleteVariableById('id1');
 
       sinon.assert.calledOnce(stub);
@@ -121,8 +122,8 @@ export function testAWorkspace() {
 
     test('deleteVariableById(id1) multiple usages cancel', function() {
       // Deleting variable with multiple usages triggers confirm dialog.
-      const stub =
-          sinon.stub(Blockly.dialog.TEST_ONLY, "confirmInternal").callsArgWith(1, false);
+      const stub = sinon.stub(Blockly.dialog.TEST_ONLY, "confirmInternal")
+                       .callsArgWith(1, false);
       this.workspace.deleteVariableById('id1');
 
       sinon.assert.calledOnce(stub);
@@ -156,15 +157,17 @@ export function testAWorkspace() {
       assertBlockVarModelName(this.workspace, 0, 'name2');
     });
 
-    test('Reference exists different capitalization rename to Name1', function() {
-      createVarBlocksNoEvents(this.workspace, ['id1']);
+    test(
+        'Reference exists different capitalization rename to Name1',
+        function() {
+          createVarBlocksNoEvents(this.workspace, ['id1']);
 
-      this.workspace.renameVariableById('id1', 'Name1');
-      assertVariableValues(this.workspace, 'Name1', 'type1', 'id1');
-      // Renaming should not have created a new variable.
-      chai.assert.equal(this.workspace.getAllVariables().length, 1);
-      assertBlockVarModelName(this.workspace, 0, 'Name1');
-    });
+          this.workspace.renameVariableById('id1', 'Name1');
+          assertVariableValues(this.workspace, 'Name1', 'type1', 'id1');
+          // Renaming should not have created a new variable.
+          chai.assert.equal(this.workspace.getAllVariables().length, 1);
+          assertBlockVarModelName(this.workspace, 0, 'Name1');
+        });
 
     suite('Two variables rename overlap', function() {
       test('Same type rename variable with id1 to name2', function() {
@@ -201,40 +204,44 @@ export function testAWorkspace() {
         assertBlockVarModelName(this.workspace, 1, 'name2');
       });
 
-      test('Same type different capitalization rename variable with id1 to Name2', function() {
-        this.workspace.createVariable('name2', 'type1', 'id2');
-        createVarBlocksNoEvents(this.workspace, ['id1', 'id2']);
+      test(
+          'Same type different capitalization rename variable with id1 to Name2',
+          function() {
+            this.workspace.createVariable('name2', 'type1', 'id2');
+            createVarBlocksNoEvents(this.workspace, ['id1', 'id2']);
 
-        this.workspace.renameVariableById('id1', 'Name2');
+            this.workspace.renameVariableById('id1', 'Name2');
 
-        // The second variable should be updated.
-        assertVariableValues(this.workspace, 'Name2', 'type1', 'id2');
-        // The first variable should have been deleted.
-        const variable = this.workspace.getVariableById('id1');
-        chai.assert.isNull(variable);
-        // There should only be one variable left.
-        chai.assert.equal(this.workspace.getAllVariables().length, 1);
+            // The second variable should be updated.
+            assertVariableValues(this.workspace, 'Name2', 'type1', 'id2');
+            // The first variable should have been deleted.
+            const variable = this.workspace.getVariableById('id1');
+            chai.assert.isNull(variable);
+            // There should only be one variable left.
+            chai.assert.equal(this.workspace.getAllVariables().length, 1);
 
-        // Both blocks should now reference variable with Name2.
-        assertBlockVarModelName(this.workspace, 0, 'Name2');
-        assertBlockVarModelName(this.workspace, 1, 'Name2');
-      });
+            // Both blocks should now reference variable with Name2.
+            assertBlockVarModelName(this.workspace, 0, 'Name2');
+            assertBlockVarModelName(this.workspace, 1, 'Name2');
+          });
 
-      test('Different type different capitalization rename variable with id1 to Name2', function() {
-        this.workspace.createVariable('name2', 'type2', 'id2');
-        createVarBlocksNoEvents(this.workspace, ['id1', 'id2']);
+      test(
+          'Different type different capitalization rename variable with id1 to Name2',
+          function() {
+            this.workspace.createVariable('name2', 'type2', 'id2');
+            createVarBlocksNoEvents(this.workspace, ['id1', 'id2']);
 
-        this.workspace.renameVariableById('id1', 'Name2');
+            this.workspace.renameVariableById('id1', 'Name2');
 
-        // Variables with different type are allowed to have the same name.
-        assertVariableValues(this.workspace, 'Name2', 'type1', 'id1');
-        // Second variable should remain unchanged.
-        assertVariableValues(this.workspace, 'name2', 'type2', 'id2');
+            // Variables with different type are allowed to have the same name.
+            assertVariableValues(this.workspace, 'Name2', 'type1', 'id1');
+            // Second variable should remain unchanged.
+            assertVariableValues(this.workspace, 'name2', 'type2', 'id2');
 
-        // Only first block should use new capitalization.
-        assertBlockVarModelName(this.workspace, 0, 'Name2');
-        assertBlockVarModelName(this.workspace, 1, 'name2');
-      });
+            // Only first block should use new capitalization.
+            assertBlockVarModelName(this.workspace, 0, 'Name2');
+            assertBlockVarModelName(this.workspace, 1, 'name2');
+          });
     });
   });
 
@@ -263,8 +270,8 @@ export function testAWorkspace() {
 
     test('Clear', function() {
       this.workspace.clear();
-      chai.assert.equal(this.workspace.getTopBlocks(true).length, 0,
-          'Clear empty workspace');
+      chai.assert.equal(
+          this.workspace.getTopBlocks(true).length, 0, 'Clear empty workspace');
       this.workspace.newBlock('');
       this.workspace.newBlock('');
       this.workspace.clear();
@@ -333,8 +340,8 @@ export function testAWorkspace() {
 
     test('Clear', function() {
       this.workspace.clear();
-      chai.assert.equal(this.workspace.getAllBlocks(true).length, 0,
-          'Clear empty workspace');
+      chai.assert.equal(
+          this.workspace.getAllBlocks(true).length, 0, 'Clear empty workspace');
       this.workspace.newBlock('');
       this.workspace.newBlock('');
       this.workspace.clear();
@@ -389,17 +396,19 @@ export function testAWorkspace() {
     });
 
     test('No instance limit', function() {
-      chai.assert.equal(this.workspace.remainingCapacityOfType('get_var_block'),
-          Infinity);
+      chai.assert.equal(
+          this.workspace.remainingCapacityOfType('get_var_block'), Infinity);
     });
 
     test('Under instance limit', function() {
       this.workspace.options.maxInstances['get_var_block'] = 3;
-      chai.assert.equal(this.workspace.remainingCapacityOfType('get_var_block'),
-          1, 'With maxInstances limit 3');
+      chai.assert.equal(
+          this.workspace.remainingCapacityOfType('get_var_block'), 1,
+          'With maxInstances limit 3');
       this.workspace.options.maxInstances['get_var_block'] = 4;
-      chai.assert.equal(this.workspace.remainingCapacityOfType('get_var_block'),
-          2, 'With maxInstances limit 4');
+      chai.assert.equal(
+          this.workspace.remainingCapacityOfType('get_var_block'), 2,
+          'With maxInstances limit 4');
     });
 
     test('Under instance limit with multiple block types', function() {
@@ -407,24 +416,27 @@ export function testAWorkspace() {
       this.workspace.newBlock('');
       this.workspace.newBlock('');
       this.workspace.options.maxInstances['get_var_block'] = 3;
-      chai.assert.equal(this.workspace.remainingCapacityOfType('get_var_block'),
-          1, 'With maxInstances limit 3');
+      chai.assert.equal(
+          this.workspace.remainingCapacityOfType('get_var_block'), 1,
+          'With maxInstances limit 3');
       this.workspace.options.maxInstances['get_var_block'] = 4;
-      chai.assert.equal(this.workspace.remainingCapacityOfType('get_var_block'),
-          2, 'With maxInstances limit 4');
+      chai.assert.equal(
+          this.workspace.remainingCapacityOfType('get_var_block'), 2,
+          'With maxInstances limit 4');
     });
 
     test('At instance limit', function() {
       this.workspace.options.maxInstances['get_var_block'] = 2;
-      chai.assert.equal(this.workspace.remainingCapacityOfType('get_var_block'),
-          0, 'With maxInstances limit 2');
+      chai.assert.equal(
+          this.workspace.remainingCapacityOfType('get_var_block'), 0,
+          'With maxInstances limit 2');
     });
 
     test('At instance limit of 0 after clear', function() {
       this.workspace.clear();
       this.workspace.options.maxInstances['get_var_block'] = 0;
-      chai.assert.equal(this.workspace.remainingCapacityOfType('get_var_block'),
-          0);
+      chai.assert.equal(
+          this.workspace.remainingCapacityOfType('get_var_block'), 0);
     });
 
     test('At instance limit with multiple block types', function() {
@@ -432,8 +444,9 @@ export function testAWorkspace() {
       this.workspace.newBlock('');
       this.workspace.newBlock('');
       this.workspace.options.maxInstances['get_var_block'] = 2;
-      chai.assert.equal(this.workspace.remainingCapacityOfType('get_var_block'),
-          0, 'With maxInstances limit 2');
+      chai.assert.equal(
+          this.workspace.remainingCapacityOfType('get_var_block'), 0,
+          'With maxInstances limit 2');
     });
 
     test('At instance limit of 0 with multiple block types', function() {
@@ -442,20 +455,22 @@ export function testAWorkspace() {
       this.workspace.newBlock('');
       this.workspace.options.maxInstances['get_var_block'] = 0;
       this.workspace.clear();
-      chai.assert.equal(this.workspace.remainingCapacityOfType('get_var_block'),
-          0);
+      chai.assert.equal(
+          this.workspace.remainingCapacityOfType('get_var_block'), 0);
     });
 
     test('Over instance limit', function() {
       this.workspace.options.maxInstances['get_var_block'] = 1;
-      chai.assert.equal(this.workspace.remainingCapacityOfType('get_var_block'),
-          -1, 'With maxInstances limit 1');
+      chai.assert.equal(
+          this.workspace.remainingCapacityOfType('get_var_block'), -1,
+          'With maxInstances limit 1');
     });
 
     test('Over instance limit of 0', function() {
       this.workspace.options.maxInstances['get_var_block'] = 0;
-      chai.assert.equal(this.workspace.remainingCapacityOfType('get_var_block'),
-          -2, 'With maxInstances limit 0');
+      chai.assert.equal(
+          this.workspace.remainingCapacityOfType('get_var_block'), -2,
+          'With maxInstances limit 0');
     });
 
     test('Over instance limit with multiple block types', function() {
@@ -463,8 +478,9 @@ export function testAWorkspace() {
       this.workspace.newBlock('');
       this.workspace.newBlock('');
       this.workspace.options.maxInstances['get_var_block'] = 1;
-      chai.assert.equal(this.workspace.remainingCapacityOfType('get_var_block'),
-          -1, 'With maxInstances limit 1');
+      chai.assert.equal(
+          this.workspace.remainingCapacityOfType('get_var_block'), -1,
+          'With maxInstances limit 1');
     });
 
     test('Over instance limit of 0 with multiple block types', function() {
@@ -472,8 +488,9 @@ export function testAWorkspace() {
       this.workspace.newBlock('');
       this.workspace.newBlock('');
       this.workspace.options.maxInstances['get_var_block'] = 0;
-      chai.assert.equal(this.workspace.remainingCapacityOfType('get_var_block'),
-          -2, 'With maxInstances limit 0');
+      chai.assert.equal(
+          this.workspace.remainingCapacityOfType('get_var_block'), -2,
+          'With maxInstances limit 0');
     });
   });
 
@@ -506,7 +523,8 @@ export function testAWorkspace() {
       this.workspace.options.maxBlocks = 1;
       this.workspace.options.maxInstances['get_var_block'] = 3;
       const typeCountsMap = {'get_var_block': 1};
-      chai.assert.isFalse(this.workspace.isCapacityAvailable(typeCountsMap),
+      chai.assert.isFalse(
+          this.workspace.isCapacityAvailable(typeCountsMap),
           'With maxBlocks limit 1 and maxInstances limit 3');
     });
 
@@ -514,7 +532,8 @@ export function testAWorkspace() {
       this.workspace.options.maxBlocks = 0;
       this.workspace.options.maxInstances['get_var_block'] = 3;
       const typeCountsMap = {'get_var_block': 1};
-      chai.assert.isFalse(this.workspace.isCapacityAvailable(typeCountsMap),
+      chai.assert.isFalse(
+          this.workspace.isCapacityAvailable(typeCountsMap),
           'With maxBlocks limit 0 and maxInstances limit 3');
     });
 
@@ -522,7 +541,8 @@ export function testAWorkspace() {
       this.workspace.options.maxBlocks = 1;
       this.workspace.options.maxInstances['get_var_block'] = 2;
       const typeCountsMap = {'get_var_block': 1};
-      chai.assert.isFalse(this.workspace.isCapacityAvailable(typeCountsMap),
+      chai.assert.isFalse(
+          this.workspace.isCapacityAvailable(typeCountsMap),
           'With maxBlocks limit 1 and maxInstances limit 2');
     });
 
@@ -530,7 +550,8 @@ export function testAWorkspace() {
       this.workspace.options.maxBlocks = 1;
       this.workspace.options.maxInstances['get_var_block'] = 1;
       const typeCountsMap = {'get_var_block': 1};
-      chai.assert.isFalse(this.workspace.isCapacityAvailable(typeCountsMap),
+      chai.assert.isFalse(
+          this.workspace.isCapacityAvailable(typeCountsMap),
           'With maxBlocks limit 1 and maxInstances limit 1');
     });
 
@@ -538,7 +559,8 @@ export function testAWorkspace() {
       this.workspace.options.maxBlocks = 0;
       this.workspace.options.maxInstances['get_var_block'] = 1;
       const typeCountsMap = {'get_var_block': 1};
-      chai.assert.isFalse(this.workspace.isCapacityAvailable(typeCountsMap),
+      chai.assert.isFalse(
+          this.workspace.isCapacityAvailable(typeCountsMap),
           'With maxBlocks limit 0 and maxInstances limit 1');
     });
 
@@ -546,7 +568,8 @@ export function testAWorkspace() {
       this.workspace.options.maxBlocks = 1;
       this.workspace.options.maxInstances['get_var_block'] = 0;
       const typeCountsMap = {'get_var_block': 1};
-      chai.assert.isFalse(this.workspace.isCapacityAvailable(typeCountsMap),
+      chai.assert.isFalse(
+          this.workspace.isCapacityAvailable(typeCountsMap),
           'With maxBlocks limit 1 and maxInstances limit 0');
     });
 
@@ -570,10 +593,12 @@ export function testAWorkspace() {
     });
 
     test('Trivial', function() {
-      chai.assert.equal(Blockly.Workspace.getById(
-          this.workspace.id), this.workspace, 'Find workspace');
-      chai.assert.equal(Blockly.Workspace.getById(
-          this.workspaceB.id), this.workspaceB, 'Find workspaceB');
+      chai.assert.equal(
+          Blockly.Workspace.getById(this.workspace.id), this.workspace,
+          'Find workspace');
+      chai.assert.equal(
+          Blockly.Workspace.getById(this.workspaceB.id), this.workspaceB,
+          'Find workspaceB');
     });
 
     test('Null id', function() {
@@ -640,17 +665,20 @@ export function testAWorkspace() {
      */
     function assertNodesEqual(actual, expected) {
       const actualString = '\n' + Blockly.Xml.domToPrettyText(actual) + '\n';
-      const expectedString = '\n' + Blockly.Xml.domToPrettyText(expected) + '\n';
+      const expectedString =
+          '\n' + Blockly.Xml.domToPrettyText(expected) + '\n';
 
       chai.assert.equal(actual.tagName, expected.tagName);
       for (let i = 0, attr; (attr = expected.attributes[i]); i++) {
-        chai.assert.equal(actual.getAttribute(attr.name), attr.value,
+        chai.assert.equal(
+            actual.getAttribute(attr.name), attr.value,
             `expected attribute ${attr.name} on ${actualString} to match ` +
-            `${expectedString}`);
+                `${expectedString}`);
       }
-      chai.assert.equal(actual.childElementCount, expected.childElementCount,
+      chai.assert.equal(
+          actual.childElementCount, expected.childElementCount,
           `expected node ${actualString} to have the same children as node ` +
-          `${expectedString}`);
+              `${expectedString}`);
       for (let i = 0; i < expected.childElementCount; i++) {
         assertNodesEqual(actual.children[i], expected.children[i]);
       }
@@ -687,7 +715,8 @@ export function testAWorkspace() {
             ],
             "previousStatement": null,
             "nextStatement": null,
-          }]);
+          }
+        ]);
       });
 
       teardown(function() {
@@ -718,63 +747,63 @@ export function testAWorkspace() {
       });
 
       test('Stack w/ child', function() {
-        testUndoDelete.call(this,
+        testUndoDelete.call(
+            this,
             '<block type="stack_block" id="1">' +
-            '  <next>' +
-            '    <block type="stack_block" id="2"></block>' +
-            '  </next>' +
-            '</block>'
-        );
+                '  <next>' +
+                '    <block type="stack_block" id="2"></block>' +
+                '  </next>' +
+                '</block>');
       });
 
       test('Row w/ child', function() {
-        testUndoDelete.call(this,
+        testUndoDelete.call(
+            this,
             '<block type="row_block" id="1">' +
-            '  <value name="INPUT">' +
-            '    <block type="row_block" id="2"></block>' +
-            '  </value>' +
-            '</block>'
-        );
+                '  <value name="INPUT">' +
+                '    <block type="row_block" id="2"></block>' +
+                '  </value>' +
+                '</block>');
       });
 
       test('Statement w/ child', function() {
-        testUndoDelete.call(this,
+        testUndoDelete.call(
+            this,
             '<block type="statement_block" id="1">' +
-            '  <statement name="STATEMENT">' +
-            '    <block type="stack_block" id="2"></block>' +
-            '  </statement>' +
-            '</block>'
-        );
+                '  <statement name="STATEMENT">' +
+                '    <block type="stack_block" id="2"></block>' +
+                '  </statement>' +
+                '</block>');
       });
 
       test('Stack w/ shadow', function() {
-        testUndoDelete.call(this,
+        testUndoDelete.call(
+            this,
             '<block type="stack_block" id="1">' +
-            '  <next>' +
-            '    <shadow type="stack_block" id="2"></shadow>' +
-            '  </next>' +
-            '</block>'
-        );
+                '  <next>' +
+                '    <shadow type="stack_block" id="2"></shadow>' +
+                '  </next>' +
+                '</block>');
       });
 
       test('Row w/ shadow', function() {
-        testUndoDelete.call(this,
+        testUndoDelete.call(
+            this,
             '<block type="row_block" id="1">' +
-            '  <value name="INPUT">' +
-            '    <shadow type="row_block" id="2"></shadow>' +
-            '  </value>' +
-            '</block>'
-        );
+                '  <value name="INPUT">' +
+                '    <shadow type="row_block" id="2"></shadow>' +
+                '  </value>' +
+                '</block>');
       });
 
       test('Statement w/ shadow', function() {
-        testUndoDelete.call(this,
+        testUndoDelete.call(
+            this,
             '<block type="statement_block" id="1">' +
-            '  <statement name="STATEMENT">' +
-            '    <shadow type="stack_block" id="2"></shadow>' +
-            '  </statement>' +
-            '</block>'
-        );
+                '  <statement name="STATEMENT">' +
+                '    <shadow type="stack_block" id="2"></shadow>' +
+                '  </statement>' +
+                '</block>');
       });
     });
 
@@ -809,7 +838,8 @@ export function testAWorkspace() {
             ],
             "previousStatement": null,
             "nextStatement": null,
-          }]);
+          }
+        ]);
       });
 
       teardown(function() {
@@ -832,8 +862,7 @@ export function testAWorkspace() {
       }
 
       test('Stack', function() {
-        const xml =
-            '<xml>' +
+        const xml = '<xml>' +
             '  <block type="stack_block" id="1"></block>' +
             '  <block type="stack_block" id="2"></block>' +
             '</xml>';
@@ -844,8 +873,7 @@ export function testAWorkspace() {
       });
 
       test('Row', function() {
-        const xml =
-            '<xml>' +
+        const xml = '<xml>' +
             '  <block type="row_block" id="1"></block>' +
             '  <block type="row_block" id="2"></block>' +
             '</xml>';
@@ -856,21 +884,19 @@ export function testAWorkspace() {
       });
 
       test('Statement', function() {
-        const xml =
-            '<xml>' +
+        const xml = '<xml>' +
             '  <block type="statement_block" id="1"></block>' +
             '  <block type="stack_block" id="2"></block>' +
             '</xml>';
 
         testUndoConnect.call(this, xml, '1', '2', (parent, child) => {
-          parent.getInput('STATEMENT').connection
-              .connect(child.previousConnection);
+          parent.getInput('STATEMENT')
+              .connection.connect(child.previousConnection);
         });
       });
 
       test('Stack w/ child', function() {
-        const xml =
-            '<xml>' +
+        const xml = '<xml>' +
             '  <block type="stack_block" id="1">' +
             '    <next>' +
             '      <block type="stack_block" id="3"></block>' +
@@ -885,8 +911,7 @@ export function testAWorkspace() {
       });
 
       test('Row w/ child', function() {
-        const xml =
-            '<xml>' +
+        const xml = '<xml>' +
             '  <block type="row_block" id="1">' +
             '    <value name="INPUT">' +
             '      <block type="row_block" id="3"></block>' +
@@ -901,8 +926,7 @@ export function testAWorkspace() {
       });
 
       test('Statement w/ child', function() {
-        const xml =
-            '<xml>' +
+        const xml = '<xml>' +
             '  <block type="statement_block" id="1">' +
             '    <statement name="STATEMENT">' +
             '      <block type="stack_block" id="3"></block>' +
@@ -912,14 +936,13 @@ export function testAWorkspace() {
             '</xml>';
 
         testUndoConnect.call(this, xml, '1', '2', (parent, child) => {
-          parent.getInput('STATEMENT').connection
-              .connect(child.previousConnection);
+          parent.getInput('STATEMENT')
+              .connection.connect(child.previousConnection);
         });
       });
 
       test('Stack w/ shadow', function() {
-        const xml =
-            '<xml>' +
+        const xml = '<xml>' +
             '  <block type="stack_block" id="1">' +
             '    <next>' +
             '      <shadow type="stack_block" id="3"></shadow>' +
@@ -934,8 +957,7 @@ export function testAWorkspace() {
       });
 
       test('Row w/ shadow', function() {
-        const xml =
-            '<xml>' +
+        const xml = '<xml>' +
             '  <block type="row_block" id="1">' +
             '    <value name="INPUT">' +
             '      <shadow type="row_block" id="3"></shadow>' +
@@ -950,8 +972,7 @@ export function testAWorkspace() {
       });
 
       test('Statement w/ shadow', function() {
-        const xml =
-            '<xml>' +
+        const xml = '<xml>' +
             '  <block type="statement_block" id="1">' +
             '    <statement name="STATEMENT">' +
             '      <shadow type="stack_block" id="3"></shadow>' +
@@ -961,8 +982,8 @@ export function testAWorkspace() {
             '</xml>';
 
         testUndoConnect.call(this, xml, '1', '2', (parent, child) => {
-          parent.getInput('STATEMENT').connection
-              .connect(child.previousConnection);
+          parent.getInput('STATEMENT')
+              .connection.connect(child.previousConnection);
         });
       });
     });
@@ -998,7 +1019,8 @@ export function testAWorkspace() {
             ],
             "previousStatement": null,
             "nextStatement": null,
-          }]);
+          }
+        ]);
       });
 
       teardown(function() {
@@ -1024,8 +1046,7 @@ export function testAWorkspace() {
       }
 
       test('Stack', function() {
-        const xml =
-            '<xml>' +
+        const xml = '<xml>' +
             '  <block type="stack_block" id="1">' +
             '    <next>' +
             '      <block type="stack_block" id="2"></block>' +
@@ -1036,8 +1057,7 @@ export function testAWorkspace() {
       });
 
       test('Row', function() {
-        const xml =
-            '<xml>' +
+        const xml = '<xml>' +
             '  <block type="row_block" id="1">' +
             '    <value name="INPUT">' +
             '      <block type="row_block" id="2"></block>' +
@@ -1048,8 +1068,7 @@ export function testAWorkspace() {
       });
 
       test('Statement', function() {
-        const xml =
-            '<xml>' +
+        const xml = '<xml>' +
             '  <block type="statement_block" id="1">' +
             '    <statement name="STATEMENT">' +
             '      <block type="stack_block" id="2"></block>' +
@@ -1060,8 +1079,7 @@ export function testAWorkspace() {
       });
 
       test('Stack w/ child', function() {
-        const xml =
-            '<xml>' +
+        const xml = '<xml>' +
             '  <block type="stack_block" id="1">' +
             '    <next>' +
             '      <block type="stack_block" id="2">' +
@@ -1076,8 +1094,7 @@ export function testAWorkspace() {
       });
 
       test('Row w/ child', function() {
-        const xml =
-            '<xml>' +
+        const xml = '<xml>' +
             '  <block type="row_block" id="1">' +
             '    <value name="INPUT">' +
             '      <block type="row_block" id="2">' +
@@ -1092,8 +1109,7 @@ export function testAWorkspace() {
       });
 
       test('Statement w/ child', function() {
-        const xml =
-            '<xml>' +
+        const xml = '<xml>' +
             '  <block type="statement_block" id="1">' +
             '    <statement name="STATEMENT">' +
             '      <block type="statement_block" id="2">' +
@@ -1110,8 +1126,7 @@ export function testAWorkspace() {
       test('Stack w/ shadow', function() {
         // TODO: For some reason on next connections shadows are
         //   serialized second.
-        const xml =
-            '<xml>' +
+        const xml = '<xml>' +
             '  <block type="stack_block" id="1">' +
             '    <next>' +
             '      <block type="stack_block" id="2"></block>' +
@@ -1120,14 +1135,14 @@ export function testAWorkspace() {
             '  </block>' +
             '</xml>';
         testUndoDisconnect.call(this, xml, '2');
-        chai.assert.equal(this.workspace.getAllBlocks().length, 2,
+        chai.assert.equal(
+            this.workspace.getAllBlocks().length, 2,
             'expected there to only be 2 blocks on the workspace ' +
-            '(check for shadows)');
+                '(check for shadows)');
       });
 
       test('Row w/ shadow', function() {
-        const xml =
-            '<xml>' +
+        const xml = '<xml>' +
             '  <block type="row_block" id="1">' +
             '    <value name="INPUT">' +
             '      <shadow type="row_block" id="3"></shadow>' +
@@ -1136,14 +1151,14 @@ export function testAWorkspace() {
             '  </block>' +
             '</xml>';
         testUndoDisconnect.call(this, xml, '2');
-        chai.assert.equal(this.workspace.getAllBlocks().length, 2,
+        chai.assert.equal(
+            this.workspace.getAllBlocks().length, 2,
             'expected there to only be 2 blocks on the workspace ' +
-            '(check for shadows)');
+                '(check for shadows)');
       });
 
       test('Statement w/ shadow', function() {
-        const xml =
-            '<xml>' +
+        const xml = '<xml>' +
             '  <block type="statement_block" id="1">' +
             '    <statement name="STATEMENT">' +
             '      <shadow type="stack_block" id="3"></shadow>' +
@@ -1301,7 +1316,8 @@ export function testAWorkspace() {
           // Check the undoStack only recorded one delete event.
           const undoStack = this.workspace.undoStack_;
           chai.assert.equal(undoStack[undoStack.length - 1].type, 'var_delete');
-          chai.assert.notEqual(undoStack[undoStack.length - 2].type, 'var_delete');
+          chai.assert.notEqual(
+              undoStack[undoStack.length - 2].type, 'var_delete');
 
           // Undo delete
           this.workspace.undo();
@@ -1329,7 +1345,8 @@ export function testAWorkspace() {
           const undoStack = this.workspace.undoStack_;
           chai.assert.equal(undoStack[undoStack.length - 1].type, 'var_delete');
           chai.assert.equal(undoStack[undoStack.length - 2].type, 'delete');
-          chai.assert.notEqual(undoStack[undoStack.length - 3].type, 'var_delete');
+          chai.assert.notEqual(
+              undoStack[undoStack.length - 3].type, 'var_delete');
 
           // Undo delete
           this.workspace.undo();
@@ -1376,151 +1393,171 @@ export function testAWorkspace() {
           assertVariableValues(this.workspace, 'name2', 'type1', 'id1');
         });
 
-        test('Reference exists different capitalization no usages rename to Name1', function() {
-          this.workspace.renameVariableById('id1', 'Name1');
+        test(
+            'Reference exists different capitalization no usages rename to Name1',
+            function() {
+              this.workspace.renameVariableById('id1', 'Name1');
 
-          this.workspace.undo();
-          assertVariableValues(this.workspace, 'name1', 'type1', 'id1');
+              this.workspace.undo();
+              assertVariableValues(this.workspace, 'name1', 'type1', 'id1');
 
-          this.workspace.undo(true);
-          assertVariableValues(this.workspace, 'Name1', 'type1', 'id1');
-        });
+              this.workspace.undo(true);
+              assertVariableValues(this.workspace, 'Name1', 'type1', 'id1');
+            });
 
-        test('Reference exists different capitalization with usages rename to Name1', function() {
-          createVarBlocksNoEvents(this.workspace, ['id1']);
-          this.workspace.renameVariableById('id1', 'Name1');
+        test(
+            'Reference exists different capitalization with usages rename to Name1',
+            function() {
+              createVarBlocksNoEvents(this.workspace, ['id1']);
+              this.workspace.renameVariableById('id1', 'Name1');
 
-          this.workspace.undo();
-          assertBlockVarModelName(this.workspace, 0, 'name1');
-          assertVariableValues(this.workspace, 'name1', 'type1', 'id1');
+              this.workspace.undo();
+              assertBlockVarModelName(this.workspace, 0, 'name1');
+              assertVariableValues(this.workspace, 'name1', 'type1', 'id1');
 
-          this.workspace.undo(true);
-          assertBlockVarModelName(this.workspace, 0, 'Name1');
-          assertVariableValues(this.workspace, 'Name1', 'type1', 'id1');
-        });
+              this.workspace.undo(true);
+              assertBlockVarModelName(this.workspace, 0, 'Name1');
+              assertVariableValues(this.workspace, 'Name1', 'type1', 'id1');
+            });
 
         suite('Two variables rename overlap', function() {
-          test('Same type no usages rename variable with id1 to name2', function() {
-            this.workspace.createVariable('name2', 'type1', 'id2');
-            this.workspace.renameVariableById('id1', 'name2');
+          test(
+              'Same type no usages rename variable with id1 to name2',
+              function() {
+                this.workspace.createVariable('name2', 'type1', 'id2');
+                this.workspace.renameVariableById('id1', 'name2');
 
-            this.workspace.undo();
-            assertVariableValues(this.workspace, 'name1', 'type1', 'id1');
-            assertVariableValues(this.workspace, 'name2', 'type1', 'id2');
+                this.workspace.undo();
+                assertVariableValues(this.workspace, 'name1', 'type1', 'id1');
+                assertVariableValues(this.workspace, 'name2', 'type1', 'id2');
 
-            this.workspace.undo(true);
-            assertVariableValues(this.workspace, 'name2', 'type1', 'id2');
-            chai.assert.isNull(this.workspace.getVariableById('id1'));
-          });
+                this.workspace.undo(true);
+                assertVariableValues(this.workspace, 'name2', 'type1', 'id2');
+                chai.assert.isNull(this.workspace.getVariableById('id1'));
+              });
 
-          test('Same type with usages rename variable with id1 to name2', function() {
-            this.workspace.createVariable('name2', 'type1', 'id2');
-            createVarBlocksNoEvents(this.workspace, ['id1', 'id2']);
-            this.workspace.renameVariableById('id1', 'name2');
+          test(
+              'Same type with usages rename variable with id1 to name2',
+              function() {
+                this.workspace.createVariable('name2', 'type1', 'id2');
+                createVarBlocksNoEvents(this.workspace, ['id1', 'id2']);
+                this.workspace.renameVariableById('id1', 'name2');
 
-            this.workspace.undo();
-            assertBlockVarModelName(this.workspace, 0, 'name1');
-            assertBlockVarModelName(this.workspace, 1, 'name2');
-            assertVariableValues(this.workspace, 'name1', 'type1', 'id1');
-            assertVariableValues(this.workspace, 'name2', 'type1', 'id2');
+                this.workspace.undo();
+                assertBlockVarModelName(this.workspace, 0, 'name1');
+                assertBlockVarModelName(this.workspace, 1, 'name2');
+                assertVariableValues(this.workspace, 'name1', 'type1', 'id1');
+                assertVariableValues(this.workspace, 'name2', 'type1', 'id2');
 
-            this.workspace.undo(true);
-            assertVariableValues(this.workspace, 'name2', 'type1', 'id2');
-            chai.assert.isNull(this.workspace.getVariableById('id1'));
-          });
+                this.workspace.undo(true);
+                assertVariableValues(this.workspace, 'name2', 'type1', 'id2');
+                chai.assert.isNull(this.workspace.getVariableById('id1'));
+              });
 
-          test('Same type different capitalization no usages rename variable with id1 to Name2', function() {
-            this.workspace.createVariable('name2', 'type1', 'id2');
-            this.workspace.renameVariableById('id1', 'Name2');
+          test(
+              'Same type different capitalization no usages rename variable with id1 to Name2',
+              function() {
+                this.workspace.createVariable('name2', 'type1', 'id2');
+                this.workspace.renameVariableById('id1', 'Name2');
 
-            this.workspace.undo();
-            assertVariableValues(this.workspace, 'name1', 'type1', 'id1');
-            assertVariableValues(this.workspace, 'name2', 'type1', 'id2');
+                this.workspace.undo();
+                assertVariableValues(this.workspace, 'name1', 'type1', 'id1');
+                assertVariableValues(this.workspace, 'name2', 'type1', 'id2');
 
-            this.workspace.undo(true);
-            assertVariableValues(this.workspace, 'Name2', 'type1', 'id2');
-            chai.assert.isNull(this.workspace.getVariable('name1'));
-          });
+                this.workspace.undo(true);
+                assertVariableValues(this.workspace, 'Name2', 'type1', 'id2');
+                chai.assert.isNull(this.workspace.getVariable('name1'));
+              });
 
-          test('Same type different capitalization with usages rename variable with id1 to Name2', function() {
-            this.workspace.createVariable('name2', 'type1', 'id2');
-            createVarBlocksNoEvents(this.workspace, ['id1', 'id2']);
-            this.workspace.renameVariableById('id1', 'Name2');
+          test(
+              'Same type different capitalization with usages rename variable with id1 to Name2',
+              function() {
+                this.workspace.createVariable('name2', 'type1', 'id2');
+                createVarBlocksNoEvents(this.workspace, ['id1', 'id2']);
+                this.workspace.renameVariableById('id1', 'Name2');
 
-            this.workspace.undo();
-            assertBlockVarModelName(this.workspace, 0, 'name1');
-            assertBlockVarModelName(this.workspace, 1, 'name2');
-            assertVariableValues(this.workspace, 'name1', 'type1', 'id1');
-            assertVariableValues(this.workspace, 'name2', 'type1', 'id2');
+                this.workspace.undo();
+                assertBlockVarModelName(this.workspace, 0, 'name1');
+                assertBlockVarModelName(this.workspace, 1, 'name2');
+                assertVariableValues(this.workspace, 'name1', 'type1', 'id1');
+                assertVariableValues(this.workspace, 'name2', 'type1', 'id2');
 
-            this.workspace.undo(true);
-            assertVariableValues(this.workspace, 'Name2', 'type1', 'id2');
-            chai.assert.isNull(this.workspace.getVariableById('id1'));
-            assertBlockVarModelName(this.workspace, 0, 'Name2');
-            assertBlockVarModelName(this.workspace, 1, 'Name2');
-          });
+                this.workspace.undo(true);
+                assertVariableValues(this.workspace, 'Name2', 'type1', 'id2');
+                chai.assert.isNull(this.workspace.getVariableById('id1'));
+                assertBlockVarModelName(this.workspace, 0, 'Name2');
+                assertBlockVarModelName(this.workspace, 1, 'Name2');
+              });
 
-          test('Different type no usages rename variable with id1 to name2', function() {
-            this.workspace.createVariable('name2', 'type2', 'id2');
-            this.workspace.renameVariableById('id1', 'name2');
+          test(
+              'Different type no usages rename variable with id1 to name2',
+              function() {
+                this.workspace.createVariable('name2', 'type2', 'id2');
+                this.workspace.renameVariableById('id1', 'name2');
 
-            this.workspace.undo();
-            assertVariableValues(this.workspace, 'name1', 'type1', 'id1');
-            assertVariableValues(this.workspace, 'name2', 'type2', 'id2');
+                this.workspace.undo();
+                assertVariableValues(this.workspace, 'name1', 'type1', 'id1');
+                assertVariableValues(this.workspace, 'name2', 'type2', 'id2');
 
-            this.workspace.undo(true);
-            assertVariableValues(this.workspace, 'name2', 'type1', 'id1');
-            assertVariableValues(this.workspace, 'name2', 'type2', 'id2');
-          });
+                this.workspace.undo(true);
+                assertVariableValues(this.workspace, 'name2', 'type1', 'id1');
+                assertVariableValues(this.workspace, 'name2', 'type2', 'id2');
+              });
 
-          test('Different type with usages rename variable with id1 to name2', function() {
-            this.workspace.createVariable('name2', 'type2', 'id2');
-            createVarBlocksNoEvents(this.workspace, ['id1', 'id2']);
-            this.workspace.renameVariableById('id1', 'name2');
+          test(
+              'Different type with usages rename variable with id1 to name2',
+              function() {
+                this.workspace.createVariable('name2', 'type2', 'id2');
+                createVarBlocksNoEvents(this.workspace, ['id1', 'id2']);
+                this.workspace.renameVariableById('id1', 'name2');
 
-            this.workspace.undo();
-            assertVariableValues(this.workspace, 'name1', 'type1', 'id1');
-            assertVariableValues(this.workspace, 'name2', 'type2', 'id2');
-            assertBlockVarModelName(this.workspace, 0, 'name1');
-            assertBlockVarModelName(this.workspace, 1, 'name2');
+                this.workspace.undo();
+                assertVariableValues(this.workspace, 'name1', 'type1', 'id1');
+                assertVariableValues(this.workspace, 'name2', 'type2', 'id2');
+                assertBlockVarModelName(this.workspace, 0, 'name1');
+                assertBlockVarModelName(this.workspace, 1, 'name2');
 
-            this.workspace.undo(true);
-            assertVariableValues(this.workspace, 'name2', 'type1', 'id1');
-            assertVariableValues(this.workspace, 'name2', 'type2', 'id2');
-            assertBlockVarModelName(this.workspace, 0, 'name2');
-            assertBlockVarModelName(this.workspace, 1, 'name2');
-          });
+                this.workspace.undo(true);
+                assertVariableValues(this.workspace, 'name2', 'type1', 'id1');
+                assertVariableValues(this.workspace, 'name2', 'type2', 'id2');
+                assertBlockVarModelName(this.workspace, 0, 'name2');
+                assertBlockVarModelName(this.workspace, 1, 'name2');
+              });
 
-          test('Different type different capitalization no usages rename variable with id1 to Name2', function() {
-            this.workspace.createVariable('name2', 'type2', 'id2');
-            this.workspace.renameVariableById('id1', 'Name2');
+          test(
+              'Different type different capitalization no usages rename variable with id1 to Name2',
+              function() {
+                this.workspace.createVariable('name2', 'type2', 'id2');
+                this.workspace.renameVariableById('id1', 'Name2');
 
-            this.workspace.undo();
-            assertVariableValues(this.workspace, 'name1', 'type1', 'id1');
-            assertVariableValues(this.workspace, 'name2', 'type2', 'id2');
+                this.workspace.undo();
+                assertVariableValues(this.workspace, 'name1', 'type1', 'id1');
+                assertVariableValues(this.workspace, 'name2', 'type2', 'id2');
 
-            this.workspace.undo(true);
-            assertVariableValues(this.workspace, 'Name2', 'type1', 'id1');
-            assertVariableValues(this.workspace, 'name2', 'type2', 'id2');
-          });
+                this.workspace.undo(true);
+                assertVariableValues(this.workspace, 'Name2', 'type1', 'id1');
+                assertVariableValues(this.workspace, 'name2', 'type2', 'id2');
+              });
 
-          test('Different type different capitalization with usages rename variable with id1 to Name2', function() {
-            this.workspace.createVariable('name2', 'type2', 'id2');
-            createVarBlocksNoEvents(this.workspace, ['id1', 'id2']);
-            this.workspace.renameVariableById('id1', 'Name2');
+          test(
+              'Different type different capitalization with usages rename variable with id1 to Name2',
+              function() {
+                this.workspace.createVariable('name2', 'type2', 'id2');
+                createVarBlocksNoEvents(this.workspace, ['id1', 'id2']);
+                this.workspace.renameVariableById('id1', 'Name2');
 
-            this.workspace.undo();
-            assertVariableValues(this.workspace, 'name1', 'type1', 'id1');
-            assertVariableValues(this.workspace, 'name2', 'type2', 'id2');
-            assertBlockVarModelName(this.workspace, 0, 'name1');
-            assertBlockVarModelName(this.workspace, 1, 'name2');
+                this.workspace.undo();
+                assertVariableValues(this.workspace, 'name1', 'type1', 'id1');
+                assertVariableValues(this.workspace, 'name2', 'type2', 'id2');
+                assertBlockVarModelName(this.workspace, 0, 'name1');
+                assertBlockVarModelName(this.workspace, 1, 'name2');
 
-            this.workspace.undo(true);
-            assertVariableValues(this.workspace, 'Name2', 'type1', 'id1');
-            assertVariableValues(this.workspace, 'name2', 'type2', 'id2');
-            assertBlockVarModelName(this.workspace, 0, 'Name2');
-            assertBlockVarModelName(this.workspace, 1, 'name2');
-          });
+                this.workspace.undo(true);
+                assertVariableValues(this.workspace, 'Name2', 'type1', 'id1');
+                assertVariableValues(this.workspace, 'name2', 'type2', 'id2');
+                assertBlockVarModelName(this.workspace, 0, 'Name2');
+                assertBlockVarModelName(this.workspace, 1, 'name2');
+              });
         });
       });
     });

--- a/tests/mocha/test_helpers/workspace.js
+++ b/tests/mocha/test_helpers/workspace.js
@@ -715,7 +715,7 @@ export function testAWorkspace() {
             ],
             "previousStatement": null,
             "nextStatement": null,
-          }
+          },
         ]);
       });
 
@@ -838,7 +838,7 @@ export function testAWorkspace() {
             ],
             "previousStatement": null,
             "nextStatement": null,
-          }
+          },
         ]);
       });
 
@@ -1019,7 +1019,7 @@ export function testAWorkspace() {
             ],
             "previousStatement": null,
             "nextStatement": null,
-          }
+          },
         ]);
       });
 

--- a/tests/mocha/theme_test.js
+++ b/tests/mocha/theme_test.js
@@ -39,7 +39,7 @@ suite('Theme', function() {
           },
         ],
         "output": null,
-      }
+      },
     ]);
   }
 

--- a/tests/mocha/theme_test.js
+++ b/tests/mocha/theme_test.js
@@ -22,23 +22,25 @@ suite('Theme', function() {
   });
 
   function defineThemeTestBlocks() {
-    Blockly.defineBlocksWithJsonArray([{
-      "type": "stack_block",
-      "message0": "",
-      "previousStatement": null,
-      "nextStatement": null,
-    },
-    {
-      "type": "row_block",
-      "message0": "%1",
-      "args0": [
-        {
-          "type": "input_value",
-          "name": "INPUT",
-        },
-      ],
-      "output": null,
-    }]);
+    Blockly.defineBlocksWithJsonArray([
+      {
+        "type": "stack_block",
+        "message0": "",
+        "previousStatement": null,
+        "nextStatement": null,
+      },
+      {
+        "type": "row_block",
+        "message0": "%1",
+        "args0": [
+          {
+            "type": "input_value",
+            "name": "INPUT",
+          },
+        ],
+        "output": null,
+      }
+    ]);
   }
 
   function createBlockStyles() {
@@ -126,7 +128,9 @@ suite('Theme', function() {
       workspace = new Blockly.WorkspaceSvg(new Blockly.Options({}));
       const blockA = workspace.newBlock('stack_block');
 
-      blockA.setStyle = function() {this.styleName_ = 'styleTwo';};
+      blockA.setStyle = function() {
+        this.styleName_ = 'styleTwo';
+      };
       const refreshToolboxSelectionStub =
           sinon.stub(workspace, 'refreshToolboxSelection');
       blockA.styleName_ = 'styleOne';
@@ -144,7 +148,8 @@ suite('Theme', function() {
 
       assertEventFired(
           this.eventsFireStub, Blockly.Events.ThemeChange,
-          {themeName: 'themeName', type: eventUtils.THEME_CHANGE}, workspace.id);
+          {themeName: 'themeName', type: eventUtils.THEME_CHANGE},
+          workspace.id);
     } finally {
       workspaceTeardown.call(this, workspace);
     }

--- a/tests/mocha/toolbox_test.js
+++ b/tests/mocha/toolbox_test.js
@@ -84,7 +84,7 @@ suite('Toolbox', function() {
             'contents': [
               {'kind': 'category', 'contents': []},
               {'kind': 'category', 'contents': []},
-            ]
+            ],
           });
           chai.assert.lengthOf(this.toolbox.contents_, 2);
           sinon.assert.called(positionStub);
@@ -144,7 +144,7 @@ suite('Toolbox', function() {
                   },
                 ],
               },
-            ]
+            ],
           };
           this.toolbox.render(jsonDef);
           chai.assert.lengthOf(this.toolbox.contents_, 1);
@@ -165,7 +165,7 @@ suite('Toolbox', function() {
               },
             ],
           },
-        ]
+        ],
       };
       chai.assert.doesNotThrow(() => {
         this.toolbox.render(jsonDef);

--- a/tests/mocha/toolbox_test.js
+++ b/tests/mocha/toolbox_test.js
@@ -33,21 +33,27 @@ suite('Toolbox', function() {
       chai.assert.isDefined(this.toolbox.HtmlDiv);
     });
     test('Init called -> HtmlDiv is inserted before parent node', function() {
-      const toolboxDiv = Blockly.common.getMainWorkspace().getInjectionDiv().childNodes[0];
-      chai.assert.equal(toolboxDiv.className,
-          'blocklyToolboxDiv blocklyNonSelectable');
+      const toolboxDiv =
+          Blockly.common.getMainWorkspace().getInjectionDiv().childNodes[0];
+      chai.assert.equal(
+          toolboxDiv.className, 'blocklyToolboxDiv blocklyNonSelectable');
     });
-    test('Init called -> Toolbox is subscribed to background and foreground colour', function() {
-      const themeManager = this.toolbox.workspace_.getThemeManager();
-      const themeManagerSpy = sinon.spy(themeManager, 'subscribe');
-      const componentManager = this.toolbox.workspace_.getComponentManager();
-      sinon.stub(componentManager, 'addComponent');
-      this.toolbox.init();
-      sinon.assert.calledWith(themeManagerSpy, this.toolbox.HtmlDiv,
-          'toolboxBackgroundColour', 'background-color');
-      sinon.assert.calledWith(themeManagerSpy, this.toolbox.HtmlDiv,
-          'toolboxForegroundColour', 'color');
-    });
+    test(
+        'Init called -> Toolbox is subscribed to background and foreground colour',
+        function() {
+          const themeManager = this.toolbox.workspace_.getThemeManager();
+          const themeManagerSpy = sinon.spy(themeManager, 'subscribe');
+          const componentManager =
+              this.toolbox.workspace_.getComponentManager();
+          sinon.stub(componentManager, 'addComponent');
+          this.toolbox.init();
+          sinon.assert.calledWith(
+              themeManagerSpy, this.toolbox.HtmlDiv, 'toolboxBackgroundColour',
+              'background-color');
+          sinon.assert.calledWith(
+              themeManagerSpy, this.toolbox.HtmlDiv, 'toolboxForegroundColour',
+              'color');
+        });
     test('Init called -> Render is called', function() {
       const renderSpy = sinon.spy(this.toolbox, 'render');
       const componentManager = this.toolbox.workspace_.getComponentManager();
@@ -70,81 +76,97 @@ suite('Toolbox', function() {
     teardown(function() {
       this.toolbox.dispose();
     });
-    test('Render called with valid toolboxDef -> Contents are created', function() {
-      const positionStub = sinon.stub(this.toolbox, 'position');
-      this.toolbox.render({'contents': [
-        {'kind': 'category', 'contents': []},
-        {'kind': 'category', 'contents': []},
-      ]});
-      chai.assert.lengthOf(this.toolbox.contents_, 2);
-      sinon.assert.called(positionStub);
-    });
+    test(
+        'Render called with valid toolboxDef -> Contents are created',
+        function() {
+          const positionStub = sinon.stub(this.toolbox, 'position');
+          this.toolbox.render({
+            'contents': [
+              {'kind': 'category', 'contents': []},
+              {'kind': 'category', 'contents': []},
+            ]
+          });
+          chai.assert.lengthOf(this.toolbox.contents_, 2);
+          sinon.assert.called(positionStub);
+        });
     // TODO: Uncomment once implemented.
-    test.skip('Toolbox definition with both blocks and categories -> Should throw an error', function() {
-      const toolbox = this.toolbox;
-      const badToolboxDef = [
-        {
-          "kind": "block",
-        },
-        {
-          "kind": "category",
-        },
-      ];
-      chai.assert.throws(function() {
-        toolbox.render({'contents': badToolboxDef});
-      }, 'Toolbox cannot have both blocks and categories in the root level.');
-    });
-    // TODO: Uncomment once implemented.
-    test.skip('Expanded set to true for a non collapsible toolbox item -> Should open flyout', function() {
-      this.toolbox.render(this.toolboxXml);
-      const selectedNode = this.toolbox.tree_.children_[0];
-      chai.assert.isTrue(selectedNode.selected_);
-    });
-    test('JSON toolbox definition -> Should create toolbox with contents', function() {
-      const jsonDef = {'contents': [
-        {
-          "kind": "category",
-          "contents": [
+    test.skip(
+        'Toolbox definition with both blocks and categories -> Should throw an error',
+        function() {
+          const toolbox = this.toolbox;
+          const badToolboxDef = [
             {
               "kind": "block",
-              "blockxml": '<block xmlns="http://www.w3.org/1999/xhtml" type="basic_block"><field name="TEXT">FirstCategory-FirstBlock</field></block>',
             },
             {
-              "kind": "label",
-              "text": "Input/Output:",
-              "web-class": "ioLabel",
+              "kind": "category",
             },
-            {
-              "kind": "button",
-              "text": "insert",
-              "callbackkey": "insertConnectionStacks",
-              "web-class": "ioLabel",
-            },
-            {
-              "kind": "sep",
-              "gap": "7",
-            },
-          ],
-        },
-      ]};
-      this.toolbox.render(jsonDef);
-      chai.assert.lengthOf(this.toolbox.contents_, 1);
-    });
+          ];
+          chai.assert.throws(function() {
+            toolbox.render({'contents': badToolboxDef});
+          }, 'Toolbox cannot have both blocks and categories in the root level.');
+        });
+    // TODO: Uncomment once implemented.
+    test.skip(
+        'Expanded set to true for a non collapsible toolbox item -> Should open flyout',
+        function() {
+          this.toolbox.render(this.toolboxXml);
+          const selectedNode = this.toolbox.tree_.children_[0];
+          chai.assert.isTrue(selectedNode.selected_);
+        });
+    test(
+        'JSON toolbox definition -> Should create toolbox with contents',
+        function() {
+          const jsonDef = {
+            'contents': [
+              {
+                "kind": "category",
+                "contents": [
+                  {
+                    "kind": "block",
+                    "blockxml":
+                        '<block xmlns="http://www.w3.org/1999/xhtml" type="basic_block"><field name="TEXT">FirstCategory-FirstBlock</field></block>',
+                  },
+                  {
+                    "kind": "label",
+                    "text": "Input/Output:",
+                    "web-class": "ioLabel",
+                  },
+                  {
+                    "kind": "button",
+                    "text": "insert",
+                    "callbackkey": "insertConnectionStacks",
+                    "web-class": "ioLabel",
+                  },
+                  {
+                    "kind": "sep",
+                    "gap": "7",
+                  },
+                ],
+              },
+            ]
+          };
+          this.toolbox.render(jsonDef);
+          chai.assert.lengthOf(this.toolbox.contents_, 1);
+        });
     test('multiple icon classes can be applied', function() {
-      const jsonDef = {'contents': [
-        {
-          "kind": "category",
-          "cssConfig": {
-            "icon": "customIcon customIconEvents",
-          },
-          "contents": [
-            {
-              "kind": "block",
-              "blockxml": '<block xmlns="http://www.w3.org/1999/xhtml" type="basic_block"><field name="TEXT">FirstCategory-FirstBlock</field></block>',
+      const jsonDef = {
+        'contents': [
+          {
+            "kind": "category",
+            "cssConfig": {
+              "icon": "customIcon customIconEvents",
             },
-          ],
-        },
-      ]};
+            "contents": [
+              {
+                "kind": "block",
+                "blockxml":
+                    '<block xmlns="http://www.w3.org/1999/xhtml" type="basic_block"><field name="TEXT">FirstCategory-FirstBlock</field></block>',
+              },
+            ],
+          },
+        ]
+      };
       chai.assert.doesNotThrow(() => {
         this.toolbox.render(jsonDef);
       });
@@ -161,8 +183,8 @@ suite('Toolbox', function() {
     });
 
     test('Toolbox clicked -> Should close flyout', function() {
-      const hideChaffStub = sinon.stub(
-        Blockly.WorkspaceSvg.prototype, "hideChaff");
+      const hideChaffStub =
+          sinon.stub(Blockly.WorkspaceSvg.prototype, "hideChaff");
       const evt = new PointerEvent('pointerdown', {});
       this.toolbox.HtmlDiv.dispatchEvent(evt);
       sinon.assert.calledOnce(hideChaffStub);
@@ -210,30 +232,36 @@ suite('Toolbox', function() {
       testCorrectFunctionCalled(this.toolbox, 'ArrowDown', 'selectNext_', true);
     });
     test('Up button is pushed -> Should call selectPrevious_', function() {
-      testCorrectFunctionCalled(this.toolbox, 'ArrowUp', 'selectPrevious_', true);
+      testCorrectFunctionCalled(
+          this.toolbox, 'ArrowUp', 'selectPrevious_', true);
     });
     test('Left button is pushed -> Should call selectParent_', function() {
-      testCorrectFunctionCalled(this.toolbox, 'ArrowLeft', 'selectParent_', true);
+      testCorrectFunctionCalled(
+          this.toolbox, 'ArrowLeft', 'selectParent_', true);
     });
     test('Right button is pushed -> Should call selectChild_', function() {
-      testCorrectFunctionCalled(this.toolbox, 'ArrowRight', 'selectChild_', true);
+      testCorrectFunctionCalled(
+          this.toolbox, 'ArrowRight', 'selectChild_', true);
     });
     test('Enter button is pushed -> Should toggle expanded', function() {
       this.toolbox.selectedItem_ = getCollapsibleItem(this.toolbox);
-      const toggleExpandedStub = sinon.stub(this.toolbox.selectedItem_, 'toggleExpanded');
+      const toggleExpandedStub =
+          sinon.stub(this.toolbox.selectedItem_, 'toggleExpanded');
       const event = createKeyDownMock('Enter');
       const preventDefaultEvent = sinon.stub(event, 'preventDefault');
       this.toolbox.onKeyDown_(event);
       sinon.assert.called(toggleExpandedStub);
       sinon.assert.called(preventDefaultEvent);
     });
-    test('Enter button is pushed when no item is selected -> Should not call prevent default', function() {
-      this.toolbox.selectedItem_ = null;
-      const event = createKeyDownMock('Enter');
-      const preventDefaultEvent = sinon.stub(event, 'preventDefault');
-      this.toolbox.onKeyDown_(event);
-      sinon.assert.notCalled(preventDefaultEvent);
-    });
+    test(
+        'Enter button is pushed when no item is selected -> Should not call prevent default',
+        function() {
+          this.toolbox.selectedItem_ = null;
+          const event = createKeyDownMock('Enter');
+          const preventDefaultEvent = sinon.stub(event, 'preventDefault');
+          this.toolbox.onKeyDown_(event);
+          sinon.assert.notCalled(preventDefaultEvent);
+        });
   });
 
   suite('Select Methods', function() {
@@ -250,11 +278,13 @@ suite('Toolbox', function() {
         const handled = this.toolbox.selectChild_();
         chai.assert.isFalse(handled);
       });
-      test('Selected item is not collapsible -> Should not handle event', function() {
-        this.toolbox.selectedItem_ = getNonCollapsibleItem(this.toolbox);
-        const handled = this.toolbox.selectChild_();
-        chai.assert.isFalse(handled);
-      });
+      test(
+          'Selected item is not collapsible -> Should not handle event',
+          function() {
+            this.toolbox.selectedItem_ = getNonCollapsibleItem(this.toolbox);
+            const handled = this.toolbox.selectChild_();
+            chai.assert.isFalse(handled);
+          });
       test('Selected item is collapsible -> Should expand', function() {
         const collapsibleItem = getCollapsibleItem(this.toolbox);
         this.toolbox.selectedItem_ = collapsibleItem;
@@ -310,7 +340,8 @@ suite('Toolbox', function() {
         this.toolbox.selectedItem_ = item;
         const handled = this.toolbox.selectNext_();
         chai.assert.isTrue(handled);
-        chai.assert.equal(this.toolbox.selectedItem_, this.toolbox.contents_[1]);
+        chai.assert.equal(
+            this.toolbox.selectedItem_, this.toolbox.contents_[1]);
       });
       test('Selected item is last item -> Should not handle event', function() {
         const item = this.toolbox.contents_[this.toolbox.contents_.length - 1];
@@ -319,15 +350,17 @@ suite('Toolbox', function() {
         chai.assert.isFalse(handled);
         chai.assert.equal(this.toolbox.selectedItem_, item);
       });
-      test('Selected item is collapsed -> Should skip over its children', function() {
-        const item = getCollapsibleItem(this.toolbox);
-        const childItem = item.flyoutItems_[0];
-        item.expanded_ = false;
-        this.toolbox.selectedItem_ = item;
-        const handled = this.toolbox.selectNext_();
-        chai.assert.isTrue(handled);
-        chai.assert.notEqual(this.toolbox.selectedItem_, childItem);
-      });
+      test(
+          'Selected item is collapsed -> Should skip over its children',
+          function() {
+            const item = getCollapsibleItem(this.toolbox);
+            const childItem = item.flyoutItems_[0];
+            item.expanded_ = false;
+            this.toolbox.selectedItem_ = item;
+            const handled = this.toolbox.selectNext_();
+            chai.assert.isTrue(handled);
+            chai.assert.notEqual(this.toolbox.selectedItem_, childItem);
+          });
     });
 
     suite('selectPrevious', function() {
@@ -336,32 +369,37 @@ suite('Toolbox', function() {
         const handled = this.toolbox.selectPrevious_();
         chai.assert.isFalse(handled);
       });
-      test('Selected item is first item -> Should not handle event', function() {
-        const item = this.toolbox.contents_[0];
-        this.toolbox.selectedItem_ = item;
-        const handled = this.toolbox.selectPrevious_();
-        chai.assert.isFalse(handled);
-        chai.assert.equal(this.toolbox.selectedItem_, item);
-      });
-      test('Previous item is selectable -> Should select previous item', function() {
-        const item = this.toolbox.contents_[1];
-        const prevItem = this.toolbox.contents_[0];
-        this.toolbox.selectedItem_ = item;
-        const handled = this.toolbox.selectPrevious_();
-        chai.assert.isTrue(handled);
-        chai.assert.equal(this.toolbox.selectedItem_, prevItem);
-      });
-      test('Previous item is collapsed -> Should skip over children of the previous item', function() {
-        const childItem = getChildItem(this.toolbox);
-        const parentItem = childItem.getParent();
-        const parentIdx = this.toolbox.contents_.indexOf(parentItem);
-        // Gets the item after the parent.
-        const item = this.toolbox.contents_[parentIdx + 1];
-        this.toolbox.selectedItem_ = item;
-        const handled = this.toolbox.selectPrevious_();
-        chai.assert.isTrue(handled);
-        chai.assert.notEqual(this.toolbox.selectedItem_, childItem);
-      });
+      test(
+          'Selected item is first item -> Should not handle event', function() {
+            const item = this.toolbox.contents_[0];
+            this.toolbox.selectedItem_ = item;
+            const handled = this.toolbox.selectPrevious_();
+            chai.assert.isFalse(handled);
+            chai.assert.equal(this.toolbox.selectedItem_, item);
+          });
+      test(
+          'Previous item is selectable -> Should select previous item',
+          function() {
+            const item = this.toolbox.contents_[1];
+            const prevItem = this.toolbox.contents_[0];
+            this.toolbox.selectedItem_ = item;
+            const handled = this.toolbox.selectPrevious_();
+            chai.assert.isTrue(handled);
+            chai.assert.equal(this.toolbox.selectedItem_, prevItem);
+          });
+      test(
+          'Previous item is collapsed -> Should skip over children of the previous item',
+          function() {
+            const childItem = getChildItem(this.toolbox);
+            const parentItem = childItem.getParent();
+            const parentIdx = this.toolbox.contents_.indexOf(parentItem);
+            // Gets the item after the parent.
+            const item = this.toolbox.contents_[parentIdx + 1];
+            this.toolbox.selectedItem_ = item;
+            const handled = this.toolbox.selectPrevious_();
+            chai.assert.isTrue(handled);
+            chai.assert.notEqual(this.toolbox.selectedItem_, childItem);
+          });
     });
   });
 
@@ -380,18 +418,22 @@ suite('Toolbox', function() {
       return newItemStub;
     }
 
-    test('Selected item and new item are null -> Should not update the flyout', function() {
-      this.selectedItem_ = null;
-      this.toolbox.setSelectedItem(null);
-      const updateFlyoutStub = sinon.stub(this.toolbox, 'updateFlyout_');
-      sinon.assert.notCalled(updateFlyoutStub);
-    });
-    test('New item is not selectable -> Should not update the flyout', function() {
-      const separator = getSeparator(this.toolbox);
-      this.toolbox.setSelectedItem(separator);
-      const updateFlyoutStub = sinon.stub(this.toolbox, 'updateFlyout_');
-      sinon.assert.notCalled(updateFlyoutStub);
-    });
+    test(
+        'Selected item and new item are null -> Should not update the flyout',
+        function() {
+          this.selectedItem_ = null;
+          this.toolbox.setSelectedItem(null);
+          const updateFlyoutStub = sinon.stub(this.toolbox, 'updateFlyout_');
+          sinon.assert.notCalled(updateFlyoutStub);
+        });
+    test(
+        'New item is not selectable -> Should not update the flyout',
+        function() {
+          const separator = getSeparator(this.toolbox);
+          this.toolbox.setSelectedItem(separator);
+          const updateFlyoutStub = sinon.stub(this.toolbox, 'updateFlyout_');
+          sinon.assert.notCalled(updateFlyoutStub);
+        });
     test('Select an item with no children -> Should select item', function() {
       const oldItem = getCollapsibleItem(this.toolbox);
       const oldItemStub = sinon.stub(oldItem, 'setSelected');
@@ -400,21 +442,25 @@ suite('Toolbox', function() {
       sinon.assert.calledWith(oldItemStub, false);
       sinon.assert.calledWith(newItemStub, true);
     });
-    test('Select previously selected item with no children -> Should deselect', function() {
-      const newItem = getNonCollapsibleItem(this.toolbox);
-      const newItemStub = setupSetSelected(this.toolbox, newItem, newItem);
-      sinon.assert.calledWith(newItemStub, false);
-    });
+    test(
+        'Select previously selected item with no children -> Should deselect',
+        function() {
+          const newItem = getNonCollapsibleItem(this.toolbox);
+          const newItemStub = setupSetSelected(this.toolbox, newItem, newItem);
+          sinon.assert.calledWith(newItemStub, false);
+        });
     test('Select collapsible item -> Should select item', function() {
       const newItem = getCollapsibleItem(this.toolbox);
       const newItemStub = setupSetSelected(this.toolbox, null, newItem);
       sinon.assert.calledWith(newItemStub, true);
     });
-    test('Select previously selected collapsible item -> Should not deselect', function() {
-      const newItem = getCollapsibleItem(this.toolbox);
-      const newItemStub = setupSetSelected(this.toolbox, newItem, newItem);
-      sinon.assert.notCalled(newItemStub);
-    });
+    test(
+        'Select previously selected collapsible item -> Should not deselect',
+        function() {
+          const newItem = getCollapsibleItem(this.toolbox);
+          const newItemStub = setupSetSelected(this.toolbox, newItem, newItem);
+          sinon.assert.notCalled(newItemStub);
+        });
   });
 
   suite('updateFlyout_', function() {
@@ -448,7 +494,8 @@ suite('Toolbox', function() {
     });
     test('Select selectable item -> Should open flyout', function() {
       const showFlyoutstub = sinon.stub(this.toolbox.flyout_, 'show');
-      const scrollToStartFlyout = sinon.stub(this.toolbox.flyout_, 'scrollToStart');
+      const scrollToStartFlyout =
+          sinon.stub(this.toolbox.flyout_, 'scrollToStart');
       const newItem = getNonCollapsibleItem(this.toolbox);
       this.toolbox.updateFlyout_(null, newItem);
       sinon.assert.called(showFlyoutstub);
@@ -464,14 +511,17 @@ suite('Toolbox', function() {
     });
 
     function checkHorizontalToolbox(toolbox) {
-      chai.assert.equal(toolbox.HtmlDiv.style.left, '0px', 'Check left position');
+      chai.assert.equal(
+          toolbox.HtmlDiv.style.left, '0px', 'Check left position');
       chai.assert.equal(toolbox.HtmlDiv.style.height, 'auto', 'Check height');
       chai.assert.equal(toolbox.HtmlDiv.style.width, '100%', 'Check width');
-      chai.assert.equal(toolbox.height_, toolbox.HtmlDiv.offsetHeight, 'Check height');
+      chai.assert.equal(
+          toolbox.height_, toolbox.HtmlDiv.offsetHeight, 'Check height');
     }
     function checkVerticalToolbox(toolbox) {
       chai.assert.equal(toolbox.HtmlDiv.style.height, '100%', 'Check height');
-      chai.assert.equal(toolbox.width_, toolbox.HtmlDiv.offsetWidth, 'Check width');
+      chai.assert.equal(
+          toolbox.width_, toolbox.HtmlDiv.offsetWidth, 'Check width');
     }
     test('HtmlDiv is not created -> Should not resize', function() {
       const toolbox = this.toolbox;
@@ -480,22 +530,27 @@ suite('Toolbox', function() {
       toolbox.position();
       chai.assert.equal(toolbox.height_, 0);
     });
-    test('Horizontal toolbox at top -> Should anchor horizontal toolbox to top', function() {
-      const toolbox = this.toolbox;
-      toolbox.toolboxPosition = Blockly.utils.toolbox.Position.TOP;
-      toolbox.horizontalLayout_ = true;
-      toolbox.position();
-      checkHorizontalToolbox(toolbox);
-      chai.assert.equal(toolbox.HtmlDiv.style.top, '0px', 'Check top');
-    });
-    test('Horizontal toolbox at bottom -> Should anchor horizontal toolbox to bottom', function() {
-      const toolbox = this.toolbox;
-      toolbox.toolboxPosition = Blockly.utils.toolbox.Position.BOTTOM;
-      toolbox.horizontalLayout_ = true;
-      toolbox.position();
-      checkHorizontalToolbox(toolbox);
-      chai.assert.equal(toolbox.HtmlDiv.style.bottom, '0px', 'Check bottom');
-    });
+    test(
+        'Horizontal toolbox at top -> Should anchor horizontal toolbox to top',
+        function() {
+          const toolbox = this.toolbox;
+          toolbox.toolboxPosition = Blockly.utils.toolbox.Position.TOP;
+          toolbox.horizontalLayout_ = true;
+          toolbox.position();
+          checkHorizontalToolbox(toolbox);
+          chai.assert.equal(toolbox.HtmlDiv.style.top, '0px', 'Check top');
+        });
+    test(
+        'Horizontal toolbox at bottom -> Should anchor horizontal toolbox to bottom',
+        function() {
+          const toolbox = this.toolbox;
+          toolbox.toolboxPosition = Blockly.utils.toolbox.Position.BOTTOM;
+          toolbox.horizontalLayout_ = true;
+          toolbox.position();
+          checkHorizontalToolbox(toolbox);
+          chai.assert.equal(
+              toolbox.HtmlDiv.style.bottom, '0px', 'Check bottom');
+        });
     test('Vertical toolbox at right -> Should anchor to right', function() {
       const toolbox = this.toolbox;
       toolbox.toolboxPosition = Blockly.utils.toolbox.Position.RIGHT;
@@ -523,13 +578,16 @@ suite('Toolbox', function() {
     function checkValue(actual, expected, value) {
       const actualVal = actual[value];
       const expectedVal = expected[value];
-      chai.assert.equal(actualVal.toUpperCase(), expectedVal.toUpperCase(), 'Checking value for: ' + value);
+      chai.assert.equal(
+          actualVal.toUpperCase(), expectedVal.toUpperCase(),
+          'Checking value for: ' + value);
     }
     function checkContents(actualContents, expectedContents) {
       chai.assert.equal(actualContents.length, expectedContents.length);
       for (let i = 0; i < actualContents.length; i++) {
         // TODO: Check the values as well as all the keys.
-        chai.assert.containsAllKeys(actualContents[i], Object.keys(expectedContents[i]));
+        chai.assert.containsAllKeys(
+            actualContents[i], Object.keys(expectedContents[i]));
       }
     }
     function checkCategory(actual, expected) {
@@ -552,24 +610,28 @@ suite('Toolbox', function() {
 
     suite('parseToolbox', function() {
       test('Category Toolbox: JSON', function() {
-        const toolboxDef = Blockly.utils.toolbox.convertToolboxDefToJson(this.categoryToolboxJSON);
+        const toolboxDef = Blockly.utils.toolbox.convertToolboxDefToJson(
+            this.categoryToolboxJSON);
         chai.assert.isNotNull(toolboxDef);
         checkCategoryToolbox(toolboxDef, this.categoryToolboxJSON);
       });
       test('Simple Toolbox: JSON', function() {
-        const toolboxDef = Blockly.utils.toolbox.convertToolboxDefToJson(this.simpleToolboxJSON);
+        const toolboxDef = Blockly.utils.toolbox.convertToolboxDefToJson(
+            this.simpleToolboxJSON);
         chai.assert.isNotNull(toolboxDef);
         checkSimpleToolbox(toolboxDef, this.simpleToolboxJSON);
       });
       test('Category Toolbox: xml', function() {
         const toolboxXml = document.getElementById('toolbox-categories');
-        const toolboxDef = Blockly.utils.toolbox.convertToolboxDefToJson(toolboxXml);
+        const toolboxDef =
+            Blockly.utils.toolbox.convertToolboxDefToJson(toolboxXml);
         chai.assert.isNotNull(toolboxDef);
         checkCategoryToolbox(toolboxDef, this.categoryToolboxJSON);
       });
       test('Simple Toolbox: xml', function() {
         const toolboxXml = document.getElementById('toolbox-simple');
-        const toolboxDef = Blockly.utils.toolbox.convertToolboxDefToJson(toolboxXml);
+        const toolboxDef =
+            Blockly.utils.toolbox.convertToolboxDefToJson(toolboxXml);
         chai.assert.isNotNull(toolboxDef);
         checkSimpleToolbox(toolboxDef, this.simpleToolboxJSON);
       });
@@ -592,7 +654,8 @@ suite('Toolbox', function() {
           ],
         };
 
-        const toolboxDef = Blockly.utils.toolbox.convertToolboxDefToJson(toolbox);
+        const toolboxDef =
+            Blockly.utils.toolbox.convertToolboxDefToJson(toolbox);
         chai.assert.isNotNull(toolboxDef);
         checkSimpleToolbox(toolboxDef, toolboxJson);
       });
@@ -615,7 +678,8 @@ suite('Toolbox', function() {
           ],
         };
 
-        const toolboxDef = Blockly.utils.toolbox.convertToolboxDefToJson(toolbox);
+        const toolboxDef =
+            Blockly.utils.toolbox.convertToolboxDefToJson(toolbox);
         chai.assert.isNotNull(toolboxDef);
         checkSimpleToolbox(toolboxDef, toolboxJson);
       });
@@ -623,21 +687,25 @@ suite('Toolbox', function() {
     suite('parseFlyout', function() {
       test('Array of Nodes', function() {
         const xmlList = getXmlArray();
-        const flyoutDef = Blockly.utils.toolbox.convertFlyoutDefToJsonArray(xmlList);
+        const flyoutDef =
+            Blockly.utils.toolbox.convertFlyoutDefToJsonArray(xmlList);
         checkContents(flyoutDef, this.simpleToolboxJSON['contents']);
       });
       test('NodeList', function() {
         const nodeList = document.getElementById('toolbox-simple').childNodes;
-        const flyoutDef = Blockly.utils.toolbox.convertFlyoutDefToJsonArray(nodeList);
+        const flyoutDef =
+            Blockly.utils.toolbox.convertFlyoutDefToJsonArray(nodeList);
         checkContents(flyoutDef, this.simpleToolboxJSON['contents']);
       });
       test('List of json', function() {
         const jsonList = this.simpleToolboxJSON['contents'];
-        const flyoutDef = Blockly.utils.toolbox.convertFlyoutDefToJsonArray(jsonList);
+        const flyoutDef =
+            Blockly.utils.toolbox.convertFlyoutDefToJsonArray(jsonList);
         checkContents(flyoutDef, this.simpleToolboxJSON['contents']);
       });
       test('Json', function() {
-        const flyoutDef = Blockly.utils.toolbox.convertFlyoutDefToJsonArray(this.simpleToolboxJSON);
+        const flyoutDef = Blockly.utils.toolbox.convertFlyoutDefToJsonArray(
+            this.simpleToolboxJSON);
         checkContents(flyoutDef, this.simpleToolboxJSON['contents']);
       });
     });
@@ -659,7 +727,8 @@ suite('Toolbox', function() {
       middleCategory.toggleExpanded();
       innerCategory.show();
 
-      chai.assert.isTrue(innerCategory.isVisible(),
+      chai.assert.isTrue(
+          innerCategory.isVisible(),
           'All ancestors are expanded, so category should be visible');
     });
     test('Child categories not visible if any ancestor not expanded', function() {
@@ -668,12 +737,14 @@ suite('Toolbox', function() {
       const innerCategory = this.toolbox.contents_[2];
 
       // Don't expand the outermost category
-      // Even though the direct parent of inner is expanded, it shouldn't be visible
-      // because all ancestor categories need to be visible, not just parent
+      // Even though the direct parent of inner is expanded, it shouldn't be
+      // visible because all ancestor categories need to be visible, not just
+      // parent
       middleCategory.toggleExpanded();
       innerCategory.show();
 
-      chai.assert.isFalse(innerCategory.isVisible(),
+      chai.assert.isFalse(
+          innerCategory.isVisible(),
           'Not all ancestors are expanded, so category should not be visible');
     });
   });

--- a/tests/mocha/tooltip_test.js
+++ b/tests/mocha/tooltip_test.js
@@ -57,7 +57,8 @@ suite('Tooltip', function() {
       // Fire pointer events directly on the relevant SVG.
       this.block.pathObject.svgPath.dispatchEvent(
           new PointerEvent('pointerover'));
-      this.block.pathObject.svgPath.dispatchEvent(new PointerEvent('pointermove'));
+      this.block.pathObject.svgPath.dispatchEvent(
+          new PointerEvent('pointermove'));
       this.clock.runAll();
 
       chai.assert.isTrue(

--- a/tests/mocha/touch_test.js
+++ b/tests/mocha/touch_test.js
@@ -4,80 +4,91 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
- goog.declareModuleId('Blockly.test.touch');
+goog.declareModuleId('Blockly.test.touch');
 
- import {sharedTestSetup, sharedTestTeardown} from './test_helpers/setup_teardown.js';
+import {sharedTestSetup, sharedTestTeardown} from './test_helpers/setup_teardown.js';
 
- suite('Touch', function() {
-    setup(function() {
-        sharedTestSetup.call(this);
+suite('Touch', function() {
+  setup(function() {
+    sharedTestSetup.call(this);
+  });
+
+  teardown(function() {
+    Blockly.Touch.clearTouchIdentifier();
+    sharedTestTeardown.call(this);
+  });
+
+  suite('shouldHandleTouch', function() {
+    test('handles pointerdown event', function() {
+      const pointerEvent = new PointerEvent('pointerdown');
+      chai.assert.isTrue(Blockly.Touch.shouldHandleEvent(pointerEvent));
     });
 
-    teardown(function() {
-        Blockly.Touch.clearTouchIdentifier();
-        sharedTestTeardown.call(this);
+    test('handles multiple pointerdown events', function() {
+      const pointerEvent1 = new PointerEvent('pointerdown');
+      const pointerEvent2 = new PointerEvent('pointerdown');
+      Blockly.Touch.shouldHandleEvent(pointerEvent1);
+      chai.assert.isTrue(Blockly.Touch.shouldHandleEvent(pointerEvent2));
     });
 
-    suite('shouldHandleTouch', function() {
-        test('handles pointerdown event', function() {
-            const pointerEvent = new PointerEvent('pointerdown');
-            chai.assert.isTrue(Blockly.Touch.shouldHandleEvent(pointerEvent));
-        });
-
-        test('handles multiple pointerdown events', function() {
-            const pointerEvent1 = new PointerEvent('pointerdown');
-            const pointerEvent2 = new PointerEvent('pointerdown');
-            Blockly.Touch.shouldHandleEvent(pointerEvent1);
-            chai.assert.isTrue(Blockly.Touch.shouldHandleEvent(pointerEvent2));
-        });
-
-        test('does not handle pointerup if not tracking touch', function() {
-            const pointerEvent = new PointerEvent('pointerup');
-            chai.assert.isFalse(Blockly.Touch.shouldHandleEvent(pointerEvent));
-        });
-
-        test('handles pointerup if already tracking a touch', function() {
-            const pointerdown = new PointerEvent('pointerdown');
-            const pointerup = new PointerEvent('pointerup');
-            // Register the pointerdown event first
-            Blockly.Touch.shouldHandleEvent(pointerdown);
-            chai.assert.isTrue(Blockly.Touch.shouldHandleEvent(pointerup));
-        });
-
-        test('handles pointerdown if this is a new touch', function() {
-            const pointerdown = new PointerEvent('pointerdown', {pointerId: 1, pointerType: 'touch'});
-            chai.assert.isTrue(Blockly.Touch.shouldHandleEvent(pointerdown));
-        });
-
-        test('does not handle pointerdown if part of a different touch', function() {
-            const pointerdown1 = new PointerEvent('pointerdown', {pointerId: 1, pointerType: 'touch'});
-            const pointerdown2 = new PointerEvent('pointerdown', {pointerId: 2, pointerType: 'touch'});
-            Blockly.Touch.shouldHandleEvent(pointerdown1);
-            chai.assert.isFalse(Blockly.Touch.shouldHandleEvent(pointerdown2));
-        });
-
-        test('does not handle pointerup if not tracking touch', function() {
-            const pointerup = new PointerEvent('pointerup', {pointerId: 1, pointerType: 'touch'});
-            chai.assert.isFalse(Blockly.Touch.shouldHandleEvent(pointerup));
-        });
-
-        test('handles pointerup if part of existing touch', function() {
-            const pointerdown = new PointerEvent('pointerdown', {pointerId: 1, pointerType: 'touch'});
-            const pointerup = new PointerEvent('pointerdown', {pointerId: 1, pointerType: 'touch'});
-            Blockly.Touch.shouldHandleEvent(pointerdown);
-            chai.assert.isTrue(Blockly.Touch.shouldHandleEvent(pointerup));
-        });
+    test('does not handle pointerup if not tracking touch', function() {
+      const pointerEvent = new PointerEvent('pointerup');
+      chai.assert.isFalse(Blockly.Touch.shouldHandleEvent(pointerEvent));
     });
 
-    suite('getTouchIdentifierFromEvent', function() {
-        test('is pointerId for mouse PointerEvents', function() {
-            const pointerdown = new PointerEvent('pointerdown', {pointerId: 7, pointerType: 'mouse'});
-            chai.assert.equal(Blockly.Touch.getTouchIdentifierFromEvent(pointerdown), 7);
+    test('handles pointerup if already tracking a touch', function() {
+      const pointerdown = new PointerEvent('pointerdown');
+      const pointerup = new PointerEvent('pointerup');
+      // Register the pointerdown event first
+      Blockly.Touch.shouldHandleEvent(pointerdown);
+      chai.assert.isTrue(Blockly.Touch.shouldHandleEvent(pointerup));
+    });
+
+    test('handles pointerdown if this is a new touch', function() {
+      const pointerdown =
+          new PointerEvent('pointerdown', {pointerId: 1, pointerType: 'touch'});
+      chai.assert.isTrue(Blockly.Touch.shouldHandleEvent(pointerdown));
+    });
+
+    test(
+        'does not handle pointerdown if part of a different touch', function() {
+          const pointerdown1 = new PointerEvent(
+              'pointerdown', {pointerId: 1, pointerType: 'touch'});
+          const pointerdown2 = new PointerEvent(
+              'pointerdown', {pointerId: 2, pointerType: 'touch'});
+          Blockly.Touch.shouldHandleEvent(pointerdown1);
+          chai.assert.isFalse(Blockly.Touch.shouldHandleEvent(pointerdown2));
         });
 
-        test('is pointerId for touch PointerEvents', function() {
-            const pointerdown = new PointerEvent('pointerdown', {pointerId: 42, pointerType: 'touch'});
-            chai.assert.equal(Blockly.Touch.getTouchIdentifierFromEvent(pointerdown), 42);
-        });
+    test('does not handle pointerup if not tracking touch', function() {
+      const pointerup =
+          new PointerEvent('pointerup', {pointerId: 1, pointerType: 'touch'});
+      chai.assert.isFalse(Blockly.Touch.shouldHandleEvent(pointerup));
     });
- });
+
+    test('handles pointerup if part of existing touch', function() {
+      const pointerdown =
+          new PointerEvent('pointerdown', {pointerId: 1, pointerType: 'touch'});
+      const pointerup =
+          new PointerEvent('pointerdown', {pointerId: 1, pointerType: 'touch'});
+      Blockly.Touch.shouldHandleEvent(pointerdown);
+      chai.assert.isTrue(Blockly.Touch.shouldHandleEvent(pointerup));
+    });
+  });
+
+  suite('getTouchIdentifierFromEvent', function() {
+    test('is pointerId for mouse PointerEvents', function() {
+      const pointerdown =
+          new PointerEvent('pointerdown', {pointerId: 7, pointerType: 'mouse'});
+      chai.assert.equal(
+          Blockly.Touch.getTouchIdentifierFromEvent(pointerdown), 7);
+    });
+
+    test('is pointerId for touch PointerEvents', function() {
+      const pointerdown = new PointerEvent(
+          'pointerdown', {pointerId: 42, pointerType: 'touch'});
+      chai.assert.equal(
+          Blockly.Touch.getTouchIdentifierFromEvent(pointerdown), 42);
+    });
+  });
+});

--- a/tests/mocha/trashcan_test.js
+++ b/tests/mocha/trashcan_test.js
@@ -16,8 +16,8 @@ import {simulateClick} from './test_helpers/user_input.js';
 suite("Trashcan", function() {
   function fireDeleteEvent(workspace, xmlString) {
     let xml = Blockly.utils.xml.textToDom(
-        '<xml xmlns="https://developers.google.com/blockly/xml">' +
-        xmlString + '</xml>');
+        '<xml xmlns="https://developers.google.com/blockly/xml">' + xmlString +
+        '</xml>');
     xml = xml.children[0];
     const block = Blockly.Xml.domToBlock(xml, workspace);
     const event = new Blockly.Events.BlockDelete(block);
@@ -43,8 +43,8 @@ suite("Trashcan", function() {
     defineStackBlock();
     defineStackBlock('stack_block2');
     defineMutatorBlocks();
-    this.workspace = Blockly.inject('blocklyDiv',
-        {'trashcan': true, 'maxTrashcanContents': Infinity});
+    this.workspace = Blockly.inject(
+        'blocklyDiv', {'trashcan': true, 'maxTrashcanContents': Infinity});
     this.trashcan = this.workspace.trashcan;
   });
   teardown(function() {
@@ -66,8 +66,7 @@ suite("Trashcan", function() {
       let xml = Blockly.utils.xml.textToDom(
           '<xml xmlns="https://developers.google.com/blockly/xml">' +
           '  <block type="test_field_block"/>' +
-          '</xml>'
-      );
+          '</xml>');
       xml = xml.children[0];
       fireNonDeleteEvent(this.workspace, xml);
       chai.assert.equal(this.trashcan.contents.length, 0);
@@ -80,10 +79,12 @@ suite("Trashcan", function() {
       simulateClick(this.trashcan.svgGroup);
 
       assertEventNotFired(
-          this.eventsFireStub, Blockly.Events.TrashcanOpen, {type: eventUtils.CLICK});
+          this.eventsFireStub, Blockly.Events.TrashcanOpen,
+          {type: eventUtils.CLICK});
       assertEventFired(
-          this.eventsFireStub, Blockly.Events.Click, {targetType: 'workspace', type: eventUtils.CLICK},
-          this.workspace.id, undefined);
+          this.eventsFireStub, Blockly.Events.Click,
+          {targetType: 'workspace', type: eventUtils.CLICK}, this.workspace.id,
+          undefined);
     });
     test("Click with contents - fires trashcanOpen", function() {
       fireDeleteEvent(this.workspace, '<block type="test_field_block"/>');
@@ -99,7 +100,8 @@ suite("Trashcan", function() {
           this.eventsFireStub, Blockly.Events.TrashcanOpen,
           {isOpen: true, type: eventUtils.TRASHCAN_OPEN}, this.workspace.id);
       assertEventNotFired(
-          this.eventsFireStub, Blockly.Events.Click, {type: eventUtils.TRASHCAN_OPEN});
+          this.eventsFireStub, Blockly.Events.Click,
+          {type: eventUtils.TRASHCAN_OPEN});
     });
     test("Click outside trashcan - fires trashcanClose", function() {
       sinon.stub(this.trashcan.flyout, 'isVisible').returns(true);
@@ -114,8 +116,9 @@ suite("Trashcan", function() {
           this.eventsFireStub, Blockly.Events.TrashcanOpen,
           {isOpen: false, type: eventUtils.TRASHCAN_OPEN}, this.workspace.id);
       assertEventFired(
-          this.eventsFireStub, Blockly.Events.Click, {targetType: 'workspace', type: eventUtils.CLICK},
-          this.workspace.id, undefined);
+          this.eventsFireStub, Blockly.Events.Click,
+          {targetType: 'workspace', type: eventUtils.CLICK}, this.workspace.id,
+          undefined);
     });
   });
   suite("Unique Contents", function() {
@@ -139,8 +142,7 @@ suite("Trashcan", function() {
       chai.assert.equal(this.trashcan.contents.length, 1);
     });
     test("No Disabled - Disabled True", function() {
-      fireDeleteEvent(
-          this.workspace, '<block type="test_field_block"/>');
+      fireDeleteEvent(this.workspace, '<block type="test_field_block"/>');
       fireDeleteEvent(
           this.workspace, '<block type="test_field_block" disabled="true"/>');
       // Disabled tags get removed because disabled blocks aren't allowed to
@@ -148,172 +150,170 @@ suite("Trashcan", function() {
       chai.assert.equal(this.trashcan.contents.length, 1);
     });
     test("Different Field Values", function() {
-      fireDeleteEvent(this.workspace,
+      fireDeleteEvent(
+          this.workspace,
           '<block type="test_field_block">' +
-          '  <field name="NAME">dummy_value1</field>' +
-          '</block>'
-      );
-      fireDeleteEvent(this.workspace,
+              '  <field name="NAME">dummy_value1</field>' +
+              '</block>');
+      fireDeleteEvent(
+          this.workspace,
           '<block type="test_field_block">' +
-          '  <field name="NAME">dummy_value2</field>' +
-          '</block>'
-      );
+              '  <field name="NAME">dummy_value2</field>' +
+              '</block>');
       chai.assert.equal(this.trashcan.contents.length, 2);
     });
     test("No Values - Values", function() {
       fireDeleteEvent(this.workspace, '<block type="row_block"/>');
-      fireDeleteEvent(this.workspace,
+      fireDeleteEvent(
+          this.workspace,
           '<block type="row_block">' +
-          '  <value name="INPUT">' +
-          '    <block type="row_block"/>' +
-          '  </value>' +
-          '</block>'
-      );
+              '  <value name="INPUT">' +
+              '    <block type="row_block"/>' +
+              '  </value>' +
+              '</block>');
       chai.assert.equal(this.trashcan.contents.length, 2);
     });
     test("Different Value Blocks", function() {
-      fireDeleteEvent(this.workspace,
+      fireDeleteEvent(
+          this.workspace,
           '<block type="row_block">' +
-          '  <value name="INPUT">' +
-          '    <block type="row_block"/>' +
-          '  </value>' +
-          '</block>'
-      );
-      fireDeleteEvent(this.workspace,
+              '  <value name="INPUT">' +
+              '    <block type="row_block"/>' +
+              '  </value>' +
+              '</block>');
+      fireDeleteEvent(
+          this.workspace,
           '<block type="row_block">' +
-          '  <value name="INPUT">' +
-          '    <block type="row_block2"/>' +
-          '  </value>' +
-          '</block>'
-      );
+              '  <value name="INPUT">' +
+              '    <block type="row_block2"/>' +
+              '  </value>' +
+              '</block>');
       chai.assert.equal(this.trashcan.contents.length, 2);
     });
     test("No Statements - Statements", function() {
       fireDeleteEvent(this.workspace, '<block type="statement_block"/>');
-      fireDeleteEvent(this.workspace,
+      fireDeleteEvent(
+          this.workspace,
           '<block type="statement_block">' +
-          '  <statement name="NAME">' +
-          '    <block type="statement_block"/>' +
-          '  </statement>' +
-          '</block>'
-      );
+              '  <statement name="NAME">' +
+              '    <block type="statement_block"/>' +
+              '  </statement>' +
+              '</block>');
       chai.assert.equal(this.trashcan.contents.length, 2);
     });
     test("Different Statement Blocks", function() {
-      fireDeleteEvent(this.workspace,
+      fireDeleteEvent(
+          this.workspace,
           '<block type="statement_block">' +
-          '  <statement name="NAME">' +
-          '    <block type="statement_block"/>' +
-          '  </statement>' +
-          '</block>'
-      );
-      fireDeleteEvent(this.workspace,
+              '  <statement name="NAME">' +
+              '    <block type="statement_block"/>' +
+              '  </statement>' +
+              '</block>');
+      fireDeleteEvent(
+          this.workspace,
           '<block type="statement_block2">' +
-          '  <statement name="NAME">' +
-          '    <block type="statement_block2"/>' +
-          '  </statement>' +
-          '</block>'
-      );
+              '  <statement name="NAME">' +
+              '    <block type="statement_block2"/>' +
+              '  </statement>' +
+              '</block>');
       chai.assert.equal(this.trashcan.contents.length, 2);
     });
     test("No Next - Next", function() {
       fireDeleteEvent(this.workspace, '<block type="stack_block"/>');
-      fireDeleteEvent(this.workspace,
+      fireDeleteEvent(
+          this.workspace,
           '<block type="stack_block">' +
-          '  <next>' +
-          '    <block type="stack_block"/>' +
-          '  </next>' +
-          '</block>'
-      );
+              '  <next>' +
+              '    <block type="stack_block"/>' +
+              '  </next>' +
+              '</block>');
       chai.assert.equal(this.trashcan.contents.length, 2);
     });
     test("Different Next Blocks", function() {
-      fireDeleteEvent(this.workspace,
+      fireDeleteEvent(
+          this.workspace,
           '<block type="stack_block">' +
-          '  <next>' +
-          '    <block type="stack_block"/>' +
-          '  </next>' +
-          '</block>'
-      );
-      fireDeleteEvent(this.workspace,
+              '  <next>' +
+              '    <block type="stack_block"/>' +
+              '  </next>' +
+              '</block>');
+      fireDeleteEvent(
+          this.workspace,
           '<block type="stack_block">' +
-          '  <next>' +
-          '    <block type="stack_block2"/>' +
-          '  </next>' +
-          '</block>'
-      );
+              '  <next>' +
+              '    <block type="stack_block2"/>' +
+              '  </next>' +
+              '</block>');
       chai.assert.equal(this.trashcan.contents.length, 2);
     });
     test("No Comment - Comment", function() {
       fireDeleteEvent(this.workspace, '<block type="test_field_block"/>');
-      fireDeleteEvent(this.workspace,
+      fireDeleteEvent(
+          this.workspace,
           '<block type="test_field_block">' +
-          '  <comment>comment_text</comment>' +
-          '</block>'
-      );
+              '  <comment>comment_text</comment>' +
+              '</block>');
       chai.assert.equal(this.trashcan.contents.length, 2);
     });
     test("Different Comment Text", function() {
-      fireDeleteEvent(this.workspace,
+      fireDeleteEvent(
+          this.workspace,
           '<block type="test_field_block">' +
-          '  <comment>comment_text1</comment>' +
-          '</block>'
-      );
-      fireDeleteEvent(this.workspace,
+              '  <comment>comment_text1</comment>' +
+              '</block>');
+      fireDeleteEvent(
+          this.workspace,
           '<block type="test_field_block">' +
-          '  <comment>comment_text2</comment>' +
-          '</block>'
-      );
+              '  <comment>comment_text2</comment>' +
+              '</block>');
       chai.assert.equal(this.trashcan.contents.length, 2);
     });
     test("Different Comment Size", function() {
-      fireDeleteEvent(this.workspace,
+      fireDeleteEvent(
+          this.workspace,
           '<block type="test_field_block">' +
-          '  <comment h="10" w="10">comment_text</comment>' +
-          '</block>'
-      );
-      fireDeleteEvent(this.workspace,
+              '  <comment h="10" w="10">comment_text</comment>' +
+              '</block>');
+      fireDeleteEvent(
+          this.workspace,
           '<block type="test_field_block">' +
-          '  <comment h="20" w="20">comment_text</comment>' +
-          '</block>'
-      );
+              '  <comment h="20" w="20">comment_text</comment>' +
+              '</block>');
       // h & w tags are removed b/c the blocks appear the same.
       chai.assert.equal(this.trashcan.contents.length, 1);
     });
     test("Different Comment Pinned", function() {
-      fireDeleteEvent(this.workspace,
+      fireDeleteEvent(
+          this.workspace,
           '<block type="test_field_block">' +
-          '  <comment pinned="false">comment_text</comment>' +
-          '</block>'
-      );
-      fireDeleteEvent(this.workspace,
+              '  <comment pinned="false">comment_text</comment>' +
+              '</block>');
+      fireDeleteEvent(
+          this.workspace,
           '<block type="test_field_block">' +
-          '  <comment pinned="true">comment_text</comment>' +
-          '</block>'
-      );
+              '  <comment pinned="true">comment_text</comment>' +
+              '</block>');
       // pinned tags are removed b/c the blocks appear the same.
       chai.assert.equal(this.trashcan.contents.length, 1);
     });
     test("Different Mutator", function() {
-      fireDeleteEvent(this.workspace,
+      fireDeleteEvent(
+          this.workspace,
           '<block type="xml_block">' +
-          '  <mutation hasInput="true"></mutation>' +
-          '</block>'
-      );
-      fireDeleteEvent(this.workspace,
+              '  <mutation hasInput="true"></mutation>' +
+              '</block>');
+      fireDeleteEvent(
+          this.workspace,
           '<block type="xml_block">' +
-          '  <mutation hasInputt="false"></mutation>' +
-          '</block>'
-      );
+              '  <mutation hasInputt="false"></mutation>' +
+              '</block>');
       chai.assert.equal(this.trashcan.contents.length, 2);
     });
   });
   suite("Max Contents", function() {
     test("Max 0", function() {
       this.workspace.options.maxTrashcanContents = 0;
-      fireDeleteEvent(this.workspace,
-          '<block type="test_field_block"/>'
-      );
+      fireDeleteEvent(this.workspace, '<block type="test_field_block"/>');
       chai.assert.equal(this.trashcan.contents.length, 0);
       this.workspace.options.maxTrashcanContents = Infinity;
     });

--- a/tests/mocha/utils_test.js
+++ b/tests/mocha/utils_test.js
@@ -30,7 +30,8 @@ suite('Utils', function() {
   suite('tokenizeInterpolation', function() {
     suite('Basic', function() {
       test('Empty string', function() {
-        chai.assert.deepEqual(Blockly.utils.parsing.tokenizeInterpolation(''), []);
+        chai.assert.deepEqual(
+            Blockly.utils.parsing.tokenizeInterpolation(''), []);
       });
 
       test('No interpolation', function() {
@@ -60,7 +61,8 @@ suite('Utils', function() {
 
       test('Multi-digit number interpolation', function() {
         chai.assert.deepEqual(
-            Blockly.utils.parsing.tokenizeInterpolation('%123Hello%456World%789'),
+            Blockly.utils.parsing.tokenizeInterpolation(
+                '%123Hello%456World%789'),
             [123, 'Hello', 456, 'World', 789]);
       });
 
@@ -120,7 +122,8 @@ suite('Utils', function() {
       test('Number reference', function() {
         Blockly.Msg['1'] = 'test string';
         chai.assert.deepEqual(
-            Blockly.utils.parsing.tokenizeInterpolation('%{bky_1}'), ['test string']);
+            Blockly.utils.parsing.tokenizeInterpolation('%{bky_1}'),
+            ['test string']);
       });
 
       test('Undefined reference', function() {
@@ -139,8 +142,7 @@ suite('Utils', function() {
       test('Not prefixed, number', function() {
         Blockly.Msg['1'] = 'test string';
         chai.assert.deepEqual(
-            Blockly.utils.parsing.tokenizeInterpolation('%{1}'),
-            ['%{1}']);
+            Blockly.utils.parsing.tokenizeInterpolation('%{1}'), ['%{1}']);
       });
 
       test('Space in ref', function() {
@@ -196,7 +198,8 @@ suite('Utils', function() {
     chai.assert.equal(resultString, '%{bky_string_ref}', 'Escaped %');
 
     resultString = Blockly.utils.parsing.replaceMessageReferences('%a');
-    chai.assert.equal(resultString, '%a', 'Unrecognized % escape code treated as literal');
+    chai.assert.equal(
+        resultString, '%a', 'Unrecognized % escape code treated as literal');
 
     resultString = Blockly.utils.parsing.replaceMessageReferences('%1');
     chai.assert.equal(resultString, '%1', 'Interpolation tokens ignored.');
@@ -204,7 +207,8 @@ suite('Utils', function() {
     chai.assert.equal(resultString, '%1 %2', 'Interpolation tokens ignored.');
     resultString =
         Blockly.utils.parsing.replaceMessageReferences('before %1 after');
-    chai.assert.equal(resultString, 'before %1 after', 'Interpolation tokens ignored.');
+    chai.assert.equal(
+        resultString, 'before %1 after', 'Interpolation tokens ignored.');
 
     // Blockly.Msg.STRING_REF cases:
     resultString =
@@ -212,23 +216,32 @@ suite('Utils', function() {
     chai.assert.equal(resultString, 'test string', 'Message ref dereferenced.');
     resultString = Blockly.utils.parsing.replaceMessageReferences(
         'before %{bky_string_ref} after');
-    chai.assert.equal(resultString, 'before test string after', 'Message ref dereferenced.');
+    chai.assert.equal(
+        resultString, 'before test string after', 'Message ref dereferenced.');
 
     // Blockly.Msg.STRING_REF_WITH_ARG cases:
     resultString = Blockly.utils.parsing.replaceMessageReferences(
         '%{bky_string_ref_with_arg}');
-    chai.assert.equal(resultString, 'test %1 string', 'Message ref dereferenced with argument preserved.');
+    chai.assert.equal(
+        resultString, 'test %1 string',
+        'Message ref dereferenced with argument preserved.');
     resultString = Blockly.utils.parsing.replaceMessageReferences(
         'before %{bky_string_ref_with_arg} after');
-    chai.assert.equal(resultString, 'before test %1 string after', 'Message ref dereferenced with argument preserved.');
+    chai.assert.equal(
+        resultString, 'before test %1 string after',
+        'Message ref dereferenced with argument preserved.');
 
     // Blockly.Msg.STRING_REF_WITH_SUBREF cases:
     resultString = Blockly.utils.parsing.replaceMessageReferences(
         '%{bky_string_ref_with_subref}');
-    chai.assert.equal(resultString, 'test subref string', 'Message ref and subref dereferenced.');
+    chai.assert.equal(
+        resultString, 'test subref string',
+        'Message ref and subref dereferenced.');
     resultString = Blockly.utils.parsing.replaceMessageReferences(
         'before %{bky_string_ref_with_subref} after');
-    chai.assert.equal(resultString, 'before test subref string after', 'Message ref and subref dereferenced.');
+    chai.assert.equal(
+        resultString, 'before test subref string after',
+        'Message ref and subref dereferenced.');
   });
 
   test('arrayRemove', function() {
@@ -264,8 +277,10 @@ suite('Utils', function() {
     chai.assert.equal(m[3], '16', 'translate(15 16), y');
 
     m = 'translate(1.23456e+42 0.123456e-42)'.match(regex);
-    chai.assert.equal(m[1], '1.23456e+42', 'translate(1.23456e+42 0.123456e-42), x');
-    chai.assert.equal(m[3], '0.123456e-42', 'translate(1.23456e+42 0.123456e-42), y');
+    chai.assert.equal(
+        m[1], '1.23456e+42', 'translate(1.23456e+42 0.123456e-42), x');
+    chai.assert.equal(
+        m[3], '0.123456e-42', 'translate(1.23456e+42 0.123456e-42), y');
   });
 
   test('XY_STYLE_REGEX_', function() {
@@ -295,8 +310,12 @@ suite('Utils', function() {
     chai.assert.equal(m[3], '16', 'transform: translate(15px 16px), y');
 
     m = 'transform: translate(1.23456e+42px 0.123456e-42px)'.match(regex);
-    chai.assert.equal(m[1], '1.23456e+42', 'transform: translate(1.23456e+42px 0.123456e-42px), x');
-    chai.assert.equal(m[3], '0.123456e-42', 'transform: translate(1.23456e+42px 0.123456e-42px), y');
+    chai.assert.equal(
+        m[1], '1.23456e+42',
+        'transform: translate(1.23456e+42px 0.123456e-42px), x');
+    chai.assert.equal(
+        m[3], '0.123456e-42',
+        'transform: translate(1.23456e+42px 0.123456e-42px), y');
 
     m = 'transform:translate3d(20px, 21px, 22px)'.match(regex);
     chai.assert.equal(m[1], '20', 'transform:translate3d(20px, 21px, 22px), x');
@@ -311,8 +330,12 @@ suite('Utils', function() {
     chai.assert.equal(m[3], '27', 'transform:translate3d(26px 27px 28px), y');
 
     m = 'transform:translate3d(1.23456e+42px 0.123456e-42px 42px)'.match(regex);
-    chai.assert.equal(m[1], '1.23456e+42', 'transform:translate3d(1.23456e+42px 0.123456e-42px 42px), x');
-    chai.assert.equal(m[3], '0.123456e-42', 'transform:translate3d(1.23456e+42px 0.123456e-42px 42px), y');
+    chai.assert.equal(
+        m[1], '1.23456e+42',
+        'transform:translate3d(1.23456e+42px 0.123456e-42px 42px), x');
+    chai.assert.equal(
+        m[3], '0.123456e-42',
+        'transform:translate3d(1.23456e+42px 0.123456e-42px 42px), y');
   });
 
   suite('DOM', function() {
@@ -336,7 +359,8 @@ suite('Utils', function() {
       chai.assert.isTrue(Blockly.utils.dom.hasClass(p, 'one'), 'Has "one"');
       chai.assert.isTrue(Blockly.utils.dom.hasClass(p, 'two'), 'Has "two"');
       chai.assert.isTrue(Blockly.utils.dom.hasClass(p, 'three'), 'Has "three"');
-      chai.assert.isFalse(Blockly.utils.dom.hasClass(p, 'four'), 'Has no "four"');
+      chai.assert.isFalse(
+          Blockly.utils.dom.hasClass(p, 'four'), 'Has no "four"');
       chai.assert.isFalse(Blockly.utils.dom.hasClass(p, 't'), 'Has no "t"');
     });
 
@@ -360,9 +384,11 @@ suite('Utils', function() {
 
   suite('String', function() {
     test('shortest string length', function() {
-      let len = Blockly.utils.string.shortestStringLength('one,two,three,four,five'.split(','));
+      let len = Blockly.utils.string.shortestStringLength(
+          'one,two,three,four,five'.split(','));
       chai.assert.equal(len, 3, 'Length of "one"');
-      len = Blockly.utils.string.shortestStringLength('one,two,three,four,five,'.split(','));
+      len = Blockly.utils.string.shortestStringLength(
+          'one,two,three,four,five,'.split(','));
       chai.assert.equal(len, 0, 'Length of ""');
       len = Blockly.utils.string.shortestStringLength(['Hello World']);
       chai.assert.equal(len, 11, 'List of one');
@@ -371,11 +397,14 @@ suite('Utils', function() {
     });
 
     test('comment word prefix', function() {
-      let len = Blockly.utils.string.commonWordPrefix('one,two,three,four,five'.split(','));
+      let len = Blockly.utils.string.commonWordPrefix(
+          'one,two,three,four,five'.split(','));
       chai.assert.equal(len, 0, 'No prefix');
-      len = Blockly.utils.string.commonWordPrefix('Xone,Xtwo,Xthree,Xfour,Xfive'.split(','));
+      len = Blockly.utils.string.commonWordPrefix(
+          'Xone,Xtwo,Xthree,Xfour,Xfive'.split(','));
       chai.assert.equal(len, 0, 'No word prefix');
-      len = Blockly.utils.string.commonWordPrefix('abc de,abc de,abc de,abc de'.split(','));
+      len = Blockly.utils.string.commonWordPrefix(
+          'abc de,abc de,abc de,abc de'.split(','));
       chai.assert.equal(len, 6, 'Full equality');
       len = Blockly.utils.string.commonWordPrefix('abc deX,abc deY'.split(','));
       chai.assert.equal(len, 4, 'One word prefix');
@@ -387,18 +416,23 @@ suite('Utils', function() {
       chai.assert.equal(len, 11, 'List of one');
       len = Blockly.utils.string.commonWordPrefix([]);
       chai.assert.equal(len, 0, 'Empty list');
-      len = Blockly.utils.string.commonWordPrefix('turn&nbsp;left,turn&nbsp;right'.split(','));
+      len = Blockly.utils.string.commonWordPrefix(
+          'turn&nbsp;left,turn&nbsp;right'.split(','));
       chai.assert.equal(len, 0, 'No prefix due to &amp;nbsp;');
-      len = Blockly.utils.string.commonWordPrefix('turn\u00A0left,turn\u00A0right'.split(','));
+      len = Blockly.utils.string.commonWordPrefix(
+          'turn\u00A0left,turn\u00A0right'.split(','));
       chai.assert.equal(len, 0, 'No prefix due to \\u00A0');
     });
 
     test('comment word suffix', function() {
-      let len = Blockly.utils.string.commonWordSuffix('one,two,three,four,five'.split(','));
+      let len = Blockly.utils.string.commonWordSuffix(
+          'one,two,three,four,five'.split(','));
       chai.assert.equal(len, 0, 'No suffix');
-      len = Blockly.utils.string.commonWordSuffix('oneX,twoX,threeX,fourX,fiveX'.split(','));
+      len = Blockly.utils.string.commonWordSuffix(
+          'oneX,twoX,threeX,fourX,fiveX'.split(','));
       chai.assert.equal(len, 0, 'No word suffix');
-      len = Blockly.utils.string.commonWordSuffix('abc de,abc de,abc de,abc de'.split(','));
+      len = Blockly.utils.string.commonWordSuffix(
+          'abc de,abc de,abc de,abc de'.split(','));
       chai.assert.equal(len, 6, 'Full equality');
       len = Blockly.utils.string.commonWordSuffix('Xabc de,Yabc de'.split(','));
       chai.assert.equal(len, 3, 'One word suffix');
@@ -422,7 +456,8 @@ suite('Utils', function() {
       chai.assert.equal(Blockly.utils.math.toRadians(180), 2 * quarter, '180');
       chai.assert.equal(Blockly.utils.math.toRadians(270), 3 * quarter, '270');
       chai.assert.equal(Blockly.utils.math.toRadians(360), 4 * quarter, '360');
-      chai.assert.equal(Blockly.utils.math.toRadians(360 + 90), 5 * quarter, '450');
+      chai.assert.equal(
+          Blockly.utils.math.toRadians(360 + 90), 5 * quarter, '450');
     });
 
     test('toDegrees', function() {
@@ -433,7 +468,8 @@ suite('Utils', function() {
       chai.assert.equal(Blockly.utils.math.toDegrees(2 * quarter), 180, '180');
       chai.assert.equal(Blockly.utils.math.toDegrees(3 * quarter), 270, '270');
       chai.assert.equal(Blockly.utils.math.toDegrees(4 * quarter), 360, '360');
-      chai.assert.equal(Blockly.utils.math.toDegrees(5 * quarter), 360 + 90, '450');
+      chai.assert.equal(
+          Blockly.utils.math.toDegrees(5 * quarter), 360 + 90, '450');
     });
   });
 });

--- a/tests/mocha/variable_map_test.js
+++ b/tests/mocha/variable_map_test.js
@@ -29,7 +29,8 @@ suite('Variable Map', function() {
     });
 
     test('Already exists', function() {
-      // Expect that when the variable already exists, the variableMap is unchanged.
+      // Expect that when the variable already exists, the variableMap is
+      // unchanged.
       this.variableMap.createVariable('name1', 'type1', 'id1');
 
       // Assert there is only one variable in the this.variableMap.
@@ -48,8 +49,8 @@ suite('Variable Map', function() {
     });
 
     test('Name already exists', function() {
-      // Expect that when a variable with the same name but a different type already
-      // exists, the new variable is created.
+      // Expect that when a variable with the same name but a different type
+      // already exists, the new variable is created.
       this.variableMap.createVariable('name1', 'type1', 'id1');
 
       // Assert there is only one variable in the this.variableMap.
@@ -269,83 +270,71 @@ suite('Variable Map', function() {
         this.variableMap.createVariable('test name', 'test type', 'test id');
 
         assertEventFired(
-          this.eventSpy,
-          Blockly.Events.VarCreate,
-          {
-            varType: 'test type',
-            varName: 'test name',
-            varId: 'test id',
-          },
-          this.workspace.id);
+            this.eventSpy, Blockly.Events.VarCreate, {
+              varType: 'test type',
+              varName: 'test name',
+              varId: 'test id',
+            },
+            this.workspace.id);
       });
 
       test(
           'create events are not fired if a variable is already exists',
           function() {
-            this.variableMap.createVariable('test name', 'test type', 'test id');
+            this.variableMap.createVariable(
+                'test name', 'test type', 'test id');
 
             this.eventSpy.resetHistory();
-            this.variableMap.createVariable('test name', 'test type', 'test id');
+            this.variableMap.createVariable(
+                'test name', 'test type', 'test id');
 
             assertEventNotFired(
-              this.eventSpy,
-              Blockly.Events.VarCreate,
-              {},
-              this.workspace.id);
+                this.eventSpy, Blockly.Events.VarCreate, {}, this.workspace.id);
           });
     });
 
     suite('variable delete events', function() {
       suite('deleting with a variable', function() {
         test('delete events are fired when a variable is deleted', function() {
-          const variable =
-              this.variableMap.createVariable('test name', 'test type', 'test id');
+          const variable = this.variableMap.createVariable(
+              'test name', 'test type', 'test id');
           this.variableMap.deleteVariable(variable);
 
           assertEventFired(
-            this.eventSpy,
-            Blockly.Events.VarDelete,
-            {
-              varType: 'test type',
-              varName: 'test name',
-              varId: 'test id',
-            },
-            this.workspace.id);
+              this.eventSpy, Blockly.Events.VarDelete, {
+                varType: 'test type',
+                varName: 'test name',
+                varId: 'test id',
+              },
+              this.workspace.id);
         });
 
         test(
             'delete events are not fired when a variable does not exist',
             function() {
-          const variable =
-              new Blockly.VariableModel(
+              const variable = new Blockly.VariableModel(
                   this.workspace, 'test name', 'test type', 'test id');
-          this.variableMap.deleteVariable(variable);
+              this.variableMap.deleteVariable(variable);
 
-          assertEventNotFired(
-            this.eventSpy,
-            Blockly.Events.VarDelete,
-            {},
-            this.workspace.id);
-        });
+              assertEventNotFired(
+                  this.eventSpy, Blockly.Events.VarDelete, {},
+                  this.workspace.id);
+            });
       });
 
       suite('deleting by ID', function() {
-        test(
-            'delete events are fired when a variable is deleted',
-            function() {
-              this.variableMap.createVariable('test name', 'test type', 'test id');
-              this.variableMap.deleteVariableById('test id');
+        test('delete events are fired when a variable is deleted', function() {
+          this.variableMap.createVariable('test name', 'test type', 'test id');
+          this.variableMap.deleteVariableById('test id');
 
-              assertEventFired(
-                this.eventSpy,
-                Blockly.Events.VarDelete,
-                {
-                  varType: 'test type',
-                  varName: 'test name',
-                  varId: 'test id',
-                },
-                this.workspace.id);
-            });
+          assertEventFired(
+              this.eventSpy, Blockly.Events.VarDelete, {
+                varType: 'test type',
+                varName: 'test name',
+                varId: 'test id',
+              },
+              this.workspace.id);
+        });
 
         test(
             'delete events are not fired when a variable does not exist',
@@ -353,10 +342,8 @@ suite('Variable Map', function() {
               this.variableMap.deleteVariableById('test id');
 
               assertEventNotFired(
-                this.eventSpy,
-                Blockly.Events.VarDelete,
-                {},
-                this.workspace.id);
+                  this.eventSpy, Blockly.Events.VarDelete, {},
+                  this.workspace.id);
             });
       });
     });
@@ -364,50 +351,41 @@ suite('Variable Map', function() {
     suite('variable rename events', function() {
       suite('renaming with variable', function() {
         test('rename events are fired when a variable is renamed', function() {
-          const variable =
-              this.variableMap.createVariable(
-                  'test name', 'test type', 'test id');
+          const variable = this.variableMap.createVariable(
+              'test name', 'test type', 'test id');
           this.variableMap.renameVariable(variable, 'new test name');
 
           assertEventFired(
-            this.eventSpy,
-            Blockly.Events.VarRename,
-            {
-              oldName: 'test name',
-              newName: 'new test name',
-              varId: 'test id',
-            },
-            this.workspace.id);
+              this.eventSpy, Blockly.Events.VarRename, {
+                oldName: 'test name',
+                newName: 'new test name',
+                varId: 'test id',
+              },
+              this.workspace.id);
         });
 
         test(
             'rename events are not fired if the variable name already matches',
             function() {
-              const variable =
-                  this.variableMap.createVariable(
-                      'test name', 'test type', 'test id');
+              const variable = this.variableMap.createVariable(
+                  'test name', 'test type', 'test id');
               this.variableMap.renameVariable(variable, 'test name');
 
               assertEventNotFired(
-                this.eventSpy,
-                Blockly.Events.VarRename,
-                {},
-                this.workspace.id);
+                  this.eventSpy, Blockly.Events.VarRename, {},
+                  this.workspace.id);
             });
 
         test(
             'rename events are not fired if the variable does not exist',
             function() {
-              const variable =
-                  new Blockly.VariableModel(
-                      'test name', 'test type', 'test id');
+              const variable = new Blockly.VariableModel(
+                  'test name', 'test type', 'test id');
               this.variableMap.renameVariable(variable, 'test name');
 
               assertEventNotFired(
-                this.eventSpy,
-                Blockly.Events.VarRename,
-                {},
-                this.workspace.id);
+                  this.eventSpy, Blockly.Events.VarRename, {},
+                  this.workspace.id);
             });
       });
 
@@ -417,14 +395,12 @@ suite('Variable Map', function() {
           this.variableMap.renameVariableById('test id', 'new test name');
 
           assertEventFired(
-            this.eventSpy,
-            Blockly.Events.VarRename,
-            {
-              oldName: 'test name',
-              newName: 'new test name',
-              varId: 'test id',
-            },
-            this.workspace.id);
+              this.eventSpy, Blockly.Events.VarRename, {
+                oldName: 'test name',
+                newName: 'new test name',
+                varId: 'test id',
+              },
+              this.workspace.id);
         });
 
         test(
@@ -435,21 +411,17 @@ suite('Variable Map', function() {
               this.variableMap.renameVariableById('test id', 'test name');
 
               assertEventNotFired(
-                this.eventSpy,
-                Blockly.Events.VarRename,
-                {},
-                this.workspace.id);
+                  this.eventSpy, Blockly.Events.VarRename, {},
+                  this.workspace.id);
             });
 
-        test(
-            'renaming throws if the variable does not exist',
-            function() {
-              // Not sure why this throws when the other one doesn't but might
-              // as well test it.
-              chai.assert.throws(() => {
-                this.variableMap.renameVariableById('test id', 'test name');
-              }, `Tried to rename a variable that didn't exist`);
-            });
+        test('renaming throws if the variable does not exist', function() {
+          // Not sure why this throws when the other one doesn't but might
+          // as well test it.
+          chai.assert.throws(() => {
+            this.variableMap.renameVariableById('test id', 'test name');
+          }, `Tried to rename a variable that didn't exist`);
+        });
       });
     });
   });

--- a/tests/mocha/variable_model_test.js
+++ b/tests/mocha/variable_model_test.js
@@ -28,20 +28,20 @@ suite('Variable Model', function() {
   });
 
   test('Null type', function() {
-    const variable = new Blockly.VariableModel(
-        this.workspace, 'test', null, 'test_id');
+    const variable =
+        new Blockly.VariableModel(this.workspace, 'test', null, 'test_id');
     chai.assert.equal(variable.type, '');
   });
 
   test('Undefined type', function() {
-    const variable = new Blockly.VariableModel(
-        this.workspace, 'test', undefined, 'test_id');
+    const variable =
+        new Blockly.VariableModel(this.workspace, 'test', undefined, 'test_id');
     chai.assert.equal(variable.type, '');
   });
 
   test('Null id', function() {
-    const variable = new Blockly.VariableModel(
-        this.workspace, 'test', 'test_type', null);
+    const variable =
+        new Blockly.VariableModel(this.workspace, 'test', 'test_type', null);
     chai.assert.equal(variable.name, 'test');
     chai.assert.equal(variable.type, 'test_type');
     chai.assert.exists(variable.id_);

--- a/tests/mocha/webdriver.js
+++ b/tests/mocha/webdriver.js
@@ -34,7 +34,10 @@ async function runMochaTestsInBrowser() {
   // Run in headless mode on Github Actions.
   if (process.env.CI) {
     options.capabilities['goog:chromeOptions'].args.push(
-        '--headless', '--no-sandbox', '--disable-dev-shm-usage',);
+        '--headless',
+        '--no-sandbox',
+        '--disable-dev-shm-usage',
+    );
   } else {
     // --disable-gpu is needed to prevent Chrome from hanging on Linux with
     // NVIDIA drivers older than v295.20. See
@@ -48,7 +51,7 @@ async function runMochaTestsInBrowser() {
   console.log('Loading URL: ' + url);
   await browser.url(url);
 
-  await browser.waitUntil(async() => {
+  await browser.waitUntil(async () => {
     const elem = await browser.$('#failureCount');
     const text = await elem.getAttribute('tests_failed');
     return text !== 'unset';
@@ -63,7 +66,8 @@ async function runMochaTestsInBrowser() {
     console.log('============Blockly Mocha Test Failures================');
     const failureMessagesEls = await browser.$$('#failureMessages p');
     if (!failureMessagesEls.length) {
-      console.log('There is at least one test failure, but no messages reported. Mocha may be failing because no tests are being run.');
+      console.log(
+          'There is at least one test failure, but no messages reported. Mocha may be failing because no tests are being run.');
     }
     for (const el of failureMessagesEls) {
       console.log(await el.getText());
@@ -81,18 +85,20 @@ async function runMochaTestsInBrowser() {
 }
 
 if (require.main === module) {
-  runMochaTestsInBrowser().catch((e) => {
-    console.error(e);
-    process.exit(1);
-  }).then(function(result) {
-    if (result) {
-      console.log('Mocha tests failed');
-      process.exit(1);
-    } else {
-      console.log('Mocha tests passed');
-      process.exit(0);
-    }
-  });
+  runMochaTestsInBrowser()
+      .catch((e) => {
+        console.error(e);
+        process.exit(1);
+      })
+      .then(function(result) {
+        if (result) {
+          console.log('Mocha tests failed');
+          process.exit(1);
+        } else {
+          console.log('Mocha tests passed');
+          process.exit(0);
+        }
+      });
 }
 
 module.exports = {runMochaTestsInBrowser};

--- a/tests/mocha/widget_div_test.js
+++ b/tests/mocha/widget_div_test.js
@@ -102,8 +102,8 @@ suite('WidgetDiv', function() {
         // Anchor placed close to the right side.
         const anchorBBox =
             makeBBox(950, 500, this.anchorSize.width, this.anchorSize.height);
-        // The widget div should be placed as far right as possible--at the edge of
-        // the screen.
+        // The widget div should be placed as far right as possible--at the edge
+        // of the screen.
         const expectedX = this.viewportBBox.width - this.widgetSize.width;
         const expectedY = anchorBBox.top + this.anchorSize.height;
         this.testWidgetPosition(
@@ -148,8 +148,8 @@ suite('WidgetDiv', function() {
         // Anchor placed close to the left side.
         const anchorBBox =
             makeBBox(10, 500, this.anchorSize.width, this.anchorSize.height);
-        // The widget div should be placed as far left as possible--at the edge of
-        // the screen.
+        // The widget div should be placed as far left as possible--at the edge
+        // of the screen.
         const expectedX = 0;
         const expectedY = anchorBBox.top + this.anchorSize.height;
         this.testWidgetPosition(
@@ -160,8 +160,8 @@ suite('WidgetDiv', function() {
         // Anchor placed close to the right side.
         const anchorBBox =
             makeBBox(950, 500, this.anchorSize.width, this.anchorSize.height);
-        // The widget div should be placed as far right as possible--at the edge of
-        // the screen.
+        // The widget div should be placed as far right as possible--at the edge
+        // of the screen.
         const expectedX = this.viewportBBox.width - this.widgetSize.width;
         const expectedY = anchorBBox.top + this.anchorSize.height;
         this.testWidgetPosition(

--- a/tests/mocha/workspace_comment_test.js
+++ b/tests/mocha/workspace_comment_test.js
@@ -176,8 +176,7 @@ suite('Workspace comment', function() {
     });
 
     test('After creation', function() {
-      chai.assert.equal(
-          this.comment.getContent(), 'comment text');
+      chai.assert.equal(this.comment.getContent(), 'comment text');
       chai.assert.equal(
           this.workspace.undoStack_.length, 1, 'Workspace undo stack');
     });

--- a/tests/mocha/workspace_svg_test.js
+++ b/tests/mocha/workspace_svg_test.js
@@ -34,7 +34,7 @@ suite('WorkspaceSvg', function() {
             'name': 'NAME',
           },
         ],
-      }
+      },
     ]);
   });
 

--- a/tests/mocha/workspace_svg_test.js
+++ b/tests/mocha/workspace_svg_test.js
@@ -19,21 +19,23 @@ suite('WorkspaceSvg', function() {
     sharedTestSetup.call(this);
     const toolbox = document.getElementById('toolbox-categories');
     this.workspace = Blockly.inject('blocklyDiv', {toolbox: toolbox});
-    Blockly.defineBlocksWithJsonArray([{
-      'type': 'simple_test_block',
-      'message0': 'simple test block',
-      'output': null,
-    },
-    {
-      'type': 'test_val_in',
-      'message0': 'test in %1',
-      'args0': [
-        {
-          'type': 'input_value',
-          'name': 'NAME',
-        },
-      ],
-    }]);
+    Blockly.defineBlocksWithJsonArray([
+      {
+        'type': 'simple_test_block',
+        'message0': 'simple test block',
+        'output': null,
+      },
+      {
+        'type': 'test_val_in',
+        'message0': 'test in %1',
+        'args0': [
+          {
+            'type': 'input_value',
+            'name': 'NAME',
+          },
+        ],
+      }
+    ]);
   });
 
   teardown(function() {
@@ -52,22 +54,22 @@ suite('WorkspaceSvg', function() {
         '  </block>' +
         '</xml>');
     Blockly.Xml.appendDomToWorkspace(dom, this.workspace);
-    chai.assert.equal(this.workspace.getAllBlocks(false).length, 1,
-        'Block count');
+    chai.assert.equal(
+        this.workspace.getAllBlocks(false).length, 1, 'Block count');
     Blockly.Xml.appendDomToWorkspace(dom, this.workspace);
-    chai.assert.equal(this.workspace.getAllBlocks(false).length, 2,
-        'Block count');
+    chai.assert.equal(
+        this.workspace.getAllBlocks(false).length, 2, 'Block count');
     const blocks = this.workspace.getAllBlocks(false);
-    chai.assert.equal(blocks[0].getRelativeToSurfaceXY().x, 21,
-        'Block 1 position x');
-    chai.assert.equal(blocks[0].getRelativeToSurfaceXY().y, 23,
-        'Block 1 position y');
-    chai.assert.equal(blocks[1].getRelativeToSurfaceXY().x, 21,
-        'Block 2 position x');
+    chai.assert.equal(
+        blocks[0].getRelativeToSurfaceXY().x, 21, 'Block 1 position x');
+    chai.assert.equal(
+        blocks[0].getRelativeToSurfaceXY().y, 23, 'Block 1 position y');
+    chai.assert.equal(
+        blocks[1].getRelativeToSurfaceXY().x, 21, 'Block 2 position x');
     // Y separation value defined in appendDomToWorkspace as 10
-    chai.assert.equal(blocks[1].getRelativeToSurfaceXY().y,
-        23 + blocks[0].getHeightWidth().height + 10,
-        'Block 2 position y');
+    chai.assert.equal(
+        blocks[1].getRelativeToSurfaceXY().y,
+        23 + blocks[0].getHeightWidth().height + 10, 'Block 2 position y');
   });
 
   test('Replacing shadow disposes of old shadow', function() {
@@ -109,14 +111,16 @@ suite('WorkspaceSvg', function() {
       }.bind(this), 'Existing toolbox is null.  Can\'t create new toolbox.');
     });
     test('Existing toolbox has no categories', function() {
-      sinon.stub(Blockly.utils.toolbox.TEST_ONLY, 'hasCategoriesInternal').returns(true);
+      sinon.stub(Blockly.utils.toolbox.TEST_ONLY, 'hasCategoriesInternal')
+          .returns(true);
       this.workspace.toolbox_ = null;
       chai.assert.throws(function() {
         this.workspace.updateToolbox({'contents': []});
       }.bind(this), 'Existing toolbox has no categories.  Can\'t change mode.');
     });
     test('Existing toolbox has categories', function() {
-      sinon.stub(Blockly.utils.toolbox.TEST_ONLY, 'hasCategoriesInternal').returns(false);
+      sinon.stub(Blockly.utils.toolbox.TEST_ONLY, 'hasCategoriesInternal')
+          .returns(false);
       this.workspace.flyout_ = null;
       chai.assert.throws(function() {
         this.workspace.updateToolbox({'contents': []});
@@ -131,13 +135,12 @@ suite('WorkspaceSvg', function() {
     }
     function assertSpyFiredViewportEvent(spy, workspace, expectedProperties) {
       assertEventFired(
-          spy, Blockly.Events.ViewportChange, expectedProperties,
-          workspace.id);
-      assertEventFired(spy, Blockly.Events.ViewportChange, expectedProperties,
-          workspace.id);
+          spy, Blockly.Events.ViewportChange, expectedProperties, workspace.id);
+      assertEventFired(
+          spy, Blockly.Events.ViewportChange, expectedProperties, workspace.id);
     }
-    function assertViewportEventFired(eventsFireStub, changeListenerSpy,
-        workspace, expectedEventCount = 1) {
+    function assertViewportEventFired(
+        eventsFireStub, changeListenerSpy, workspace, expectedEventCount = 1) {
       const metrics = workspace.getMetrics();
       const expectedProperties = {
         scale: workspace.scale,
@@ -153,8 +156,9 @@ suite('WorkspaceSvg', function() {
       sinon.assert.callCount(changeListenerSpy, expectedEventCount);
       sinon.assert.callCount(eventsFireStub, expectedEventCount);
     }
-    function runViewportEventTest(eventTriggerFunc, eventsFireStub,
-        changeListenerSpy, workspace, clock, expectedEventCount = 1) {
+    function runViewportEventTest(
+        eventTriggerFunc, eventsFireStub, changeListenerSpy, workspace, clock,
+        expectedEventCount = 1) {
       clock.runAll();
       resetEventHistory(eventsFireStub, changeListenerSpy);
       eventTriggerFunc();
@@ -171,37 +175,37 @@ suite('WorkspaceSvg', function() {
 
     suite('zoom', function() {
       test('setScale', function() {
-        runViewportEventTest(() => this.workspace.setScale(2),
-            this.eventsFireStub, this.changeListenerSpy, this.workspace,
-            this.clock);
+        runViewportEventTest(
+            () => this.workspace.setScale(2), this.eventsFireStub,
+            this.changeListenerSpy, this.workspace, this.clock);
       });
       test('zoom(50, 50, 1)', function() {
-        runViewportEventTest(() => this.workspace.zoom(50, 50, 1),
-            this.eventsFireStub, this.changeListenerSpy, this.workspace,
-            this.clock);
+        runViewportEventTest(
+            () => this.workspace.zoom(50, 50, 1), this.eventsFireStub,
+            this.changeListenerSpy, this.workspace, this.clock);
       });
       test('zoom(50, 50, -1)', function() {
-        runViewportEventTest(() => this.workspace.zoom(50, 50, -1),
-            this.eventsFireStub, this.changeListenerSpy, this.workspace,
-            this.clock);
+        runViewportEventTest(
+            () => this.workspace.zoom(50, 50, -1), this.eventsFireStub,
+            this.changeListenerSpy, this.workspace, this.clock);
       });
       test('zoomCenter(1)', function() {
-        runViewportEventTest(() => this.workspace.zoomCenter(1),
-            this.eventsFireStub, this.changeListenerSpy, this.workspace,
-            this.clock);
+        runViewportEventTest(
+            () => this.workspace.zoomCenter(1), this.eventsFireStub,
+            this.changeListenerSpy, this.workspace, this.clock);
       });
       test('zoomCenter(-1)', function() {
-        runViewportEventTest(() => this.workspace.zoomCenter(-1),
-            this.eventsFireStub, this.changeListenerSpy, this.workspace,
-            this.clock);
+        runViewportEventTest(
+            () => this.workspace.zoomCenter(-1), this.eventsFireStub,
+            this.changeListenerSpy, this.workspace, this.clock);
       });
       test('zoomToFit', function() {
         const block = this.workspace.newBlock('stack_block');
         block.initSvg();
         block.render();
-        runViewportEventTest(() => this.workspace.zoomToFit(),
-            this.eventsFireStub, this.changeListenerSpy, this.workspace,
-            this.clock);
+        runViewportEventTest(
+            () => this.workspace.zoomToFit(), this.eventsFireStub,
+            this.changeListenerSpy, this.workspace, this.clock);
       });
     });
     suite('scroll', function() {
@@ -209,19 +213,19 @@ suite('WorkspaceSvg', function() {
         const block = this.workspace.newBlock('stack_block');
         block.initSvg();
         block.render();
-        runViewportEventTest(() => this.workspace.centerOnBlock(block.id),
-            this.eventsFireStub, this.changeListenerSpy, this.workspace,
-            this.clock);
+        runViewportEventTest(
+            () => this.workspace.centerOnBlock(block.id), this.eventsFireStub,
+            this.changeListenerSpy, this.workspace, this.clock);
       });
       test('scroll', function() {
-        runViewportEventTest(() => this.workspace.scroll(50, 50),
-            this.eventsFireStub, this.changeListenerSpy, this.workspace,
-            this.clock);
+        runViewportEventTest(
+            () => this.workspace.scroll(50, 50), this.eventsFireStub,
+            this.changeListenerSpy, this.workspace, this.clock);
       });
       test('scrollCenter', function() {
-        runViewportEventTest(() => this.workspace.scrollCenter(),
-            this.eventsFireStub, this.changeListenerSpy, this.workspace,
-            this.clock);
+        runViewportEventTest(
+            () => this.workspace.scrollCenter(), this.eventsFireStub,
+            this.changeListenerSpy, this.workspace, this.clock);
       });
     });
     suite('Blocks triggering viewport changes', function() {
@@ -232,10 +236,12 @@ suite('WorkspaceSvg', function() {
         this.clock.runAll();
         resetEventHistory(this.eventsFireStub, this.changeListenerSpy);
         // Expect 2 events, 1 move, 1 viewport
-        runViewportEventTest(() => {
-          block.moveBy(1000, 1000);
-        }, this.eventsFireStub, this.changeListenerSpy, this.workspace,
-        this.clock, 2);
+        runViewportEventTest(
+            () => {
+              block.moveBy(1000, 1000);
+            },
+            this.eventsFireStub, this.changeListenerSpy, this.workspace,
+            this.clock, 2);
       });
       test('domToWorkspace that doesn\'t trigger scroll', function() {
         // 4 blocks with space in center.
@@ -253,11 +259,14 @@ suite('WorkspaceSvg', function() {
         this.clock.runAll();
         resetEventHistory(this.eventsFireStub, this.changeListenerSpy);
         // Add block in center of other blocks, not triggering scroll.
-        Blockly.Xml.domToWorkspace(Blockly.utils.xml.textToDom(
-            '<block type="controls_if" x="188" y="163"></block>'), this.workspace);
+        Blockly.Xml.domToWorkspace(
+            Blockly.utils.xml.textToDom(
+                '<block type="controls_if" x="188" y="163"></block>'),
+            this.workspace);
         this.clock.runAll();
         assertEventNotFired(
-            this.eventsFireStub, Blockly.Events.ViewportChange, {type: eventUtils.VIEWPORT_CHANGE});
+            this.eventsFireStub, Blockly.Events.ViewportChange,
+            {type: eventUtils.VIEWPORT_CHANGE});
         assertEventNotFired(
             this.changeListenerSpy, Blockly.Events.ViewportChange,
             {type: eventUtils.VIEWPORT_CHANGE});
@@ -287,23 +296,28 @@ suite('WorkspaceSvg', function() {
             this.changeListenerSpy, Blockly.Events.ViewportChange,
             {type: eventUtils.VIEWPORT_CHANGE});
       });
-      test.skip('domToWorkspace multiple blocks triggers one viewport event', function() {
-        // TODO: Un-skip after adding filtering for consecutive viewport events.
-        const addingMultipleBlocks = () => {
-          Blockly.Xml.domToWorkspace(
-              Blockly.utils.xml.textToDom(
-                  '<xml xmlns="https://developers.google.com/blockly/xml">' +
-                  '<block type="controls_if" x="88" y="88"></block>' +
-                  '<block type="controls_if" x="288" y="88"></block>' +
-                  '<block type="controls_if" x="88" y="238"></block>' +
-                  '<block type="controls_if" x="288" y="238"></block>' +
-                  '</xml>'),
-              this.workspace);
-        };
-        // Expect 10 events, 4 create, 4 move, 1 viewport, 1 finished loading
-        runViewportEventTest(addingMultipleBlocks, this.eventsFireStub,
-            this.changeListenerSpy, this.workspace, this.clock, 10);
-      });
+      test.skip(
+          'domToWorkspace multiple blocks triggers one viewport event',
+          function() {
+            // TODO: Un-skip after adding filtering for consecutive viewport
+            // events.
+            const addingMultipleBlocks = () => {
+              Blockly.Xml.domToWorkspace(
+                  Blockly.utils.xml.textToDom(
+                      '<xml xmlns="https://developers.google.com/blockly/xml">' +
+                      '<block type="controls_if" x="88" y="88"></block>' +
+                      '<block type="controls_if" x="288" y="88"></block>' +
+                      '<block type="controls_if" x="88" y="238"></block>' +
+                      '<block type="controls_if" x="288" y="238"></block>' +
+                      '</xml>'),
+                  this.workspace);
+            };
+            // Expect 10 events, 4 create, 4 move, 1 viewport, 1 finished
+            // loading
+            runViewportEventTest(
+                addingMultipleBlocks, this.eventsFireStub,
+                this.changeListenerSpy, this.workspace, this.clock, 10);
+          });
     });
   });
   suite('Workspace Base class', function() {

--- a/tests/mocha/xml_test.js
+++ b/tests/mocha/xml_test.js
@@ -71,7 +71,7 @@ suite('XML', function() {
       '      </block>',
       '    </statement>',
       '  </block>',
-      '</xml>'
+      '</xml>',
     ].join('\n');
   });
   teardown(function() {

--- a/tests/mocha/xml_test.js
+++ b/tests/mocha/xml_test.js
@@ -71,7 +71,8 @@ suite('XML', function() {
       '      </block>',
       '    </statement>',
       '  </block>',
-      '</xml>'].join('\n');
+      '</xml>'
+    ].join('\n');
   });
   teardown(function() {
     sharedTestTeardown.call(this);
@@ -87,16 +88,17 @@ suite('XML', function() {
 
     test(
         'text with hex-encoded NCR Control characters are properly ' +
-        'deserialized',
+            'deserialized',
         function() {
-          const dom = Blockly.utils.xml.textToDom('<xml>&#x1;&#x9;&#x1F;</xml>');
+          const dom =
+              Blockly.utils.xml.textToDom('<xml>&#x1;&#x9;&#x1F;</xml>');
           assertXmlDoc(dom);
           chai.assert.equal(dom.firstChild.textContent, '\u0001\t\u001f');
         });
 
     test(
         'text with dec-encoded NCR Control characters are properly ' +
-        'deserialized',
+            'deserialized',
         function() {
           const dom = Blockly.utils.xml.textToDom('<xml>&#1;&#9;&#31</xml>');
           assertXmlDoc(dom);
@@ -130,8 +132,8 @@ suite('XML', function() {
             },
           ],
         }]);
-        const block = new Blockly.Block(this.workspace,
-            'field_angle_test_block');
+        const block =
+            new Blockly.Block(this.workspace, 'field_angle_test_block');
         const resultFieldDom = Blockly.Xml.blockToDom(block).childNodes[0];
         assertNonVariableField(resultFieldDom, 'ANGLE', '90');
       });
@@ -147,8 +149,8 @@ suite('XML', function() {
             },
           ],
         }]);
-        const block = new Blockly.Block(this.workspace,
-            'field_checkbox_test_block');
+        const block =
+            new Blockly.Block(this.workspace, 'field_checkbox_test_block');
         const resultFieldDom = Blockly.Xml.blockToDom(block).childNodes[0];
         assertNonVariableField(resultFieldDom, 'CHECKBOX', 'TRUE');
       });
@@ -164,8 +166,8 @@ suite('XML', function() {
             },
           ],
         }]);
-        const block = new Blockly.Block(this.workspace,
-            'field_colour_test_block');
+        const block =
+            new Blockly.Block(this.workspace, 'field_colour_test_block');
         const resultFieldDom = Blockly.Xml.blockToDom(block).childNodes[0];
         assertNonVariableField(resultFieldDom, 'COLOUR', '#000099');
       });
@@ -194,8 +196,8 @@ suite('XML', function() {
             },
           ],
         }]);
-        const block = new Blockly.Block(this.workspace,
-            'field_dropdown_test_block');
+        const block =
+            new Blockly.Block(this.workspace, 'field_dropdown_test_block');
         const resultFieldDom = Blockly.Xml.blockToDom(block).childNodes[0];
         assertNonVariableField(resultFieldDom, 'DROPDOWN', 'A');
       });
@@ -207,15 +209,16 @@ suite('XML', function() {
             {
               "type": "field_image",
               "name": "IMAGE",
-              "src": "https://blockly-demo.appspot.com/static/tests/media/a.png",
+              "src":
+                  "https://blockly-demo.appspot.com/static/tests/media/a.png",
               "width": 32,
               "height": 32,
               "alt": "A",
             },
           ],
         }]);
-        const block = new Blockly.Block(this.workspace,
-            'field_image_test_block');
+        const block =
+            new Blockly.Block(this.workspace, 'field_image_test_block');
         const resultFieldDom = Blockly.Xml.blockToDom(block);
         assertNonSerializingFieldDom(resultFieldDom);
       });
@@ -231,8 +234,8 @@ suite('XML', function() {
             },
           ],
         }]);
-        const block = new Blockly.Block(this.workspace,
-            'field_label_test_block');
+        const block =
+            new Blockly.Block(this.workspace, 'field_label_test_block');
         const resultFieldDom = Blockly.Xml.blockToDom(block);
         assertNonSerializingFieldDom(resultFieldDom);
       });
@@ -248,8 +251,8 @@ suite('XML', function() {
             },
           ],
         }]);
-        const block = new Blockly.Block(this.workspace,
-            'field_label_serializable_test_block');
+        const block = new Blockly.Block(
+            this.workspace, 'field_label_serializable_test_block');
         const resultFieldDom = Blockly.Xml.blockToDom(block).childNodes[0];
         assertNonVariableField(resultFieldDom, 'LABEL', 'default');
       });
@@ -265,8 +268,8 @@ suite('XML', function() {
             },
           ],
         }]);
-        const block = new Blockly.Block(this.workspace,
-            'field_number_test_block');
+        const block =
+            new Blockly.Block(this.workspace, 'field_number_test_block');
         const resultFieldDom = Blockly.Xml.blockToDom(block).childNodes[0];
         assertNonVariableField(resultFieldDom, 'NUMBER', '97');
       });
@@ -282,8 +285,8 @@ suite('XML', function() {
             },
           ],
         }]);
-        const block = new Blockly.Block(this.workspace,
-            'field_text_input_test_block');
+        const block =
+            new Blockly.Block(this.workspace, 'field_text_input_test_block');
         const resultFieldDom = Blockly.Xml.blockToDom(block).childNodes[0];
         assertNonVariableField(resultFieldDom, 'TEXT', 'default');
       });
@@ -303,32 +306,34 @@ suite('XML', function() {
         });
         test('Variable Trivial', function() {
           this.workspace.createVariable('name1', '', 'id1');
-          const block = new Blockly.Block(this.workspace,
-              'field_variable_test_block');
+          const block =
+              new Blockly.Block(this.workspace, 'field_variable_test_block');
           block.inputList[0].fieldRow[0].setValue('id1');
           const resultFieldDom = Blockly.Xml.blockToDom(block).childNodes[0];
           assertVariableDomField(resultFieldDom, 'VAR', null, 'id1', 'name1');
         });
         test('Variable Typed', function() {
           this.workspace.createVariable('name1', 'string', 'id1');
-          const block = new Blockly.Block(this.workspace,
-              'field_variable_test_block');
+          const block =
+              new Blockly.Block(this.workspace, 'field_variable_test_block');
           block.inputList[0].fieldRow[0].setValue('id1');
           const resultFieldDom = Blockly.Xml.blockToDom(block).childNodes[0];
-          assertVariableDomField(resultFieldDom, 'VAR', 'string', 'id1', 'name1');
+          assertVariableDomField(
+              resultFieldDom, 'VAR', 'string', 'id1', 'name1');
         });
         test('Variable Default Case', function() {
           createGenUidStubWithReturns('1');
           this.workspace.createVariable('name1');
 
           Blockly.Events.disable();
-          const block = new Blockly.Block(this.workspace,
-              'field_variable_test_block');
+          const block =
+              new Blockly.Block(this.workspace, 'field_variable_test_block');
           block.inputList[0].fieldRow[0].setValue('1');
           Blockly.Events.enable();
 
           const resultFieldDom = Blockly.Xml.blockToDom(block).childNodes[0];
-          // Expect type is null and ID is '1' since we don't specify type and ID.
+          // Expect type is null and ID is '1' since we don't specify type and
+          // ID.
           assertVariableDomField(resultFieldDom, 'VAR', null, '1', 'name1');
         });
       });
@@ -336,9 +341,9 @@ suite('XML', function() {
     suite('Comments', function() {
       suite('Headless', function() {
         setup(function() {
-          this.block = Blockly.Xml.domToBlock(Blockly.utils.xml.textToDom(
-              '<block type="empty_block"/>'
-          ), this.workspace);
+          this.block = Blockly.Xml.domToBlock(
+              Blockly.utils.xml.textToDom('<block type="empty_block"/>'),
+              this.workspace);
         });
         test('Text', function() {
           this.block.setCommentText('test text');
@@ -361,9 +366,9 @@ suite('XML', function() {
         setup(function() {
           // Let the parent teardown dispose of it.
           this.workspace = Blockly.inject('blocklyDiv', {comments: true});
-          this.block = Blockly.Xml.domToBlock(Blockly.utils.xml.textToDom(
-              '<block type="empty_block"/>'
-          ), this.workspace);
+          this.block = Blockly.Xml.domToBlock(
+              Blockly.utils.xml.textToDom('<block type="empty_block"/>'),
+              this.workspace);
         });
         teardown(function() {
           workspaceTeardown.call(this, this.workspace);
@@ -446,16 +451,16 @@ suite('XML', function() {
       // If events are enabled during block construction, it will create a
       // default variable.
       Blockly.Events.disable();
-      const block = new Blockly.Block(this.workspace, 'field_variable_test_block');
+      const block =
+          new Blockly.Block(this.workspace, 'field_variable_test_block');
       block.inputList[0].fieldRow[0].setValue('id1');
       Blockly.Events.enable();
 
-      const resultDom = Blockly.Xml.variablesToDom(this.workspace.getAllVariables());
+      const resultDom =
+          Blockly.Xml.variablesToDom(this.workspace.getAllVariables());
       chai.assert.equal(resultDom.children.length, 2);
-      assertVariableDom(resultDom.children[0], null, 'id1',
-          'name1');
-      assertVariableDom(resultDom.children[1], 'type2', 'id2',
-          'name2');
+      assertVariableDom(resultDom.children[0], null, 'id1', 'name1');
+      assertVariableDom(resultDom.children[1], 'type2', 'id2', 'name2');
     });
     test('No variables', function() {
       const resultDom =
@@ -468,17 +473,17 @@ suite('XML', function() {
     test('Round tripping', function() {
       const dom = Blockly.utils.xml.textToDom(this.complexXmlText);
       const text = Blockly.Xml.domToText(dom);
-      chai.assert.equal(text.replace(/\s+/g, ''),
-          this.complexXmlText.replace(/\s+/g, ''), 'Round trip');
+      chai.assert.equal(
+          text.replace(/\s+/g, ''), this.complexXmlText.replace(/\s+/g, ''),
+          'Round trip');
     });
 
     test('control characters are escaped', function() {
       const dom = Blockly.utils.xml.createElement('xml');
-      dom.appendChild(Blockly.utils.xml.createTextNode('')); // u0001
+      dom.appendChild(Blockly.utils.xml.createTextNode(''));  // u0001
       chai.assert.equal(
           Blockly.utils.xml.domToText(dom),
-          '<xml xmlns="https://developers.google.com/blockly/xml">&#1;</xml>'
-      );
+          '<xml xmlns="https://developers.google.com/blockly/xml">&#1;</xml>');
     });
 
     test('ampersands are escaped', function() {
@@ -486,8 +491,7 @@ suite('XML', function() {
       dom.appendChild(Blockly.utils.xml.createTextNode('&'));
       chai.assert.equal(
           Blockly.Xml.domToText(dom),
-          '<xml xmlns="https://developers.google.com/blockly/xml">&amp;</xml>'
-      );
+          '<xml xmlns="https://developers.google.com/blockly/xml">&amp;</xml>');
     });
   });
 
@@ -495,8 +499,9 @@ suite('XML', function() {
     test('Round tripping', function() {
       const dom = Blockly.utils.xml.textToDom(this.complexXmlText);
       const text = Blockly.Xml.domToPrettyText(dom);
-      chai.assert.equal(text.replace(/\s+/g, ''),
-          this.complexXmlText.replace(/\s+/g, ''), 'Round trip');
+      chai.assert.equal(
+          text.replace(/\s+/g, ''), this.complexXmlText.replace(/\s+/g, ''),
+          'Round trip');
     });
   });
   suite('domToBlock', function() {
@@ -529,52 +534,58 @@ suite('XML', function() {
     suite('Comments', function() {
       suite('Headless', function() {
         test('Text', function() {
-          const block = Blockly.Xml.domToBlock(Blockly.utils.xml.textToDom(
-              '<block type="empty_block">' +
-              '  <comment>test text</comment>' +
-              '</block>'
-          ), this.workspace);
+          const block = Blockly.Xml.domToBlock(
+              Blockly.utils.xml.textToDom(
+                  '<block type="empty_block">' +
+                  '  <comment>test text</comment>' +
+                  '</block>'),
+              this.workspace);
           chai.assert.equal(block.getCommentText(), 'test text');
         });
         test('No Text', function() {
-          const block = Blockly.Xml.domToBlock(Blockly.utils.xml.textToDom(
-              '<block type="empty_block">' +
-              '  <comment></comment>' +
-              '</block>'
-          ), this.workspace);
+          const block = Blockly.Xml.domToBlock(
+              Blockly.utils.xml.textToDom(
+                  '<block type="empty_block">' +
+                  '  <comment></comment>' +
+                  '</block>'),
+              this.workspace);
           chai.assert.equal(block.getCommentText(), '');
         });
         test('Size', function() {
-          const block = Blockly.Xml.domToBlock(Blockly.utils.xml.textToDom(
-              '<block type="empty_block">' +
-              '  <comment w="100" h="200">test text</comment>' +
-              '</block>'
-          ), this.workspace);
-          chai.assert.deepEqual(block.commentModel.size,
-              {width: 100, height: 200});
+          const block = Blockly.Xml.domToBlock(
+              Blockly.utils.xml.textToDom(
+                  '<block type="empty_block">' +
+                  '  <comment w="100" h="200">test text</comment>' +
+                  '</block>'),
+              this.workspace);
+          chai.assert.deepEqual(
+              block.commentModel.size, {width: 100, height: 200});
         });
         test('Pinned True', function() {
-          const block = Blockly.Xml.domToBlock(Blockly.utils.xml.textToDom(
-              '<block type="empty_block">' +
-              '  <comment pinned="true">test text</comment>' +
-              '</block>'
-          ), this.workspace);
+          const block = Blockly.Xml.domToBlock(
+              Blockly.utils.xml.textToDom(
+                  '<block type="empty_block">' +
+                  '  <comment pinned="true">test text</comment>' +
+                  '</block>'),
+              this.workspace);
           chai.assert.isTrue(block.commentModel.pinned);
         });
         test('Pinned False', function() {
-          const block = Blockly.Xml.domToBlock(Blockly.utils.xml.textToDom(
-              '<block type="empty_block">' +
-              '  <comment pinned="false">test text</comment>' +
-              '</block>'
-          ), this.workspace);
+          const block = Blockly.Xml.domToBlock(
+              Blockly.utils.xml.textToDom(
+                  '<block type="empty_block">' +
+                  '  <comment pinned="false">test text</comment>' +
+                  '</block>'),
+              this.workspace);
           chai.assert.isFalse(block.commentModel.pinned);
         });
         test('Pinned Undefined', function() {
-          const block = Blockly.Xml.domToBlock(Blockly.utils.xml.textToDom(
-              '<block type="empty_block">' +
-              '  <comment>test text</comment>' +
-              '</block>'
-          ), this.workspace);
+          const block = Blockly.Xml.domToBlock(
+              Blockly.utils.xml.textToDom(
+                  '<block type="empty_block">' +
+                  '  <comment>test text</comment>' +
+                  '</block>'),
+              this.workspace);
           chai.assert.isFalse(block.commentModel.pinned);
         });
       });
@@ -587,64 +598,71 @@ suite('XML', function() {
         });
 
         test('Text', function() {
-          const block = Blockly.Xml.domToBlock(Blockly.utils.xml.textToDom(
-              '<block type="empty_block">' +
-              '  <comment>test text</comment>' +
-              '</block>'
-          ), this.workspace);
+          const block = Blockly.Xml.domToBlock(
+              Blockly.utils.xml.textToDom(
+                  '<block type="empty_block">' +
+                  '  <comment>test text</comment>' +
+                  '</block>'),
+              this.workspace);
           chai.assert.equal(block.getCommentText(), 'test text');
           chai.assert.isNotNull(block.getCommentIcon());
         });
         test('No Text', function() {
-          const block = Blockly.Xml.domToBlock(Blockly.utils.xml.textToDom(
-              '<block type="empty_block">' +
-              '  <comment></comment>' +
-              '</block>'
-          ), this.workspace);
+          const block = Blockly.Xml.domToBlock(
+              Blockly.utils.xml.textToDom(
+                  '<block type="empty_block">' +
+                  '  <comment></comment>' +
+                  '</block>'),
+              this.workspace);
           chai.assert.equal(block.getCommentText(), '');
           chai.assert.isNotNull(block.getCommentIcon());
         });
         test('Size', function() {
-          const block = Blockly.Xml.domToBlock(Blockly.utils.xml.textToDom(
-              '<block type="empty_block">' +
-              '  <comment w="100" h="200">test text</comment>' +
-              '</block>'
-          ), this.workspace);
-          chai.assert.deepEqual(block.commentModel.size,
-              {width: 100, height: 200});
+          const block = Blockly.Xml.domToBlock(
+              Blockly.utils.xml.textToDom(
+                  '<block type="empty_block">' +
+                  '  <comment w="100" h="200">test text</comment>' +
+                  '</block>'),
+              this.workspace);
+          chai.assert.deepEqual(
+              block.commentModel.size, {width: 100, height: 200});
           chai.assert.isNotNull(block.getCommentIcon());
-          chai.assert.deepEqual(block.getCommentIcon().getBubbleSize(),
+          chai.assert.deepEqual(
+              block.getCommentIcon().getBubbleSize(),
               {width: 100, height: 200});
         });
         suite('Pinned', function() {
           test('Pinned True', function() {
-            const block = Blockly.Xml.domToBlock(Blockly.utils.xml.textToDom(
-                '<block type="empty_block">' +
-                '  <comment pinned="true">test text</comment>' +
-                '</block>'
-            ), this.workspace);
+            const block = Blockly.Xml.domToBlock(
+                Blockly.utils.xml.textToDom(
+                    '<block type="empty_block">' +
+                    '  <comment pinned="true">test text</comment>' +
+                    '</block>'),
+                this.workspace);
             this.clock.runAll();
             chai.assert.isTrue(block.commentModel.pinned);
             chai.assert.isNotNull(block.getCommentIcon());
             chai.assert.isTrue(block.getCommentIcon().isVisible());
           });
           test('Pinned False', function() {
-            const block = Blockly.Xml.domToBlock(Blockly.utils.xml.textToDom(
-                '<block type="empty_block">' +
-                '  <comment pinned="false">test text</comment>' +
-                '</block>'
-            ), this.workspace);
+            const block = Blockly.Xml.domToBlock(
+                Blockly.utils.xml.textToDom(
+                    '<block type="empty_block">' +
+                    '  <comment pinned="false">test text</comment>' +
+                    '</block>'),
+                this.workspace);
             this.clock.runAll();
             chai.assert.isFalse(block.commentModel.pinned);
             chai.assert.isNotNull(block.getCommentIcon());
             chai.assert.isFalse(block.getCommentIcon().isVisible());
           });
           test('Pinned Undefined', function() {
-            const block = Blockly.Xml.domToBlock(Blockly.utils.xml.textToDom(
-                '<block type="empty_block">' +
-                '  <comment>test text</comment>' +
-                '</block>'
-            ), this.workspace);
+            const block = Blockly.Xml.domToBlock(
+                Blockly.utils.xml.textToDom(
+                    '<block type="empty_block">' +
+                    '  <comment>test text</comment>' +
+                    '</block>'),
+                this.workspace);
             this.clock.runAll();
             chai.assert.isFalse(block.commentModel.pinned);
             chai.assert.isNotNull(block.getCommentIcon());
@@ -681,7 +699,8 @@ suite('XML', function() {
           '  </block>' +
           '</xml>');
       Blockly.Xml.domToWorkspace(dom, this.workspace);
-      chai.assert.equal(this.workspace.getAllBlocks(false).length, 1, 'Block count');
+      chai.assert.equal(
+          this.workspace.getAllBlocks(false).length, 1, 'Block count');
       assertVariableValues(this.workspace, 'name1', '', '1');
     });
     test('Variables at top', function() {
@@ -697,7 +716,8 @@ suite('XML', function() {
           '  </block>' +
           '</xml>');
       Blockly.Xml.domToWorkspace(dom, this.workspace);
-      chai.assert.equal(this.workspace.getAllBlocks(false).length, 1, 'Block count');
+      chai.assert.equal(
+          this.workspace.getAllBlocks(false).length, 1, 'Block count');
       assertVariableValues(this.workspace, 'name1', 'type1', 'id1');
       assertVariableValues(this.workspace, 'name2', 'type2', 'id2');
       assertVariableValues(this.workspace, 'name3', '', 'id3');
@@ -765,9 +785,11 @@ suite('XML', function() {
           '  </block>' +
           '</xml>');
       Blockly.Xml.appendDomToWorkspace(dom, this.workspace);
-      chai.assert.equal(this.workspace.getAllBlocks(false).length, 1, 'Block count');
+      chai.assert.equal(
+          this.workspace.getAllBlocks(false).length, 1, 'Block count');
       const newBlockIds = Blockly.Xml.appendDomToWorkspace(dom, this.workspace);
-      chai.assert.equal(this.workspace.getAllBlocks(false).length, 2, 'Block count');
+      chai.assert.equal(
+          this.workspace.getAllBlocks(false).length, 2, 'Block count');
       chai.assert.equal(newBlockIds.length, 1, 'Number of new block ids');
     });
   });
@@ -796,9 +818,9 @@ suite('XML', function() {
     };
     suite('Rendered -> XML -> Headless -> XML', function() {
       test('Comment', function() {
-        const block = Blockly.Xml.domToBlock(Blockly.utils.xml.textToDom(
-            '<block type="empty_block"/>'
-        ), this.renderedWorkspace);
+        const block = Blockly.Xml.domToBlock(
+            Blockly.utils.xml.textToDom('<block type="empty_block"/>'),
+            this.renderedWorkspace);
         block.setCommentText('test text');
         block.getCommentIcon().setBubbleSize(100, 100);
         block.getCommentIcon().setVisible(true);
@@ -807,9 +829,9 @@ suite('XML', function() {
     });
     suite('Headless -> XML -> Rendered -> XML', function() {
       test('Comment', function() {
-        const block = Blockly.Xml.domToBlock(Blockly.utils.xml.textToDom(
-            '<block type="empty_block"/>'
-        ), this.headlessWorkspace);
+        const block = Blockly.Xml.domToBlock(
+            Blockly.utils.xml.textToDom('<block type="empty_block"/>'),
+            this.headlessWorkspace);
         block.setCommentText('test text');
         block.commentModel.size = new Blockly.utils.Size(100, 100);
         block.commentModel.pinned = true;

--- a/tests/mocha/zoom_controls_test.js
+++ b/tests/mocha/zoom_controls_test.js
@@ -15,8 +15,7 @@ import {simulateClick} from './test_helpers/user_input.js';
 suite("Zoom Controls", function() {
   setup(function() {
     sharedTestSetup.call(this);
-    this.workspace = Blockly.inject('blocklyDiv',
-        {'zoom': {'controls': true}});
+    this.workspace = Blockly.inject('blocklyDiv', {'zoom': {'controls': true}});
     this.zoomControls = this.workspace.zoomControls_;
   });
   teardown(function() {
@@ -34,7 +33,8 @@ suite("Zoom Controls", function() {
 
       assertEventFired(
           this.eventsFireStub, Blockly.Events.Click,
-          {targetType: 'zoom_controls', type: eventUtils.CLICK}, this.workspace.id, undefined);
+          {targetType: 'zoom_controls', type: eventUtils.CLICK},
+          this.workspace.id, undefined);
       assertEventNotFired(
           this.eventsFireStub, Blockly.Events.Click,
           {targetType: 'workspace', type: eventUtils.CLICK});
@@ -45,7 +45,8 @@ suite("Zoom Controls", function() {
 
       assertEventFired(
           this.eventsFireStub, Blockly.Events.Click,
-          {targetType: 'zoom_controls', type: eventUtils.CLICK}, this.workspace.id, undefined);
+          {targetType: 'zoom_controls', type: eventUtils.CLICK},
+          this.workspace.id, undefined);
       assertEventNotFired(
           this.eventsFireStub, Blockly.Events.Click,
           {targetType: 'workspace', type: eventUtils.CLICK});
@@ -56,7 +57,8 @@ suite("Zoom Controls", function() {
 
       assertEventFired(
           this.eventsFireStub, Blockly.Events.Click,
-          {targetType: 'zoom_controls', type: eventUtils.CLICK}, this.workspace.id, undefined);
+          {targetType: 'zoom_controls', type: eventUtils.CLICK},
+          this.workspace.id, undefined);
       assertEventNotFired(
           this.eventsFireStub, Blockly.Events.Click,
           {targetType: 'workspace', type: eventUtils.CLICK});


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [x] I ran `npm run format` and `npm run lint`

## The details
### Resolves

Work on #6993 

### Proposed Changes

- Updates the GitHub Action clang-format to run on generators and mocha tests as well
- Updates the local clang-format to run on the same, and not blocks (for now, see the issue for more info)
- Updates eslint config to use 80 as the line length, and adds an exception for template literals and import/export statements (which approximates what clang-format does)
- Updates the clang-format rules to set [`JavaScriptQuotes`](https://clang.llvm.org/docs/ClangFormatStyleOptions.html#javascriptquotes) to `Leave`. I do not know why I had to set this, because I checked the `google` style config and it's supposed to be the default option. Despite that, if I did not set it here, it changed multiple instances like `const codeStringThatContainsStrings = "import 'foo'"`  to `'import \'foo\''` which is probably undesirable (though in all of the code in core, we do just escape the single quotes, probably because of this formatting rule). This is also important because otherwise JSON blobs in tests (which are constructed manually, not using json.stringify) would be converted to single quotes and potentially break some tests.
- Runs the formatter (and eslint auto-fixer) on all the code after these rules are applied, so changes to non-configuration files are the result of these tools, with two exceptions:
    - Added a clang-format disable to one test with a bulky multi-line array that clang-format would butcher but isn't typical of our codebase. Apologies, forgot to stick this in its own commit but it's [here](https://github.com/google/blockly/pull/7000/files#diff-4a436a782bac6956364bbcffe3320e4b57d8ec830d18c37b6967910908a83481R175)
    - Added an eslint-disable to one comment that was already being ignored by clang-format. (in its own commit)
- Fixes a missing semicolon that causes compilation errors after formatting
- Updates the CI action to NOT lint the `tests/mocha/.mocharc.js` file. By default this CI action lints dotfiles but local does not. To resolve this discrepancy, you have two options:
    - Specifically exclude this dotfile
    - Have the local clang-format also run on dotfiles. This is possible by passing an option to the gulp task. But the [thing clang-format wants to do to this file](https://github.com/google/blockly/actions/runs/4759851822/jobs/8459536695) makes no sense. My only explanation is that somehow it thinks this file is json... there's an option to not have this space in json but not until clang-format 17, which isn't compatible with the CI action we're using

#### Behavior Before Change

Inconsistent formatting locally vs CI

#### Behavior After Change

Consistent formatting locally and on CI, and more formatted files.

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information
