### PR TITLE
chore: delete unused fuction clearTransformAttributes_

### DIFF
--- a/core/block_svg.ts
+++ b/core/block_svg.ts
@@ -428,21 +428,13 @@ export class BlockSvg
     this.getSvgRoot().setAttribute('transform', this.getTranslation());
   }
 
-  /**
-   * Clear the block of transform="..." attributes.
-   * Used when the block is switching from 3d to 2d transform or vice versa.
-   */
-  private clearTransformAttributes_() {
-    this.getSvgRoot().removeAttribute('transform');
-  }
-
   /** Snap this block to the nearest grid point. */
   snapToGrid() {
     if (this.isDeadOrDying()) {
       return; // Deleted block.
     }
     if (this.workspace.isDragging()) {
-      return; // Don't bump blocks during a drag.;
+      return; // Don't bump blocks during a drag.
     }
 
     if (this.getParent()) {
@@ -1085,7 +1077,6 @@ export class BlockSvg
   }
 
   // Overrides of functions on Blockly.Block that take into account whether the
-
   // block has been rendered.
 
   /**


### PR DESCRIPTION
## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [x] I ran `npm run format` and `npm run lint`

## The details

### Proposed Changes

Delete an unused function on `blockSvg` that was probably used for drag surface transformations in the past. Not breaking because it's private.