### PR TITLE
fix: bubbles not being dragged

### DIFF
--- a/core/bubbles/bubble.ts
+++ b/core/bubbles/bubble.ts
@@ -108,7 +108,7 @@ export abstract class Bubble implements IBubble {
 
     browserEvents.conditionalBind(
       this.background,
-      'pointerDown',
+      'pointerdown',
       this,
       this.onMouseDown
     );


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [X] I ran `npm run format` and `npm run lint`

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
N/A

### Proposed Changes

Fix typo.

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
Make blocks draggable.

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->
Manually tested dragging by hacking the bubble into the warning icon.

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->
N/A

### Additional Information

<!-- Anything else we should know? -->
N/A
