### PR TITLE
fix: switch most remaining render calls to queueRender

### DIFF
--- a/blocks/procedures.js
+++ b/blocks/procedures.js
@@ -756,9 +756,6 @@ const PROCEDURE_CALL_COMMON = {
       this.quarkConnections_ = {};
       this.quarkIds_ = [];
     }
-    // Switch off rendering while the block is rebuilt.
-    const savedRendered = this.rendered;
-    this.rendered = false;
     // Update the quarkConnections_ with existing connections.
     for (let i = 0; i < this.arguments_.length; i++) {
       const input = this.getInput('ARG' + i);
@@ -797,11 +794,6 @@ const PROCEDURE_CALL_COMMON = {
           }
         }
       }
-    }
-    // Restore rendering and show the changes.
-    this.rendered = savedRendered;
-    if (this.rendered) {
-      this.render();
     }
   },
   /**

--- a/core/block_svg.ts
+++ b/core/block_svg.ts
@@ -1000,6 +1000,8 @@ export class BlockSvg extends Block implements IASTNodeLocationSvg,
       this.comment = null;  // For backwards compatibility.
     }
     if (this.rendered) {
+      // Icons must force an immediate render so that bubbles can be opened
+      // immedately at the correct position.
       this.render();
       // Adding or removing a comment icon will cause the block to change shape.
       this.bumpNeighbours();
@@ -1078,6 +1080,8 @@ export class BlockSvg extends Block implements IASTNodeLocationSvg,
       }
     }
     if (changedState && this.rendered) {
+      // Icons must force an immediate render so that bubbles can be opened
+      // immedately at the correct position.
       this.render();
       // Adding or removing a warning icon will cause the block to change shape.
       this.bumpNeighbours();
@@ -1099,6 +1103,8 @@ export class BlockSvg extends Block implements IASTNodeLocationSvg,
       mutator.createIcon();
     }
     if (this.rendered) {
+      // Icons must force an immediate render so that bubbles can be opened
+      // immedately at the correct position.
       this.render();
       // Adding or removing a mutator icon will cause the block to change shape.
       this.bumpNeighbours();

--- a/core/flyout_horizontal.ts
+++ b/core/flyout_horizontal.ts
@@ -244,7 +244,6 @@ export class HorizontalFlyout extends Flyout {
           // a block.
           child.isInFlyout = true;
         }
-        block!.render();
         const root = block!.getSvgRoot();
         const blockHW = block!.getHeightWidth();
         // Figure out where to place the block.

--- a/core/flyout_vertical.ts
+++ b/core/flyout_vertical.ts
@@ -225,7 +225,6 @@ export class VerticalFlyout extends Flyout {
           // a block.
           child.isInFlyout = true;
         }
-        block!.render();
         const root = block!.getSvgRoot();
         const blockHW = block!.getHeightWidth();
         const moveX =

--- a/core/mutator.ts
+++ b/core/mutator.ts
@@ -335,7 +335,7 @@ export class Mutator extends Icon {
       this.rootBlock = block.decompose!(ws)!;
       const blocks = this.rootBlock.getDescendants(false);
       for (let i = 0, child; child = blocks[i]; i++) {
-        child.render();
+        child.queueRender();
       }
       // The root block should not be draggable or deletable.
       this.rootBlock.setMovable(false);

--- a/core/rendered_connection.ts
+++ b/core/rendered_connection.ts
@@ -514,12 +514,7 @@ export class RenderedConnection extends Connection {
       return;
     }
     blockShadow.initSvg();
-    blockShadow.render(false);
-
-    const parentBlock = this.getSourceBlock();
-    if (parentBlock.rendered) {
-      parentBlock.queueRender();
-    }
+    blockShadow.queueRender();
   }
 
   /**

--- a/core/workspace_svg.ts
+++ b/core/workspace_svg.ts
@@ -1301,7 +1301,7 @@ export class WorkspaceSvg extends Workspace implements IASTNodeLocationSvg {
     const blocks = this.getAllBlocks(false);
     // Render each block.
     for (let i = blocks.length - 1; i >= 0; i--) {
-      blocks[i].render(false);
+      blocks[i].queueRender();
     }
 
     if (this.currentGesture_) {


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [X] I ran `npm run format` and `npm run lint`

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Was looking at https://github.com/google/blockly/issues/6980 and realized it would be easier to document if we just have one rendering path rather than two :P So I'm looking at trying to get rid of the old one.

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
Looked through all of the remaining uses of `render` and switched any over to `queueRender` that could use `queueRender`.

Remaining uses of `render` after this PR include icons (because they need to know their locations immediately) and deserialization (because it's causing forced layouts that I need to investigate).

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
Unification of rendering paths.

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->
Manual poking at things.

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->
N/A - but soon! hopefully 🤞 

### Additional Information

<!-- Anything else we should know? -->
The plan for the icons is to add a function to the render management system that forces an immediate render of all queued renders.
