### PR TITLE
fix(tests): Make test `import`s correct and more consistent

### DIFF
--- a/tests/mocha/comment_deserialization_test.js
+++ b/tests/mocha/comment_deserialization_test.js
@@ -10,7 +10,6 @@ import {
   sharedTestSetup,
   sharedTestTeardown,
 } from './test_helpers/setup_teardown.js';
-import {CommentIcon} from '../../build/src/core/icons/comment_icon.js';
 import {simulateClick} from './test_helpers/user_input.js';
 
 suite('Comment Deserialization', function () {
@@ -62,8 +61,7 @@ suite('Comment Deserialization', function () {
       const icon = block.getIcon(Blockly.icons.CommentIcon.TYPE);
       icon.setBubbleVisible(true);
       // Check comment bubble size.
-      const comment = block.getIcon(CommentIcon.TYPE);
-      const bubbleSize = comment.getBubbleSize();
+      const bubbleSize = icon.getBubbleSize();
       chai.assert.isNotNaN(bubbleSize.width);
       chai.assert.isNotNaN(bubbleSize.height);
       chai.assert.equal(icon.getText(), text);

--- a/tests/mocha/comment_deserialization_test.js
+++ b/tests/mocha/comment_deserialization_test.js
@@ -10,7 +10,7 @@ import {
   sharedTestSetup,
   sharedTestTeardown,
 } from './test_helpers/setup_teardown.js';
-import {CommentIcon} from '../../core/icons/comment_icon.js';
+import {CommentIcon} from '../../build/src/core/icons/comment_icon.js';
 import {simulateClick} from './test_helpers/user_input.js';
 
 suite('Comment Deserialization', function () {

--- a/tests/mocha/contextmenu_items_test.js
+++ b/tests/mocha/contextmenu_items_test.js
@@ -459,7 +459,7 @@ suite('Context Menu Items', function () {
       });
 
       test('Creates comment if one did not exist', function () {
-        chai.assert.isNull(
+        chai.assert.isUndefined(
           this.block.getIcon(CommentIcon.TYPE),
           'New block should not have a comment'
         );

--- a/tests/mocha/contextmenu_items_test.js
+++ b/tests/mocha/contextmenu_items_test.js
@@ -11,7 +11,7 @@ import {
   sharedTestTeardown,
   workspaceTeardown,
 } from './test_helpers/setup_teardown.js';
-import {CommentIcon} from '../../core/icons/comment_icon.js';
+import {CommentIcon} from '../../build/src/core/icons/comment_icon.js';
 
 suite('Context Menu Items', function () {
   setup(function () {

--- a/tests/mocha/contextmenu_items_test.js
+++ b/tests/mocha/contextmenu_items_test.js
@@ -11,7 +11,6 @@ import {
   sharedTestTeardown,
   workspaceTeardown,
 } from './test_helpers/setup_teardown.js';
-import {CommentIcon} from '../../build/src/core/icons/comment_icon.js';
 
 suite('Context Menu Items', function () {
   setup(function () {
@@ -460,11 +459,11 @@ suite('Context Menu Items', function () {
 
       test('Creates comment if one did not exist', function () {
         chai.assert.isUndefined(
-          this.block.getIcon(CommentIcon.TYPE),
+          this.block.getIcon(Blockly.icons.CommentIcon.TYPE),
           'New block should not have a comment'
         );
         this.commentOption.callback(this.scope);
-        chai.assert.exists(this.block.getIcon(CommentIcon.TYPE));
+        chai.assert.exists(this.block.getIcon(Blockly.icons.CommentIcon.TYPE));
         chai.assert.isEmpty(
           this.block.getCommentText(),
           'Block should have empty comment text'

--- a/tests/mocha/field_multilineinput_test.js
+++ b/tests/mocha/field_multilineinput_test.js
@@ -23,11 +23,11 @@ import {
   workspaceTeardown,
 } from './test_helpers/setup_teardown.js';
 import {runCodeGenerationTestSuites} from './test_helpers/code_generation.js';
-import {dartGenerator} from '../../generators/dart.js';
-import {javascriptGenerator} from '../../generators/javascript.js';
-import {luaGenerator} from '../../generators/lua.js';
-import {phpGenerator} from '../../generators/php.js';
-import {pythonGenerator} from '../../generators/python.js';
+import {dartGenerator} from '../../build/src/generators/dart.js';
+import {javascriptGenerator} from '../../build/src/generators/javascript.js';
+import {luaGenerator} from '../../build/src/generators/lua.js';
+import {phpGenerator} from '../../build/src/generators/php.js';
+import {pythonGenerator} from '../../build/src/generators/python.js';
 
 suite('Multiline Input Fields', function () {
   setup(function () {

--- a/tests/mocha/generator_test.js
+++ b/tests/mocha/generator_test.js
@@ -7,11 +7,11 @@
 goog.declareModuleId('Blockly.test.generator');
 
 import * as Blockly from '../../build/src/core/blockly.js';
-import {DartGenerator} from '../../generators/dart/dart_generator.js';
-import {JavascriptGenerator} from '../../generators/javascript/javascript_generator.js';
-import {LuaGenerator} from '../../generators/lua/lua_generator.js';
-import {PhpGenerator} from '../../generators/php/php_generator.js';
-import {PythonGenerator} from '../../generators/python/python_generator.js';
+import {DartGenerator} from '../../build/src/generators/dart/dart_generator.js';
+import {JavascriptGenerator} from '../../build/src/generators/javascript/javascript_generator.js';
+import {LuaGenerator} from '../../build/src/generators/lua/lua_generator.js';
+import {PhpGenerator} from '../../build/src/generators/php/php_generator.js';
+import {PythonGenerator} from '../../build/src/generators/python/python_generator.js';
 import {
   sharedTestSetup,
   sharedTestTeardown,

--- a/tests/mocha/xml_test.js
+++ b/tests/mocha/xml_test.js
@@ -13,7 +13,7 @@ import {
   sharedTestTeardown,
   workspaceTeardown,
 } from './test_helpers/setup_teardown.js';
-import {CommentIcon} from '../../core/icons/comment_icon.js';
+import {CommentIcon} from '../../build/src/core/icons/comment_icon.js';
 import {assertVariableValues} from './test_helpers/variables.js';
 
 suite('XML', function () {

--- a/tests/mocha/xml_test.js
+++ b/tests/mocha/xml_test.js
@@ -13,7 +13,6 @@ import {
   sharedTestTeardown,
   workspaceTeardown,
 } from './test_helpers/setup_teardown.js';
-import {CommentIcon} from '../../build/src/core/icons/comment_icon.js';
 import {assertVariableValues} from './test_helpers/variables.js';
 
 suite('XML', function () {
@@ -443,7 +442,7 @@ suite('XML', function () {
         test('Size', function () {
           this.block.setCommentText('test text');
           this.block
-            .getIcon(CommentIcon.TYPE)
+            .getIcon(Blockly.icons.CommentIcon.TYPE)
             .setBubbleSize(new Blockly.utils.Size(100, 200));
           const xml = Blockly.Xml.blockToDom(this.block);
           const commentXml = xml.firstChild;
@@ -453,7 +452,9 @@ suite('XML', function () {
         });
         test('Pinned True', function () {
           this.block.setCommentText('test text');
-          this.block.getIcon(CommentIcon.TYPE).setBubbleVisible(true);
+          this.block
+            .getIcon(Blockly.icons.CommentIcon.TYPE)
+            .setBubbleVisible(true);
           const xml = Blockly.Xml.blockToDom(this.block);
           const commentXml = xml.firstChild;
           chai.assert.equal(commentXml.tagName, 'comment');
@@ -698,7 +699,7 @@ suite('XML', function () {
             this.workspace
           );
           chai.assert.equal(block.getCommentText(), 'test text');
-          chai.assert.isOk(block.getIcon(CommentIcon.TYPE));
+          chai.assert.isOk(block.getIcon(Blockly.icons.CommentIcon.TYPE));
         });
         test('No Text', function () {
           const block = Blockly.Xml.domToBlock(
@@ -723,7 +724,7 @@ suite('XML', function () {
           );
           chai.assert.isOk(block.getIcon(Blockly.icons.CommentIcon.TYPE));
           chai.assert.deepEqual(
-            block.getIcon(CommentIcon.TYPE).getBubbleSize(),
+            block.getIcon(Blockly.icons.CommentIcon.TYPE).getBubbleSize(),
             {
               width: 100,
               height: 200,


### PR DESCRIPTION
## The basics

- [X] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [X] I ran `npm run format` and `npm run lint`

## The details
### Resolves

Addresses the cause of #7224 being filed, though without making more than a token effort to address the issue as written.

### Proposed Changes

* Fix invalid `import` paths in mocha tests.  This resolves the warnings generated during `buildDeps` by
`closure-make-deps`.

* Fix failing context menu item test:
  * The test appears to have been wrong: `Block.prototype.getIcon` is typed as
        getIcon<T extends IIcon>(/* ... */): T | undefined
    and documented as "@returns The icon with the given type if it exists on the block, undefined otherwise."

* Clean up inconsistent usage of `CommentIcon` in the test files touched by PR #7200 to be consistent with existing usage of `Blockly.icons.CommentIcon` instead of importing it separately.

#### Behaviour Before Change

* Scary (but apparently not sufficiently scary) warnings generated by `closure-make-deps` during buildDeps.
* Only 2800 mocha tests were being run, due to errors loading certain test files that were only being reported in the browser console (and one of the non-runners would have failed).

#### Behaviour After Change

* No deps warnings.
* 2976 mocha tests are run and none fail.

### Reason for Changes

Better to run tests than not; better to pass than fail.

### Test Coverage

Restored.

### Additional Information

Still can't be sure that all mocha tests are actually being run!