### PR TITLE
fix: prefer mp3 file for disconnect sound

### DIFF
--- a/core/inject.ts
+++ b/core/inject.ts
@@ -365,8 +365,8 @@ function loadSounds(pathToMedia: string, workspace: WorkspaceSvg) {
   );
   audioMgr.load(
     [
-      pathToMedia + 'disconnect.wav',
       pathToMedia + 'disconnect.mp3',
+      pathToMedia + 'disconnect.wav',
       pathToMedia + 'disconnect.ogg',
     ],
     'disconnect'


### PR DESCRIPTION
The disconnect.mp3 entry should be first in the list, like the others. Otherwise it loads the .wav file when an mp3 would work.

<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [ ] I ran `npm run format` and `npm run lint`

## The details
### Resolves

The disconnect.wav file loads instead of the mp3.

### Proposed Changes

fix the order in the list of alternatives


