### PR TITLE
fix: Update category.ts to produce valid "aria-level" attributes

### DIFF
--- a/core/toolbox/category.ts
+++ b/core/toolbox/category.ts
@@ -181,7 +181,7 @@ export class ToolboxCategory extends ToolboxItem implements
     this.htmlDiv_ = this.createContainer_();
     aria.setRole(this.htmlDiv_, aria.Role.TREEITEM);
     aria.setState(this.htmlDiv_, aria.State.SELECTED, false);
-    aria.setState(this.htmlDiv_, aria.State.LEVEL, this.level_);
+    aria.setState(this.htmlDiv_, aria.State.LEVEL, this.level_ + 1);
 
     this.rowDiv_ = this.createRowContainer_();
     this.rowDiv_.style.pointerEvents = 'auto';


### PR DESCRIPTION
The Aria level system starts with 1, but the variable 'this.level_' is zero-indexed and starts with 0, so be aware of this discrepancy when working with the code.

## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [x] I ran `npm run format` and `npm run lint`

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes https://github.com/google/blockly/issues/7027

### Proposed Changes

Increase aria-level to start with 1 instead of 0.

#### Behavior Before Change

The aria-level starts with 0.

#### Behavior After Change

The aria-level starts with 1.

### Reason for Changes

There are no aria-level with 0.

### Test Coverage

-

### Documentation

-

### Additional Information

-

Refs: #7027