### PR TITLE
refactor(generators)!: `CodeGenerator` per-block-type generator function dictionary

### DIFF
--- a/generators/dart/colour.js
+++ b/generators/dart/colour.js
@@ -16,13 +16,13 @@ import {dartGenerator as Dart} from '../dart.js';
 
 Dart.addReservedWords('Math');
 
-Dart['colour_picker'] = function(block) {
+Dart.forBlock['colour_picker'] = function(block) {
   // Colour picker.
   const code = Dart.quote_(block.getFieldValue('COLOUR'));
   return [code, Dart.ORDER_ATOMIC];
 };
 
-Dart['colour_random'] = function(block) {
+Dart.forBlock['colour_random'] = function(block) {
   // Generate a random colour.
   Dart.definitions_['import_dart_math'] = "import 'dart:math' as Math;";
   const functionName = Dart.provideFunction_('colour_random', `
@@ -38,7 +38,7 @@ String ${Dart.FUNCTION_NAME_PLACEHOLDER_}() {
   return [code, Dart.ORDER_UNARY_POSTFIX];
 };
 
-Dart['colour_rgb'] = function(block) {
+Dart.forBlock['colour_rgb'] = function(block) {
   // Compose a colour from RGB components expressed as percentages.
   const red = Dart.valueToCode(block, 'RED',
       Dart.ORDER_NONE) || 0;
@@ -69,7 +69,7 @@ String ${Dart.FUNCTION_NAME_PLACEHOLDER_}(num r, num g, num b) {
   return [code, Dart.ORDER_UNARY_POSTFIX];
 };
 
-Dart['colour_blend'] = function(block) {
+Dart.forBlock['colour_blend'] = function(block) {
   // Blend two colours together.
   const c1 = Dart.valueToCode(block, 'COLOUR1', Dart.ORDER_NONE) || "'#000000'";
   const c2 = Dart.valueToCode(block, 'COLOUR2', Dart.ORDER_NONE) || "'#000000'";

--- a/generators/dart/lists.js
+++ b/generators/dart/lists.js
@@ -17,12 +17,12 @@ import {dartGenerator as Dart} from '../dart.js';
 
 Dart.addReservedWords('Math');
 
-Dart['lists_create_empty'] = function(block) {
+Dart.forBlock['lists_create_empty'] = function(block) {
   // Create an empty list.
   return ['[]', Dart.ORDER_ATOMIC];
 };
 
-Dart['lists_create_with'] = function(block) {
+Dart.forBlock['lists_create_with'] = function(block) {
   // Create a list with any number of elements of any type.
   const elements = new Array(block.itemCount_);
   for (let i = 0; i < block.itemCount_; i++) {
@@ -32,7 +32,7 @@ Dart['lists_create_with'] = function(block) {
   return [code, Dart.ORDER_ATOMIC];
 };
 
-Dart['lists_repeat'] = function(block) {
+Dart.forBlock['lists_repeat'] = function(block) {
   // Create a list with one element repeated.
   const element = Dart.valueToCode(block, 'ITEM', Dart.ORDER_NONE) || 'null';
   const repeatCount = Dart.valueToCode(block, 'NUM', Dart.ORDER_NONE) || '0';
@@ -40,21 +40,21 @@ Dart['lists_repeat'] = function(block) {
   return [code, Dart.ORDER_UNARY_POSTFIX];
 };
 
-Dart['lists_length'] = function(block) {
+Dart.forBlock['lists_length'] = function(block) {
   // String or array length.
   const list =
       Dart.valueToCode(block, 'VALUE', Dart.ORDER_UNARY_POSTFIX) || '[]';
   return [list + '.length', Dart.ORDER_UNARY_POSTFIX];
 };
 
-Dart['lists_isEmpty'] = function(block) {
+Dart.forBlock['lists_isEmpty'] = function(block) {
   // Is the string null or array empty?
   const list =
       Dart.valueToCode(block, 'VALUE', Dart.ORDER_UNARY_POSTFIX) || '[]';
   return [list + '.isEmpty', Dart.ORDER_UNARY_POSTFIX];
 };
 
-Dart['lists_indexOf'] = function(block) {
+Dart.forBlock['lists_indexOf'] = function(block) {
   // Find an item in the list.
   const operator =
       block.getFieldValue('END') === 'FIRST' ? 'indexOf' : 'lastIndexOf';
@@ -68,7 +68,7 @@ Dart['lists_indexOf'] = function(block) {
   return [code, Dart.ORDER_UNARY_POSTFIX];
 };
 
-Dart['lists_getIndex'] = function(block) {
+Dart.forBlock['lists_getIndex'] = function(block) {
   // Get element at index.
   // Note: Until January 2013 this block did not have MODE or WHERE inputs.
   const mode = block.getFieldValue('MODE') || 'GET';
@@ -222,7 +222,7 @@ dynamic ${Dart.FUNCTION_NAME_PLACEHOLDER_}(List my_list) {
   throw Error('Unhandled combination (lists_getIndex).');
 };
 
-Dart['lists_setIndex'] = function(block) {
+Dart.forBlock['lists_setIndex'] = function(block) {
   // Set element at index.
   // Note: Until February 2013 this block did not have MODE or WHERE inputs.
   const mode = block.getFieldValue('MODE') || 'GET';
@@ -298,7 +298,7 @@ Dart['lists_setIndex'] = function(block) {
   throw Error('Unhandled combination (lists_setIndex).');
 };
 
-Dart['lists_getSublist'] = function(block) {
+Dart.forBlock['lists_getSublist'] = function(block) {
   // Get sublist.
   const list =
       Dart.valueToCode(block, 'LIST', Dart.ORDER_UNARY_POSTFIX) || '[]';
@@ -372,7 +372,7 @@ List ${Dart.FUNCTION_NAME_PLACEHOLDER_}(List list, String where1, num at1, Strin
   return [code, Dart.ORDER_UNARY_POSTFIX];
 };
 
-Dart['lists_sort'] = function(block) {
+Dart.forBlock['lists_sort'] = function(block) {
   // Block for sorting a list.
   const list = Dart.valueToCode(block, 'LIST', Dart.ORDER_NONE) || '[]';
   const direction = block.getFieldValue('DIRECTION') === '1' ? 1 : -1;
@@ -399,7 +399,7 @@ List ${Dart.FUNCTION_NAME_PLACEHOLDER_}(List list, String type, int direction) {
   ];
 };
 
-Dart['lists_split'] = function(block) {
+Dart.forBlock['lists_split'] = function(block) {
   // Block for splitting text into a list, or joining a list into text.
   let input = Dart.valueToCode(block, 'INPUT', Dart.ORDER_UNARY_POSTFIX);
   const delimiter = Dart.valueToCode(block, 'DELIM', Dart.ORDER_NONE) || "''";
@@ -422,7 +422,7 @@ Dart['lists_split'] = function(block) {
   return [code, Dart.ORDER_UNARY_POSTFIX];
 };
 
-Dart['lists_reverse'] = function(block) {
+Dart.forBlock['lists_reverse'] = function(block) {
   // Block for reversing a list.
   const list = Dart.valueToCode(block, 'LIST', Dart.ORDER_NONE) || '[]';
   // XXX What should the operator precedence be for a `new`?

--- a/generators/dart/logic.js
+++ b/generators/dart/logic.js
@@ -14,7 +14,7 @@ goog.declareModuleId('Blockly.Dart.logic');
 import {dartGenerator as Dart} from '../dart.js';
 
 
-Dart['controls_if'] = function(block) {
+Dart.forBlock['controls_if'] = function(block) {
   // If/elseif/else condition.
   let n = 0;
   let code = '', branchCode, conditionCode;
@@ -50,9 +50,9 @@ Dart['controls_if'] = function(block) {
   return code + '\n';
 };
 
-Dart['controls_ifelse'] = Dart['controls_if'];
+Dart.forBlock['controls_ifelse'] = Dart.forBlock['controls_if'];
 
-Dart['logic_compare'] = function(block) {
+Dart.forBlock['logic_compare'] = function(block) {
   // Comparison operator.
   const OPERATORS =
       {'EQ': '==', 'NEQ': '!=', 'LT': '<', 'LTE': '<=', 'GT': '>', 'GTE': '>='};
@@ -66,7 +66,7 @@ Dart['logic_compare'] = function(block) {
   return [code, order];
 };
 
-Dart['logic_operation'] = function(block) {
+Dart.forBlock['logic_operation'] = function(block) {
   // Operations 'and', 'or'.
   const operator = (block.getFieldValue('OP') === 'AND') ? '&&' : '||';
   const order =
@@ -91,7 +91,7 @@ Dart['logic_operation'] = function(block) {
   return [code, order];
 };
 
-Dart['logic_negate'] = function(block) {
+Dart.forBlock['logic_negate'] = function(block) {
   // Negation.
   const order = Dart.ORDER_UNARY_PREFIX;
   const argument0 = Dart.valueToCode(block, 'BOOL', order) || 'true';
@@ -99,18 +99,18 @@ Dart['logic_negate'] = function(block) {
   return [code, order];
 };
 
-Dart['logic_boolean'] = function(block) {
+Dart.forBlock['logic_boolean'] = function(block) {
   // Boolean values true and false.
   const code = (block.getFieldValue('BOOL') === 'TRUE') ? 'true' : 'false';
   return [code, Dart.ORDER_ATOMIC];
 };
 
-Dart['logic_null'] = function(block) {
+Dart.forBlock['logic_null'] = function(block) {
   // Null data type.
   return ['null', Dart.ORDER_ATOMIC];
 };
 
-Dart['logic_ternary'] = function(block) {
+Dart.forBlock['logic_ternary'] = function(block) {
   // Ternary operator.
   const value_if =
       Dart.valueToCode(block, 'IF', Dart.ORDER_CONDITIONAL) || 'false';

--- a/generators/dart/loops.js
+++ b/generators/dart/loops.js
@@ -16,7 +16,7 @@ import * as stringUtils from '../../core/utils/string.js';
 import {NameType} from '../../core/names.js';
 
 
-Dart['controls_repeat_ext'] = function(block) {
+Dart.forBlock['controls_repeat_ext'] = function(block) {
   let repeats;
   // Repeat n times.
   if (block.getField('TIMES')) {
@@ -40,9 +40,9 @@ Dart['controls_repeat_ext'] = function(block) {
   return code;
 };
 
-Dart['controls_repeat'] = Dart['controls_repeat_ext'];
+Dart.forBlock['controls_repeat'] = Dart.forBlock['controls_repeat_ext'];
 
-Dart['controls_whileUntil'] = function(block) {
+Dart.forBlock['controls_whileUntil'] = function(block) {
   // Do while/until loop.
   const until = block.getFieldValue('MODE') === 'UNTIL';
   let argument0 =
@@ -57,7 +57,7 @@ Dart['controls_whileUntil'] = function(block) {
   return 'while (' + argument0 + ') {\n' + branch + '}\n';
 };
 
-Dart['controls_for'] = function(block) {
+Dart.forBlock['controls_for'] = function(block) {
   // For loop.
   const variable0 =
       Dart.nameDB_.getName(block.getFieldValue('VAR'), NameType.VARIABLE);
@@ -117,7 +117,7 @@ Dart['controls_for'] = function(block) {
   return code;
 };
 
-Dart['controls_forEach'] = function(block) {
+Dart.forBlock['controls_forEach'] = function(block) {
   // For each loop.
   const variable0 =
       Dart.nameDB_.getName(block.getFieldValue('VAR'), NameType.VARIABLE);
@@ -130,7 +130,7 @@ Dart['controls_forEach'] = function(block) {
   return code;
 };
 
-Dart['controls_flow_statements'] = function(block) {
+Dart.forBlock['controls_flow_statements'] = function(block) {
   // Flow statements: continue, break.
   let xfix = '';
   if (Dart.STATEMENT_PREFIX) {

--- a/generators/dart/math.js
+++ b/generators/dart/math.js
@@ -17,7 +17,7 @@ import {dartGenerator as Dart} from '../dart.js';
 
 Dart.addReservedWords('Math');
 
-Dart['math_number'] = function(block) {
+Dart.forBlock['math_number'] = function(block) {
   // Numeric value.
   let code = Number(block.getFieldValue('NUM'));
   let order;
@@ -35,7 +35,7 @@ Dart['math_number'] = function(block) {
   return [code, order];
 };
 
-Dart['math_arithmetic'] = function(block) {
+Dart.forBlock['math_arithmetic'] = function(block) {
   // Basic arithmetic operators, and power.
   const OPERATORS = {
     'ADD': [' + ', Dart.ORDER_ADDITIVE],
@@ -60,7 +60,7 @@ Dart['math_arithmetic'] = function(block) {
   return [code, order];
 };
 
-Dart['math_single'] = function(block) {
+Dart.forBlock['math_single'] = function(block) {
   // Math operators with single operand.
   const operator = block.getFieldValue('OP');
   let code;
@@ -144,7 +144,7 @@ Dart['math_single'] = function(block) {
   return [code, Dart.ORDER_MULTIPLICATIVE];
 };
 
-Dart['math_constant'] = function(block) {
+Dart.forBlock['math_constant'] = function(block) {
   // Constants: PI, E, the Golden Ratio, sqrt(2), 1/sqrt(2), INFINITY.
   const CONSTANTS = {
     'PI': ['Math.pi', Dart.ORDER_UNARY_POSTFIX],
@@ -161,7 +161,7 @@ Dart['math_constant'] = function(block) {
   return CONSTANTS[constant];
 };
 
-Dart['math_number_property'] = function(block) {
+Dart.forBlock['math_number_property'] = function(block) {
   // Check if a number is even, odd, prime, whole, positive, or negative
   // or if it is divisible by certain number. Returns true or false.
   const PROPERTIES = {
@@ -216,7 +216,7 @@ bool ${Dart.FUNCTION_NAME_PLACEHOLDER_}(n) {
   return [code, outputOrder];
 };
 
-Dart['math_change'] = function(block) {
+Dart.forBlock['math_change'] = function(block) {
   // Add to a variable in place.
   const argument0 =
       Dart.valueToCode(block, 'DELTA', Dart.ORDER_ADDITIVE) || '0';
@@ -227,11 +227,11 @@ Dart['math_change'] = function(block) {
 };
 
 // Rounding functions have a single operand.
-Dart['math_round'] = Dart['math_single'];
+Dart.forBlock['math_round'] = Dart.forBlock['math_single'];
 // Trigonometry functions have a single operand.
-Dart['math_trig'] = Dart['math_single'];
+Dart.forBlock['math_trig'] = Dart.forBlock['math_single'];
 
-Dart['math_on_list'] = function(block) {
+Dart.forBlock['math_on_list'] = function(block) {
   // Math functions for lists.
   const func = block.getFieldValue('OP');
   const list = Dart.valueToCode(block, 'LIST', Dart.ORDER_NONE) || '[]';
@@ -386,7 +386,7 @@ dynamic ${Dart.FUNCTION_NAME_PLACEHOLDER_}(List myList) {
   return [code, Dart.ORDER_UNARY_POSTFIX];
 };
 
-Dart['math_modulo'] = function(block) {
+Dart.forBlock['math_modulo'] = function(block) {
   // Remainder computation.
   const argument0 =
       Dart.valueToCode(block, 'DIVIDEND', Dart.ORDER_MULTIPLICATIVE) || '0';
@@ -396,7 +396,7 @@ Dart['math_modulo'] = function(block) {
   return [code, Dart.ORDER_MULTIPLICATIVE];
 };
 
-Dart['math_constrain'] = function(block) {
+Dart.forBlock['math_constrain'] = function(block) {
   // Constrain a number between two limits.
   Dart.definitions_['import_dart_math'] = 'import \'dart:math\' as Math;';
   const argument0 = Dart.valueToCode(block, 'VALUE', Dart.ORDER_NONE) || '0';
@@ -408,7 +408,7 @@ Dart['math_constrain'] = function(block) {
   return [code, Dart.ORDER_UNARY_POSTFIX];
 };
 
-Dart['math_random_int'] = function(block) {
+Dart.forBlock['math_random_int'] = function(block) {
   // Random integer between [X] and [Y].
   Dart.definitions_['import_dart_math'] = 'import \'dart:math\' as Math;';
   const argument0 = Dart.valueToCode(block, 'FROM', Dart.ORDER_NONE) || '0';
@@ -428,13 +428,13 @@ int ${Dart.FUNCTION_NAME_PLACEHOLDER_}(num a, num b) {
   return [code, Dart.ORDER_UNARY_POSTFIX];
 };
 
-Dart['math_random_float'] = function(block) {
+Dart.forBlock['math_random_float'] = function(block) {
   // Random fraction between 0 and 1.
   Dart.definitions_['import_dart_math'] = 'import \'dart:math\' as Math;';
   return ['new Math.Random().nextDouble()', Dart.ORDER_UNARY_POSTFIX];
 };
 
-Dart['math_atan2'] = function(block) {
+Dart.forBlock['math_atan2'] = function(block) {
   // Arctangent of point (X, Y) in degrees from -180 to 180.
   Dart.definitions_['import_dart_math'] = 'import \'dart:math\' as Math;';
   const argument0 = Dart.valueToCode(block, 'X', Dart.ORDER_NONE) || '0';

--- a/generators/dart/procedures.js
+++ b/generators/dart/procedures.js
@@ -15,7 +15,7 @@ import {NameType} from '../../core/names.js';
 import {dartGenerator as Dart} from '../dart.js';
 
 
-Dart['procedures_defreturn'] = function(block) {
+Dart.forBlock['procedures_defreturn'] = function(block) {
   // Define a procedure with a return value.
   const funcName =
       Dart.nameDB_.getName(block.getFieldValue('NAME'), NameType.PROCEDURE);
@@ -60,9 +60,9 @@ Dart['procedures_defreturn'] = function(block) {
 
 // Defining a procedure without a return value uses the same generator as
 // a procedure with a return value.
-Dart['procedures_defnoreturn'] = Dart['procedures_defreturn'];
+Dart.forBlock['procedures_defnoreturn'] = Dart.forBlock['procedures_defreturn'];
 
-Dart['procedures_callreturn'] = function(block) {
+Dart.forBlock['procedures_callreturn'] = function(block) {
   // Call a procedure with a return value.
   const funcName =
       Dart.nameDB_.getName(block.getFieldValue('NAME'), NameType.PROCEDURE);
@@ -75,15 +75,15 @@ Dart['procedures_callreturn'] = function(block) {
   return [code, Dart.ORDER_UNARY_POSTFIX];
 };
 
-Dart['procedures_callnoreturn'] = function(block) {
+Dart.forBlock['procedures_callnoreturn'] = function(block) {
   // Call a procedure with no return value.
   // Generated code is for a function call as a statement is the same as a
   // function call as a value, with the addition of line ending.
-  const tuple = Dart['procedures_callreturn'](block);
+  const tuple = Dart.forBlock['procedures_callreturn'](block);
   return tuple[0] + ';\n';
 };
 
-Dart['procedures_ifreturn'] = function(block) {
+Dart.forBlock['procedures_ifreturn'] = function(block) {
   // Conditionally return value from a procedure.
   const condition =
       Dart.valueToCode(block, 'CONDITION', Dart.ORDER_NONE) || 'false';

--- a/generators/dart/text.js
+++ b/generators/dart/text.js
@@ -17,13 +17,13 @@ import {dartGenerator as Dart} from '../dart.js';
 
 Dart.addReservedWords('Html,Math');
 
-Dart['text'] = function(block) {
+Dart.forBlock['text'] = function(block) {
   // Text value.
   const code = Dart.quote_(block.getFieldValue('TEXT'));
   return [code, Dart.ORDER_ATOMIC];
 };
 
-Dart['text_multiline'] = function(block) {
+Dart.forBlock['text_multiline'] = function(block) {
   // Text value.
   const code = Dart.multiline_quote_(block.getFieldValue('TEXT'));
   const order =
@@ -31,7 +31,7 @@ Dart['text_multiline'] = function(block) {
   return [code, order];
 };
 
-Dart['text_join'] = function(block) {
+Dart.forBlock['text_join'] = function(block) {
   // Create a string made up of any number of elements of any type.
   switch (block.itemCount_) {
     case 0:
@@ -54,7 +54,7 @@ Dart['text_join'] = function(block) {
   }
 };
 
-Dart['text_append'] = function(block) {
+Dart.forBlock['text_append'] = function(block) {
   // Append to a variable in place.
   const varName =
       Dart.nameDB_.getName(block.getFieldValue('VAR'), NameType.VARIABLE);
@@ -62,21 +62,21 @@ Dart['text_append'] = function(block) {
   return varName + ' = [' + varName + ', ' + value + '].join();\n';
 };
 
-Dart['text_length'] = function(block) {
+Dart.forBlock['text_length'] = function(block) {
   // String or array length.
   const text =
       Dart.valueToCode(block, 'VALUE', Dart.ORDER_UNARY_POSTFIX) || "''";
   return [text + '.length', Dart.ORDER_UNARY_POSTFIX];
 };
 
-Dart['text_isEmpty'] = function(block) {
+Dart.forBlock['text_isEmpty'] = function(block) {
   // Is the string null or array empty?
   const text =
       Dart.valueToCode(block, 'VALUE', Dart.ORDER_UNARY_POSTFIX) || "''";
   return [text + '.isEmpty', Dart.ORDER_UNARY_POSTFIX];
 };
 
-Dart['text_indexOf'] = function(block) {
+Dart.forBlock['text_indexOf'] = function(block) {
   // Search the text for a substring.
   const operator =
       block.getFieldValue('END') === 'FIRST' ? 'indexOf' : 'lastIndexOf';
@@ -90,7 +90,7 @@ Dart['text_indexOf'] = function(block) {
   return [code, Dart.ORDER_UNARY_POSTFIX];
 };
 
-Dart['text_charAt'] = function(block) {
+Dart.forBlock['text_charAt'] = function(block) {
   // Get letter at index.
   // Note: Until January 2013 this block did not have the WHERE input.
   const where = block.getFieldValue('WHERE') || 'FROM_START';
@@ -137,7 +137,7 @@ String ${Dart.FUNCTION_NAME_PLACEHOLDER_}(String text) {
   throw Error('Unhandled option (text_charAt).');
 };
 
-Dart['text_getSubstring'] = function(block) {
+Dart.forBlock['text_getSubstring'] = function(block) {
   // Get substring.
   const where1 = block.getFieldValue('WHERE1');
   const where2 = block.getFieldValue('WHERE2');
@@ -215,7 +215,7 @@ String ${Dart.FUNCTION_NAME_PLACEHOLDER_}(String text, String where1, num at1, S
   return [code, Dart.ORDER_UNARY_POSTFIX];
 };
 
-Dart['text_changeCase'] = function(block) {
+Dart.forBlock['text_changeCase'] = function(block) {
   // Change capitalization.
   const OPERATORS = {
     'UPPERCASE': '.toUpperCase()',
@@ -252,7 +252,7 @@ String ${Dart.FUNCTION_NAME_PLACEHOLDER_}(String str) {
   return [code, Dart.ORDER_UNARY_POSTFIX];
 };
 
-Dart['text_trim'] = function(block) {
+Dart.forBlock['text_trim'] = function(block) {
   // Trim spaces.
   const OPERATORS = {
     'LEFT': '.replaceFirst(new RegExp(r\'^\\s+\'), \'\')',
@@ -265,13 +265,13 @@ Dart['text_trim'] = function(block) {
   return [text + operator, Dart.ORDER_UNARY_POSTFIX];
 };
 
-Dart['text_print'] = function(block) {
+Dart.forBlock['text_print'] = function(block) {
   // Print statement.
   const msg = Dart.valueToCode(block, 'TEXT', Dart.ORDER_NONE) || "''";
   return 'print(' + msg + ');\n';
 };
 
-Dart['text_prompt_ext'] = function(block) {
+Dart.forBlock['text_prompt_ext'] = function(block) {
   // Prompt function.
   Dart.definitions_['import_dart_html'] = 'import \'dart:html\' as Html;';
   let msg;
@@ -291,9 +291,9 @@ Dart['text_prompt_ext'] = function(block) {
   return [code, Dart.ORDER_UNARY_POSTFIX];
 };
 
-Dart['text_prompt'] = Dart['text_prompt_ext'];
+Dart.forBlock['text_prompt'] = Dart.forBlock['text_prompt_ext'];
 
-Dart['text_count'] = function(block) {
+Dart.forBlock['text_count'] = function(block) {
   const text = Dart.valueToCode(block, 'TEXT', Dart.ORDER_NONE) || "''";
   const sub = Dart.valueToCode(block, 'SUB', Dart.ORDER_NONE) || "''";
   // Substring count is not a native Dart function.  Define one.
@@ -318,7 +318,7 @@ int ${Dart.FUNCTION_NAME_PLACEHOLDER_}(String haystack, String needle) {
   return [code, Dart.ORDER_UNARY_POSTFIX];
 };
 
-Dart['text_replace'] = function(block) {
+Dart.forBlock['text_replace'] = function(block) {
   const text =
       Dart.valueToCode(block, 'TEXT', Dart.ORDER_UNARY_POSTFIX) || "''";
   const from = Dart.valueToCode(block, 'FROM', Dart.ORDER_NONE) || "''";
@@ -327,7 +327,7 @@ Dart['text_replace'] = function(block) {
   return [code, Dart.ORDER_UNARY_POSTFIX];
 };
 
-Dart['text_reverse'] = function(block) {
+Dart.forBlock['text_reverse'] = function(block) {
   // There isn't a sensible way to do this in Dart. See:
   // http://stackoverflow.com/a/21613700/3529104
   // Implementing something is possibly better than not implementing anything?

--- a/generators/dart/variables.js
+++ b/generators/dart/variables.js
@@ -15,14 +15,14 @@ import {NameType} from '../../core/names.js';
 import {dartGenerator as Dart} from '../dart.js';
 
 
-Dart['variables_get'] = function(block) {
+Dart.forBlock['variables_get'] = function(block) {
   // Variable getter.
   const code =
       Dart.nameDB_.getName(block.getFieldValue('VAR'), NameType.VARIABLE);
   return [code, Dart.ORDER_ATOMIC];
 };
 
-Dart['variables_set'] = function(block) {
+Dart.forBlock['variables_set'] = function(block) {
   // Variable setter.
   const argument0 =
       Dart.valueToCode(block, 'VALUE', Dart.ORDER_ASSIGNMENT) || '0';

--- a/generators/dart/variables_dynamic.js
+++ b/generators/dart/variables_dynamic.js
@@ -16,5 +16,5 @@ import './variables.js';
 
 
 // Dart is dynamically typed.
-Dart['variables_get_dynamic'] = Dart['variables_get'];
-Dart['variables_set_dynamic'] = Dart['variables_set'];
+Dart.forBlock['variables_get_dynamic'] = Dart.forBlock['variables_get'];
+Dart.forBlock['variables_set_dynamic'] = Dart.forBlock['variables_set'];

--- a/generators/javascript/colour.js
+++ b/generators/javascript/colour.js
@@ -14,13 +14,13 @@ goog.declareModuleId('Blockly.JavaScript.colour');
 import {javascriptGenerator as JavaScript} from '../javascript.js';
 
 
-JavaScript['colour_picker'] = function(block) {
+JavaScript.forBlock['colour_picker'] = function(block) {
   // Colour picker.
   const code = JavaScript.quote_(block.getFieldValue('COLOUR'));
   return [code, JavaScript.ORDER_ATOMIC];
 };
 
-JavaScript['colour_random'] = function(block) {
+JavaScript.forBlock['colour_random'] = function(block) {
   // Generate a random colour.
   const functionName = JavaScript.provideFunction_('colourRandom', `
 function ${JavaScript.FUNCTION_NAME_PLACEHOLDER_}() {
@@ -32,7 +32,7 @@ function ${JavaScript.FUNCTION_NAME_PLACEHOLDER_}() {
   return [code, JavaScript.ORDER_FUNCTION_CALL];
 };
 
-JavaScript['colour_rgb'] = function(block) {
+JavaScript.forBlock['colour_rgb'] = function(block) {
   // Compose a colour from RGB components expressed as percentages.
   const red = JavaScript.valueToCode(block, 'RED', JavaScript.ORDER_NONE) || 0;
   const green =
@@ -54,7 +54,7 @@ function ${JavaScript.FUNCTION_NAME_PLACEHOLDER_}(r, g, b) {
   return [code, JavaScript.ORDER_FUNCTION_CALL];
 };
 
-JavaScript['colour_blend'] = function(block) {
+JavaScript.forBlock['colour_blend'] = function(block) {
   // Blend two colours together.
   const c1 = JavaScript.valueToCode(block, 'COLOUR1', JavaScript.ORDER_NONE) ||
       "'#000000'";

--- a/generators/javascript/lists.js
+++ b/generators/javascript/lists.js
@@ -16,12 +16,12 @@ import {NameType} from '../../core/names.js';
 import {javascriptGenerator as JavaScript} from '../javascript.js';
 
 
-JavaScript['lists_create_empty'] = function(block) {
+JavaScript.forBlock['lists_create_empty'] = function(block) {
   // Create an empty list.
   return ['[]', JavaScript.ORDER_ATOMIC];
 };
 
-JavaScript['lists_create_with'] = function(block) {
+JavaScript.forBlock['lists_create_with'] = function(block) {
   // Create a list with any number of elements of any type.
   const elements = new Array(block.itemCount_);
   for (let i = 0; i < block.itemCount_; i++) {
@@ -33,7 +33,7 @@ JavaScript['lists_create_with'] = function(block) {
   return [code, JavaScript.ORDER_ATOMIC];
 };
 
-JavaScript['lists_repeat'] = function(block) {
+JavaScript.forBlock['lists_repeat'] = function(block) {
   // Create a list with one element repeated.
   const functionName = JavaScript.provideFunction_('listsRepeat', `
 function ${JavaScript.FUNCTION_NAME_PLACEHOLDER_}(value, n) {
@@ -52,21 +52,21 @@ function ${JavaScript.FUNCTION_NAME_PLACEHOLDER_}(value, n) {
   return [code, JavaScript.ORDER_FUNCTION_CALL];
 };
 
-JavaScript['lists_length'] = function(block) {
+JavaScript.forBlock['lists_length'] = function(block) {
   // String or array length.
   const list =
       JavaScript.valueToCode(block, 'VALUE', JavaScript.ORDER_MEMBER) || '[]';
   return [list + '.length', JavaScript.ORDER_MEMBER];
 };
 
-JavaScript['lists_isEmpty'] = function(block) {
+JavaScript.forBlock['lists_isEmpty'] = function(block) {
   // Is the string null or array empty?
   const list =
       JavaScript.valueToCode(block, 'VALUE', JavaScript.ORDER_MEMBER) || '[]';
   return ['!' + list + '.length', JavaScript.ORDER_LOGICAL_NOT];
 };
 
-JavaScript['lists_indexOf'] = function(block) {
+JavaScript.forBlock['lists_indexOf'] = function(block) {
   // Find an item in the list.
   const operator =
       block.getFieldValue('END') === 'FIRST' ? 'indexOf' : 'lastIndexOf';
@@ -81,7 +81,7 @@ JavaScript['lists_indexOf'] = function(block) {
   return [code, JavaScript.ORDER_FUNCTION_CALL];
 };
 
-JavaScript['lists_getIndex'] = function(block) {
+JavaScript.forBlock['lists_getIndex'] = function(block) {
   // Get element at index.
   // Note: Until January 2013 this block did not have MODE or WHERE inputs.
   const mode = block.getFieldValue('MODE') || 'GET';
@@ -162,7 +162,7 @@ function ${JavaScript.FUNCTION_NAME_PLACEHOLDER_}(list, remove) {
   throw Error('Unhandled combination (lists_getIndex).');
 };
 
-JavaScript['lists_setIndex'] = function(block) {
+JavaScript.forBlock['lists_setIndex'] = function(block) {
   // Set element at index.
   // Note: Until February 2013 this block did not have MODE or WHERE inputs.
   let list =
@@ -262,7 +262,7 @@ const getSubstringIndex = function(listName, where, opt_at) {
   }
 };
 
-JavaScript['lists_getSublist'] = function(block) {
+JavaScript.forBlock['lists_getSublist'] = function(block) {
   // Get sublist.
   const list =
       JavaScript.valueToCode(block, 'LIST', JavaScript.ORDER_MEMBER) || '[]';
@@ -342,7 +342,7 @@ function ${JavaScript.FUNCTION_NAME_PLACEHOLDER_}(sequence${at1Param}${at2Param}
   return [code, JavaScript.ORDER_FUNCTION_CALL];
 };
 
-JavaScript['lists_sort'] = function(block) {
+JavaScript.forBlock['lists_sort'] = function(block) {
   // Block for sorting a list.
   const list =
       JavaScript.valueToCode(block, 'LIST', JavaScript.ORDER_FUNCTION_CALL) ||
@@ -371,7 +371,7 @@ function ${JavaScript.FUNCTION_NAME_PLACEHOLDER_}(type, direction) {
   ];
 };
 
-JavaScript['lists_split'] = function(block) {
+JavaScript.forBlock['lists_split'] = function(block) {
   // Block for splitting text into a list, or joining a list into text.
   let input = JavaScript.valueToCode(block, 'INPUT', JavaScript.ORDER_MEMBER);
   const delimiter =
@@ -395,7 +395,7 @@ JavaScript['lists_split'] = function(block) {
   return [code, JavaScript.ORDER_FUNCTION_CALL];
 };
 
-JavaScript['lists_reverse'] = function(block) {
+JavaScript.forBlock['lists_reverse'] = function(block) {
   // Block for reversing a list.
   const list =
       JavaScript.valueToCode(block, 'LIST', JavaScript.ORDER_FUNCTION_CALL) ||

--- a/generators/javascript/logic.js
+++ b/generators/javascript/logic.js
@@ -14,7 +14,7 @@ goog.declareModuleId('Blockly.JavaScript.logic');
 import {javascriptGenerator as JavaScript} from '../javascript.js';
 
 
-JavaScript['controls_if'] = function(block) {
+JavaScript.forBlock['controls_if'] = function(block) {
   // If/elseif/else condition.
   let n = 0;
   let code = '';
@@ -51,9 +51,9 @@ JavaScript['controls_if'] = function(block) {
   return code + '\n';
 };
 
-JavaScript['controls_ifelse'] = JavaScript['controls_if'];
+JavaScript.forBlock['controls_ifelse'] = JavaScript.forBlock['controls_if'];
 
-JavaScript['logic_compare'] = function(block) {
+JavaScript.forBlock['logic_compare'] = function(block) {
   // Comparison operator.
   const OPERATORS =
       {'EQ': '==', 'NEQ': '!=', 'LT': '<', 'LTE': '<=', 'GT': '>', 'GTE': '>='};
@@ -67,7 +67,7 @@ JavaScript['logic_compare'] = function(block) {
   return [code, order];
 };
 
-JavaScript['logic_operation'] = function(block) {
+JavaScript.forBlock['logic_operation'] = function(block) {
   // Operations 'and', 'or'.
   const operator = (block.getFieldValue('OP') === 'AND') ? '&&' : '||';
   const order = (operator === '&&') ? JavaScript.ORDER_LOGICAL_AND :
@@ -92,7 +92,7 @@ JavaScript['logic_operation'] = function(block) {
   return [code, order];
 };
 
-JavaScript['logic_negate'] = function(block) {
+JavaScript.forBlock['logic_negate'] = function(block) {
   // Negation.
   const order = JavaScript.ORDER_LOGICAL_NOT;
   const argument0 = JavaScript.valueToCode(block, 'BOOL', order) || 'true';
@@ -100,18 +100,18 @@ JavaScript['logic_negate'] = function(block) {
   return [code, order];
 };
 
-JavaScript['logic_boolean'] = function(block) {
+JavaScript.forBlock['logic_boolean'] = function(block) {
   // Boolean values true and false.
   const code = (block.getFieldValue('BOOL') === 'TRUE') ? 'true' : 'false';
   return [code, JavaScript.ORDER_ATOMIC];
 };
 
-JavaScript['logic_null'] = function(block) {
+JavaScript.forBlock['logic_null'] = function(block) {
   // Null data type.
   return ['null', JavaScript.ORDER_ATOMIC];
 };
 
-JavaScript['logic_ternary'] = function(block) {
+JavaScript.forBlock['logic_ternary'] = function(block) {
   // Ternary operator.
   const value_if =
       JavaScript.valueToCode(block, 'IF', JavaScript.ORDER_CONDITIONAL) ||

--- a/generators/javascript/loops.js
+++ b/generators/javascript/loops.js
@@ -16,7 +16,7 @@ import {NameType} from '../../core/names.js';
 import {javascriptGenerator as JavaScript} from '../javascript.js';
 
 
-JavaScript['controls_repeat_ext'] = function(block) {
+JavaScript.forBlock['controls_repeat_ext'] = function(block) {
   // Repeat n times.
   let repeats;
   if (block.getField('TIMES')) {
@@ -44,9 +44,9 @@ JavaScript['controls_repeat_ext'] = function(block) {
   return code;
 };
 
-JavaScript['controls_repeat'] = JavaScript['controls_repeat_ext'];
+JavaScript.forBlock['controls_repeat'] = JavaScript.forBlock['controls_repeat_ext'];
 
-JavaScript['controls_whileUntil'] = function(block) {
+JavaScript.forBlock['controls_whileUntil'] = function(block) {
   // Do while/until loop.
   const until = block.getFieldValue('MODE') === 'UNTIL';
   let argument0 =
@@ -62,7 +62,7 @@ JavaScript['controls_whileUntil'] = function(block) {
   return 'while (' + argument0 + ') {\n' + branch + '}\n';
 };
 
-JavaScript['controls_for'] = function(block) {
+JavaScript.forBlock['controls_for'] = function(block) {
   // For loop.
   const variable0 =
       JavaScript.nameDB_.getName(block.getFieldValue('VAR'), NameType.VARIABLE);
@@ -124,7 +124,7 @@ JavaScript['controls_for'] = function(block) {
   return code;
 };
 
-JavaScript['controls_forEach'] = function(block) {
+JavaScript.forBlock['controls_forEach'] = function(block) {
   // For each loop.
   const variable0 =
       JavaScript.nameDB_.getName(block.getFieldValue('VAR'), NameType.VARIABLE);
@@ -149,7 +149,7 @@ JavaScript['controls_forEach'] = function(block) {
   return code;
 };
 
-JavaScript['controls_flow_statements'] = function(block) {
+JavaScript.forBlock['controls_flow_statements'] = function(block) {
   // Flow statements: continue, break.
   let xfix = '';
   if (JavaScript.STATEMENT_PREFIX) {

--- a/generators/javascript/math.js
+++ b/generators/javascript/math.js
@@ -16,7 +16,7 @@ import {NameType} from '../../core/names.js';
 import {javascriptGenerator as JavaScript} from '../javascript.js';
 
 
-JavaScript['math_number'] = function(block) {
+JavaScript.forBlock['math_number'] = function(block) {
   // Numeric value.
   const code = Number(block.getFieldValue('NUM'));
   const order = code >= 0 ? JavaScript.ORDER_ATOMIC :
@@ -24,7 +24,7 @@ JavaScript['math_number'] = function(block) {
   return [code, order];
 };
 
-JavaScript['math_arithmetic'] = function(block) {
+JavaScript.forBlock['math_arithmetic'] = function(block) {
   // Basic arithmetic operators, and power.
   const OPERATORS = {
     'ADD': [' + ', JavaScript.ORDER_ADDITION],
@@ -48,7 +48,7 @@ JavaScript['math_arithmetic'] = function(block) {
   return [code, order];
 };
 
-JavaScript['math_single'] = function(block) {
+JavaScript.forBlock['math_single'] = function(block) {
   // Math operators with single operand.
   const operator = block.getFieldValue('OP');
   let code;
@@ -132,7 +132,7 @@ JavaScript['math_single'] = function(block) {
   return [code, JavaScript.ORDER_DIVISION];
 };
 
-JavaScript['math_constant'] = function(block) {
+JavaScript.forBlock['math_constant'] = function(block) {
   // Constants: PI, E, the Golden Ratio, sqrt(2), 1/sqrt(2), INFINITY.
   const CONSTANTS = {
     'PI': ['Math.PI', JavaScript.ORDER_MEMBER],
@@ -145,7 +145,7 @@ JavaScript['math_constant'] = function(block) {
   return CONSTANTS[block.getFieldValue('CONSTANT')];
 };
 
-JavaScript['math_number_property'] = function(block) {
+JavaScript.forBlock['math_number_property'] = function(block) {
   // Check if a number is even, odd, prime, whole, positive, or negative
   // or if it is divisible by certain number. Returns true or false.
   const PROPERTIES = {
@@ -198,7 +198,7 @@ function ${JavaScript.FUNCTION_NAME_PLACEHOLDER_}(n) {
   return [code, outputOrder];
 };
 
-JavaScript['math_change'] = function(block) {
+JavaScript.forBlock['math_change'] = function(block) {
   // Add to a variable in place.
   const argument0 = JavaScript.valueToCode(block, 'DELTA',
       JavaScript.ORDER_ADDITION) || '0';
@@ -209,11 +209,11 @@ JavaScript['math_change'] = function(block) {
 };
 
 // Rounding functions have a single operand.
-JavaScript['math_round'] = JavaScript['math_single'];
+JavaScript.forBlock['math_round'] = JavaScript.forBlock['math_single'];
 // Trigonometry functions have a single operand.
-JavaScript['math_trig'] = JavaScript['math_single'];
+JavaScript.forBlock['math_trig'] = JavaScript.forBlock['math_single'];
 
-JavaScript['math_on_list'] = function(block) {
+JavaScript.forBlock['math_on_list'] = function(block) {
   // Math functions for lists.
   const func = block.getFieldValue('OP');
   let list;
@@ -341,7 +341,7 @@ function ${JavaScript.FUNCTION_NAME_PLACEHOLDER_}(list) {
   return [code, JavaScript.ORDER_FUNCTION_CALL];
 };
 
-JavaScript['math_modulo'] = function(block) {
+JavaScript.forBlock['math_modulo'] = function(block) {
   // Remainder computation.
   const argument0 = JavaScript.valueToCode(block, 'DIVIDEND',
       JavaScript.ORDER_MODULUS) || '0';
@@ -351,7 +351,7 @@ JavaScript['math_modulo'] = function(block) {
   return [code, JavaScript.ORDER_MODULUS];
 };
 
-JavaScript['math_constrain'] = function(block) {
+JavaScript.forBlock['math_constrain'] = function(block) {
   // Constrain a number between two limits.
   const argument0 = JavaScript.valueToCode(block, 'VALUE',
       JavaScript.ORDER_NONE) || '0';
@@ -364,7 +364,7 @@ JavaScript['math_constrain'] = function(block) {
   return [code, JavaScript.ORDER_FUNCTION_CALL];
 };
 
-JavaScript['math_random_int'] = function(block) {
+JavaScript.forBlock['math_random_int'] = function(block) {
   // Random integer between [X] and [Y].
   const argument0 = JavaScript.valueToCode(block, 'FROM',
       JavaScript.ORDER_NONE) || '0';
@@ -385,12 +385,12 @@ function ${JavaScript.FUNCTION_NAME_PLACEHOLDER_}(a, b) {
   return [code, JavaScript.ORDER_FUNCTION_CALL];
 };
 
-JavaScript['math_random_float'] = function(block) {
+JavaScript.forBlock['math_random_float'] = function(block) {
   // Random fraction between 0 and 1.
   return ['Math.random()', JavaScript.ORDER_FUNCTION_CALL];
 };
 
-JavaScript['math_atan2'] = function(block) {
+JavaScript.forBlock['math_atan2'] = function(block) {
   // Arctangent of point (X, Y) in degrees from -180 to 180.
   const argument0 = JavaScript.valueToCode(block, 'X',
       JavaScript.ORDER_NONE) || '0';

--- a/generators/javascript/procedures.js
+++ b/generators/javascript/procedures.js
@@ -15,7 +15,7 @@ import {NameType} from '../../core/names.js';
 import {javascriptGenerator as JavaScript} from '../javascript.js';
 
 
-JavaScript['procedures_defreturn'] = function(block) {
+JavaScript.forBlock['procedures_defreturn'] = function(block) {
   // Define a procedure with a return value.
   const funcName = JavaScript.nameDB_.getName(
       block.getFieldValue('NAME'), NameType.PROCEDURE);
@@ -61,9 +61,9 @@ JavaScript['procedures_defreturn'] = function(block) {
 
 // Defining a procedure without a return value uses the same generator as
 // a procedure with a return value.
-JavaScript['procedures_defnoreturn'] = JavaScript['procedures_defreturn'];
+JavaScript.forBlock['procedures_defnoreturn'] = JavaScript.forBlock['procedures_defreturn'];
 
-JavaScript['procedures_callreturn'] = function(block) {
+JavaScript.forBlock['procedures_callreturn'] = function(block) {
   // Call a procedure with a return value.
   const funcName = JavaScript.nameDB_.getName(
       block.getFieldValue('NAME'), NameType.PROCEDURE);
@@ -77,15 +77,15 @@ JavaScript['procedures_callreturn'] = function(block) {
   return [code, JavaScript.ORDER_FUNCTION_CALL];
 };
 
-JavaScript['procedures_callnoreturn'] = function(block) {
+JavaScript.forBlock['procedures_callnoreturn'] = function(block) {
   // Call a procedure with no return value.
   // Generated code is for a function call as a statement is the same as a
   // function call as a value, with the addition of line ending.
-  const tuple = JavaScript['procedures_callreturn'](block);
+  const tuple = JavaScript.forBlock['procedures_callreturn'](block);
   return tuple[0] + ';\n';
 };
 
-JavaScript['procedures_ifreturn'] = function(block) {
+JavaScript.forBlock['procedures_ifreturn'] = function(block) {
   // Conditionally return value from a procedure.
   const condition =
       JavaScript.valueToCode(block, 'CONDITION', JavaScript.ORDER_NONE) ||

--- a/generators/javascript/text.js
+++ b/generators/javascript/text.js
@@ -53,13 +53,13 @@ const getSubstringIndex = function(stringName, where, opt_at) {
   }
 };
 
-JavaScript['text'] = function(block) {
+JavaScript.forBlock['text'] = function(block) {
   // Text value.
   const code = JavaScript.quote_(block.getFieldValue('TEXT'));
   return [code, JavaScript.ORDER_ATOMIC];
 };
 
-JavaScript['text_multiline'] = function(block) {
+JavaScript.forBlock['text_multiline'] = function(block) {
   // Text value.
   const code = JavaScript.multiline_quote_(block.getFieldValue('TEXT'));
   const order = code.indexOf('+') !== -1 ? JavaScript.ORDER_ADDITION :
@@ -67,7 +67,7 @@ JavaScript['text_multiline'] = function(block) {
   return [code, order];
 };
 
-JavaScript['text_join'] = function(block) {
+JavaScript.forBlock['text_join'] = function(block) {
   // Create a string made up of any number of elements of any type.
   switch (block.itemCount_) {
     case 0:
@@ -99,7 +99,7 @@ JavaScript['text_join'] = function(block) {
   }
 };
 
-JavaScript['text_append'] = function(block) {
+JavaScript.forBlock['text_append'] = function(block) {
   // Append to a variable in place.
   const varName = JavaScript.nameDB_.getName(
       block.getFieldValue('VAR'), NameType.VARIABLE);
@@ -110,21 +110,21 @@ JavaScript['text_append'] = function(block) {
   return code;
 };
 
-JavaScript['text_length'] = function(block) {
+JavaScript.forBlock['text_length'] = function(block) {
   // String or array length.
   const text = JavaScript.valueToCode(block, 'VALUE',
       JavaScript.ORDER_MEMBER) || "''";
   return [text + '.length', JavaScript.ORDER_MEMBER];
 };
 
-JavaScript['text_isEmpty'] = function(block) {
+JavaScript.forBlock['text_isEmpty'] = function(block) {
   // Is the string null or array empty?
   const text = JavaScript.valueToCode(block, 'VALUE',
       JavaScript.ORDER_MEMBER) || "''";
   return ['!' + text + '.length', JavaScript.ORDER_LOGICAL_NOT];
 };
 
-JavaScript['text_indexOf'] = function(block) {
+JavaScript.forBlock['text_indexOf'] = function(block) {
   // Search the text for a substring.
   const operator = block.getFieldValue('END') === 'FIRST' ?
       'indexOf' : 'lastIndexOf';
@@ -140,7 +140,7 @@ JavaScript['text_indexOf'] = function(block) {
   return [code, JavaScript.ORDER_FUNCTION_CALL];
 };
 
-JavaScript['text_charAt'] = function(block) {
+JavaScript.forBlock['text_charAt'] = function(block) {
   // Get letter at index.
   // Note: Until January 2013 this block did not have the WHERE input.
   const where = block.getFieldValue('WHERE') || 'FROM_START';
@@ -181,7 +181,7 @@ function ${JavaScript.FUNCTION_NAME_PLACEHOLDER_}(text) {
   throw Error('Unhandled option (text_charAt).');
 };
 
-JavaScript['text_getSubstring'] = function(block) {
+JavaScript.forBlock['text_getSubstring'] = function(block) {
   // Get substring.
   const where1 = block.getFieldValue('WHERE1');
   const where2 = block.getFieldValue('WHERE2');
@@ -259,7 +259,7 @@ function ${JavaScript.FUNCTION_NAME_PLACEHOLDER_}(sequence${at1Param}${at2Param}
   return [code, JavaScript.ORDER_FUNCTION_CALL];
 };
 
-JavaScript['text_changeCase'] = function(block) {
+JavaScript.forBlock['text_changeCase'] = function(block) {
   // Change capitalization.
   const OPERATORS = {
     'UPPERCASE': '.toUpperCase()',
@@ -286,7 +286,7 @@ function ${JavaScript.FUNCTION_NAME_PLACEHOLDER_}(str) {
   return [code, JavaScript.ORDER_FUNCTION_CALL];
 };
 
-JavaScript['text_trim'] = function(block) {
+JavaScript.forBlock['text_trim'] = function(block) {
   // Trim spaces.
   const OPERATORS = {
     'LEFT': ".replace(/^[\\s\\xa0]+/, '')",
@@ -299,14 +299,14 @@ JavaScript['text_trim'] = function(block) {
   return [text + operator, JavaScript.ORDER_FUNCTION_CALL];
 };
 
-JavaScript['text_print'] = function(block) {
+JavaScript.forBlock['text_print'] = function(block) {
   // Print statement.
   const msg = JavaScript.valueToCode(block, 'TEXT',
       JavaScript.ORDER_NONE) || "''";
   return 'window.alert(' + msg + ');\n';
 };
 
-JavaScript['text_prompt_ext'] = function(block) {
+JavaScript.forBlock['text_prompt_ext'] = function(block) {
   // Prompt function.
   let msg;
   if (block.getField('TEXT')) {
@@ -324,9 +324,9 @@ JavaScript['text_prompt_ext'] = function(block) {
   return [code, JavaScript.ORDER_FUNCTION_CALL];
 };
 
-JavaScript['text_prompt'] = JavaScript['text_prompt_ext'];
+JavaScript.forBlock['text_prompt'] = JavaScript.forBlock['text_prompt_ext'];
 
-JavaScript['text_count'] = function(block) {
+JavaScript.forBlock['text_count'] = function(block) {
   const text = JavaScript.valueToCode(block, 'TEXT',
       JavaScript.ORDER_NONE) || "''";
   const sub = JavaScript.valueToCode(block, 'SUB',
@@ -344,7 +344,7 @@ function ${JavaScript.FUNCTION_NAME_PLACEHOLDER_}(haystack, needle) {
   return [code, JavaScript.ORDER_FUNCTION_CALL];
 };
 
-JavaScript['text_replace'] = function(block) {
+JavaScript.forBlock['text_replace'] = function(block) {
   const text = JavaScript.valueToCode(block, 'TEXT',
       JavaScript.ORDER_NONE) || "''";
   const from = JavaScript.valueToCode(block, 'FROM',
@@ -363,7 +363,7 @@ function ${JavaScript.FUNCTION_NAME_PLACEHOLDER_}(haystack, needle, replacement)
   return [code, JavaScript.ORDER_FUNCTION_CALL];
 };
 
-JavaScript['text_reverse'] = function(block) {
+JavaScript.forBlock['text_reverse'] = function(block) {
   const text = JavaScript.valueToCode(block, 'TEXT',
       JavaScript.ORDER_MEMBER) || "''";
   const code = text + ".split('').reverse().join('')";

--- a/generators/javascript/variables.js
+++ b/generators/javascript/variables.js
@@ -15,14 +15,14 @@ import {NameType} from '../../core/names.js';
 import {javascriptGenerator as JavaScript} from '../javascript.js';
 
 
-JavaScript['variables_get'] = function(block) {
+JavaScript.forBlock['variables_get'] = function(block) {
   // Variable getter.
   const code = JavaScript.nameDB_.getName(block.getFieldValue('VAR'),
       NameType.VARIABLE);
   return [code, JavaScript.ORDER_ATOMIC];
 };
 
-JavaScript['variables_set'] = function(block) {
+JavaScript.forBlock['variables_set'] = function(block) {
   // Variable setter.
   const argument0 = JavaScript.valueToCode(
                         block, 'VALUE', JavaScript.ORDER_ASSIGNMENT) || '0';

--- a/generators/javascript/variables_dynamic.js
+++ b/generators/javascript/variables_dynamic.js
@@ -16,5 +16,5 @@ import './variables.js';
 
 
 // JavaScript is dynamically typed.
-JavaScript['variables_get_dynamic'] = JavaScript['variables_get'];
-JavaScript['variables_set_dynamic'] = JavaScript['variables_set'];
+JavaScript.forBlock['variables_get_dynamic'] = JavaScript.forBlock['variables_get'];
+JavaScript.forBlock['variables_set_dynamic'] = JavaScript.forBlock['variables_set'];

--- a/generators/lua/colour.js
+++ b/generators/lua/colour.js
@@ -14,19 +14,19 @@ goog.declareModuleId('Blockly.Lua.colour');
 import {luaGenerator as Lua} from '../lua.js';
 
 
-Lua['colour_picker'] = function(block) {
+Lua.forBlock['colour_picker'] = function(block) {
   // Colour picker.
   const code = Lua.quote_(block.getFieldValue('COLOUR'));
   return [code, Lua.ORDER_ATOMIC];
 };
 
-Lua['colour_random'] = function(block) {
+Lua.forBlock['colour_random'] = function(block) {
   // Generate a random colour.
   const code = 'string.format("#%06x", math.random(0, 2^24 - 1))';
   return [code, Lua.ORDER_HIGH];
 };
 
-Lua['colour_rgb'] = function(block) {
+Lua.forBlock['colour_rgb'] = function(block) {
   // Compose a colour from RGB components expressed as percentages.
   const functionName = Lua.provideFunction_('colour_rgb', `
 function ${Lua.FUNCTION_NAME_PLACEHOLDER_}(r, g, b)
@@ -43,7 +43,7 @@ end
   return [code, Lua.ORDER_HIGH];
 };
 
-Lua['colour_blend'] = function(block) {
+Lua.forBlock['colour_blend'] = function(block) {
   // Blend two colours together.
   const functionName = Lua.provideFunction_('colour_blend', `
 function ${Lua.FUNCTION_NAME_PLACEHOLDER_}(colour1, colour2, ratio)

--- a/generators/lua/lists.js
+++ b/generators/lua/lists.js
@@ -15,12 +15,12 @@ import {NameType} from '../../core/names.js';
 import {luaGenerator as Lua} from '../lua.js';
 
 
-Lua['lists_create_empty'] = function(block) {
+Lua.forBlock['lists_create_empty'] = function(block) {
   // Create an empty list.
   return ['{}', Lua.ORDER_HIGH];
 };
 
-Lua['lists_create_with'] = function(block) {
+Lua.forBlock['lists_create_with'] = function(block) {
   // Create a list with any number of elements of any type.
   const elements = new Array(block.itemCount_);
   for (let i = 0; i < block.itemCount_; i++) {
@@ -30,7 +30,7 @@ Lua['lists_create_with'] = function(block) {
   return [code, Lua.ORDER_HIGH];
 };
 
-Lua['lists_repeat'] = function(block) {
+Lua.forBlock['lists_repeat'] = function(block) {
   // Create a list with one element repeated.
   const functionName = Lua.provideFunction_('create_list_repeated', `
 function ${Lua.FUNCTION_NAME_PLACEHOLDER_}(item, count)
@@ -47,20 +47,20 @@ end
   return [code, Lua.ORDER_HIGH];
 };
 
-Lua['lists_length'] = function(block) {
+Lua.forBlock['lists_length'] = function(block) {
   // String or array length.
   const list = Lua.valueToCode(block, 'VALUE', Lua.ORDER_UNARY) || '{}';
   return ['#' + list, Lua.ORDER_UNARY];
 };
 
-Lua['lists_isEmpty'] = function(block) {
+Lua.forBlock['lists_isEmpty'] = function(block) {
   // Is the string null or array empty?
   const list = Lua.valueToCode(block, 'VALUE', Lua.ORDER_UNARY) || '{}';
   const code = '#' + list + ' == 0';
   return [code, Lua.ORDER_RELATIONAL];
 };
 
-Lua['lists_indexOf'] = function(block) {
+Lua.forBlock['lists_indexOf'] = function(block) {
   // Find an item in the list.
   const item = Lua.valueToCode(block, 'FIND', Lua.ORDER_NONE) || "''";
   const list = Lua.valueToCode(block, 'VALUE', Lua.ORDER_NONE) || '{}';
@@ -113,7 +113,7 @@ const getListIndex = function(listName, where, opt_at) {
   }
 };
 
-Lua['lists_getIndex'] = function(block) {
+Lua.forBlock['lists_getIndex'] = function(block) {
   // Get element at index.
   // Note: Until January 2013 this block did not have MODE or WHERE inputs.
   const mode = block.getFieldValue('MODE') || 'GET';
@@ -191,7 +191,7 @@ Lua['lists_getIndex'] = function(block) {
   }
 };
 
-Lua['lists_setIndex'] = function(block) {
+Lua.forBlock['lists_setIndex'] = function(block) {
   // Set element at index.
   // Note: Until February 2013 this block did not have MODE or WHERE inputs.
   let list = Lua.valueToCode(block, 'LIST', Lua.ORDER_HIGH) || '{}';
@@ -223,7 +223,7 @@ Lua['lists_setIndex'] = function(block) {
   return code + '\n';
 };
 
-Lua['lists_getSublist'] = function(block) {
+Lua.forBlock['lists_getSublist'] = function(block) {
   // Get sublist.
   const list = Lua.valueToCode(block, 'LIST', Lua.ORDER_NONE) || '{}';
   const where1 = block.getFieldValue('WHERE1');
@@ -258,7 +258,7 @@ end
   return [code, Lua.ORDER_HIGH];
 };
 
-Lua['lists_sort'] = function(block) {
+Lua.forBlock['lists_sort'] = function(block) {
   // Block for sorting a list.
   const list = Lua.valueToCode(block, 'LIST', Lua.ORDER_NONE) || '{}';
   const direction = block.getFieldValue('DIRECTION') === '1' ? 1 : -1;
@@ -292,7 +292,7 @@ end
   return [code, Lua.ORDER_HIGH];
 };
 
-Lua['lists_split'] = function(block) {
+Lua.forBlock['lists_split'] = function(block) {
   // Block for splitting text into a list, or joining a list into text.
   let input = Lua.valueToCode(block, 'INPUT', Lua.ORDER_NONE);
   const delimiter = Lua.valueToCode(block, 'DELIM', Lua.ORDER_NONE) || "''";
@@ -331,7 +331,7 @@ end
   return [code, Lua.ORDER_HIGH];
 };
 
-Lua['lists_reverse'] = function(block) {
+Lua.forBlock['lists_reverse'] = function(block) {
   // Block for reversing a list.
   const list = Lua.valueToCode(block, 'LIST', Lua.ORDER_NONE) || '{}';
   const functionName = Lua.provideFunction_('list_reverse', `

--- a/generators/lua/logic.js
+++ b/generators/lua/logic.js
@@ -14,7 +14,7 @@ goog.declareModuleId('Blockly.Lua.logic');
 import {luaGenerator as Lua} from '../lua.js';
 
 
-Lua['controls_if'] = function(block) {
+Lua.forBlock['controls_if'] = function(block) {
   // If/elseif/else condition.
   let n = 0;
   let code = '';
@@ -47,9 +47,9 @@ Lua['controls_if'] = function(block) {
   return code + 'end\n';
 };
 
-Lua['controls_ifelse'] = Lua['controls_if'];
+Lua.forBlock['controls_ifelse'] = Lua.forBlock['controls_if'];
 
-Lua['logic_compare'] = function(block) {
+Lua.forBlock['logic_compare'] = function(block) {
   // Comparison operator.
   const OPERATORS =
       {'EQ': '==', 'NEQ': '~=', 'LT': '<', 'LTE': '<=', 'GT': '>', 'GTE': '>='};
@@ -60,7 +60,7 @@ Lua['logic_compare'] = function(block) {
   return [code, Lua.ORDER_RELATIONAL];
 };
 
-Lua['logic_operation'] = function(block) {
+Lua.forBlock['logic_operation'] = function(block) {
   // Operations 'and', 'or'.
   const operator = (block.getFieldValue('OP') === 'AND') ? 'and' : 'or';
   const order = (operator === 'and') ? Lua.ORDER_AND : Lua.ORDER_OR;
@@ -84,25 +84,25 @@ Lua['logic_operation'] = function(block) {
   return [code, order];
 };
 
-Lua['logic_negate'] = function(block) {
+Lua.forBlock['logic_negate'] = function(block) {
   // Negation.
   const argument0 = Lua.valueToCode(block, 'BOOL', Lua.ORDER_UNARY) || 'true';
   const code = 'not ' + argument0;
   return [code, Lua.ORDER_UNARY];
 };
 
-Lua['logic_boolean'] = function(block) {
+Lua.forBlock['logic_boolean'] = function(block) {
   // Boolean values true and false.
   const code = (block.getFieldValue('BOOL') === 'TRUE') ? 'true' : 'false';
   return [code, Lua.ORDER_ATOMIC];
 };
 
-Lua['logic_null'] = function(block) {
+Lua.forBlock['logic_null'] = function(block) {
   // Null data type.
   return ['nil', Lua.ORDER_ATOMIC];
 };
 
-Lua['logic_ternary'] = function(block) {
+Lua.forBlock['logic_ternary'] = function(block) {
   // Ternary operator.
   const value_if = Lua.valueToCode(block, 'IF', Lua.ORDER_AND) || 'false';
   const value_then = Lua.valueToCode(block, 'THEN', Lua.ORDER_AND) || 'nil';

--- a/generators/lua/loops.js
+++ b/generators/lua/loops.js
@@ -42,7 +42,7 @@ const addContinueLabel = function(branch) {
   }
 };
 
-Lua['controls_repeat_ext'] = function(block) {
+Lua.forBlock['controls_repeat_ext'] = function(block) {
   // Repeat n times.
   let repeats;
   if (block.getField('TIMES')) {
@@ -66,9 +66,9 @@ Lua['controls_repeat_ext'] = function(block) {
   return code;
 };
 
-Lua['controls_repeat'] = Lua['controls_repeat_ext'];
+Lua.forBlock['controls_repeat'] = Lua.forBlock['controls_repeat_ext'];
 
-Lua['controls_whileUntil'] = function(block) {
+Lua.forBlock['controls_whileUntil'] = function(block) {
   // Do while/until loop.
   const until = block.getFieldValue('MODE') === 'UNTIL';
   let argument0 =
@@ -84,7 +84,7 @@ Lua['controls_whileUntil'] = function(block) {
   return 'while ' + argument0 + ' do\n' + branch + 'end\n';
 };
 
-Lua['controls_for'] = function(block) {
+Lua.forBlock['controls_for'] = function(block) {
   // For loop.
   const variable0 =
       Lua.nameDB_.getName(block.getFieldValue('VAR'), NameType.VARIABLE);
@@ -124,7 +124,7 @@ Lua['controls_for'] = function(block) {
   return code;
 };
 
-Lua['controls_forEach'] = function(block) {
+Lua.forBlock['controls_forEach'] = function(block) {
   // For each loop.
   const variable0 =
       Lua.nameDB_.getName(block.getFieldValue('VAR'), NameType.VARIABLE);
@@ -137,7 +137,7 @@ Lua['controls_forEach'] = function(block) {
   return code;
 };
 
-Lua['controls_flow_statements'] = function(block) {
+Lua.forBlock['controls_flow_statements'] = function(block) {
   // Flow statements: continue, break.
   let xfix = '';
   if (Lua.STATEMENT_PREFIX) {

--- a/generators/lua/math.js
+++ b/generators/lua/math.js
@@ -15,14 +15,14 @@ import {NameType} from '../../core/names.js';
 import {luaGenerator as Lua} from '../lua.js';
 
 
-Lua['math_number'] = function(block) {
+Lua.forBlock['math_number'] = function(block) {
   // Numeric value.
   const code = Number(block.getFieldValue('NUM'));
   const order = code < 0 ? Lua.ORDER_UNARY : Lua.ORDER_ATOMIC;
   return [code, order];
 };
 
-Lua['math_arithmetic'] = function(block) {
+Lua.forBlock['math_arithmetic'] = function(block) {
   // Basic arithmetic operators, and power.
   const OPERATORS = {
     'ADD': [' + ', Lua.ORDER_ADDITIVE],
@@ -40,7 +40,7 @@ Lua['math_arithmetic'] = function(block) {
   return [code, order];
 };
 
-Lua['math_single'] = function(block) {
+Lua.forBlock['math_single'] = function(block) {
   // Math operators with single operand.
   const operator = block.getFieldValue('OP');
   let arg;
@@ -110,7 +110,7 @@ Lua['math_single'] = function(block) {
   return [code, Lua.ORDER_HIGH];
 };
 
-Lua['math_constant'] = function(block) {
+Lua.forBlock['math_constant'] = function(block) {
   // Constants: PI, E, the Golden Ratio, sqrt(2), 1/sqrt(2), INFINITY.
   const CONSTANTS = {
     'PI': ['math.pi', Lua.ORDER_HIGH],
@@ -123,7 +123,7 @@ Lua['math_constant'] = function(block) {
   return CONSTANTS[block.getFieldValue('CONSTANT')];
 };
 
-Lua['math_number_property'] = function(block) {
+Lua.forBlock['math_number_property'] = function(block) {
   // Check if a number is even, odd, prime, whole, positive, or negative
   // or if it is divisible by certain number. Returns true or false.
   const PROPERTIES = {
@@ -181,7 +181,7 @@ end
   return [code, outputOrder];
 };
 
-Lua['math_change'] = function(block) {
+Lua.forBlock['math_change'] = function(block) {
   // Add to a variable in place.
   const argument0 = Lua.valueToCode(block, 'DELTA', Lua.ORDER_ADDITIVE) || '0';
   const varName =
@@ -190,11 +190,11 @@ Lua['math_change'] = function(block) {
 };
 
 // Rounding functions have a single operand.
-Lua['math_round'] = Lua['math_single'];
+Lua.forBlock['math_round'] = Lua.forBlock['math_single'];
 // Trigonometry functions have a single operand.
-Lua['math_trig'] = Lua['math_single'];
+Lua.forBlock['math_trig'] = Lua.forBlock['math_single'];
 
-Lua['math_on_list'] = function(block) {
+Lua.forBlock['math_on_list'] = function(block) {
   // Math functions for lists.
   const func = block.getFieldValue('OP');
   const list = Lua.valueToCode(block, 'LIST', Lua.ORDER_NONE) || '{}';
@@ -361,7 +361,7 @@ end
   return [functionName + '(' + list + ')', Lua.ORDER_HIGH];
 };
 
-Lua['math_modulo'] = function(block) {
+Lua.forBlock['math_modulo'] = function(block) {
   // Remainder computation.
   const argument0 =
       Lua.valueToCode(block, 'DIVIDEND', Lua.ORDER_MULTIPLICATIVE) || '0';
@@ -371,7 +371,7 @@ Lua['math_modulo'] = function(block) {
   return [code, Lua.ORDER_MULTIPLICATIVE];
 };
 
-Lua['math_constrain'] = function(block) {
+Lua.forBlock['math_constrain'] = function(block) {
   // Constrain a number between two limits.
   const argument0 = Lua.valueToCode(block, 'VALUE', Lua.ORDER_NONE) || '0';
   const argument1 =
@@ -383,7 +383,7 @@ Lua['math_constrain'] = function(block) {
   return [code, Lua.ORDER_HIGH];
 };
 
-Lua['math_random_int'] = function(block) {
+Lua.forBlock['math_random_int'] = function(block) {
   // Random integer between [X] and [Y].
   const argument0 = Lua.valueToCode(block, 'FROM', Lua.ORDER_NONE) || '0';
   const argument1 = Lua.valueToCode(block, 'TO', Lua.ORDER_NONE) || '0';
@@ -391,12 +391,12 @@ Lua['math_random_int'] = function(block) {
   return [code, Lua.ORDER_HIGH];
 };
 
-Lua['math_random_float'] = function(block) {
+Lua.forBlock['math_random_float'] = function(block) {
   // Random fraction between 0 and 1.
   return ['math.random()', Lua.ORDER_HIGH];
 };
 
-Lua['math_atan2'] = function(block) {
+Lua.forBlock['math_atan2'] = function(block) {
   // Arctangent of point (X, Y) in degrees from -180 to 180.
   const argument0 = Lua.valueToCode(block, 'X', Lua.ORDER_NONE) || '0';
   const argument1 = Lua.valueToCode(block, 'Y', Lua.ORDER_NONE) || '0';

--- a/generators/lua/procedures.js
+++ b/generators/lua/procedures.js
@@ -15,7 +15,7 @@ import {NameType} from '../../core/names.js';
 import {luaGenerator as Lua} from '../lua.js';
 
 
-Lua['procedures_defreturn'] = function(block) {
+Lua.forBlock['procedures_defreturn'] = function(block) {
   // Define a procedure with a return value.
   const funcName =
       Lua.nameDB_.getName(block.getFieldValue('NAME'), NameType.PROCEDURE);
@@ -61,9 +61,9 @@ Lua['procedures_defreturn'] = function(block) {
 
 // Defining a procedure without a return value uses the same generator as
 // a procedure with a return value.
-Lua['procedures_defnoreturn'] = Lua['procedures_defreturn'];
+Lua.forBlock['procedures_defnoreturn'] = Lua.forBlock['procedures_defreturn'];
 
-Lua['procedures_callreturn'] = function(block) {
+Lua.forBlock['procedures_callreturn'] = function(block) {
   // Call a procedure with a return value.
   const funcName =
       Lua.nameDB_.getName(block.getFieldValue('NAME'), NameType.PROCEDURE);
@@ -76,15 +76,15 @@ Lua['procedures_callreturn'] = function(block) {
   return [code, Lua.ORDER_HIGH];
 };
 
-Lua['procedures_callnoreturn'] = function(block) {
+Lua.forBlock['procedures_callnoreturn'] = function(block) {
   // Call a procedure with no return value.
   // Generated code is for a function call as a statement is the same as a
   // function call as a value, with the addition of line ending.
-  const tuple = Lua['procedures_callreturn'](block);
+  const tuple = Lua.forBlock['procedures_callreturn'](block);
   return tuple[0] + '\n';
 };
 
-Lua['procedures_ifreturn'] = function(block) {
+Lua.forBlock['procedures_ifreturn'] = function(block) {
   // Conditionally return value from a procedure.
   const condition =
       Lua.valueToCode(block, 'CONDITION', Lua.ORDER_NONE) || 'false';

--- a/generators/lua/text.js
+++ b/generators/lua/text.js
@@ -15,13 +15,13 @@ import {NameType} from '../../core/names.js';
 import {luaGenerator as Lua} from '../lua.js';
 
 
-Lua['text'] = function(block) {
+Lua.forBlock['text'] = function(block) {
   // Text value.
   const code = Lua.quote_(block.getFieldValue('TEXT'));
   return [code, Lua.ORDER_ATOMIC];
 };
 
-Lua['text_multiline'] = function(block) {
+Lua.forBlock['text_multiline'] = function(block) {
   // Text value.
   const code = Lua.multiline_quote_(block.getFieldValue('TEXT'));
   const order =
@@ -29,7 +29,7 @@ Lua['text_multiline'] = function(block) {
   return [code, order];
 };
 
-Lua['text_join'] = function(block) {
+Lua.forBlock['text_join'] = function(block) {
   // Create a string made up of any number of elements of any type.
   if (block.itemCount_ === 0) {
     return ["''", Lua.ORDER_ATOMIC];
@@ -54,7 +54,7 @@ Lua['text_join'] = function(block) {
   }
 };
 
-Lua['text_append'] = function(block) {
+Lua.forBlock['text_append'] = function(block) {
   // Append to a variable in place.
   const varName =
       Lua.nameDB_.getName(block.getFieldValue('VAR'), NameType.VARIABLE);
@@ -63,19 +63,19 @@ Lua['text_append'] = function(block) {
   return varName + ' = ' + varName + ' .. ' + value + '\n';
 };
 
-Lua['text_length'] = function(block) {
+Lua.forBlock['text_length'] = function(block) {
   // String or array length.
   const text = Lua.valueToCode(block, 'VALUE', Lua.ORDER_UNARY) || "''";
   return ['#' + text, Lua.ORDER_UNARY];
 };
 
-Lua['text_isEmpty'] = function(block) {
+Lua.forBlock['text_isEmpty'] = function(block) {
   // Is the string null or array empty?
   const text = Lua.valueToCode(block, 'VALUE', Lua.ORDER_UNARY) || "''";
   return ['#' + text + ' == 0', Lua.ORDER_RELATIONAL];
 };
 
-Lua['text_indexOf'] = function(block) {
+Lua.forBlock['text_indexOf'] = function(block) {
   // Search the text for a substring.
   const substring = Lua.valueToCode(block, 'FIND', Lua.ORDER_NONE) || "''";
   const text = Lua.valueToCode(block, 'VALUE', Lua.ORDER_NONE) || "''";
@@ -105,7 +105,7 @@ end
   return [code, Lua.ORDER_HIGH];
 };
 
-Lua['text_charAt'] = function(block) {
+Lua.forBlock['text_charAt'] = function(block) {
   // Get letter at index.
   // Note: Until January 2013 this block did not have the WHERE input.
   const where = block.getFieldValue('WHERE') || 'FROM_START';
@@ -151,7 +151,7 @@ end
   return [code, Lua.ORDER_HIGH];
 };
 
-Lua['text_getSubstring'] = function(block) {
+Lua.forBlock['text_getSubstring'] = function(block) {
   // Get substring.
   const text = Lua.valueToCode(block, 'STRING', Lua.ORDER_NONE) || "''";
 
@@ -188,7 +188,7 @@ Lua['text_getSubstring'] = function(block) {
   return [code, Lua.ORDER_HIGH];
 };
 
-Lua['text_changeCase'] = function(block) {
+Lua.forBlock['text_changeCase'] = function(block) {
   // Change capitalization.
   const operator = block.getFieldValue('CASE');
   const text = Lua.valueToCode(block, 'TEXT', Lua.ORDER_NONE) || "''";
@@ -225,7 +225,7 @@ end
   return [code, Lua.ORDER_HIGH];
 };
 
-Lua['text_trim'] = function(block) {
+Lua.forBlock['text_trim'] = function(block) {
   // Trim spaces.
   const OPERATORS = {LEFT: '^%s*(,-)', RIGHT: '(.-)%s*$', BOTH: '^%s*(.-)%s*$'};
   const operator = OPERATORS[block.getFieldValue('MODE')];
@@ -234,13 +234,13 @@ Lua['text_trim'] = function(block) {
   return [code, Lua.ORDER_HIGH];
 };
 
-Lua['text_print'] = function(block) {
+Lua.forBlock['text_print'] = function(block) {
   // Print statement.
   const msg = Lua.valueToCode(block, 'TEXT', Lua.ORDER_NONE) || "''";
   return 'print(' + msg + ')\n';
 };
 
-Lua['text_prompt_ext'] = function(block) {
+Lua.forBlock['text_prompt_ext'] = function(block) {
   // Prompt function.
   let msg;
   if (block.getField('TEXT')) {
@@ -267,9 +267,9 @@ end
   return [code, Lua.ORDER_HIGH];
 };
 
-Lua['text_prompt'] = Lua['text_prompt_ext'];
+Lua.forBlock['text_prompt'] = Lua.forBlock['text_prompt_ext'];
 
-Lua['text_count'] = function(block) {
+Lua.forBlock['text_count'] = function(block) {
   const text = Lua.valueToCode(block, 'TEXT', Lua.ORDER_NONE) || "''";
   const sub = Lua.valueToCode(block, 'SUB', Lua.ORDER_NONE) || "''";
   const functionName = Lua.provideFunction_('text_count', `
@@ -294,7 +294,7 @@ end
   return [code, Lua.ORDER_HIGH];
 };
 
-Lua['text_replace'] = function(block) {
+Lua.forBlock['text_replace'] = function(block) {
   const text = Lua.valueToCode(block, 'TEXT', Lua.ORDER_NONE) || "''";
   const from = Lua.valueToCode(block, 'FROM', Lua.ORDER_NONE) || "''";
   const to = Lua.valueToCode(block, 'TO', Lua.ORDER_NONE) || "''";
@@ -320,7 +320,7 @@ end
   return [code, Lua.ORDER_HIGH];
 };
 
-Lua['text_reverse'] = function(block) {
+Lua.forBlock['text_reverse'] = function(block) {
   const text = Lua.valueToCode(block, 'TEXT', Lua.ORDER_NONE) || "''";
   const code = 'string.reverse(' + text + ')';
   return [code, Lua.ORDER_HIGH];

--- a/generators/lua/variables.js
+++ b/generators/lua/variables.js
@@ -15,14 +15,14 @@ import {NameType} from '../../core/names.js';
 import {luaGenerator as Lua} from '../lua.js';
 
 
-Lua['variables_get'] = function(block) {
+Lua.forBlock['variables_get'] = function(block) {
   // Variable getter.
   const code =
       Lua.nameDB_.getName(block.getFieldValue('VAR'), NameType.VARIABLE);
   return [code, Lua.ORDER_ATOMIC];
 };
 
-Lua['variables_set'] = function(block) {
+Lua.forBlock['variables_set'] = function(block) {
   // Variable setter.
   const argument0 = Lua.valueToCode(block, 'VALUE', Lua.ORDER_NONE) || '0';
   const varName =

--- a/generators/lua/variables_dynamic.js
+++ b/generators/lua/variables_dynamic.js
@@ -16,5 +16,5 @@ import './variables.js';
 
 
 // Lua is dynamically typed.
-Lua['variables_get_dynamic'] = Lua['variables_get'];
-Lua['variables_set_dynamic'] = Lua['variables_set'];
+Lua.forBlock['variables_get_dynamic'] = Lua.forBlock['variables_get'];
+Lua.forBlock['variables_set_dynamic'] = Lua.forBlock['variables_set'];

--- a/generators/php/colour.js
+++ b/generators/php/colour.js
@@ -14,13 +14,13 @@ goog.declareModuleId('Blockly.PHP.colour');
 import {phpGenerator as PHP} from '../php.js';
 
 
-PHP['colour_picker'] = function(block) {
+PHP.forBlock['colour_picker'] = function(block) {
   // Colour picker.
   const code = PHP.quote_(block.getFieldValue('COLOUR'));
   return [code, PHP.ORDER_ATOMIC];
 };
 
-PHP['colour_random'] = function(block) {
+PHP.forBlock['colour_random'] = function(block) {
   // Generate a random colour.
   const functionName = PHP.provideFunction_('colour_random', `
 function ${PHP.FUNCTION_NAME_PLACEHOLDER_}() {
@@ -31,7 +31,7 @@ function ${PHP.FUNCTION_NAME_PLACEHOLDER_}() {
   return [code, PHP.ORDER_FUNCTION_CALL];
 };
 
-PHP['colour_rgb'] = function(block) {
+PHP.forBlock['colour_rgb'] = function(block) {
   // Compose a colour from RGB components expressed as percentages.
   const red = PHP.valueToCode(block, 'RED', PHP.ORDER_NONE) || 0;
   const green = PHP.valueToCode(block, 'GREEN', PHP.ORDER_NONE) || 0;
@@ -52,7 +52,7 @@ function ${PHP.FUNCTION_NAME_PLACEHOLDER_}($r, $g, $b) {
   return [code, PHP.ORDER_FUNCTION_CALL];
 };
 
-PHP['colour_blend'] = function(block) {
+PHP.forBlock['colour_blend'] = function(block) {
   // Blend two colours together.
   const c1 = PHP.valueToCode(block, 'COLOUR1', PHP.ORDER_NONE) || "'#000000'";
   const c2 = PHP.valueToCode(block, 'COLOUR2', PHP.ORDER_NONE) || "'#000000'";

--- a/generators/php/lists.js
+++ b/generators/php/lists.js
@@ -26,12 +26,12 @@ import * as stringUtils from '../../core/utils/string.js';
 import {NameType} from '../../core/names.js';
 import {phpGenerator as PHP} from '../php.js';
 
-PHP['lists_create_empty'] = function(block) {
+PHP.forBlock['lists_create_empty'] = function(block) {
   // Create an empty list.
   return ['array()', PHP.ORDER_FUNCTION_CALL];
 };
 
-PHP['lists_create_with'] = function(block) {
+PHP.forBlock['lists_create_with'] = function(block) {
   // Create a list with any number of elements of any type.
   let code = new Array(block.itemCount_);
   for (let i = 0; i < block.itemCount_; i++) {
@@ -41,7 +41,7 @@ PHP['lists_create_with'] = function(block) {
   return [code, PHP.ORDER_FUNCTION_CALL];
 };
 
-PHP['lists_repeat'] = function(block) {
+PHP.forBlock['lists_repeat'] = function(block) {
   // Create a list with one element repeated.
   const functionName = PHP.provideFunction_('lists_repeat', `
 function ${PHP.FUNCTION_NAME_PLACEHOLDER_}($value, $count) {
@@ -58,7 +58,7 @@ function ${PHP.FUNCTION_NAME_PLACEHOLDER_}($value, $count) {
   return [code, PHP.ORDER_FUNCTION_CALL];
 };
 
-PHP['lists_length'] = function(block) {
+PHP.forBlock['lists_length'] = function(block) {
   // String or array length.
   const functionName = PHP.provideFunction_('length', `
 function ${PHP.FUNCTION_NAME_PLACEHOLDER_}($value) {
@@ -73,14 +73,14 @@ function ${PHP.FUNCTION_NAME_PLACEHOLDER_}($value) {
   return [functionName + '(' + list + ')', PHP.ORDER_FUNCTION_CALL];
 };
 
-PHP['lists_isEmpty'] = function(block) {
+PHP.forBlock['lists_isEmpty'] = function(block) {
   // Is the string null or array empty?
   const argument0 =
       PHP.valueToCode(block, 'VALUE', PHP.ORDER_FUNCTION_CALL) || 'array()';
   return ['empty(' + argument0 + ')', PHP.ORDER_FUNCTION_CALL];
 };
 
-PHP['lists_indexOf'] = function(block) {
+PHP.forBlock['lists_indexOf'] = function(block) {
   // Find an item in the list.
   const argument0 = PHP.valueToCode(block, 'FIND', PHP.ORDER_NONE) || "''";
   const argument1 = PHP.valueToCode(block, 'VALUE', PHP.ORDER_MEMBER) || '[]';
@@ -118,7 +118,7 @@ function ${PHP.FUNCTION_NAME_PLACEHOLDER_}($haystack, $needle) {
   return [code, PHP.ORDER_FUNCTION_CALL];
 };
 
-PHP['lists_getIndex'] = function(block) {
+PHP.forBlock['lists_getIndex'] = function(block) {
   // Get element at index.
   const mode = block.getFieldValue('MODE') || 'GET';
   const where = block.getFieldValue('WHERE') || 'FROM_START';
@@ -232,7 +232,7 @@ function ${PHP.FUNCTION_NAME_PLACEHOLDER_}(&$list) {
   throw Error('Unhandled combination (lists_getIndex).');
 };
 
-PHP['lists_setIndex'] = function(block) {
+PHP.forBlock['lists_setIndex'] = function(block) {
   // Set element at index.
   // Note: Until February 2013 this block did not have MODE or WHERE inputs.
   const mode = block.getFieldValue('MODE') || 'GET';
@@ -328,7 +328,7 @@ function ${PHP.FUNCTION_NAME_PLACEHOLDER_}(&$list, $at, $value) {
   throw Error('Unhandled combination (lists_setIndex).');
 };
 
-PHP['lists_getSublist'] = function(block) {
+PHP.forBlock['lists_getSublist'] = function(block) {
   // Get sublist.
   const list = PHP.valueToCode(block, 'LIST', PHP.ORDER_NONE) || 'array()';
   const where1 = block.getFieldValue('WHERE1');
@@ -424,7 +424,7 @@ function ${PHP.FUNCTION_NAME_PLACEHOLDER_}($list, $where1, $at1, $where2, $at2) 
   return [code, PHP.ORDER_FUNCTION_CALL];
 };
 
-PHP['lists_sort'] = function(block) {
+PHP.forBlock['lists_sort'] = function(block) {
   // Block for sorting a list.
   const listCode = PHP.valueToCode(block, 'LIST', PHP.ORDER_NONE) || 'array()';
   const direction = block.getFieldValue('DIRECTION') === '1' ? 1 : -1;
@@ -450,7 +450,7 @@ function ${PHP.FUNCTION_NAME_PLACEHOLDER_}($list, $type, $direction) {
   return [sortCode, PHP.ORDER_FUNCTION_CALL];
 };
 
-PHP['lists_split'] = function(block) {
+PHP.forBlock['lists_split'] = function(block) {
   // Block for splitting text into a list, or joining a list into text.
   let value_input = PHP.valueToCode(block, 'INPUT', PHP.ORDER_NONE);
   const value_delim = PHP.valueToCode(block, 'DELIM', PHP.ORDER_NONE) || "''";
@@ -473,7 +473,7 @@ PHP['lists_split'] = function(block) {
   return [code, PHP.ORDER_FUNCTION_CALL];
 };
 
-PHP['lists_reverse'] = function(block) {
+PHP.forBlock['lists_reverse'] = function(block) {
   // Block for reversing a list.
   const list = PHP.valueToCode(block, 'LIST', PHP.ORDER_NONE) || '[]';
   const code = 'array_reverse(' + list + ')';

--- a/generators/php/logic.js
+++ b/generators/php/logic.js
@@ -14,7 +14,7 @@ goog.declareModuleId('Blockly.PHP.logic');
 import {phpGenerator as PHP} from '../php.js';
 
 
-PHP['controls_if'] = function(block) {
+PHP.forBlock['controls_if'] = function(block) {
   // If/elseif/else condition.
   let n = 0;
   let code = '', branchCode, conditionCode;
@@ -47,9 +47,9 @@ PHP['controls_if'] = function(block) {
   return code + '\n';
 };
 
-PHP['controls_ifelse'] = PHP['controls_if'];
+PHP.forBlock['controls_ifelse'] = PHP.forBlock['controls_if'];
 
-PHP['logic_compare'] = function(block) {
+PHP.forBlock['logic_compare'] = function(block) {
   // Comparison operator.
   const OPERATORS =
       {'EQ': '==', 'NEQ': '!=', 'LT': '<', 'LTE': '<=', 'GT': '>', 'GTE': '>='};
@@ -62,7 +62,7 @@ PHP['logic_compare'] = function(block) {
   return [code, order];
 };
 
-PHP['logic_operation'] = function(block) {
+PHP.forBlock['logic_operation'] = function(block) {
   // Operations 'and', 'or'.
   const operator = (block.getFieldValue('OP') === 'AND') ? '&&' : '||';
   const order =
@@ -87,7 +87,7 @@ PHP['logic_operation'] = function(block) {
   return [code, order];
 };
 
-PHP['logic_negate'] = function(block) {
+PHP.forBlock['logic_negate'] = function(block) {
   // Negation.
   const order = PHP.ORDER_LOGICAL_NOT;
   const argument0 = PHP.valueToCode(block, 'BOOL', order) || 'true';
@@ -95,18 +95,18 @@ PHP['logic_negate'] = function(block) {
   return [code, order];
 };
 
-PHP['logic_boolean'] = function(block) {
+PHP.forBlock['logic_boolean'] = function(block) {
   // Boolean values true and false.
   const code = (block.getFieldValue('BOOL') === 'TRUE') ? 'true' : 'false';
   return [code, PHP.ORDER_ATOMIC];
 };
 
-PHP['logic_null'] = function(block) {
+PHP.forBlock['logic_null'] = function(block) {
   // Null data type.
   return ['null', PHP.ORDER_ATOMIC];
 };
 
-PHP['logic_ternary'] = function(block) {
+PHP.forBlock['logic_ternary'] = function(block) {
   // Ternary operator.
   const value_if =
       PHP.valueToCode(block, 'IF', PHP.ORDER_CONDITIONAL) || 'false';

--- a/generators/php/loops.js
+++ b/generators/php/loops.js
@@ -16,7 +16,7 @@ import {NameType} from '../../core/names.js';
 import {phpGenerator as PHP} from '../php.js';
 
 
-PHP['controls_repeat_ext'] = function(block) {
+PHP.forBlock['controls_repeat_ext'] = function(block) {
   // Repeat n times.
   let repeats;
   if (block.getField('TIMES')) {
@@ -40,9 +40,9 @@ PHP['controls_repeat_ext'] = function(block) {
   return code;
 };
 
-PHP['controls_repeat'] = PHP['controls_repeat_ext'];
+PHP.forBlock['controls_repeat'] = PHP.forBlock['controls_repeat_ext'];
 
-PHP['controls_whileUntil'] = function(block) {
+PHP.forBlock['controls_whileUntil'] = function(block) {
   // Do while/until loop.
   const until = block.getFieldValue('MODE') === 'UNTIL';
   let argument0 =
@@ -57,7 +57,7 @@ PHP['controls_whileUntil'] = function(block) {
   return 'while (' + argument0 + ') {\n' + branch + '}\n';
 };
 
-PHP['controls_for'] = function(block) {
+PHP.forBlock['controls_for'] = function(block) {
   // For loop.
   const variable0 =
       PHP.nameDB_.getName(block.getFieldValue('VAR'), NameType.VARIABLE);
@@ -116,7 +116,7 @@ PHP['controls_for'] = function(block) {
   return code;
 };
 
-PHP['controls_forEach'] = function(block) {
+PHP.forBlock['controls_forEach'] = function(block) {
   // For each loop.
   const variable0 =
       PHP.nameDB_.getName(block.getFieldValue('VAR'), NameType.VARIABLE);
@@ -130,7 +130,7 @@ PHP['controls_forEach'] = function(block) {
   return code;
 };
 
-PHP['controls_flow_statements'] = function(block) {
+PHP.forBlock['controls_flow_statements'] = function(block) {
   // Flow statements: continue, break.
   let xfix = '';
   if (PHP.STATEMENT_PREFIX) {

--- a/generators/php/math.js
+++ b/generators/php/math.js
@@ -15,7 +15,7 @@ import {NameType} from '../../core/names.js';
 import {phpGenerator as PHP} from '../php.js';
 
 
-PHP['math_number'] = function(block) {
+PHP.forBlock['math_number'] = function(block) {
   // Numeric value.
   let code = Number(block.getFieldValue('NUM'));
   const order = code >= 0 ? PHP.ORDER_ATOMIC : PHP.ORDER_UNARY_NEGATION;
@@ -27,7 +27,7 @@ PHP['math_number'] = function(block) {
   return [code, order];
 };
 
-PHP['math_arithmetic'] = function(block) {
+PHP.forBlock['math_arithmetic'] = function(block) {
   // Basic arithmetic operators, and power.
   const OPERATORS = {
     'ADD': [' + ', PHP.ORDER_ADDITION],
@@ -45,7 +45,7 @@ PHP['math_arithmetic'] = function(block) {
   return [code, order];
 };
 
-PHP['math_single'] = function(block) {
+PHP.forBlock['math_single'] = function(block) {
   // Math operators with single operand.
   const operator = block.getFieldValue('OP');
   let code;
@@ -126,7 +126,7 @@ PHP['math_single'] = function(block) {
   return [code, PHP.ORDER_DIVISION];
 };
 
-PHP['math_constant'] = function(block) {
+PHP.forBlock['math_constant'] = function(block) {
   // Constants: PI, E, the Golden Ratio, sqrt(2), 1/sqrt(2), INFINITY.
   const CONSTANTS = {
     'PI': ['M_PI', PHP.ORDER_ATOMIC],
@@ -139,7 +139,7 @@ PHP['math_constant'] = function(block) {
   return CONSTANTS[block.getFieldValue('CONSTANT')];
 };
 
-PHP['math_number_property'] = function(block) {
+PHP.forBlock['math_number_property'] = function(block) {
   // Check if a number is even, odd, prime, whole, positive, or negative
   // or if it is divisible by certain number. Returns true or false.
   const PROPERTIES = {
@@ -193,7 +193,7 @@ function ${PHP.FUNCTION_NAME_PLACEHOLDER_}($n) {
   return [code, outputOrder];
 };
 
-PHP['math_change'] = function(block) {
+PHP.forBlock['math_change'] = function(block) {
   // Add to a variable in place.
   const argument0 = PHP.valueToCode(block, 'DELTA', PHP.ORDER_ADDITION) || '0';
   const varName =
@@ -202,11 +202,11 @@ PHP['math_change'] = function(block) {
 };
 
 // Rounding functions have a single operand.
-PHP['math_round'] = PHP['math_single'];
+PHP.forBlock['math_round'] = PHP.forBlock['math_single'];
 // Trigonometry functions have a single operand.
-PHP['math_trig'] = PHP['math_single'];
+PHP.forBlock['math_trig'] = PHP.forBlock['math_single'];
 
-PHP['math_on_list'] = function(block) {
+PHP.forBlock['math_on_list'] = function(block) {
   // Math functions for lists.
   const func = block.getFieldValue('OP');
   let list;
@@ -297,7 +297,7 @@ function ${PHP.FUNCTION_NAME_PLACEHOLDER_}($list) {
   return [code, PHP.ORDER_FUNCTION_CALL];
 };
 
-PHP['math_modulo'] = function(block) {
+PHP.forBlock['math_modulo'] = function(block) {
   // Remainder computation.
   const argument0 =
       PHP.valueToCode(block, 'DIVIDEND', PHP.ORDER_MODULUS) || '0';
@@ -306,7 +306,7 @@ PHP['math_modulo'] = function(block) {
   return [code, PHP.ORDER_MODULUS];
 };
 
-PHP['math_constrain'] = function(block) {
+PHP.forBlock['math_constrain'] = function(block) {
   // Constrain a number between two limits.
   const argument0 = PHP.valueToCode(block, 'VALUE', PHP.ORDER_NONE) || '0';
   const argument1 = PHP.valueToCode(block, 'LOW', PHP.ORDER_NONE) || '0';
@@ -317,7 +317,7 @@ PHP['math_constrain'] = function(block) {
   return [code, PHP.ORDER_FUNCTION_CALL];
 };
 
-PHP['math_random_int'] = function(block) {
+PHP.forBlock['math_random_int'] = function(block) {
   // Random integer between [X] and [Y].
   const argument0 = PHP.valueToCode(block, 'FROM', PHP.ORDER_NONE) || '0';
   const argument1 = PHP.valueToCode(block, 'TO', PHP.ORDER_NONE) || '0';
@@ -333,12 +333,12 @@ function ${PHP.FUNCTION_NAME_PLACEHOLDER_}($a, $b) {
   return [code, PHP.ORDER_FUNCTION_CALL];
 };
 
-PHP['math_random_float'] = function(block) {
+PHP.forBlock['math_random_float'] = function(block) {
   // Random fraction between 0 and 1.
   return ['(float)rand()/(float)getrandmax()', PHP.ORDER_FUNCTION_CALL];
 };
 
-PHP['math_atan2'] = function(block) {
+PHP.forBlock['math_atan2'] = function(block) {
   // Arctangent of point (X, Y) in degrees from -180 to 180.
   const argument0 = PHP.valueToCode(block, 'X', PHP.ORDER_NONE) || '0';
   const argument1 = PHP.valueToCode(block, 'Y', PHP.ORDER_NONE) || '0';

--- a/generators/php/procedures.js
+++ b/generators/php/procedures.js
@@ -16,7 +16,7 @@ import {NameType} from '../../core/names.js';
 import {phpGenerator as PHP} from '../php.js';
 
 
-PHP['procedures_defreturn'] = function(block) {
+PHP.forBlock['procedures_defreturn'] = function(block) {
   // Define a procedure with a return value.
   // First, add a 'global' statement for every variable that is not shadowed by
   // a local parameter.
@@ -80,9 +80,9 @@ PHP['procedures_defreturn'] = function(block) {
 
 // Defining a procedure without a return value uses the same generator as
 // a procedure with a return value.
-PHP['procedures_defnoreturn'] = PHP['procedures_defreturn'];
+PHP.forBlock['procedures_defnoreturn'] = PHP.forBlock['procedures_defreturn'];
 
-PHP['procedures_callreturn'] = function(block) {
+PHP.forBlock['procedures_callreturn'] = function(block) {
   // Call a procedure with a return value.
   const funcName =
       PHP.nameDB_.getName(block.getFieldValue('NAME'), NameType.PROCEDURE);
@@ -95,15 +95,15 @@ PHP['procedures_callreturn'] = function(block) {
   return [code, PHP.ORDER_FUNCTION_CALL];
 };
 
-PHP['procedures_callnoreturn'] = function(block) {
+PHP.forBlock['procedures_callnoreturn'] = function(block) {
   // Call a procedure with no return value.
   // Generated code is for a function call as a statement is the same as a
   // function call as a value, with the addition of line ending.
-  const tuple = PHP['procedures_callreturn'](block);
+  const tuple = PHP.forBlock['procedures_callreturn'](block);
   return tuple[0] + ';\n';
 };
 
-PHP['procedures_ifreturn'] = function(block) {
+PHP.forBlock['procedures_ifreturn'] = function(block) {
   // Conditionally return value from a procedure.
   const condition =
       PHP.valueToCode(block, 'CONDITION', PHP.ORDER_NONE) || 'false';

--- a/generators/php/text.js
+++ b/generators/php/text.js
@@ -15,13 +15,13 @@ import {NameType} from '../../core/names.js';
 import {phpGenerator as PHP} from '../php.js';
 
 
-PHP['text'] = function(block) {
+PHP.forBlock['text'] = function(block) {
   // Text value.
   const code = PHP.quote_(block.getFieldValue('TEXT'));
   return [code, PHP.ORDER_ATOMIC];
 };
 
-PHP['text_multiline'] = function(block) {
+PHP.forBlock['text_multiline'] = function(block) {
   // Text value.
   const code = PHP.multiline_quote_(block.getFieldValue('TEXT'));
   const order =
@@ -29,7 +29,7 @@ PHP['text_multiline'] = function(block) {
   return [code, order];
 };
 
-PHP['text_join'] = function(block) {
+PHP.forBlock['text_join'] = function(block) {
   // Create a string made up of any number of elements of any type.
   if (block.itemCount_ === 0) {
     return ["''", PHP.ORDER_ATOMIC];
@@ -54,7 +54,7 @@ PHP['text_join'] = function(block) {
   }
 };
 
-PHP['text_append'] = function(block) {
+PHP.forBlock['text_append'] = function(block) {
   // Append to a variable in place.
   const varName =
       PHP.nameDB_.getName(block.getFieldValue('VAR'), NameType.VARIABLE);
@@ -62,7 +62,7 @@ PHP['text_append'] = function(block) {
   return varName + ' .= ' + value + ';\n';
 };
 
-PHP['text_length'] = function(block) {
+PHP.forBlock['text_length'] = function(block) {
   // String or array length.
   const functionName = PHP.provideFunction_('length', `
 function ${PHP.FUNCTION_NAME_PLACEHOLDER_}($value) {
@@ -76,13 +76,13 @@ function ${PHP.FUNCTION_NAME_PLACEHOLDER_}($value) {
   return [functionName + '(' + text + ')', PHP.ORDER_FUNCTION_CALL];
 };
 
-PHP['text_isEmpty'] = function(block) {
+PHP.forBlock['text_isEmpty'] = function(block) {
   // Is the string null or array empty?
   const text = PHP.valueToCode(block, 'VALUE', PHP.ORDER_NONE) || "''";
   return ['empty(' + text + ')', PHP.ORDER_FUNCTION_CALL];
 };
 
-PHP['text_indexOf'] = function(block) {
+PHP.forBlock['text_indexOf'] = function(block) {
   // Search the text for a substring.
   const operator =
       block.getFieldValue('END') === 'FIRST' ? 'strpos' : 'strrpos';
@@ -107,7 +107,7 @@ function ${PHP.FUNCTION_NAME_PLACEHOLDER_}($text, $search) {
   return [code, PHP.ORDER_FUNCTION_CALL];
 };
 
-PHP['text_charAt'] = function(block) {
+PHP.forBlock['text_charAt'] = function(block) {
   // Get letter at index.
   const where = block.getFieldValue('WHERE') || 'FROM_START';
   const textOrder = (where === 'RANDOM') ? PHP.ORDER_NONE : PHP.ORDER_NONE;
@@ -144,7 +144,7 @@ function ${PHP.FUNCTION_NAME_PLACEHOLDER_}($text) {
   throw Error('Unhandled option (text_charAt).');
 };
 
-PHP['text_getSubstring'] = function(block) {
+PHP.forBlock['text_getSubstring'] = function(block) {
   // Get substring.
   const where1 = block.getFieldValue('WHERE1');
   const where2 = block.getFieldValue('WHERE2');
@@ -183,7 +183,7 @@ function ${PHP.FUNCTION_NAME_PLACEHOLDER_}($text, $where1, $at1, $where2, $at2) 
   }
 };
 
-PHP['text_changeCase'] = function(block) {
+PHP.forBlock['text_changeCase'] = function(block) {
   // Change capitalization.
   const text = PHP.valueToCode(block, 'TEXT', PHP.ORDER_NONE) || "''";
   let code;
@@ -197,7 +197,7 @@ PHP['text_changeCase'] = function(block) {
   return [code, PHP.ORDER_FUNCTION_CALL];
 };
 
-PHP['text_trim'] = function(block) {
+PHP.forBlock['text_trim'] = function(block) {
   // Trim spaces.
   const OPERATORS = {'LEFT': 'ltrim', 'RIGHT': 'rtrim', 'BOTH': 'trim'};
   const operator = OPERATORS[block.getFieldValue('MODE')];
@@ -205,13 +205,13 @@ PHP['text_trim'] = function(block) {
   return [operator + '(' + text + ')', PHP.ORDER_FUNCTION_CALL];
 };
 
-PHP['text_print'] = function(block) {
+PHP.forBlock['text_print'] = function(block) {
   // Print statement.
   const msg = PHP.valueToCode(block, 'TEXT', PHP.ORDER_NONE) || "''";
   return 'print(' + msg + ');\n';
 };
 
-PHP['text_prompt_ext'] = function(block) {
+PHP.forBlock['text_prompt_ext'] = function(block) {
   // Prompt function.
   let msg;
   if (block.getField('TEXT')) {
@@ -229,9 +229,9 @@ PHP['text_prompt_ext'] = function(block) {
   return [code, PHP.ORDER_FUNCTION_CALL];
 };
 
-PHP['text_prompt'] = PHP['text_prompt_ext'];
+PHP.forBlock['text_prompt'] = PHP.forBlock['text_prompt_ext'];
 
-PHP['text_count'] = function(block) {
+PHP.forBlock['text_count'] = function(block) {
   const text = PHP.valueToCode(block, 'TEXT', PHP.ORDER_NONE) || "''";
   const sub = PHP.valueToCode(block, 'SUB', PHP.ORDER_NONE) || "''";
   const code = 'strlen(' + sub + ') === 0' +
@@ -240,7 +240,7 @@ PHP['text_count'] = function(block) {
   return [code, PHP.ORDER_CONDITIONAL];
 };
 
-PHP['text_replace'] = function(block) {
+PHP.forBlock['text_replace'] = function(block) {
   const text = PHP.valueToCode(block, 'TEXT', PHP.ORDER_NONE) || "''";
   const from = PHP.valueToCode(block, 'FROM', PHP.ORDER_NONE) || "''";
   const to = PHP.valueToCode(block, 'TO', PHP.ORDER_NONE) || "''";
@@ -248,7 +248,7 @@ PHP['text_replace'] = function(block) {
   return [code, PHP.ORDER_FUNCTION_CALL];
 };
 
-PHP['text_reverse'] = function(block) {
+PHP.forBlock['text_reverse'] = function(block) {
   const text = PHP.valueToCode(block, 'TEXT', PHP.ORDER_NONE) || "''";
   const code = 'strrev(' + text + ')';
   return [code, PHP.ORDER_FUNCTION_CALL];

--- a/generators/php/variables.js
+++ b/generators/php/variables.js
@@ -15,14 +15,14 @@ import {NameType} from '../../core/names.js';
 import {phpGenerator as PHP} from '../php.js';
 
 
-PHP['variables_get'] = function(block) {
+PHP.forBlock['variables_get'] = function(block) {
   // Variable getter.
   const code =
       PHP.nameDB_.getName(block.getFieldValue('VAR'), NameType.VARIABLE);
   return [code, PHP.ORDER_ATOMIC];
 };
 
-PHP['variables_set'] = function(block) {
+PHP.forBlock['variables_set'] = function(block) {
   // Variable setter.
   const argument0 =
       PHP.valueToCode(block, 'VALUE', PHP.ORDER_ASSIGNMENT) || '0';

--- a/generators/php/variables_dynamic.js
+++ b/generators/php/variables_dynamic.js
@@ -16,5 +16,5 @@ import './variables.js';
 
 
 // PHP is dynamically typed.
-PHP['variables_get_dynamic'] = PHP['variables_get'];
-PHP['variables_set_dynamic'] = PHP['variables_set'];
+PHP.forBlock['variables_get_dynamic'] = PHP.forBlock['variables_get'];
+PHP.forBlock['variables_set_dynamic'] = PHP.forBlock['variables_set'];

--- a/generators/python/colour.js
+++ b/generators/python/colour.js
@@ -14,20 +14,20 @@ goog.declareModuleId('Blockly.Python.colour');
 import {pythonGenerator as Python} from '../python.js';
 
 
-Python['colour_picker'] = function(block) {
+Python.forBlock['colour_picker'] = function(block) {
   // Colour picker.
   const code = Python.quote_(block.getFieldValue('COLOUR'));
   return [code, Python.ORDER_ATOMIC];
 };
 
-Python['colour_random'] = function(block) {
+Python.forBlock['colour_random'] = function(block) {
   // Generate a random colour.
   Python.definitions_['import_random'] = 'import random';
   const code = '\'#%06x\' % random.randint(0, 2**24 - 1)';
   return [code, Python.ORDER_FUNCTION_CALL];
 };
 
-Python['colour_rgb'] = function(block) {
+Python.forBlock['colour_rgb'] = function(block) {
   // Compose a colour from RGB components expressed as percentages.
   const functionName = Python.provideFunction_('colour_rgb', `
 def ${Python.FUNCTION_NAME_PLACEHOLDER_}(r, g, b):
@@ -43,7 +43,7 @@ def ${Python.FUNCTION_NAME_PLACEHOLDER_}(r, g, b):
   return [code, Python.ORDER_FUNCTION_CALL];
 };
 
-Python['colour_blend'] = function(block) {
+Python.forBlock['colour_blend'] = function(block) {
   // Blend two colours together.
   const functionName = Python.provideFunction_('colour_blend', `
 def ${Python.FUNCTION_NAME_PLACEHOLDER_}(colour1, colour2, ratio):

--- a/generators/python/lists.js
+++ b/generators/python/lists.js
@@ -16,12 +16,12 @@ import {NameType} from '../../core/names.js';
 import {pythonGenerator as Python} from '../python.js';
 
 
-Python['lists_create_empty'] = function(block) {
+Python.forBlock['lists_create_empty'] = function(block) {
   // Create an empty list.
   return ['[]', Python.ORDER_ATOMIC];
 };
 
-Python['lists_create_with'] = function(block) {
+Python.forBlock['lists_create_with'] = function(block) {
   // Create a list with any number of elements of any type.
   const elements = new Array(block.itemCount_);
   for (let i = 0; i < block.itemCount_; i++) {
@@ -32,7 +32,7 @@ Python['lists_create_with'] = function(block) {
   return [code, Python.ORDER_ATOMIC];
 };
 
-Python['lists_repeat'] = function(block) {
+Python.forBlock['lists_repeat'] = function(block) {
   // Create a list with one element repeated.
   const item = Python.valueToCode(block, 'ITEM', Python.ORDER_NONE) || 'None';
   const times =
@@ -41,20 +41,20 @@ Python['lists_repeat'] = function(block) {
   return [code, Python.ORDER_MULTIPLICATIVE];
 };
 
-Python['lists_length'] = function(block) {
+Python.forBlock['lists_length'] = function(block) {
   // String or array length.
   const list = Python.valueToCode(block, 'VALUE', Python.ORDER_NONE) || '[]';
   return ['len(' + list + ')', Python.ORDER_FUNCTION_CALL];
 };
 
-Python['lists_isEmpty'] = function(block) {
+Python.forBlock['lists_isEmpty'] = function(block) {
   // Is the string null or array empty?
   const list = Python.valueToCode(block, 'VALUE', Python.ORDER_NONE) || '[]';
   const code = 'not len(' + list + ')';
   return [code, Python.ORDER_LOGICAL_NOT];
 };
 
-Python['lists_indexOf'] = function(block) {
+Python.forBlock['lists_indexOf'] = function(block) {
   // Find an item in the list.
   const item = Python.valueToCode(block, 'FIND', Python.ORDER_NONE) || '[]';
   const list = Python.valueToCode(block, 'VALUE', Python.ORDER_NONE) || "''";
@@ -88,7 +88,7 @@ def ${Python.FUNCTION_NAME_PLACEHOLDER_}(my_list, elem):
   return [code, Python.ORDER_FUNCTION_CALL];
 };
 
-Python['lists_getIndex'] = function(block) {
+Python.forBlock['lists_getIndex'] = function(block) {
   // Get element at index.
   // Note: Until January 2013 this block did not have MODE or WHERE inputs.
   const mode = block.getFieldValue('MODE') || 'GET';
@@ -170,7 +170,7 @@ def ${Python.FUNCTION_NAME_PLACEHOLDER_}(myList):
   throw Error('Unhandled combination (lists_getIndex).');
 };
 
-Python['lists_setIndex'] = function(block) {
+Python.forBlock['lists_setIndex'] = function(block) {
   // Set element at index.
   // Note: Until February 2013 this block did not have MODE or WHERE inputs.
   let list = Python.valueToCode(block, 'LIST', Python.ORDER_MEMBER) || '[]';
@@ -241,7 +241,7 @@ Python['lists_setIndex'] = function(block) {
   throw Error('Unhandled combination (lists_setIndex).');
 };
 
-Python['lists_getSublist'] = function(block) {
+Python.forBlock['lists_getSublist'] = function(block) {
   // Get sublist.
   const list = Python.valueToCode(block, 'LIST', Python.ORDER_MEMBER) || '[]';
   const where1 = block.getFieldValue('WHERE1');
@@ -290,7 +290,7 @@ Python['lists_getSublist'] = function(block) {
   return [code, Python.ORDER_MEMBER];
 };
 
-Python['lists_sort'] = function(block) {
+Python.forBlock['lists_sort'] = function(block) {
   // Block for sorting a list.
   const list = (Python.valueToCode(block, 'LIST', Python.ORDER_NONE) || '[]');
   const type = block.getFieldValue('TYPE');
@@ -317,7 +317,7 @@ def ${Python.FUNCTION_NAME_PLACEHOLDER_}(my_list, type, reverse):
   return [code, Python.ORDER_FUNCTION_CALL];
 };
 
-Python['lists_split'] = function(block) {
+Python.forBlock['lists_split'] = function(block) {
   // Block for splitting text into a list, or joining a list into text.
   const mode = block.getFieldValue('MODE');
   let code;
@@ -338,7 +338,7 @@ Python['lists_split'] = function(block) {
   return [code, Python.ORDER_FUNCTION_CALL];
 };
 
-Python['lists_reverse'] = function(block) {
+Python.forBlock['lists_reverse'] = function(block) {
   // Block for reversing a list.
   const list = Python.valueToCode(block, 'LIST', Python.ORDER_NONE) || '[]';
   const code = 'list(reversed(' + list + '))';

--- a/generators/python/logic.js
+++ b/generators/python/logic.js
@@ -14,7 +14,7 @@ goog.declareModuleId('Blockly.Python.logic');
 import {pythonGenerator as Python} from '../python.js';
 
 
-Python['controls_if'] = function(block) {
+Python.forBlock['controls_if'] = function(block) {
   // If/elseif/else condition.
   let n = 0;
   let code = '', branchCode, conditionCode;
@@ -49,9 +49,9 @@ Python['controls_if'] = function(block) {
   return code;
 };
 
-Python['controls_ifelse'] = Python['controls_if'];
+Python.forBlock['controls_ifelse'] = Python.forBlock['controls_if'];
 
-Python['logic_compare'] = function(block) {
+Python.forBlock['logic_compare'] = function(block) {
   // Comparison operator.
   const OPERATORS =
       {'EQ': '==', 'NEQ': '!=', 'LT': '<', 'LTE': '<=', 'GT': '>', 'GTE': '>='};
@@ -63,7 +63,7 @@ Python['logic_compare'] = function(block) {
   return [code, order];
 };
 
-Python['logic_operation'] = function(block) {
+Python.forBlock['logic_operation'] = function(block) {
   // Operations 'and', 'or'.
   const operator = (block.getFieldValue('OP') === 'AND') ? 'and' : 'or';
   const order =
@@ -88,7 +88,7 @@ Python['logic_operation'] = function(block) {
   return [code, order];
 };
 
-Python['logic_negate'] = function(block) {
+Python.forBlock['logic_negate'] = function(block) {
   // Negation.
   const argument0 =
       Python.valueToCode(block, 'BOOL', Python.ORDER_LOGICAL_NOT) || 'True';
@@ -96,18 +96,18 @@ Python['logic_negate'] = function(block) {
   return [code, Python.ORDER_LOGICAL_NOT];
 };
 
-Python['logic_boolean'] = function(block) {
+Python.forBlock['logic_boolean'] = function(block) {
   // Boolean values true and false.
   const code = (block.getFieldValue('BOOL') === 'TRUE') ? 'True' : 'False';
   return [code, Python.ORDER_ATOMIC];
 };
 
-Python['logic_null'] = function(block) {
+Python.forBlock['logic_null'] = function(block) {
   // Null data type.
   return ['None', Python.ORDER_ATOMIC];
 };
 
-Python['logic_ternary'] = function(block) {
+Python.forBlock['logic_ternary'] = function(block) {
   // Ternary operator.
   const value_if =
       Python.valueToCode(block, 'IF', Python.ORDER_CONDITIONAL) || 'False';

--- a/generators/python/loops.js
+++ b/generators/python/loops.js
@@ -16,7 +16,7 @@ import {NameType} from '../../core/names.js';
 import {pythonGenerator as Python} from '../python.js';
 
 
-Python['controls_repeat_ext'] = function(block) {
+Python.forBlock['controls_repeat_ext'] = function(block) {
   // Repeat n times.
   let repeats;
   if (block.getField('TIMES')) {
@@ -38,9 +38,9 @@ Python['controls_repeat_ext'] = function(block) {
   return code;
 };
 
-Python['controls_repeat'] = Python['controls_repeat_ext'];
+Python.forBlock['controls_repeat'] = Python.forBlock['controls_repeat_ext'];
 
-Python['controls_whileUntil'] = function(block) {
+Python.forBlock['controls_whileUntil'] = function(block) {
   // Do while/until loop.
   const until = block.getFieldValue('MODE') === 'UNTIL';
   let argument0 = Python.valueToCode(
@@ -55,7 +55,7 @@ Python['controls_whileUntil'] = function(block) {
   return 'while ' + argument0 + ':\n' + branch;
 };
 
-Python['controls_for'] = function(block) {
+Python.forBlock['controls_for'] = function(block) {
   // For loop.
   const variable0 =
       Python.nameDB_.getName(block.getFieldValue('VAR'), NameType.VARIABLE);
@@ -163,7 +163,7 @@ def ${Python.FUNCTION_NAME_PLACEHOLDER_}(start, stop, step):
   return code;
 };
 
-Python['controls_forEach'] = function(block) {
+Python.forBlock['controls_forEach'] = function(block) {
   // For each loop.
   const variable0 =
       Python.nameDB_.getName(block.getFieldValue('VAR'), NameType.VARIABLE);
@@ -175,7 +175,7 @@ Python['controls_forEach'] = function(block) {
   return code;
 };
 
-Python['controls_flow_statements'] = function(block) {
+Python.forBlock['controls_flow_statements'] = function(block) {
   // Flow statements: continue, break.
   let xfix = '';
   if (Python.STATEMENT_PREFIX) {

--- a/generators/python/math.js
+++ b/generators/python/math.js
@@ -18,7 +18,7 @@ import {pythonGenerator as Python} from '../python.js';
 // If any new block imports any library, add that library name here.
 Python.addReservedWords('math,random,Number');
 
-Python['math_number'] = function(block) {
+Python.forBlock['math_number'] = function(block) {
   // Numeric value.
   let code = Number(block.getFieldValue('NUM'));
   let order;
@@ -34,7 +34,7 @@ Python['math_number'] = function(block) {
   return [code, order];
 };
 
-Python['math_arithmetic'] = function(block) {
+Python.forBlock['math_arithmetic'] = function(block) {
   // Basic arithmetic operators, and power.
   const OPERATORS = {
     'ADD': [' + ', Python.ORDER_ADDITIVE],
@@ -57,7 +57,7 @@ Python['math_arithmetic'] = function(block) {
   // legibility of the generated code.
 };
 
-Python['math_single'] = function(block) {
+Python.forBlock['math_single'] = function(block) {
   // Math operators with single operand.
   const operator = block.getFieldValue('OP');
   let code;
@@ -134,7 +134,7 @@ Python['math_single'] = function(block) {
   return [code, Python.ORDER_MULTIPLICATIVE];
 };
 
-Python['math_constant'] = function(block) {
+Python.forBlock['math_constant'] = function(block) {
   // Constants: PI, E, the Golden Ratio, sqrt(2), 1/sqrt(2), INFINITY.
   const CONSTANTS = {
     'PI': ['math.pi', Python.ORDER_MEMBER],
@@ -151,7 +151,7 @@ Python['math_constant'] = function(block) {
   return CONSTANTS[constant];
 };
 
-Python['math_number_property'] = function(block) {
+Python.forBlock['math_number_property'] = function(block) {
    // Check if a number is even, odd, prime, whole, positive, or negative
    // or if it is divisible by certain number. Returns true or false.
   const PROPERTIES = {
@@ -210,7 +210,7 @@ def ${Python.FUNCTION_NAME_PLACEHOLDER_}(n):
   return [code, outputOrder];
 };
 
-Python['math_change'] = function(block) {
+Python.forBlock['math_change'] = function(block) {
   // Add to a variable in place.
   Python.definitions_['from_numbers_import_Number'] =
       'from numbers import Number';
@@ -223,11 +223,11 @@ Python['math_change'] = function(block) {
 };
 
 // Rounding functions have a single operand.
-Python['math_round'] = Python['math_single'];
+Python.forBlock['math_round'] = Python.forBlock['math_single'];
 // Trigonometry functions have a single operand.
-Python['math_trig'] = Python['math_single'];
+Python.forBlock['math_trig'] = Python.forBlock['math_single'];
 
-Python['math_on_list'] = function(block) {
+Python.forBlock['math_on_list'] = function(block) {
   // Math functions for lists.
   const func = block.getFieldValue('OP');
   const list = Python.valueToCode(block, 'LIST', Python.ORDER_NONE) || '[]';
@@ -324,7 +324,7 @@ def ${Python.FUNCTION_NAME_PLACEHOLDER_}(numbers):
   return [code, Python.ORDER_FUNCTION_CALL];
 };
 
-Python['math_modulo'] = function(block) {
+Python.forBlock['math_modulo'] = function(block) {
   // Remainder computation.
   const argument0 =
       Python.valueToCode(block, 'DIVIDEND', Python.ORDER_MULTIPLICATIVE) || '0';
@@ -334,7 +334,7 @@ Python['math_modulo'] = function(block) {
   return [code, Python.ORDER_MULTIPLICATIVE];
 };
 
-Python['math_constrain'] = function(block) {
+Python.forBlock['math_constrain'] = function(block) {
   // Constrain a number between two limits.
   const argument0 =
       Python.valueToCode(block, 'VALUE', Python.ORDER_NONE) || '0';
@@ -346,7 +346,7 @@ Python['math_constrain'] = function(block) {
   return [code, Python.ORDER_FUNCTION_CALL];
 };
 
-Python['math_random_int'] = function(block) {
+Python.forBlock['math_random_int'] = function(block) {
   // Random integer between [X] and [Y].
   Python.definitions_['import_random'] = 'import random';
   const argument0 = Python.valueToCode(block, 'FROM', Python.ORDER_NONE) || '0';
@@ -355,13 +355,13 @@ Python['math_random_int'] = function(block) {
   return [code, Python.ORDER_FUNCTION_CALL];
 };
 
-Python['math_random_float'] = function(block) {
+Python.forBlock['math_random_float'] = function(block) {
   // Random fraction between 0 and 1.
   Python.definitions_['import_random'] = 'import random';
   return ['random.random()', Python.ORDER_FUNCTION_CALL];
 };
 
-Python['math_atan2'] = function(block) {
+Python.forBlock['math_atan2'] = function(block) {
   // Arctangent of point (X, Y) in degrees from -180 to 180.
   Python.definitions_['import_math'] = 'import math';
   const argument0 = Python.valueToCode(block, 'X', Python.ORDER_NONE) || '0';

--- a/generators/python/procedures.js
+++ b/generators/python/procedures.js
@@ -16,7 +16,7 @@ import {NameType} from '../../core/names.js';
 import {pythonGenerator as Python} from '../python.js';
 
 
-Python['procedures_defreturn'] = function(block) {
+Python.forBlock['procedures_defreturn'] = function(block) {
   // Define a procedure with a return value.
   // First, add a 'global' statement for every variable that is not shadowed by
   // a local parameter.
@@ -84,9 +84,9 @@ Python['procedures_defreturn'] = function(block) {
 
 // Defining a procedure without a return value uses the same generator as
 // a procedure with a return value.
-Python['procedures_defnoreturn'] = Python['procedures_defreturn'];
+Python.forBlock['procedures_defnoreturn'] = Python.forBlock['procedures_defreturn'];
 
-Python['procedures_callreturn'] = function(block) {
+Python.forBlock['procedures_callreturn'] = function(block) {
   // Call a procedure with a return value.
   const funcName =
       Python.nameDB_.getName(block.getFieldValue('NAME'), NameType.PROCEDURE);
@@ -99,15 +99,15 @@ Python['procedures_callreturn'] = function(block) {
   return [code, Python.ORDER_FUNCTION_CALL];
 };
 
-Python['procedures_callnoreturn'] = function(block) {
+Python.forBlock['procedures_callnoreturn'] = function(block) {
   // Call a procedure with no return value.
   // Generated code is for a function call as a statement is the same as a
   // function call as a value, with the addition of line ending.
-  const tuple = Python['procedures_callreturn'](block);
+  const tuple = Python.forBlock['procedures_callreturn'](block);
   return tuple[0] + '\n';
 };
 
-Python['procedures_ifreturn'] = function(block) {
+Python.forBlock['procedures_ifreturn'] = function(block) {
   // Conditionally return value from a procedure.
   const condition =
       Python.valueToCode(block, 'CONDITION', Python.ORDER_NONE) || 'False';

--- a/generators/python/text.js
+++ b/generators/python/text.js
@@ -16,13 +16,13 @@ import {NameType} from '../../core/names.js';
 import {pythonGenerator as Python} from '../python.js';
 
 
-Python['text'] = function(block) {
+Python.forBlock['text'] = function(block) {
   // Text value.
   const code = Python.quote_(block.getFieldValue('TEXT'));
   return [code, Python.ORDER_ATOMIC];
 };
 
-Python['text_multiline'] = function(block) {
+Python.forBlock['text_multiline'] = function(block) {
   // Text value.
   const code = Python.multiline_quote_(block.getFieldValue('TEXT'));
   const order =
@@ -50,7 +50,7 @@ const forceString = function(value) {
   return ['str(' + value + ')', Python.ORDER_FUNCTION_CALL];
 };
 
-Python['text_join'] = function(block) {
+Python.forBlock['text_join'] = function(block) {
   // Create a string made up of any number of elements of any type.
   // Should we allow joining by '-' or ',' or any other characters?
   switch (block.itemCount_) {
@@ -84,7 +84,7 @@ Python['text_join'] = function(block) {
   }
 };
 
-Python['text_append'] = function(block) {
+Python.forBlock['text_append'] = function(block) {
   // Append to a variable in place.
   const varName =
       Python.nameDB_.getName(block.getFieldValue('VAR'), NameType.VARIABLE);
@@ -92,20 +92,20 @@ Python['text_append'] = function(block) {
   return varName + ' = str(' + varName + ') + ' + forceString(value)[0] + '\n';
 };
 
-Python['text_length'] = function(block) {
+Python.forBlock['text_length'] = function(block) {
   // Is the string null or array empty?
   const text = Python.valueToCode(block, 'VALUE', Python.ORDER_NONE) || "''";
   return ['len(' + text + ')', Python.ORDER_FUNCTION_CALL];
 };
 
-Python['text_isEmpty'] = function(block) {
+Python.forBlock['text_isEmpty'] = function(block) {
   // Is the string null or array empty?
   const text = Python.valueToCode(block, 'VALUE', Python.ORDER_NONE) || "''";
   const code = 'not len(' + text + ')';
   return [code, Python.ORDER_LOGICAL_NOT];
 };
 
-Python['text_indexOf'] = function(block) {
+Python.forBlock['text_indexOf'] = function(block) {
   // Search the text for a substring.
   // Should we allow for non-case sensitive???
   const operator = block.getFieldValue('END') === 'FIRST' ? 'find' : 'rfind';
@@ -120,7 +120,7 @@ Python['text_indexOf'] = function(block) {
   return [code, Python.ORDER_FUNCTION_CALL];
 };
 
-Python['text_charAt'] = function(block) {
+Python.forBlock['text_charAt'] = function(block) {
   // Get letter at index.
   // Note: Until January 2013 this block did not have the WHERE input.
   const where = block.getFieldValue('WHERE') || 'FROM_START';
@@ -160,7 +160,7 @@ def ${Python.FUNCTION_NAME_PLACEHOLDER_}(text):
   throw Error('Unhandled option (text_charAt).');
 };
 
-Python['text_getSubstring'] = function(block) {
+Python.forBlock['text_getSubstring'] = function(block) {
   // Get substring.
   const where1 = block.getFieldValue('WHERE1');
   const where2 = block.getFieldValue('WHERE2');
@@ -210,7 +210,7 @@ Python['text_getSubstring'] = function(block) {
   return [code, Python.ORDER_MEMBER];
 };
 
-Python['text_changeCase'] = function(block) {
+Python.forBlock['text_changeCase'] = function(block) {
   // Change capitalization.
   const OPERATORS = {
     'UPPERCASE': '.upper()',
@@ -223,7 +223,7 @@ Python['text_changeCase'] = function(block) {
   return [code, Python.ORDER_FUNCTION_CALL];
 };
 
-Python['text_trim'] = function(block) {
+Python.forBlock['text_trim'] = function(block) {
   // Trim spaces.
   const OPERATORS = {
     'LEFT': '.lstrip()',
@@ -236,13 +236,13 @@ Python['text_trim'] = function(block) {
   return [code, Python.ORDER_FUNCTION_CALL];
 };
 
-Python['text_print'] = function(block) {
+Python.forBlock['text_print'] = function(block) {
   // Print statement.
   const msg = Python.valueToCode(block, 'TEXT', Python.ORDER_NONE) || "''";
   return 'print(' + msg + ')\n';
 };
 
-Python['text_prompt_ext'] = function(block) {
+Python.forBlock['text_prompt_ext'] = function(block) {
   // Prompt function.
   const functionName = Python.provideFunction_('text_prompt', `
 def ${Python.FUNCTION_NAME_PLACEHOLDER_}(msg):
@@ -267,16 +267,16 @@ def ${Python.FUNCTION_NAME_PLACEHOLDER_}(msg):
   return [code, Python.ORDER_FUNCTION_CALL];
 };
 
-Python['text_prompt'] = Python['text_prompt_ext'];
+Python.forBlock['text_prompt'] = Python.forBlock['text_prompt_ext'];
 
-Python['text_count'] = function(block) {
+Python.forBlock['text_count'] = function(block) {
   const text = Python.valueToCode(block, 'TEXT', Python.ORDER_MEMBER) || "''";
   const sub = Python.valueToCode(block, 'SUB', Python.ORDER_NONE) || "''";
   const code = text + '.count(' + sub + ')';
   return [code, Python.ORDER_FUNCTION_CALL];
 };
 
-Python['text_replace'] = function(block) {
+Python.forBlock['text_replace'] = function(block) {
   const text = Python.valueToCode(block, 'TEXT', Python.ORDER_MEMBER) || "''";
   const from = Python.valueToCode(block, 'FROM', Python.ORDER_NONE) || "''";
   const to = Python.valueToCode(block, 'TO', Python.ORDER_NONE) || "''";
@@ -284,7 +284,7 @@ Python['text_replace'] = function(block) {
   return [code, Python.ORDER_MEMBER];
 };
 
-Python['text_reverse'] = function(block) {
+Python.forBlock['text_reverse'] = function(block) {
   const text = Python.valueToCode(block, 'TEXT', Python.ORDER_MEMBER) || "''";
   const code = text + '[::-1]';
   return [code, Python.ORDER_MEMBER];

--- a/generators/python/variables.js
+++ b/generators/python/variables.js
@@ -15,14 +15,14 @@ import {NameType} from '../../core/names.js';
 import {pythonGenerator as Python} from '../python.js';
 
 
-Python['variables_get'] = function(block) {
+Python.forBlock['variables_get'] = function(block) {
   // Variable getter.
   const code =
       Python.nameDB_.getName(block.getFieldValue('VAR'), NameType.VARIABLE);
   return [code, Python.ORDER_ATOMIC];
 };
 
-Python['variables_set'] = function(block) {
+Python.forBlock['variables_set'] = function(block) {
   // Variable setter.
   const argument0 =
       Python.valueToCode(block, 'VALUE', Python.ORDER_NONE) || '0';

--- a/generators/python/variables_dynamic.js
+++ b/generators/python/variables_dynamic.js
@@ -16,5 +16,5 @@ import './variables.js';
 
 
 // Python is dynamically typed.
-Python['variables_get_dynamic'] = Python['variables_get'];
-Python['variables_set_dynamic'] = Python['variables_set'];
+Python.forBlock['variables_get_dynamic'] = Python.forBlock['variables_get'];
+Python.forBlock['variables_set_dynamic'] = Python.forBlock['variables_set'];

--- a/tests/mocha/generator_test.js
+++ b/tests/mocha/generator_test.js
@@ -97,6 +97,8 @@ suite('Generator', function () {
         rowBlock.disabled = blockDisabled;
 
         const code = generator.blockToCode(rowBlock, opt_thisOnly);
+        delete generator.forBlock['stack_block'];
+        delete generator.forBlock['row_block'];
         chai.assert.equal(code, expectedCode, opt_message);
       };
     });

--- a/tests/mocha/generator_test.js
+++ b/tests/mocha/generator_test.js
@@ -87,10 +87,10 @@ suite('Generator', function () {
         expectedCode,
         opt_message
       ) {
-        generator.row_block = function (_) {
+        generator.forBlock['row_block'] = function (_) {
           return 'row_block';
         };
-        generator.stack_block = function (_) {
+        generator.forBlock['stack_block'] = function (_) {
           return 'stack_block';
         };
         rowBlock.nextConnection.connect(stackBlock.previousConnection);
@@ -170,7 +170,7 @@ suite('Generator', function () {
           expectedCode,
           opt_message
         ) {
-          generator.test_loop_block = function (block) {
+          generator.forBlock['test_loop_block'] = function (block) {
             return '{' + generator.statementToCode(block, 'DO') + '}';
           };
           blockA.getInput('DO').connection.connect(blockB.previousConnection);

--- a/tests/mocha/insertion_marker_test.js
+++ b/tests/mocha/insertion_marker_test.js
@@ -52,10 +52,10 @@ suite('InsertionMarkers', function () {
   });
   suite('Code Generation', function () {
     setup(function () {
-      javascriptGenerator['stack_block'] = function (block) {
+      javascriptGenerator.forBlock['stack_block'] = function (block) {
         return 'stack[' + block.id + '];\n';
       };
-      javascriptGenerator['row_block'] = function (block) {
+      javascriptGenerator.forBlock['row_block'] = function (block) {
         const value = javascriptGenerator.valueToCode(
           block,
           'INPUT',
@@ -64,7 +64,7 @@ suite('InsertionMarkers', function () {
         const code = 'row[' + block.id + '](' + value + ')';
         return [code, javascriptGenerator.ORDER_NONE];
       };
-      javascriptGenerator['statement_block'] = function (block) {
+      javascriptGenerator.forBlock['statement_block'] = function (block) {
         return (
           'statement[' +
           block.id +
@@ -83,9 +83,9 @@ suite('InsertionMarkers', function () {
       };
     });
     teardown(function () {
-      delete javascriptGenerator['stack_block'];
-      delete javascriptGenerator['row_block'];
-      delete javascriptGenerator['statement_block'];
+      delete javascriptGenerator.forBlock['stack_block'];
+      delete javascriptGenerator.forBlock['row_block'];
+      delete javascriptGenerator.forBlock['statement_block'];
     });
     test('Marker Surrounds', function () {
       const xml = Blockly.utils.xml.textToDom(


### PR DESCRIPTION
## The basics

- [X] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [X] I ran `npm run format` and `npm run lint`

## The details
### Resolves

Fixes #7084 

### Proposed Changes

Implements per-block-type generator function dictionary, per proposal #7084.

#### Behaviour Before Change

`CodeGenerator.prototype.blockToCode` uses generator function at `this[block_type]`.

#### Behaviour After Change

`CodeGenerator.prototype.blockToCode` preferentially uses generator function at `this.forBlock[block_type]`, falling back to `this[block_type]` if the former does not exist (and issuing a deprecation warning if the latter does).

Code in `generators/*/*` is updated to install generator functions at the new location.

### Reason for Changes

See #7084.

### Test Coverage

No changes to manual test procedures anticipated.

### Documentation

We should update our generator demos/codelabs to use the new dictionary.

### Additional Information

BREAKING CHANGE: this PR moves the generator functions we provide from their previous location directly on the `CodeGenerator` instances to the new `.forBlock` dictionary on each instance.  This does not oblige external
developers to do the same for their custom generators, but they will need to update any code that references the generator
functions we provide (in `generators/*/*`, i.e. on `javascriptGenerator`, `dartGenerator` etc.) e.g. to replace the implementation or reuse the implementation for a different block type.

Old style:

    langGenerator['my_block_type'] = function(block) {/* ... */};
    langGenerator['my_other_block_type'] = langGenerator['existing_block_type'];

New style:

    langGenerator.forBlock['my_block_type'] = function(block) {/* ... */};
    langGenerator.forBlock['my_other_block_type'] = langGenerator.forBlock['existing_block_type'];
