### PR TITLE
fix: have inputs construct connections

### DIFF
--- a/core/block.ts
+++ b/core/block.ts
@@ -1569,13 +1569,7 @@ export class Block implements IASTNodeLocation, IDeletable {
    * @returns The input object created.
    */
   appendValueInput(name: string): Input {
-    return this.appendInput(
-      new ValueInput(
-        name,
-        this,
-        this.makeConnection_(ConnectionType.INPUT_VALUE)
-      )
-    );
+    return this.appendInput(new ValueInput(name, this));
   }
 
   /**
@@ -1587,13 +1581,7 @@ export class Block implements IASTNodeLocation, IDeletable {
    */
   appendStatementInput(name: string): Input {
     this.statementInputCount++;
-    return this.appendInput(
-      new StatementInput(
-        name,
-        this,
-        this.makeConnection_(ConnectionType.NEXT_STATEMENT)
-      )
-    );
+    return this.appendInput(new StatementInput(name, this));
   }
 
   /**
@@ -1633,7 +1621,7 @@ export class Block implements IASTNodeLocation, IDeletable {
       false
     );
     if (!inputConstructor) return null;
-    return this.appendInput(new inputConstructor(name, this, null));
+    return this.appendInput(new inputConstructor(name, this));
   }
 
   /**
@@ -2310,8 +2298,9 @@ export class Block implements IASTNodeLocation, IDeletable {
    *
    * @param type The type of the connection to create.
    * @returns A new connection of the specified type.
+   * @internal
    */
-  protected makeConnection_(type: number): Connection {
+  public makeConnection_(type: number): Connection {
     return new Connection(this, type);
   }
 

--- a/core/block.ts
+++ b/core/block.ts
@@ -2300,7 +2300,7 @@ export class Block implements IASTNodeLocation, IDeletable {
    * @returns A new connection of the specified type.
    * @internal
    */
-  public makeConnection_(type: number): Connection {
+  makeConnection_(type: ConnectionType): Connection {
     return new Connection(this, type);
   }
 

--- a/core/block_svg.ts
+++ b/core/block_svg.ts
@@ -1469,8 +1469,9 @@ export class BlockSvg
    *
    * @param type The type of the connection to create.
    * @returns A new connection of the specified type.
+   * @internal
    */
-  protected override makeConnection_(type: number): RenderedConnection {
+  public override makeConnection_(type: number): RenderedConnection {
     return new RenderedConnection(this, type);
   }
 

--- a/core/block_svg.ts
+++ b/core/block_svg.ts
@@ -1471,7 +1471,7 @@ export class BlockSvg
    * @returns A new connection of the specified type.
    * @internal
    */
-  public override makeConnection_(type: number): RenderedConnection {
+  override makeConnection_(type: ConnectionType): RenderedConnection {
     return new RenderedConnection(this, type);
   }
 

--- a/core/inputs/dummy_input.ts
+++ b/core/inputs/dummy_input.ts
@@ -18,6 +18,6 @@ export class DummyInput extends Input {
    * @param block The block containing this input.
    */
   constructor(public name: string, block: Block) {
-    super(name, block, null);
+    super(name, block);
   }
 }

--- a/core/inputs/input.ts
+++ b/core/inputs/input.ts
@@ -36,6 +36,8 @@ export class Input {
 
   public readonly type: inputTypes = inputTypes.CUSTOM;
 
+  public connection: Connection | null = null;
+
   /**
    * @param name Language-neutral identifier which may used to find this input
    *     again.
@@ -44,11 +46,7 @@ export class Input {
    *     input, `null` will always be passed, and then the subclass can
    *     optionally construct a connection.
    */
-  constructor(
-    public name: string,
-    private sourceBlock: Block,
-    public connection: Connection | null
-  ) {}
+  constructor(public name: string, private sourceBlock: Block) {}
 
   /**
    * Get the source block for this input.
@@ -297,6 +295,10 @@ export class Input {
     if (this.connection) {
       this.connection.dispose();
     }
+  }
+
+  protected makeConnection(type: number): Connection {
+    return this.sourceBlock.makeConnection_(type);
   }
 }
 

--- a/core/inputs/input.ts
+++ b/core/inputs/input.ts
@@ -18,6 +18,7 @@ import '../field_label.js';
 import type {Block} from '../block.js';
 import type {BlockSvg} from '../block_svg.js';
 import type {Connection} from '../connection.js';
+import type {ConnectionType} from '../connection_type.js';
 import type {Field} from '../field.js';
 import * as fieldRegistry from '../field_registry.js';
 import type {RenderedConnection} from '../rendered_connection.js';
@@ -294,7 +295,15 @@ export class Input {
     }
   }
 
-  protected makeConnection(type: number): Connection {
+  /**
+   * Constructs a connection based on the type of this input's source block.
+   * Properly handles constructing headless connections for headless blocks
+   * and rendered connections for rendered blocks.
+   *
+   * @returns a connection of the given type, which is either a headless
+   *     or rendered connection, based on the type of this input's source block.
+   */
+  protected makeConnection(type: ConnectionType): Connection {
     return this.sourceBlock.makeConnection_(type);
   }
 }

--- a/core/inputs/input.ts
+++ b/core/inputs/input.ts
@@ -42,9 +42,6 @@ export class Input {
    * @param name Language-neutral identifier which may used to find this input
    *     again.
    * @param sourceBlock The block containing this input.
-   * @param connection Optional connection for this input. If this is a custom
-   *     input, `null` will always be passed, and then the subclass can
-   *     optionally construct a connection.
    */
   constructor(public name: string, private sourceBlock: Block) {}
 

--- a/core/inputs/statement_input.ts
+++ b/core/inputs/statement_input.ts
@@ -20,7 +20,6 @@ export class StatementInput extends Input {
    * @param name Language-neutral identifier which may used to find this input
    *     again.
    * @param block The block containing this input.
-   * @param connection The statement connection for this input.
    */
   constructor(public name: string, block: Block) {
     // Errors are maintained for people not using typescript.

--- a/core/inputs/statement_input.ts
+++ b/core/inputs/statement_input.ts
@@ -6,6 +6,7 @@
 
 import type {Block} from '../block.js';
 import type {Connection} from '../connection.js';
+import {ConnectionType} from '../connection_type.js';
 import {Input} from './input.js';
 import {inputTypes} from './input_types.js';
 
@@ -13,20 +14,19 @@ import {inputTypes} from './input_types.js';
 export class StatementInput extends Input {
   readonly type = inputTypes.STATEMENT;
 
+  public connection: Connection;
+
   /**
    * @param name Language-neutral identifier which may used to find this input
    *     again.
    * @param block The block containing this input.
    * @param connection The statement connection for this input.
    */
-  constructor(
-    public name: string,
-    block: Block,
-    public connection: Connection
-  ) {
+  constructor(public name: string, block: Block) {
     // Errors are maintained for people not using typescript.
     if (!name) throw new Error('Statement inputs must have a non-empty name');
-    if (!connection) throw new Error('Value inputs must have a connection');
-    super(name, block, connection);
+
+    super(name, block);
+    this.connection = this.makeConnection(ConnectionType.NEXT_STATEMENT);
   }
 }

--- a/core/inputs/value_input.ts
+++ b/core/inputs/value_input.ts
@@ -5,7 +5,7 @@
  */
 
 import type {Block} from '../block.js';
-import type {Connection} from '../connection.js';
+import {ConnectionType} from '../connection_type.js';
 import {Input} from './input.js';
 import {inputTypes} from './input_types.js';
 
@@ -19,14 +19,10 @@ export class ValueInput extends Input {
    * @param block The block containing this input.
    * @param connection The value connection for this input.
    */
-  constructor(
-    public name: string,
-    block: Block,
-    public connection: Connection
-  ) {
+  constructor(public name: string, block: Block) {
     // Errors are maintained for people not using typescript.
     if (!name) throw new Error('Value inputs must have a non-empty name');
-    if (!connection) throw new Error('Value inputs must have a connection');
-    super(name, block, connection);
+    super(name, block);
+    this.connection = this.makeConnection(ConnectionType.INPUT_VALUE);
   }
 }

--- a/core/inputs/value_input.ts
+++ b/core/inputs/value_input.ts
@@ -17,7 +17,6 @@ export class ValueInput extends Input {
    * @param name Language-neutral identifier which may used to find this input
    *     again.
    * @param block The block containing this input.
-   * @param connection The value connection for this input.
    */
   constructor(public name: string, block: Block) {
     // Errors are maintained for people not using typescript.


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [X] I ran `npm run format` and `npm run lint`

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #2062 

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
Makes it so that inputs must + can easily construct their own connections (for inputs that have connections).

#### Behavior Before Change

<!--TODO: Image, gif or explanation of behavior before this pull request. -->
Inputs were passed their connections, except for custom inputs which weren't. It was difficult for custom inputs to construct their own connections, because they had to deal with rendered vs headless.

#### Behavior After Change

<!--TODO: Image, gif or explanation of behavior after this pull request. -->
All inputs must construct their own connections. They can easily do this using the `protected makeConnection` method.

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
This makes built-in inputs and custom inputs more consistent. It also makes custom inputs with connections easier to implement.

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->
N/A

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->
N/A

### Additional Information

<!-- Anything else we should know? -->
N/A
