### PR TITLE
fix: update disabled status after rendering

### DIFF
--- a/core/block_svg.ts
+++ b/core/block_svg.ts
@@ -1578,6 +1578,11 @@ export class BlockSvg
       this.rendered = true;
       dom.startTextWidthCache();
 
+      if (!this.isEnabled()) {
+        // Apply disabled styles if needed.
+        this.updateDisabled();
+      }
+
       if (this.isCollapsed()) {
         this.updateCollapsed_();
       }

--- a/tests/mocha/block_test.js
+++ b/tests/mocha/block_test.js
@@ -2144,6 +2144,22 @@ suite('Blocks', function () {
         // Child blocks should stay disabled if they have been set.
         chai.assert.isTrue(blockB.disabled);
       });
+      test('Disabled blocks from JSON should have proper disabled status', function () {
+        const blockJson = {
+          'type': 'controls_if',
+          'enabled': false,
+        };
+        Blockly.serialization.blocks.append(blockJson, this.workspace);
+        const block = this.workspace.getTopBlocks(false)[0];
+        chai.assert.isTrue(
+          block.visuallyDisabled,
+          'block should have visuallyDisabled set because it is disabled'
+        );
+        chai.assert.isFalse(
+          block.isEnabled(),
+          'block should be marked disabled because enabled json property was set to false'
+        );
+      });
     });
   });
 


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [ ] I branched from develop
- [ ] My pull request is against develop
- [ ] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [ ] I ran `npm run format` and `npm run lint`

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #7113 

### Proposed Changes

Calls `updateDisabled` if the block is disabled during the `render` call for a block.

The reason this happened in JSON and not XML is that XML sets the disabled state after rendering. JSON sets it before rendering. When the block was eventually rendered in JSON, it looked correct because it had the correct `enabled` property, but the `visuallyDisabled` property was not set (because the block was not rendered at the time of the original `updateDisabled` call). So this just calls that function again during render which updates the state as needed.

#### Behavior Before Change

See detailed reproduction steps in linked bug. If you loaded from json, the block would look and be disabled, but the block's `visuallyDisabled` property was not set. So the visual state would be out of sync with the actual state of the block.

#### Behavior After Change

Disabled blocks loaded from json behave as expected.

### Reason for Changes

bug fixes

### Test Coverage
manual testing, added test case

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->

### Documentation

no

### Additional Information

<!-- Anything else we should know? -->
