### PR TITLE
refactor(tests): Migrate mocha tests from `goog.require` to `import`

### DIFF
--- a/tests/mocha/field_multilineinput_test.js
+++ b/tests/mocha/field_multilineinput_test.js
@@ -23,11 +23,11 @@ import {
   workspaceTeardown,
 } from './test_helpers/setup_teardown.js';
 import {runCodeGenerationTestSuites} from './test_helpers/code_generation.js';
-const {dartGenerator} = goog.require('Blockly.Dart.all');
-const {javascriptGenerator} = goog.require('Blockly.JavaScript.all');
-const {luaGenerator} = goog.require('Blockly.Lua.all');
-const {phpGenerator} = goog.require('Blockly.PHP.all');
-const {pythonGenerator} = goog.require('Blockly.Python.all');
+import {dartGenerator} from '../../generators/dart.js';
+import {javascriptGenerator} from '../../generators/javascript.js';
+import {luaGenerator} from '../../generators/lua.js';
+import {phpGenerator} from '../../generators/php.js';
+import {pythonGenerator} from '../../generators/python.js';
 
 suite('Multiline Input Fields', function () {
   setup(function () {

--- a/tests/mocha/generator_test.js
+++ b/tests/mocha/generator_test.js
@@ -7,11 +7,11 @@
 goog.declareModuleId('Blockly.test.generator');
 
 import * as Blockly from '../../build/src/core/blockly.js';
-const {DartGenerator} = goog.require('Blockly.Dart');
-const {JavascriptGenerator} = goog.require('Blockly.JavaScript');
-const {LuaGenerator} = goog.require('Blockly.Lua');
-const {PhpGenerator} = goog.require('Blockly.PHP');
-const {PythonGenerator} = goog.require('Blockly.Python');
+import {DartGenerator} from '../../generators/dart/dart_generator.js';
+import {JavascriptGenerator} from '../../generators/javascript/javascript_generator.js';
+import {LuaGenerator} from '../../generators/lua/lua_generator.js';
+import {PhpGenerator} from '../../generators/php/php_generator.js';
+import {PythonGenerator} from '../../generators/python/python_generator.js';
 import {
   sharedTestSetup,
   sharedTestTeardown,


### PR DESCRIPTION
## The basics

- [X] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [X] I ran `npm run format` and `npm run lint`

## The details
### Resolves

Part of #6858.

### Proposed Changes

Migrate the two remaining uses of goog.require in the mocha tests from goog.require to import.

### Reason for Changes

Trying to make it possible to get rid of `base.js`.

### Test Coverage

Passes `npm test`.
