### PR TITLE
fix: Restore `HSV_SATURATION` and `HSV_VALUE` accessors and deprecate

### DIFF
--- a/core/main.js
+++ b/core/main.js
@@ -16,6 +16,7 @@ goog.module('Blockly.main');
 const Blockly = goog.require('Blockly');
 const Msg = goog.require('Blockly.Msg');
 const colour = goog.require('Blockly.utils.colour');
+const deprecation = goog.require('Blockly.utils.deprecation');
 
 /*
  * Aliased functions and properties that used to be on the Blockly namespace.
@@ -31,13 +32,27 @@ Object.defineProperties(Blockly, {
    * Must be in the range of 0 (inclusive) to 1 (exclusive).
    * @name Blockly.HSV_SATURATION
    * @type {number}
+   * @deprecated Use Blockly.colour.getHsvSaturation() / .setHsvSaturation(
+   *     instead.  (July 2023)
    * @suppress {checkTypes}
    */
   HSV_SATURATION: {
     get: function () {
+      deprecation.warn(
+        'Blockly.HSV_SATURATION',
+        'version 10',
+        'version 11',
+        'Blockly.colour.getHsvSaturation()'
+      );
       return colour.getHsvSaturation();
     },
     set: function (newValue) {
+      deprecation.warn(
+        'Blockly.HSV_SATURATION',
+        'version 10',
+        'version 11',
+        'Blockly.colour.setHsvSaturation()'
+      );
       colour.setHsvSaturation(newValue);
     },
   },
@@ -46,13 +61,27 @@ Object.defineProperties(Blockly, {
    * Must be in the range of 0 (inclusive) to 1 (exclusive).
    * @name Blockly.HSV_VALUE
    * @type {number}
+   * @deprecated Use Blockly.colour.getHsvValue() / .setHsvValue instead.
+   *     (July 2023)
    * @suppress {checkTypes}
    */
   HSV_VALUE: {
     get: function () {
+      deprecation.warn(
+        'Blockly.HSV_VALUE',
+        'version 10',
+        'version 11',
+        'Blockly.colour.getHsvValue()'
+      );
       return colour.getHsvValue();
     },
     set: function (newValue) {
+      deprecation.warn(
+        'Blockly.HSV_VALUE',
+        'version 10',
+        'version 11',
+        'Blockly.colour.setHsvValue()'
+      );
       colour.setHsvValue(newValue);
     },
   },

--- a/core/main.js
+++ b/core/main.js
@@ -13,9 +13,50 @@
 
 goog.module('Blockly.main');
 
-/** @suppress {extraRequire} */
-goog.require('Blockly');
+const Blockly = goog.require('Blockly');
 const Msg = goog.require('Blockly.Msg');
+const colour = goog.require('Blockly.utils.colour');
+
+/*
+ * Aliased functions and properties that used to be on the Blockly namespace.
+ * Everything in this section is deprecated. Both external and internal code
+ * should avoid using these functions and use the designated replacements.
+ * Everything in this section will be removed in a future version of Blockly.
+ */
+
+// Add accessors for properties on Blockly that have now been deprecated.
+Object.defineProperties(Blockly, {
+  /**
+   * The richness of block colours, regardless of the hue.
+   * Must be in the range of 0 (inclusive) to 1 (exclusive).
+   * @name Blockly.HSV_SATURATION
+   * @type {number}
+   * @suppress {checkTypes}
+   */
+  HSV_SATURATION: {
+    get: function () {
+      return colour.getHsvSaturation();
+    },
+    set: function (newValue) {
+      colour.setHsvSaturation(newValue);
+    },
+  },
+  /**
+   * The intensity of block colours, regardless of the hue.
+   * Must be in the range of 0 (inclusive) to 1 (exclusive).
+   * @name Blockly.HSV_VALUE
+   * @type {number}
+   * @suppress {checkTypes}
+   */
+  HSV_VALUE: {
+    get: function () {
+      return colour.getHsvValue();
+    },
+    set: function (newValue) {
+      colour.setHsvValue(newValue);
+    },
+  },
+});
 
 // If Blockly is compiled with ADVANCED_COMPILATION and/or loaded as a
 // CJS or ES module there will not be a Blockly global variable


### PR DESCRIPTION
## The basics

- [X] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [X] I ran `npm run format` and `npm run lint`

## The details
### Resolves

Developer errors/confusion caused by the removal of `HSV_SATURATION` and `HSV_VALUE` by PR #7077 despite them not having previously been formally deprecated.

### Proposed Changes

Restore these accessors but mark them as deprecated.

### Reason for Changes

Reduce developer pain.

### Test Coverage

Passes `npm test`.

### Documentation

This was an undocumented and not-previously-promulgated change in Blockly v10.0.0.  If we do not revert (via this PR or similar) we should at least issue an errata to the release notes.

### Additional Information

**DEPRECATION:** `Blockly.HSV_SATURATION` and `Blockly.HSV_VALUE` are deprecated and will be removed in a future version of Blockly.  Use `Blockly.colour.getHsvSaturation` / `Blockly.colour.setHsvSaturation` and `Blockly.colour.getHsvValue` / `Blockly.colour.setHsvValue` instead.
