### PR TITLE
chore: add css classes to individual zoom controls

### DIFF
--- a/core/zoom_controls.ts
+++ b/core/zoom_controls.ts
@@ -256,7 +256,7 @@ export class ZoomControls implements IPositionable {
         */
     this.zoomOutGroup = dom.createSvgElement(
       Svg.G,
-      {'class': 'blocklyZoom'},
+      {'class': 'blocklyZoom blocklyZoomOut'},
       this.svgGroup
     );
     const clip = dom.createSvgElement(
@@ -320,7 +320,7 @@ export class ZoomControls implements IPositionable {
         */
     this.zoomInGroup = dom.createSvgElement(
       Svg.G,
-      {'class': 'blocklyZoom'},
+      {'class': 'blocklyZoom blocklyZoomIn'},
       this.svgGroup
     );
     const clip = dom.createSvgElement(
@@ -401,7 +401,7 @@ export class ZoomControls implements IPositionable {
         */
     this.zoomResetGroup = dom.createSvgElement(
       Svg.G,
-      {'class': 'blocklyZoom'},
+      {'class': 'blocklyZoom blocklyZoomReset'},
       this.svgGroup
     );
     const clip = dom.createSvgElement(


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I branched from develop
- [X] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [X] I ran `npm run format` and `npm run lint`

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes N/A

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->

Adds specific css classes to individual zoom controls. This allows external developers to style the zoom controls individually. It also allows us to easily reference individual zoom controls in automated UI tests.