### PR TITLE
fix: Allow for unattached elements during inject call

### DIFF
--- a/core/inject.ts
+++ b/core/inject.ts
@@ -46,7 +46,10 @@ export function inject(
     containerElement = container;
   }
   // Verify that the container is in document.
-  if (!document.contains(containerElement)) {
+  if (
+    !document.contains(containerElement) &&
+    document !== containerElement?.ownerDocument
+  ) {
     throw Error('Error: container is not in current document');
   }
   const options = new Options(opt_options || ({} as BlocklyOptions));


### PR DESCRIPTION
## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [x] I ran `npm run format` and `npm run lint`

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes an issue where a Blockly workspace cannot be injected into a yet-to-be-attached element.

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
Check whether the ownerDocument of the injection div is the current document if the initial check for containment fails (e.g., due to the element not having been append elsewhere to the DOM).

#### Behavior Before Change

<!--TODO: Image, gif or explanation of behavior before this pull request. -->
If a `div` is created and `inject` is called to create a workspace before that div has been attached, an error is thrown.

#### Behavior After Change

<!--TODO: Image, gif or explanation of behavior after this pull request. -->
The check for membership in the document is made more permissive, so if the `div` is owned by the `document` it will still be used to create a workspace (to be attached at a later time).

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
In App Inventor, screens are separated into design and blocks, with the design being shown first. We must create a workspace and have it contain the blocks to participate in code generation, but the workspace will not be shown until the user clicks on the "Blocks" button. The existing check is too restrictive in the cases where a workspace needs to be created before it is shown.

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->
Tested by loading the playground (semantics of existing working Blockly apps should not change) and also in the branch of App Inventor being brought up to date with mainline Blockly.

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->
No documentation updates should be required as part of this change.

### Additional Information

<!-- Anything else we should know? -->
