### PR TITLE
chore: make MutatorIcon.prototype.getWorkspace public

### DIFF
--- a/core/icons/mutator_icon.ts
+++ b/core/icons/mutator_icon.ts
@@ -307,7 +307,10 @@ export class MutatorIcon extends Icon implements IHasBubble {
     eventUtils.setGroup(existingGroup);
   }
 
-  /** @internal */
+  /**
+   * @returns The workspace of the mini workspace bubble, if the bubble is
+   *     currently open.
+   */
   getWorkspace(): WorkspaceSvg | undefined {
     return this.miniWorkspaceBubble?.getWorkspace();
   }


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [X] I ran `npm run format` and `npm run lint`

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes N/A

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
Makes it possible for external developers to access the workspace of the mutator icon.

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
Found that this was access in samples, so there are use cases for accessing it.

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->
N/A

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->
N/A

### Additional Information

<!-- Anything else we should know? -->
N/A
