### PR TITLE
chore: fix hiding bubbles on collapse

### DIFF
--- a/core/icons/icon.ts
+++ b/core/icons/icon.ts
@@ -7,6 +7,7 @@
 import type {Block} from '../block.js';
 import type {BlockSvg} from '../block_svg.js';
 import * as browserEvents from '../browser_events.js';
+import { hasBubble } from '../interfaces/i_has_bubble.js';
 import type {IIcon} from '../interfaces/i_icon.js';
 import {Coordinate} from '../utils/coordinate.js';
 import * as dom from '../utils/dom.js';
@@ -74,6 +75,9 @@ export abstract class Icon implements IIcon {
       this.svgRoot.style.display = 'none';
     } else {
       this.svgRoot.style.display = 'block';
+    }
+    if (hasBubble(this)) {
+      this.setBubbleVisible(false);
     }
   }
 

--- a/core/icons/icon.ts
+++ b/core/icons/icon.ts
@@ -7,7 +7,7 @@
 import type {Block} from '../block.js';
 import type {BlockSvg} from '../block_svg.js';
 import * as browserEvents from '../browser_events.js';
-import { hasBubble } from '../interfaces/i_has_bubble.js';
+import {hasBubble} from '../interfaces/i_has_bubble.js';
 import type {IIcon} from '../interfaces/i_icon.js';
 import {Coordinate} from '../utils/coordinate.js';
 import * as dom from '../utils/dom.js';


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [X] I ran `npm run format` and `npm run lint`

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes N/A

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
Has icons hide their bubble when the block is collapsed

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
Fixin buggies.

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->

Manually tested collapsing with open bubbles.

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->
N/A

### Additional Information

<!-- Anything else we should know? -->
N/A
