### PR TITLE
Wrong formulation for the block TEXT_CHARAT in the french language file fr.json

### DIFF
--- a/msg/json/fr.json
+++ b/msg/json/fr.json
@@ -227,7 +227,7 @@
 	"TEXT_INDEXOF_TITLE": "%2 %3 dans le texte %1",
 	"TEXT_INDEXOF_OPERATOR_FIRST": "trouver la première occurrence de la chaîne",
 	"TEXT_INDEXOF_OPERATOR_LAST": "trouver la dernière occurrence du texte",
-	"TEXT_CHARAT_TITLE": "%2 dans le texte %1",
+	"TEXT_CHARAT_TITLE": "dans le texte %1 %2",
 	"TEXT_CHARAT_FROM_START": "obtenir la lettre nº",
 	"TEXT_CHARAT_FROM_END": "obtenir la lettre nº (depuis la fin)",
 	"TEXT_CHARAT_FIRST": "obtenir la première lettre",


### PR DESCRIPTION
There was a wrong formulation. The good order in french is the  same than in english:

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x ] I branched from develop
- [x ] My pull request is against develop
- [x ] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [x ] I ran `npm run format` and `npm run lint`

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes 

### Proposed Changes

- "dans le texte %1 %2" is equivalent and the correct formulation for "in the text %1 %2" and it works with all combinaisons of %2

