### PR TITLE
chore: change the way we look for upstream remote

### DIFF
--- a/scripts/gulpfiles/git_tasks.js
+++ b/scripts/gulpfiles/git_tasks.js
@@ -35,12 +35,10 @@ let upstream = null;
  */
 function getUpstream() {
   if (upstream) return upstream;
-  for (const line of String(execSync('git remote -v')).split('\n')) {
-    const [remote, url] = line.split('\t');
-    if (url.includes('github.com/google/blockly')) {
-      upstream = remote;
-      return upstream;
-    }
+  const remote = String(execSync('git remote -v | grep "google/blockly" | cut -f1 | head -1'));
+  if (remote) {
+    upstream = remote;
+    return upstream;
   }
   throw new Error('Unable to determine upstream URL');
 }

--- a/scripts/gulpfiles/git_tasks.js
+++ b/scripts/gulpfiles/git_tasks.js
@@ -37,7 +37,8 @@ function getUpstream() {
   if (upstream) return upstream;
   for (const line of String(execSync('git remote -v')).split('\n')) {
     if (line.includes('google/blockly')) {
-      return line.split('\t')[0];
+      upstream = line.split('\t')[0];
+      return upstream;
     }
   }
   throw new Error('Unable to determine upstream URL');

--- a/scripts/gulpfiles/git_tasks.js
+++ b/scripts/gulpfiles/git_tasks.js
@@ -35,10 +35,10 @@ let upstream = null;
  */
 function getUpstream() {
   if (upstream) return upstream;
-  const remote = String(execSync('git remote -v | grep "google/blockly" | cut -f1 | head -1'));
-  if (remote) {
-    upstream = remote;
-    return upstream;
+  for (const line of String(execSync('git remote -v')).split('\n')) {
+    if (line.includes('google/blockly')) {
+      return line.split('\t')[0];
+    }
   }
   throw new Error('Unable to determine upstream URL');
 }


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [x] I ran `npm run format` and `npm run lint`

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes the fact that `npm run updateGithubPages` did not run for me

### Proposed Changes

Changes the methodology for finding a git remote name. The old way doesn't work for me because the output of `git remote -v` looks like this for me (snippet):

```text
upstream		git@github.com:google/blockly.git (fetch)
```

(ok that probably didn't work, but it seems like there's an extra tab between the name and the url, idk why)
Also, the url text the old way was looking for doesn't work for me because I use SSH for git, not HTTPS.


#### Behavior Before Change

Assumes the user is using https. Assumes there is only one tab in the git output :/

#### Behavior After Change

Hopefully finds the upstream remote name for everyone!

### Reason for Changes

I'm trying to update github pages

### Test Coverage

Prettttty sure this works locally, but hard to test the entire process given that the `updateGithubPages` script stashes and resets git branches. I tested by commenting out all the parts of the task except the one that fetches the remote.

### Documentation

no

### Additional Information

- Not sure this would work for windows. But also not sure that matters because non-core-team members would not be able to run this command anyway as they don't have access to push to the google/blockly repo. Also not sure the old method worked on windows. I don't know much about windows in general.
- Could also maybe solve this by not doing a git reset. I thought about deleting the `gh-pages` branch locally, checking out a new copy based on develop (which you can do via specifying the remote URL instead of the name), then force pushing to overwrite the remote version of gh-pages branch at the end. I think that would work. But this is less of a change and I think this should also work, so we'll see?
