### PR TITLE
fix(demos): Update BlockFactory generator stub generator

### DIFF
--- a/demos/blockfactory/factory_utils.js
+++ b/demos/blockfactory/factory_utils.js
@@ -80,10 +80,10 @@ FactoryUtils.getGeneratorStub = function(block, generatorLanguage) {
     return '  var ' + root + '_' + name;
   }
   // The makevar function lives in the original update generator.
-  var language = generatorLanguage;
+  var language = generatorLanguage.toLowerCase();
   var code = [];
-  code.push("Blockly." + language + "['" + block.type +
-            "'] = function(block) {");
+  code.push(`${language}.${language}Generator.forBlock['${block.type}'] = ` +
+            'function(block, generator) {');
 
   // Generate getters for any fields or inputs.
   for (var i = 0, input; input = block.inputList[i]; i++) {
@@ -93,42 +93,34 @@ FactoryUtils.getGeneratorStub = function(block, generatorLanguage) {
         continue;
       }
       if (field instanceof Blockly.FieldVariable) {
-        // Subclass of Blockly.FieldDropdown, must test first.
-        code.push(makeVar('variable', name) +
-                  " = Blockly." + language +
-                  ".nameDB_.getName(block.getFieldValue('" + name +
-                  "'), Blockly.Variables.NAME_TYPE);");
-      } else if (field instanceof Blockly.FieldAngle) {
-        // Subclass of Blockly.FieldTextInput, must test first.
-        code.push(makeVar('angle', name) +
-                  " = block.getFieldValue('" + name + "');");
-      } else if (field instanceof Blockly.FieldColour) {
-        code.push(makeVar('colour', name) +
-                  " = block.getFieldValue('" + name + "');");
+        // FieldVariable is subclass of FieldDropdown; must test first.
+        code.push(`${makeVar('variable', name)} = ` +
+                  `generator.nameDB_.getName(block.getFieldValue('${name}'), ` +
+                  `Blockly.Variables.NAME_TYPE);`);
       } else if (field instanceof Blockly.FieldCheckbox) {
-        code.push(makeVar('checkbox', name) +
-                  " = block.getFieldValue('" + name + "') === 'TRUE';");
-      } else if (field instanceof Blockly.FieldDropdown) {
-        code.push(makeVar('dropdown', name) +
-                  " = block.getFieldValue('" + name + "');");
-      } else if (field instanceof Blockly.FieldNumber) {
-        code.push(makeVar('number', name) +
-                  " = block.getFieldValue('" + name + "');");
-      } else if (field instanceof Blockly.FieldTextInput) {
-        code.push(makeVar('text', name) +
-                  " = block.getFieldValue('" + name + "');");
+        code.push(`${makeVar('checkbox', name)} = ` +
+                  `block.getFieldValue('${name}') === 'TRUE';`);
+      } else {
+        let prefix =
+            // Angle is subclass of FieldTextInput; must test first.
+            field instanceof Blockly.FieldAngle ? 'angle' :
+            field instanceof Blockly.FieldColour ? 'colour' :
+            field instanceof Blockly.FieldDropdown ? 'dropdown' :
+            field instanceof Blockly.FieldNumber ? 'number' :
+            field instanceof Blockly.FieldTextInput ? 'text' :
+            'field';  // Default if subclass not found.
+        code.push(`${makeVar(prefix, name)} = block.getFieldValue('${name}');`);
       }
     }
     var name = input.name;
     if (name) {
       if (input.type === Blockly.INPUT_VALUE) {
-        code.push(makeVar('value', name) +
-                  " = Blockly." + language + ".valueToCode(block, '" + name +
-                  "', Blockly." + language + ".ORDER_ATOMIC);");
+        code.push(`${makeVar('value', name)} = ` +
+                  `generator.valueToCode(block, '${name}', ` +
+                  `${language}.Order.ATOMIC);`);
       } else if (input.type === Blockly.NEXT_STATEMENT) {
-        code.push(makeVar('statements', name) +
-                  " = Blockly." + language + ".statementToCode(block, '" +
-                  name + "');");
+        code.push(`${makeVar('statements', name)} = ` +
+                  `generator.statementToCode(block, '${name}');`);
       }
     }
   }


### PR DESCRIPTION
## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [X] I ran `npm run format` and `npm run lint`

## The details

### Proposed Changes

Update the BlockFactory block generator function stub generator to apply recent changes in generator function best practices:

- Use `<language>Genarator` instead of `Blockly.<Language>`.
- Put generator functions in the `.forBlock` dictionary.
- Accept (and use) a second `generator` argument that is the calling CodeGenerator object.
- User `Order.ATOMIC` enum instead of `.ORDER_ATOMIC`.

Also:

- Prefix (e.g.) `javascriptGenerator` and `Order` with `javascript.`.
- Use template literals where useful.
- DRY up all the non-special field stub code generation.

### Reason for Changes

Ensure developer generator functions are as modern as possible.

### Additional Information

I added `language.` prefix to places where the stub code references `langaugeGenerator` and `Order`, as is necessary when loading the generators as a script (e.g. via a `<script>` tag), but we expect that many users will be doing `import {languageGenerator, Order} from 'blockly/language'`.  Should we provide a "use named imports" tickbox or something like that?
