### PR TITLE
fix: Utilize getIcon instead of getCommentIcon in tests

### DIFF
--- a/core/block_svg.ts
+++ b/core/block_svg.ts
@@ -18,6 +18,7 @@ import './events/events_selected.js';
 import {Block} from './block.js';
 import * as blockAnimations from './block_animations.js';
 import * as browserEvents from './browser_events.js';
+import {CommentIcon} from './icons/comment_icon.js';
 import * as common from './common.js';
 import {config} from './config.js';
 import type {Connection} from './connection.js';
@@ -59,6 +60,7 @@ import {WarningIcon} from './icons/warning_icon.js';
 import type {Workspace} from './workspace.js';
 import type {WorkspaceSvg} from './workspace_svg.js';
 import {queueRender} from './render_management.js';
+import * as deprecation from './utils/deprecation.js';
 import {IconType} from './icons/icon_types.js';
 
 /**
@@ -884,6 +886,18 @@ export class BlockSvg
     for (const child of this.getChildren(false)) {
       child.updateDisabled();
     }
+  }
+
+  /**
+   * Get the comment icon attached to this block, or null if the block has no
+   * comment.
+   *
+   * @returns The comment icon attached to this block, or null.
+   * @deprecated Use getIcon. To be remove in v11.
+   */
+  getCommentIcon(): CommentIcon | null {
+    deprecation.warn('getCommentIcon', 'v10', 'v11', 'getIcon');
+    return (this.getIcon(CommentIcon.TYPE) ?? null) as CommentIcon | null;
   }
 
   /**

--- a/core/block_svg.ts
+++ b/core/block_svg.ts
@@ -18,7 +18,6 @@ import './events/events_selected.js';
 import {Block} from './block.js';
 import * as blockAnimations from './block_animations.js';
 import * as browserEvents from './browser_events.js';
-import {CommentIcon} from './icons/comment_icon.js';
 import * as common from './common.js';
 import {config} from './config.js';
 import type {Connection} from './connection.js';
@@ -60,7 +59,6 @@ import {WarningIcon} from './icons/warning_icon.js';
 import type {Workspace} from './workspace.js';
 import type {WorkspaceSvg} from './workspace_svg.js';
 import {queueRender} from './render_management.js';
-import * as deprecation from './utils/deprecation.js';
 import {IconType} from './icons/icon_types.js';
 
 /**

--- a/core/block_svg.ts
+++ b/core/block_svg.ts
@@ -889,18 +889,6 @@ export class BlockSvg
   }
 
   /**
-   * Get the comment icon attached to this block, or null if the block has no
-   * comment.
-   *
-   * @returns The comment icon attached to this block, or null.
-   * @deprecated Use getIcon. To be remove in v11.
-   */
-  getCommentIcon(): CommentIcon | null {
-    deprecation.warn('getCommentIcon', 'v10', 'v11', 'getIcon');
-    return (this.getIcon(CommentIcon.TYPE) ?? null) as CommentIcon | null;
-  }
-
-  /**
    * Set this block's warning text.
    *
    * @param text The text, or null to delete.

--- a/tests/mocha/comment_deserialization_test.js
+++ b/tests/mocha/comment_deserialization_test.js
@@ -10,6 +10,7 @@ import {
   sharedTestSetup,
   sharedTestTeardown,
 } from './test_helpers/setup_teardown.js';
+import {CommentIcon} from '../../core/icons/comment_icon.js';
 import {simulateClick} from './test_helpers/user_input.js';
 
 suite('Comment Deserialization', function () {
@@ -61,7 +62,7 @@ suite('Comment Deserialization', function () {
       const icon = block.getIcon(Blockly.icons.CommentIcon.TYPE);
       icon.setBubbleVisible(true);
       // Check comment bubble size.
-      const comment = block.getCommentIcon();
+      const comment = block.getIcon(CommentIcon.TYPE);
       const bubbleSize = comment.getBubbleSize();
       chai.assert.isNotNaN(bubbleSize.width);
       chai.assert.isNotNaN(bubbleSize.height);

--- a/tests/mocha/contextmenu_items_test.js
+++ b/tests/mocha/contextmenu_items_test.js
@@ -11,6 +11,7 @@ import {
   sharedTestTeardown,
   workspaceTeardown,
 } from './test_helpers/setup_teardown.js';
+import {CommentIcon} from '../../core/icons/comment_icon.js';
 
 suite('Context Menu Items', function () {
   setup(function () {
@@ -459,11 +460,11 @@ suite('Context Menu Items', function () {
 
       test('Creates comment if one did not exist', function () {
         chai.assert.isNull(
-          this.block.getCommentIcon(),
+          this.block.getIcon(CommentIcon.TYPE),
           'New block should not have a comment'
         );
         this.commentOption.callback(this.scope);
-        chai.assert.exists(this.block.getCommentIcon());
+        chai.assert.exists(this.block.getIcon(CommentIcon.TYPE));
         chai.assert.isEmpty(
           this.block.getCommentText(),
           'Block should have empty comment text'

--- a/tests/mocha/xml_test.js
+++ b/tests/mocha/xml_test.js
@@ -13,6 +13,7 @@ import {
   sharedTestTeardown,
   workspaceTeardown,
 } from './test_helpers/setup_teardown.js';
+import {CommentIcon} from '../../core/icons/comment_icon.js';
 import {assertVariableValues} from './test_helpers/variables.js';
 
 suite('XML', function () {
@@ -442,7 +443,7 @@ suite('XML', function () {
         test('Size', function () {
           this.block.setCommentText('test text');
           this.block
-            .getCommentIcon()
+            .getIcon(CommentIcon.TYPE)
             .setBubbleSize(new Blockly.utils.Size(100, 200));
           const xml = Blockly.Xml.blockToDom(this.block);
           const commentXml = xml.firstChild;
@@ -452,7 +453,7 @@ suite('XML', function () {
         });
         test('Pinned True', function () {
           this.block.setCommentText('test text');
-          this.block.getCommentIcon().setBubbleVisible(true);
+          this.block.getIcon(CommentIcon.TYPE).setBubbleVisible(true);
           const xml = Blockly.Xml.blockToDom(this.block);
           const commentXml = xml.firstChild;
           chai.assert.equal(commentXml.tagName, 'comment');
@@ -697,7 +698,7 @@ suite('XML', function () {
             this.workspace
           );
           chai.assert.equal(block.getCommentText(), 'test text');
-          chai.assert.isOk(block.getCommentIcon());
+          chai.assert.isOk(block.getIcon(CommentIcon.TYPE));
         });
         test('No Text', function () {
           const block = Blockly.Xml.domToBlock(
@@ -721,7 +722,7 @@ suite('XML', function () {
             this.workspace
           );
           chai.assert.isOk(block.getIcon(Blockly.icons.CommentIcon.TYPE));
-          chai.assert.deepEqual(block.getCommentIcon().getBubbleSize(), {
+          chai.assert.deepEqual(block.getIcon(CommentIcon.TYPE).getBubbleSize(), {
             width: 100,
             height: 200,
           });

--- a/tests/mocha/xml_test.js
+++ b/tests/mocha/xml_test.js
@@ -722,10 +722,13 @@ suite('XML', function () {
             this.workspace
           );
           chai.assert.isOk(block.getIcon(Blockly.icons.CommentIcon.TYPE));
-          chai.assert.deepEqual(block.getIcon(CommentIcon.TYPE).getBubbleSize(), {
-            width: 100,
-            height: 200,
-          });
+          chai.assert.deepEqual(
+            block.getIcon(CommentIcon.TYPE).getBubbleSize(),
+            {
+              width: 100,
+              height: 200,
+            }
+          );
         });
         suite('Pinned', function () {
           test('Pinned True', function () {


### PR DESCRIPTION
## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [x] I ran `npm run format` and `npm run lint`

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #7164 

### Proposed Changes

utilize `getIcon()` in preparation for v11

### Behavior Before Change
![image](https://github.com/google/blockly/assets/70596906/d51fcd85-2c7e-4548-b2aa-28a3acbf68c3)

### Behavior After Change
![image](https://github.com/google/blockly/assets/70596906/ab5d8918-f7b3-412e-8824-2d8bdbeb2136)

### Reason for Changes

> The mocha tests are currently outputting deprecation warnings to the console because of calls to getCommentIcon. (https://github.com/google/blockly/issues/7164#issue-1757210807)

### Test Coverage

`npm run test:mocha:interactive` -> check console

### Documentation

Removed deprecation function, docstring, and dependencies from `block_svg.ts`

### Additional Information

N/A