### PR TITLE
chore: update app engine version names

### DIFF
--- a/scripts/gulpfiles/appengine_tasks.js
+++ b/scripts/gulpfiles/appengine_tasks.js
@@ -122,13 +122,8 @@ function deployToAndClean(demoVersion) {
  * package.json.
  */
 function getDemosVersion() {
-  const minorVersion = packageJson.version.split('.')[1];
-  const patchVersion = packageJson.version.split('.')[2];
-  let demoVersion = minorVersion;
-  if (patchVersion !== 0) {
-    demoVersion += '-' + patchVersion;
-  }
-  return demoVersion;
+  // Replace all '.' with '-' e.g. 9-3-3-beta-2
+  return packageJson.version.replace(/\./g, '-');
 }
 
 /**


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [x] I ran `npm run format` and `npm run lint`

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes bad names for app engine versions

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->

#### Behavior Before Change

names for app engine versions were based on minor-patch version numbers. This made sense when the minor number was a date, but doesn't make sense now that we're using true semver.

#### Behavior After Change

The version number for app engine is just the version number with all `.` replaced with `-` e.g. `10-0-0` or `9-3-4-beta-4`

### Reason for Changes

We keep overwriting old versions on app engine. This makes it harder to go back and look at old versions of blockly. It's nice to be able to look back easily at any published version of blockly.

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->

### Documentation

I'll update our team docs

### Additional Information

I did not touch the format of the "beta" version of the command, because that is used for e.g. testing week and not real published betas of the package. So it makes more sense to use the date for that because it might be updated every day of testing week, or something, when we might not be publishing real beta versions of the package. This format will not overlap the format if we ever do publish the app engine site based on an actual beta of the package.
