### PR TITLE
fix: gestures problems

### DIFF
--- a/core/gesture.ts
+++ b/core/gesture.ts
@@ -545,6 +545,15 @@ export class Gesture {
         /* opt_noCaptureIdentifier */ true
       )
     );
+    this.boundEvents.push(
+      browserEvents.conditionalBind(
+        document,
+        'touchcancel',
+        null,
+        this.handleUp.bind(this),
+        /* opt_noCaptureIdentifier */ true
+      )
+    );
 
     e.preventDefault();
     e.stopPropagation();

--- a/core/gesture.ts
+++ b/core/gesture.ts
@@ -691,8 +691,6 @@ export class Gesture {
 
     if (this.isPinchZoomEnabled && this.cachedPoints.size === 2) {
       this.handlePinch(e);
-    } else {
-      this.handleMove(e);
     }
   }
 


### PR DESCRIPTION
## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [x] I ran `npm run format` and `npm run lint`

## The details
### Resolves

Fixes https://github.com/google/blockly/issues/7134
Fixes https://github.com/google/blockly/issues/7137

### Proposed Changes

Remove the problematic line of code that generates this loop

Add a listener to the event "touchcancel" who executes "handleUp" function

#### Behavior Before Change

Infinite loop because "handleTouchMove" call "handleMove" that call "handleTouchMove" and so on...

The block stays selected

#### Behavior After Change

Infinite loop removed.

The block is deselected like a "pointerup" occurs.

### Reason for Changes

The infinite loop causes the browser to crash

Impossible to use the interface after an app switch (android home button)

### Test Coverage

Manuel tests

### Documentation

No

### Additional Information

Sorry for the mess in the pull requests, this is the first time I've done one. Please refer to the original pull request  [#7136](https://github.com/google/blockly/pull/7136) for further explanations.
