### PR TITLE
chore(generators): Fix nits

### DIFF
--- a/core/generator.ts
+++ b/core/generator.ts
@@ -19,6 +19,15 @@ import {Names, NameType} from './names.js';
 import type {Workspace} from './workspace.js';
 import {warn} from './utils/deprecation.js';
 
+/**
+ * Type declaration for per-block-type generator functions.
+ *
+ * @see {@link https://developers.google.com/blockly/guides/create-custom-blocks/generating-code}
+ * @param block The Block instance to generate code for.
+ * @returns A string containing the generated code (for statement blocks),
+ *     or a [code, precedence] tuple (for value/expression blocks), or
+ *     null if no code should be emitted for block.
+ */
 export type BlockGenerator = (block: Block) => [string, number] | string | null;
 
 /**

--- a/generators/dart.js
+++ b/generators/dart.js
@@ -24,6 +24,7 @@ import {inputTypes} from '../core/inputs/input_types.js';
 /**
  * Order of operation ENUMs.
  * https://dart.dev/guides/language/language-tour#operators
+ * @enum {number}
  */
 export const Order = {
   ATOMIC: 0,         // 0 "" ...

--- a/generators/javascript.js
+++ b/generators/javascript.js
@@ -164,7 +164,8 @@ export class JavascriptGenerator extends CodeGenerator {
     // Add user variables, but only ones that are being used.
     const variables = Variables.allUsedVarModels(workspace);
     for (let i = 0; i < variables.length; i++) {
-      defvars.push(this.nameDB_.getName(variables[i].getId(), NameType.VARIABLE));
+      defvars.push(
+        this.nameDB_.getName(variables[i].getId(), NameType.VARIABLE));
     }
 
     // Declare all of the variables.
@@ -236,7 +237,8 @@ export class JavascriptGenerator extends CodeGenerator {
    * Calls any statements following this block.
    * @param {!Block} block The current block.
    * @param {string} code The JavaScript code created for this block.
-   * @param {boolean=} opt_thisOnly True to generate code for only this statement.
+   * @param {boolean=} opt_thisOnly True to generate code for only this
+   *     statement.
    * @return {string} JavaScript code with comments and subsequent blocks added.
    * @protected
    */
@@ -264,7 +266,8 @@ export class JavascriptGenerator extends CodeGenerator {
         }
       }
     }
-    const nextBlock = block.nextConnection && block.nextConnection.targetBlock();
+    const nextBlock =
+        block.nextConnection && block.nextConnection.targetBlock();
     const nextCode = opt_thisOnly ? '' : this.blockToCode(nextBlock);
     return commentCode + code + nextCode;
   }

--- a/generators/python.js
+++ b/generators/python.js
@@ -231,7 +231,6 @@ export class PythonGenerator extends CodeGenerator {
    * @protected
    */
   quote_(string) {
-    // Can't use goog.string.quote since % must also be escaped.
     string = string.replace(/\\/g, '\\\\').replace(/\n/g, '\\\n');
   
     // Follow the CPython behaviour of repr() for a non-byte string.


### PR DESCRIPTION
## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [X] I ran `npm run format` and `npm run lint`

## The details
### Resolves

Addresses various nits that escaped previous PRs:

* Add TSDoc for `BlockGenerator` in `core/generator.ts` for PR #7150.
* Fix bad formating in `generators/javascript.js` from PR #7153.
* Add missing `@enum` tag that should have been included in PR #7160.
* Delete obsolete comment from `generators/python.js` for PR #7163.

Fixes #7085.