### PR TITLE
chore: add test helpers for connecting blocks

### DIFF
--- a/core/rendered_connection.ts
+++ b/core/rendered_connection.ts
@@ -262,7 +262,6 @@ export class RenderedConnection extends Connection {
    * Get the offset of this connection relative to the top left of its block.
    *
    * @returns The offset of the connection.
-   * @internal
    */
   getOffsetInBlock(): Coordinate {
     return this.offsetInBlock;

--- a/core/utils/svg_math.ts
+++ b/core/utils/svg_math.ts
@@ -175,6 +175,40 @@ export function screenToWsCoordinates(
   return finalOffsetMainWs;
 }
 
+export function wsToScreenCoordinates(
+  ws: WorkspaceSvg,
+  workspaceCoordinates: Coordinate,
+): Coordinate {
+  const workspaceX = workspaceCoordinates.x;
+  const workspaceY = workspaceCoordinates.y;
+
+  const injectionDiv = ws.getInjectionDiv();
+  // Bounding rect coordinates are in client coordinates, meaning that they
+  // are in pixels relative to the upper left corner of the visible browser
+  // window.  These coordinates change when you scroll the browser window.
+  const boundingRect = injectionDiv.getBoundingClientRect();
+
+  // The client coordinates offset by the injection div's upper left corner.
+  const clientOffsetPixels = new Coordinate(
+    workspaceX + boundingRect.left,
+    workspaceY + boundingRect.top
+  );
+
+  // The offset in pixels between the main workspace's origin and the upper
+  // left corner of the injection div.
+  const mainOffsetPixels = ws.getOriginOffsetInPixels();
+
+  // The position of the new comment in pixels relative to the origin of the
+  // main workspace.
+  const finalOffsetPixels = Coordinate.sum(
+    clientOffsetPixels,
+    mainOffsetPixels
+  );
+  // The position in main workspace coordinates.
+  const finalOffsetMainWs = finalOffsetPixels.scale(ws.scale);
+  return finalOffsetMainWs;
+}
+
 export const TEST_ONLY = {
   XY_REGEX,
   XY_STYLE_REGEX,

--- a/core/utils/svg_math.ts
+++ b/core/utils/svg_math.ts
@@ -177,7 +177,7 @@ export function screenToWsCoordinates(
 
 /**
  * Converts workspace coordinates to screen coordinates.
- * 
+ *
  * @param ws The workspace to get the coordinates out of.
  * @param workspaceCoordinates  The workspace coordinates to be converted
  *     to screen coordinates.
@@ -185,7 +185,7 @@ export function screenToWsCoordinates(
  */
 export function wsToScreenCoordinates(
   ws: WorkspaceSvg,
-  workspaceCoordinates: Coordinate,
+  workspaceCoordinates: Coordinate
 ): Coordinate {
   // Fix workspace scale vs browser scale.
   const screenCoordinates = workspaceCoordinates.scale(ws.scale);

--- a/core/utils/svg_math.ts
+++ b/core/utils/svg_math.ts
@@ -175,38 +175,32 @@ export function screenToWsCoordinates(
   return finalOffsetMainWs;
 }
 
+/**
+ * Converts workspace coordinates to screen coordinates.
+ * 
+ * @param ws The workspace to get the coordinates out of.
+ * @param workspaceCoordinates  The workspace coordinates to be converted
+ *     to screen coordinates.
+ * @returns The screen coordinates.
+ */
 export function wsToScreenCoordinates(
   ws: WorkspaceSvg,
   workspaceCoordinates: Coordinate,
 ): Coordinate {
-  const workspaceX = workspaceCoordinates.x;
-  const workspaceY = workspaceCoordinates.y;
+  // Fix workspace scale vs browser scale.
+  const screenCoordinates = workspaceCoordinates.scale(ws.scale);
+  const screenX = screenCoordinates.x;
+  const screenY = screenCoordinates.y;
 
   const injectionDiv = ws.getInjectionDiv();
-  // Bounding rect coordinates are in client coordinates, meaning that they
-  // are in pixels relative to the upper left corner of the visible browser
-  // window.  These coordinates change when you scroll the browser window.
   const boundingRect = injectionDiv.getBoundingClientRect();
+  const mainOffset = ws.getOriginOffsetInPixels();
 
-  // The client coordinates offset by the injection div's upper left corner.
-  const clientOffsetPixels = new Coordinate(
-    workspaceX + boundingRect.left,
-    workspaceY + boundingRect.top
+  // Fix workspace origin vs browser origin.
+  return new Coordinate(
+    screenX + boundingRect.left + mainOffset.x,
+    screenY + boundingRect.top + mainOffset.y
   );
-
-  // The offset in pixels between the main workspace's origin and the upper
-  // left corner of the injection div.
-  const mainOffsetPixels = ws.getOriginOffsetInPixels();
-
-  // The position of the new comment in pixels relative to the origin of the
-  // main workspace.
-  const finalOffsetPixels = Coordinate.sum(
-    clientOffsetPixels,
-    mainOffsetPixels
-  );
-  // The position in main workspace coordinates.
-  const finalOffsetMainWs = finalOffsetPixels.scale(ws.scale);
-  return finalOffsetMainWs;
 }
 
 export const TEST_ONLY = {

--- a/tests/browser/test/procedure_test.js
+++ b/tests/browser/test/procedure_test.js
@@ -20,7 +20,6 @@ const {
 
 let browser;
 
-
 suite('Testing Connecting Blocks', function (done) {
   // Setting timeout to unlimited as the webdriver takes a longer time to run than most mocha test
   this.timeout(0);
@@ -75,7 +74,7 @@ suite('Testing Connecting Blocks', function (done) {
     const doSomethingCaller = await getSelectedBlockElement(browser);
 
     // Connect the doSomething caller to doSomething2
-    await connect (browser, doSomethingCaller, 'OUTPUT', doSomething2, 'RETURN');
+    await connect(browser, doSomethingCaller, 'OUTPUT', doSomething2, 'RETURN');
 
     // Drag out print from flyout.
     const printFlyout = await getBlockTypeFromCategory(

--- a/tests/browser/test/procedure_test.js
+++ b/tests/browser/test/procedure_test.js
@@ -13,60 +13,13 @@ const {
   testSetup,
   testFileLocations,
   getSelectedBlockElement,
-  getSelectedBlockId,
   getNthBlockOfCategory,
   getBlockTypeFromCategory,
+  connect,
 } = require('./test_setup');
 
 let browser;
 
-async function getLocationOfBlock(browser, id) {
-  return await browser.execute((id) => {
-    const block = Blockly.getMainWorkspace().getBlockById(id);
-    return block.getRelativeToSurfaceXY();
-  }, id);
-}
-
-async function getLocationOfBlockConnection(browser, id, connectionName) {
-  return await browser.execute((id, connectionName) => {
-    const block = Blockly.getMainWorkspace().getBlockById(id);
-
-    let connection;
-    switch (connectionName) {
-      case 'OUTPUT':
-        connection = block.outputConnection;
-        break;
-      case 'PREVIOUS':
-        connection = block.previousConnection;
-        break;
-      case 'NEXT':
-        connection = block.nextConnection;
-        break;
-      default:
-        connection = block.getInput(connectionName).connection;
-        break;
-    }
-
-    const loc = Blockly.utils.Coordinate.sum(
-        block.getRelativeToSurfaceXY(), connection.getOffsetInBlock());
-    return Blockly.utils.svgMath.wsToScreenCoordinates(
-        Blockly.getMainWorkspace(), loc);
-  }, id, connectionName);
-}
-
-async function connect(
-    browser, draggedBlock, draggedConnection, targetBlock, targetConnection) {
-  const draggedLocation = await getLocationOfBlockConnection(
-      browser, draggedBlock.id, draggedConnection);
-  const targetLocation = await getLocationOfBlockConnection(
-      browser, targetBlock.id, targetConnection);
-  
-  const delta = {
-    x: targetLocation.x - draggedLocation.x,
-    y: targetLocation.y - draggedLocation.y,
-  }
-  await draggedBlock.dragAndDrop(delta);
-}
 
 suite('Testing Connecting Blocks', function (done) {
   // Setting timeout to unlimited as the webdriver takes a longer time to run than most mocha test
@@ -77,7 +30,7 @@ suite('Testing Connecting Blocks', function (done) {
     browser = await testSetup(testFileLocations.code);
   });
 
-  test.only('Testing Procedure', async function () {
+  test('Testing Procedure', async function () {
     // Drag out first function
     let proceduresDefReturn = await getBlockTypeFromCategory(
       browser,
@@ -159,6 +112,6 @@ suite('Testing Connecting Blocks', function (done) {
 
   // Teardown entire suite after test are done running
   suiteTeardown(async function () {
-    // await browser.deleteSession();
+    await browser.deleteSession();
   });
 });

--- a/tests/browser/test/test_setup.js
+++ b/tests/browser/test/test_setup.js
@@ -73,17 +73,21 @@ const testFileLocations = {
   playground: 2,
 };
 
+async function getSelectedBlockId(browser) {
+  return await browser.execute(() => {
+    // Note: selected is an ICopyable and I am assuming that it is a BlockSvg.
+    return Blockly.common.getSelected()?.id;
+  });
+}
+
 /**
  * @param {Browser} browser The active WebdriverIO Browser object.
  * @return {WebElement} The selected block's root SVG element, as an interactable
  *     browser element.
  */
 async function getSelectedBlockElement(browser) {
-  const result = await browser.execute(() => {
-    // Note: selected is an ICopyable and I am assuming that it is a BlockSvg.
-    return Blockly.common.getSelected()?.id;
-  });
-  return await browser.$(`[data-id="${result}"]`);
+  const id = await getSelectedBlockId(browser);
+  return getBlockElementById(browser, id);
 }
 
 /**
@@ -93,7 +97,9 @@ async function getSelectedBlockElement(browser) {
  *     interactable browser element.
  */
 async function getBlockElementById(browser, id) {
-  return await browser.$(`[data-id="${id}"]`);
+  const elem = await browser.$(`[data-id="${id}"]`);
+  elem['id'] = id;
+  return elem;
 }
 async function getCategory(browser, categoryName) {
   const categories = await browser.$$('.blocklyTreeLabel');
@@ -131,13 +137,14 @@ async function getBlockTypeFromCategory(browser, categoryName, blockType) {
       .getWorkspace()
       .getBlocksByType(blockType)[0].id;
   }, blockType);
-  return await browser.$(`[data-id="${id}"]`);
+  return getBlockElementById(browser, id);
 }
 
 module.exports = {
   testSetup,
   testFileLocations,
   getSelectedBlockElement,
+  getSelectedBlockId,
   getBlockElementById,
   getCategory,
   getNthBlockOfCategory,

--- a/tests/browser/test/test_setup.js
+++ b/tests/browser/test/test_setup.js
@@ -140,6 +140,47 @@ async function getBlockTypeFromCategory(browser, categoryName, blockType) {
   return getBlockElementById(browser, id);
 }
 
+async function getLocationOfBlockConnection(browser, id, connectionName) {
+  return await browser.execute((id, connectionName) => {
+    const block = Blockly.getMainWorkspace().getBlockById(id);
+
+    let connection;
+    switch (connectionName) {
+      case 'OUTPUT':
+        connection = block.outputConnection;
+        break;
+      case 'PREVIOUS':
+        connection = block.previousConnection;
+        break;
+      case 'NEXT':
+        connection = block.nextConnection;
+        break;
+      default:
+        connection = block.getInput(connectionName).connection;
+        break;
+    }
+
+    const loc = Blockly.utils.Coordinate.sum(
+        block.getRelativeToSurfaceXY(), connection.getOffsetInBlock());
+    return Blockly.utils.svgMath.wsToScreenCoordinates(
+        Blockly.getMainWorkspace(), loc);
+  }, id, connectionName);
+}
+
+async function connect(
+    browser, draggedBlock, draggedConnection, targetBlock, targetConnection) {
+  const draggedLocation = await getLocationOfBlockConnection(
+      browser, draggedBlock.id, draggedConnection);
+  const targetLocation = await getLocationOfBlockConnection(
+      browser, targetBlock.id, targetConnection);
+  
+  const delta = {
+    x: targetLocation.x - draggedLocation.x,
+    y: targetLocation.y - draggedLocation.y,
+  }
+  await draggedBlock.dragAndDrop(delta);
+}
+
 module.exports = {
   testSetup,
   testFileLocations,
@@ -149,4 +190,5 @@ module.exports = {
   getCategory,
   getNthBlockOfCategory,
   getBlockTypeFromCategory,
+  connect,
 };

--- a/tests/browser/test/test_setup.js
+++ b/tests/browser/test/test_setup.js
@@ -141,43 +141,62 @@ async function getBlockTypeFromCategory(browser, categoryName, blockType) {
 }
 
 async function getLocationOfBlockConnection(browser, id, connectionName) {
-  return await browser.execute((id, connectionName) => {
-    const block = Blockly.getMainWorkspace().getBlockById(id);
+  return await browser.execute(
+    (id, connectionName) => {
+      const block = Blockly.getMainWorkspace().getBlockById(id);
 
-    let connection;
-    switch (connectionName) {
-      case 'OUTPUT':
-        connection = block.outputConnection;
-        break;
-      case 'PREVIOUS':
-        connection = block.previousConnection;
-        break;
-      case 'NEXT':
-        connection = block.nextConnection;
-        break;
-      default:
-        connection = block.getInput(connectionName).connection;
-        break;
-    }
+      let connection;
+      switch (connectionName) {
+        case 'OUTPUT':
+          connection = block.outputConnection;
+          break;
+        case 'PREVIOUS':
+          connection = block.previousConnection;
+          break;
+        case 'NEXT':
+          connection = block.nextConnection;
+          break;
+        default:
+          connection = block.getInput(connectionName).connection;
+          break;
+      }
 
-    const loc = Blockly.utils.Coordinate.sum(
-        block.getRelativeToSurfaceXY(), connection.getOffsetInBlock());
-    return Blockly.utils.svgMath.wsToScreenCoordinates(
-        Blockly.getMainWorkspace(), loc);
-  }, id, connectionName);
+      const loc = Blockly.utils.Coordinate.sum(
+        block.getRelativeToSurfaceXY(),
+        connection.getOffsetInBlock()
+      );
+      return Blockly.utils.svgMath.wsToScreenCoordinates(
+        Blockly.getMainWorkspace(),
+        loc
+      );
+    },
+    id,
+    connectionName
+  );
 }
 
 async function connect(
-    browser, draggedBlock, draggedConnection, targetBlock, targetConnection) {
+  browser,
+  draggedBlock,
+  draggedConnection,
+  targetBlock,
+  targetConnection
+) {
   const draggedLocation = await getLocationOfBlockConnection(
-      browser, draggedBlock.id, draggedConnection);
+    browser,
+    draggedBlock.id,
+    draggedConnection
+  );
   const targetLocation = await getLocationOfBlockConnection(
-      browser, targetBlock.id, targetConnection);
-  
+    browser,
+    targetBlock.id,
+    targetConnection
+  );
+
   const delta = {
     x: targetLocation.x - draggedLocation.x,
     y: targetLocation.y - draggedLocation.y,
-  }
+  };
   await draggedBlock.dragAndDrop(delta);
 }
 


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [X] I ran `npm run format` and `npm run lint`

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes https://github.com/google/blockly/issues/7227

### Proposed Changes

Adds a test helper for connecting blocks together.

Also makes `getOffsetInBlock` public because I needed it.

### Testing

Tested that the logic still worked with a scaled (aka zoomed) workspace!