### PR TITLE
fix(build): Fix path issue on Windows

### DIFF
--- a/scripts/gulpfiles/build_tasks.js
+++ b/scripts/gulpfiles/build_tasks.js
@@ -560,7 +560,7 @@ function getChunkOptions() {
     // Figure out which chunk this is by looking for one of the
     // known chunk entrypoints in chunkFiles.  N.B.: O(n*m).  :-(
     const chunk = chunks.find(
-        chunk => chunkFiles.find(f => f.endsWith('/' + chunk.entry)));
+        chunk => chunkFiles.find(f => f.endsWith(path.sep + chunk.entry)));
     if (!chunk) throw new Error('Unable to identify chunk');
 
     // Replace nicknames with the names we chose.


### PR DESCRIPTION
## The basics

- [X] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [X] I ran `npm run format` and `npm run lint`

## The details
### Resolves

Fixes #6864.

### Proposed Changes

Look for `path.sep` instead of hard-coded `'/'` when parsing output of `closure-make-deps`.

#### Behaviour Before Change

`npm run minify` (and therefore `build`, `package`, etc.) fails on Windows.

#### Behaviour After Change

Hopefully less failing.
