### PR TITLE
fix(blocks): Mark previously-`@private` methods `@internal`

### DIFF
--- a/blocks/logic.ts
+++ b/blocks/logic.ts
@@ -505,6 +505,8 @@ const CONTROLS_IF_MUTATOR_MIXIN = {
   },
   /**
    * Modify this block to have the correct number of inputs.
+   *
+   * @internal
    */
   updateShape_: function (this: IfBlock) {
     // Delete everything.

--- a/blocks/text.ts
+++ b/blocks/text.ts
@@ -297,6 +297,7 @@ const GET_SUBSTRING_BLOCK = {
    * Create or delete an input for a numeric index.
    * This block has two such inputs, independent of each other.
    *
+   * @internal
    * @param n Which input to modify (either 1 or 2).
    * @param isAt True if the input includes a value connection, false otherwise.
    */
@@ -445,6 +446,7 @@ const PROMPT_COMMON = {
   /**
    * Modify this block to have the correct output type.
    *
+   * @internal
    * @param newOp The new output type. Should be either 'TEXT' or 'NUMBER'.
    */
   updateType_: function (this: PromptCommonBlock, newOp: string) {
@@ -857,6 +859,7 @@ const JOIN_MUTATOR_MIXIN = {
   },
   /**
    * Modify this block to have the correct number of inputs.
+   *
    */
   updateShape_: function (this: JoinMutatorBlock) {
     if (this.itemCount_ && this.getInput('EMPTY')) {
@@ -955,6 +958,7 @@ const CHARAT_MUTATOR_MIXIN = {
   /**
    * Create or delete an input for the numeric index.
    *
+   * @internal
    * @param isAt True if the input should exist.
    */
   updateAt_: function (this: CharAtBlock, isAt: boolean) {


### PR DESCRIPTION
## The basics

- [X] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [X] I ran `npm run format` and `npm run lint`

## The details
### Proposed Changes

Where certain block mixin methods had been marked `@private`, and these annotations had been deleted while migrating the containing files to TypeScript, mark those methods as `@internal`.

#### Behaviour Before Change

These methods might have appeared in our `.d.ts` files and external documentation.

#### Behaviour After Change

These methods should not appear in our `d.ts` files or external documentation.

### Reason for Changes

The migration PRs were not intended to change any API.

### Test Coverage

Passes `npm test`.  No changes to manual testing required.

### Documentation

…may be sparser than before, intentionally.

### Additional Information

I'm not actually sure if these methods appear in our external documentation at the moment—I'd guess not.   But better to keep it that way.
