### PR TITLE
fix(demos): Update code demo to use new script import names for generators

### DIFF
--- a/demos/code/code.js
+++ b/demos/code/code.js
@@ -356,15 +356,15 @@ Code.renderContent = function() {
         Blockly.serialization.workspaces.save(Code.workspace), null, 2);
     jsonTextarea.focus();
   } else if (content.id === 'content_javascript') {
-    Code.attemptCodeGeneration(Blockly.JavaScript);
+    Code.attemptCodeGeneration(javascript.javascriptGenerator);
   } else if (content.id === 'content_python') {
-    Code.attemptCodeGeneration(Blockly.Python);
+    Code.attemptCodeGeneration(python.pythonGenerator);
   } else if (content.id === 'content_php') {
-    Code.attemptCodeGeneration(Blockly.PHP);
+    Code.attemptCodeGeneration(php.phpGenerator);
   } else if (content.id === 'content_dart') {
-    Code.attemptCodeGeneration(Blockly.Dart);
+    Code.attemptCodeGeneration(dart.dartGenerator);
   } else if (content.id === 'content_lua') {
-    Code.attemptCodeGeneration(Blockly.Lua);
+    Code.attemptCodeGeneration(lua.luaGenerator);
   }
   if (typeof PR === 'object') {
     PR.prettyPrint();
@@ -395,7 +395,7 @@ Code.checkAllGeneratorFunctionsDefined = function(generator) {
   var missingBlockGenerators = [];
   for (var i = 0; i < blocks.length; i++) {
     var blockType = blocks[i].type;
-    if (!generator[blockType]) {
+    if (!generator.forBlock[blockType]) {
       if (missingBlockGenerators.indexOf(blockType) === -1) {
         missingBlockGenerators.push(blockType);
       }
@@ -477,7 +477,7 @@ Code.init = function() {
 
   // Add to reserved word list: Local variables in execution environment (runJS)
   // and the infinite loop detection function.
-  Blockly.JavaScript.addReservedWords('code,timeouts,checkTimeout');
+  javascript.javascriptGenerator.addReservedWords('code,timeouts,checkTimeout');
 
   Code.loadBlocks('');
 
@@ -588,15 +588,15 @@ Code.runJS = function(event) {
     event.preventDefault();
   }
 
-  Blockly.JavaScript.INFINITE_LOOP_TRAP = 'checkTimeout();\n';
+  javascript.javascriptGenerator.INFINITE_LOOP_TRAP = 'checkTimeout();\n';
   var timeouts = 0;
   var checkTimeout = function() {
     if (timeouts++ > 1000000) {
       throw MSG['timeout'];
     }
   };
-  var code = Blockly.JavaScript.workspaceToCode(Code.workspace);
-  Blockly.JavaScript.INFINITE_LOOP_TRAP = null;
+  var code = javascript.javascriptGenerator.workspaceToCode(Code.workspace);
+  javascript.javascriptGenerator.INFINITE_LOOP_TRAP = null;
   try {
     eval(code);
   } catch (e) {


### PR DESCRIPTION
## The basics

- [X] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [X] I ran `npm run format` and `npm run lint`

## The details
### Resolves

Fixes errors in `Code.checkAllGeneratorFunctionsDefined` caused by the breaking change in PR #7150, implementing the `.forBlock` dictionary.

### Proposed Changes

* Update the `demos/code/` demo to use the new import names (e.g. `BlocklyJavaScript` -> `javascript.javascriptGenerator`.
* Fix `Code.checkAllGeneratorFunctionsDefined` by having it use `.forBlocks` dictionary.

#### Behaviour Before Change

Code generation fails with dialog warning about missing generator functions.

#### Behaviour After Change

Code generation works.

### Reason for Changes

Keep code functional and up-to-date.

### Test Coverage

Manually tested.
