### PR TITLE
fix: circle animation persistence

### DIFF
--- a/core/block_animations.ts
+++ b/core/block_animations.ts
@@ -148,9 +148,13 @@ export function connectionUiEffect(block: BlockSvg) {
 
   animation.beginElement();
   // Delete circle after 150ms
-  setTimeout(() => {
-    dom.removeNode(ripple);
-  }, 150, ripple);
+  setTimeout(
+    () => {
+      dom.removeNode(ripple);
+    },
+    150,
+    ripple
+  );
 }
 
 /**

--- a/core/block_animations.ts
+++ b/core/block_animations.ts
@@ -122,27 +122,35 @@ export function connectionUiEffect(block: BlockSvg) {
     },
     workspace.getParentSvg()
   );
-  // Start the animation.
-  connectionUiStep(ripple, new Date(), scale);
-}
+  const animation = dom.createSvgElement(
+    Svg.ANIMATE,
+    {
+      'id': 'animationCircle',
+      'begin': 'indefinite',
+      'attributeName': 'r',
+      'dur': '150ms',
+      'from': 0,
+      'to': 25 * scale,
+    },
+    ripple
+  );
+  dom.createSvgElement(
+    Svg.ANIMATE,
+    {
+      'attributeName': 'opacity',
+      'begin': 'animationCircle.begin',
+      'dur': '150ms',
+      'from': 1,
+      'to': 0,
+    },
+    ripple
+  );
 
-/**
- * Expand a ripple around a connection.
- *
- * @param ripple Element to animate.
- * @param start Date of animation's start.
- * @param scale Scale of workspace.
- */
-function connectionUiStep(ripple: SVGElement, start: Date, scale: number) {
-  const ms = new Date().getTime() - start.getTime();
-  const percent = ms / 150;
-  if (percent > 1) {
+  animation.beginElement();
+  // Delete circle after 150ms
+  setTimeout(() => {
     dom.removeNode(ripple);
-  } else {
-    ripple.setAttribute('r', String(percent * 25 * scale));
-    ripple.style.opacity = String(1 - percent);
-    disconnectPid = setTimeout(connectionUiStep, 10, ripple, start, scale);
-  }
+  }, 150, ripple);
 }
 
 /**


### PR DESCRIPTION
## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [x] I ran `npm run format` and `npm run lint`

## The details
### Resolves

Fixes https://github.com/google/blockly/issues/7241

### Proposed Changes

Switch animation method : Use the "animate" element and remove the "circle" element after 150ms (duration of the animation)

#### Behavior Before Change

See issue

#### Behavior After Change

No more circles

### Reason for Changes

When there are many circles, the interface becomes unusable

### Test Coverage

N/A

### Documentation

No

### Additional Information

No
