### PR TITLE
chore: deprecate minimalist renderer

### DIFF
--- a/core/renderers/minimalist/constants.ts
+++ b/core/renderers/minimalist/constants.ts
@@ -8,13 +8,27 @@ import * as goog from '../../../closure/goog/goog.js';
 goog.declareModuleId('Blockly.minimalist.ConstantProvider');
 
 import {ConstantProvider as BaseConstantProvider} from '../common/constants.js';
+import * as deprecation from '../../utils/deprecation.js';
 
 /**
  * An object that provides constants for rendering blocks in the minimalist
  * renderer.
+ *
+ * @deprecated Use Blockly.blockRendering.ConstantProvider instead.
+ *     To be removed in v11.
  */
 export class ConstantProvider extends BaseConstantProvider {
+  /**
+   * @deprecated Use Blockly.blockRendering.ConstantProvider instead.
+   *     To be removed in v11.
+   */
   constructor() {
     super();
+    deprecation.warn(
+      'Blockly.minimalist.ConstantProvider',
+      'v10',
+      'v11',
+      'Blockly.blockRendering.ConstantProvider'
+    );
   }
 }

--- a/core/renderers/minimalist/drawer.ts
+++ b/core/renderers/minimalist/drawer.ts
@@ -9,19 +9,32 @@ goog.declareModuleId('Blockly.minimalist.Drawer');
 
 import type {BlockSvg} from '../../block_svg.js';
 import {Drawer as BaseDrawer} from '../common/drawer.js';
+import * as deprecation from '../../utils/deprecation.js';
 
 import type {RenderInfo} from './info.js';
 
 /**
  * An object that draws a block based on the given rendering information.
+ *
+ * @deprecated Use Blockly.blockRendering.Drawer instead.
+ *     To be removed in v11.
  */
 export class Drawer extends BaseDrawer {
   /**
    * @param block The block to render.
    * @param info An object containing all information needed to render this
    *     block.
+   *
+   * @deprecated Use Blockly.blockRendering.Drawer instead.
+   *     To be removed in v11.
    */
   constructor(block: BlockSvg, info: RenderInfo) {
     super(block, info);
+    deprecation.warn(
+      'Blockly.minimalist.Drawer',
+      'v10',
+      'v11',
+      'Blockly.blockRendering.Drawer'
+    );
   }
 }

--- a/core/renderers/minimalist/info.ts
+++ b/core/renderers/minimalist/info.ts
@@ -9,6 +9,7 @@ goog.declareModuleId('Blockly.minimalist.RenderInfo');
 
 import type {BlockSvg} from '../../block_svg.js';
 import {RenderInfo as BaseRenderInfo} from '../common/info.js';
+import * as deprecation from '../../utils/deprecation.js';
 
 import type {Renderer} from './renderer.js';
 
@@ -18,6 +19,9 @@ import type {Renderer} from './renderer.js';
  * This measure pass does not propagate changes to the block (although fields
  * may choose to rerender when getSize() is called).  However, calling it
  * repeatedly may be expensive.
+ *
+ * @deprecated Use Blockly.blockRendering.RenderInfo instead. To be removed
+ *     in v11.
  */
 export class RenderInfo extends BaseRenderInfo {
   // Exclamation is fine b/c this is assigned by the super constructor.
@@ -26,9 +30,17 @@ export class RenderInfo extends BaseRenderInfo {
   /**
    * @param renderer The renderer in use.
    * @param block The block to measure.
+   * @deprecated Use Blockly.blockRendering.RenderInfo instead. To be removed
+   *     in v11.
    */
   constructor(renderer: Renderer, block: BlockSvg) {
     super(renderer, block);
+    deprecation.warn(
+      'Blockly.minimalist.RenderInfo',
+      'v10',
+      'v11',
+      'Blockly.blockRendering.RenderInfo'
+    );
   }
 
   /**

--- a/core/renderers/minimalist/renderer.ts
+++ b/core/renderers/minimalist/renderer.ts
@@ -11,6 +11,7 @@ import type {BlockSvg} from '../../block_svg.js';
 import * as blockRendering from '../common/block_rendering.js';
 import type {RenderInfo as BaseRenderInfo} from '../common/info.js';
 import {Renderer as BaseRenderer} from '../common/renderer.js';
+import * as deprecation from '../../utils/deprecation.js';
 
 import {ConstantProvider} from './constants.js';
 import {Drawer} from './drawer.js';
@@ -18,13 +19,24 @@ import {RenderInfo} from './info.js';
 
 /**
  * The minimalist renderer.
+ *
+ * @deprecated Use Blockly.blockRendering.Renderer instead. To be removed
+ *     in v11.
  */
 export class Renderer extends BaseRenderer {
   /**
    * @param name The renderer name.
+   * @deprecated Use Blockly.blockRendering.Renderer instead. To be removed
+   *     in v11.
    */
   constructor(name: string) {
     super(name);
+    deprecation.warn(
+      'Blockly.minimalist.Renderer',
+      'v10',
+      'v11',
+      'Blockly.blockRendering.Renderer'
+    );
   }
 
   /**

--- a/scripts/migration/renamings.json5
+++ b/scripts/migration/renamings.json5
@@ -1516,6 +1516,10 @@
       oldName: 'Blockly.Bubble',
       newName: 'Blockly.bubbles.Bubble',
     },
+    {
+      oldName: 'Blockly.minimalist',
+      newPath: 'Blockly.blockRendering',
+    },
     // The following renamings serve two purposes:
     // - Record that the langGenerator instances have moved to a
     //   different module (though this is not actually actioned by the


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [X] I ran `npm run format` and `npm run lint`

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes N/A

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
Deprecates the minimalist renderer.

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
The minimalist renderer doesn't do anything, it literally just wraps the base renderer classes. Based on [the custom renderer talk from 2019](https://youtu.be/Er4JLJD1Ni8?t=328) it seems these were provided forpeople forking blockly  as a handy place to start editting files. We don't want people to fork blockly anymore so we should remove these.

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->
N/A

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->
N/A

### Additional Information

<!-- Anything else we should know? -->
N/A

## Deprecations

The `Blockly.minimalist` renderer has been deprecated. If you were using this, the `Blockly.blockRendering` render (i.e. the base renderer) provides exactly the same functionality.