### PR TITLE
chore(tests): Stop testing on node.js v14

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
         # TODO (#2114): re-enable osx build.
         # os: [ubuntu-latest, macos-latest]
         os: [ubuntu-latest]
-        node-version: [14.x, 16.x, 18.x, 20.x]
+        node-version: [16.x, 18.x, 20.x]
         # See supported Node.js release schedule at
         # https://nodejs.org/en/about/releases/
 


### PR DESCRIPTION
This formally ends our support for node.js v14.

## The basics

- [X] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [X] I ran `npm run format` and `npm run lint`

## The details
### Proposed Changes

Remove `14.x` from our node-version test matrix.

#### Behaviour Before Change

We run `npm test` on node.js v14 in CI.

#### Behaviour After Change

We no longer test on v14, only v16, v18 and v20.

### Reason for Changes

Node.js v14's LTS period has ended, and some of our dev dependencies no longer support it.  By dropping it as a test target we can update our dev dependencies to current versions.

### Test Coverage

Reduced.

