### PR TITLE
chore: delete unused function getFirstStatementConnection

### DIFF
--- a/core/block.ts
+++ b/core/block.ts
@@ -625,25 +625,6 @@ export class Block implements IASTNodeLocation, IDeletable {
   }
 
   /**
-   * Return the connection on the first statement input on this block, or null
-   * if there are none.
-   *
-   * @returns The first statement connection or null.
-   * @internal
-   */
-  getFirstStatementConnection(): Connection | null {
-    for (let i = 0, input; (input = this.inputList[i]); i++) {
-      if (
-        input.connection &&
-        input.connection.type === ConnectionType.NEXT_STATEMENT
-      ) {
-        return input.connection;
-      }
-    }
-    return null;
-  }
-
-  /**
    * Return the top-most block in this block's tree.
    * This will return itself if this block is at the top level.
    *

--- a/core/block_svg.ts
+++ b/core/block_svg.ts
@@ -1530,14 +1530,6 @@ export class BlockSvg
   }
 
   /**
-   * @returns The first statement connection or null.
-   * @internal
-   */
-  override getFirstStatementConnection(): RenderedConnection | null {
-    return super.getFirstStatementConnection() as RenderedConnection | null;
-  }
-
-  /**
    * Find all the blocks that are directly nested inside this one.
    * Includes value and statement inputs, as well as any following statement.
    * Excludes any connection on an output tab or any preceding statement.


### PR DESCRIPTION
## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [x] I ran `npm run format` and `npm run lint`

## The details
### Resolves

See https://github.com/google/blockly/issues/3096 

This probably existed for implementing scratch-style dragging rules but is completely unused in core.

### Proposed Changes
Delete unused function.

### Additional information
Not a breaking change because this function is `internal`.
