### PR TITLE
fix(build): Correct typos in PR #7169

### DIFF
--- a/scripts/gulpfiles/build_tasks.js
+++ b/scripts/gulpfiles/build_tasks.js
@@ -113,7 +113,7 @@ const chunks = [
     entry: path.join(TSC_OUTPUT_DIR, 'generators', 'javascript.js'),
     exports: 'module$build$src$generators$javascript',
     scriptExport: 'javascript',
-    scriptNamedExports: {'Blockly.Javascript': 'javascriptGenerator'},
+    scriptNamedExports: {'Blockly.JavaScript': 'javascriptGenerator'},
   },
   {
     name: 'python',
@@ -134,14 +134,14 @@ const chunks = [
     entry: path.join(TSC_OUTPUT_DIR, 'generators', 'lua.js'),
     exports: 'module$build$src$generators$lua',
     scriptExport: 'lua',
-    scriptNameExports: {'Blockly.Lua': 'luaGenerator'},
+    scriptNamedExports: {'Blockly.Lua': 'luaGenerator'},
   },
   {
     name: 'dart',
     entry: path.join(TSC_OUTPUT_DIR, 'generators', 'dart.js'),
     exports: 'module$build$src$generators$dart',
     scriptExport: 'dart',
-    scriptNameExports: {'Blockly.Dart': 'dartGenerator'},
+    scriptNamedExports: {'Blockly.Dart': 'dartGenerator'},
   }
 ];
 


### PR DESCRIPTION
## The basics

- [X] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [X] I ran `npm run format` and `npm run lint`

## The details
### Resolves

Three separate mistakes left only the Python and PHP chunks with the correct code for the legacy script exports.

### Proposed Changes

Fix typos

#### Behaviour Before Change

Only `python_compressed.js` and `php_compressed.js` had correct code for legacy exports (`Blockly.<Lang>`) in their UMD wrappers.

#### Behaviour After Change

All five `<lang>_compressed.js` chunks get correct wrappers.

### Reason for Changes

Don't want to break developer's code.

### Test Coverage

Output manually checked.

