### PR TITLE
fix: Make props of ConnectionState optional

### DIFF
--- a/core/serialization/blocks.ts
+++ b/core/serialization/blocks.ts
@@ -37,8 +37,8 @@ import * as serializationRegistry from './registry.js';
  * Represents the state of a connection.
  */
 export interface ConnectionState {
-  shadow: State | undefined;
-  block: State | undefined;
+  shadow?: State;
+  block?: State;
 }
 
 /**


### PR DESCRIPTION
## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [ ] I ran `npm run format` and `npm run lint`

## The details
### Proposed Changes
Makes props in ConnectionState optional, so that the [code in documentation](https://developers.google.com/blockly/guides/configure/web/toolbox#preset_blocks) works.

#### Behavior Before Change
Previously, one had to specify both `block` and `shadow` and write `undefined` into one of them:
```typescript
{
  "kind": "flyoutToolbox",
  "contents": [
    {
      "kind": "block",
      "type": "controls_for",
      "inputs": {
        "FROM": {
          "block": {
            "type": "math_number",
            "fields": {
              "NUM": 1
            },
            "shadow": undefined, // error if omitted
          }
        },
        // ...
      }
    },
  ]
}
```

#### Behavior After Change
Now we can use the code written in the documentation:
```typescript
{
  "kind": "flyoutToolbox",
  "contents": [
    {
      "kind": "block",
      "type": "controls_for",
      "inputs": {
        "FROM": {
          "block": {
            "type": "math_number",
            "fields": {
              "NUM": 1
            }
          }
        },
        // ...
      }
    },
  ]
}
```

### Reason for Changes

This way it is both more convenient and matches the documentation better.