### PR TITLE
fix: set flyout visbility on calling setExpanded

### DIFF
--- a/core/toolbox/collapsible_category.ts
+++ b/core/toolbox/collapsible_category.ts
@@ -185,7 +185,7 @@ export class CollapsibleToolboxCategory
   }
 
   /**
-   * Opens or closes the current category.
+   * Opens or closes the current category and the associated flyout.
    *
    * @param isExpanded True to expand the category, false to close.
    */
@@ -200,6 +200,7 @@ export class CollapsibleToolboxCategory
       this.subcategoriesDiv_!.style.display = 'none';
       this.closeIcon_(this.iconDom_);
     }
+    this.parentToolbox_.getFlyout()?.setVisible(isExpanded);
     aria.setState(
       this.htmlDiv_ as HTMLDivElement,
       aria.State.EXPANDED,

--- a/core/toolbox/collapsible_category.ts
+++ b/core/toolbox/collapsible_category.ts
@@ -197,10 +197,10 @@ export class CollapsibleToolboxCategory
       this.subcategoriesDiv_!.style.display = 'block';
       this.openIcon_(this.iconDom_);
     } else {
+      this.parentToolbox_.getFlyout()?.setVisible(false);
       this.subcategoriesDiv_!.style.display = 'none';
       this.closeIcon_(this.iconDom_);
     }
-    this.parentToolbox_.getFlyout()?.setVisible(isExpanded);
     aria.setState(
       this.htmlDiv_ as HTMLDivElement,
       aria.State.EXPANDED,


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [x] I ran `npm run format` and `npm run lint`

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #7174 

### Proposed Changes

call `setVisible(isExpanded)` on the `parentToolbox_`'s flyout to update visibility

#### Behavior Before Change

flyout is not closed when `setExpanded(false)` is called on `collapsible_category`, contrary to expected behavior

https://github.com/google/blockly/assets/70596906/cca9a332-7d9e-463f-9d78-aaf5569ead69

#### Behavior After Change

flyout is hidden along with collapsed category

https://github.com/google/blockly/assets/70596906/ccd9b5dd-9b33-46db-aea5-ab09296bd121

### Reason for Changes

fulfilling expected behavior in every case

### Test Coverage

tested full functionality of expand/collapse by opening, switching, and unfocus clicking the flyout/collapsible regions before and after changes 

### Documentation

updated setExpanded` docstring