### PR TITLE
fix: properly pass the block to the icon constructor in blockfactory blocks

### DIFF
--- a/demos/blockfactory/blocks.js
+++ b/demos/blockfactory/blocks.js
@@ -336,8 +336,8 @@ Blockly.Blocks['field_dropdown'] = {
     this.updateShape_();
     this.setPreviousStatement(true, 'Field');
     this.setNextStatement(true, 'Field');
-    this.setMutator(new Blockly.icons.MutatorIcon(['field_dropdown_option_text',
-                                         'field_dropdown_option_image']));
+    this.setMutator(new Blockly.icons.MutatorIcon(
+        ['field_dropdown_option_text', 'field_dropdown_option_image'], this));
     this.setColour(160);
     this.setTooltip('Dropdown menu with a list of options.');
     this.setHelpUrl('https://www.youtube.com/watch?v=s2_xaEvcVI0#t=386');
@@ -611,7 +611,7 @@ Blockly.Blocks['type_group'] = {
     this.typeCount_ = 2;
     this.updateShape_();
     this.setOutput(true, 'Type');
-    this.setMutator(new Blockly.icons.MutatorIcon(['type_group_item']));
+    this.setMutator(new Blockly.icons.MutatorIcon(['type_group_item'], this));
     this.setColour(230);
     this.setTooltip('Allows more than one type to be accepted.');
     this.setHelpUrl('https://www.youtube.com/watch?v=s2_xaEvcVI0#t=677');


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [X] I ran `npm run format` and `npm run lint`

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes N/A

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
Properly passes the block to the mutator icon constructor in the block factory demos.

#### Behavior Before Change

<!--TODO: Image, gif or explanation of behavior before this pull request. -->
The block factory field blocks would cause console errors.

#### Behavior After Change

<!--TODO: Image, gif or explanation of behavior after this pull request. -->
No Errors

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
The block factory should be usable!

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->
N/A

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->
Going to update the description of the mutator refactor PR to include info about needing to pass the block to the constructor. Previously passing the block was optional (even though it was not marked as optional).

### Additional Information

<!-- Anything else we should know? -->
N/A
