### PR TITLE
fix: icons not having their locations updated

### DIFF
--- a/core/render_management.ts
+++ b/core/render_management.ts
@@ -138,6 +138,7 @@ function updateConnectionLocations(block: BlockSvg, blockOrigin: Coordinate) {
  * @param block The block to update the icon locations of.
  */
 function updateIconLocations(block: BlockSvg) {
+  if (!block.getIcons) return;
   for (const icon of block.getIcons()) {
     icon.computeIconLocation();
   }

--- a/core/render_management.ts
+++ b/core/render_management.ts
@@ -86,6 +86,7 @@ function doRenders() {
 
     renderBlock(block);
     updateConnectionLocations(block, block.getRelativeToSurfaceXY());
+    updateIconLocations(block);
   }
   for (const workspace of workspaces) {
     workspace.resizeContents();
@@ -127,5 +128,20 @@ function updateConnectionLocations(block: BlockSvg, blockOrigin: Coordinate) {
       updateConnectionLocations(
           target, Coordinate.sum(blockOrigin, target.relativeCoords));
     }
+  }
+}
+
+/**
+ * Updates all icons that are children of the given block with their new
+ * locations.
+ *
+ * @param block The block to update the icon locations of.
+ */
+function updateIconLocations(block: BlockSvg) {
+  for (const icon of block.getIcons()) {
+    icon.computeIconLocation();
+  }
+  for (const child of block.getChildren(false)) {
+    updateIconLocations(child);
   }
 }


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [X] I ran `npm run format` and `npm run lint`

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #6999

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
Adds a step to the queued render process that updates the location of icons.

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
Elements of a block don't get to decide where they are positioned, but some of them (icons and connections) need to know where they're positioned. Before the code for updating icons was hidden inside `moveConnections` which was triggered via `renderedConnection.tighten`. Now it has been separated out so that it is clear what's happening.

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->
Just manual testing =(

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->
N/A

### Additional Information

<!-- Anything else we should know? -->
N/A
