### PR TITLE
feat(tests): add right click tests and helpers

### DIFF
--- a/tests/browser/test/basic_playground_test.js
+++ b/tests/browser/test/basic_playground_test.js
@@ -9,7 +9,7 @@
  */
 
 const chai = require('chai');
-const {testSetup, testFileLocations} = require('./test_setup');
+const {testSetup, testFileLocations, dragNthBlockFromFlyout} = require('./test_setup');
 
 let browser;
 suite('Testing Connecting Blocks', function (done) {
@@ -41,6 +41,68 @@ suite('Testing Connecting Blocks', function (done) {
     chai.assert.isTrue(blockOnWorkspace);
   });
 
+  // Teardown entire suite after test are done running
+  suiteTeardown(async function () {
+    await browser.deleteSession();
+  });
+});
+
+
+suite('Right Clicking on Blocks', function (done) {
+  // Setting timeout to unlimited as the webdriver takes a longer time to run than most mocha test
+  this.timeout(0);
+
+  // Setup Selenium for all of the tests
+  suiteSetup(async function () {
+    browser = await testSetup(testFileLocations.playground);
+  });
+
+  test('Collapse', async function () {
+    const block = await dragNthBlockFromFlyout(browser, 'Loops', 0, 20, 20);
+    await block.click({button: 2});
+    await new Promise((resolve) => setTimeout(resolve, 2000)); // 2 sec
+    
+    const blockId = block.id;
+  let isCollapsed = await browser.execute((blockId) => {
+    return Blockly.getMainWorkspace().getBlockById(blockId).isCollapsed();
+  }, blockId);
+  chai.assert.isFalse(isCollapsed);
+
+    const collapse = await browser.$('div=Collapse Block');
+    await collapse.click();
+
+    await new Promise((resolve) => setTimeout(resolve, 2000)); // 2 sec
+
+    isCollapsed = await browser.execute((blockId) => {
+      return Blockly.getMainWorkspace().getBlockById(blockId).isCollapsed();
+    }, blockId);
+
+  chai.assert.isTrue(isCollapsed);
+  });
+
+  
+  test('Expand', async function () {
+    // Drag out block
+    // Right click
+    // Collapse
+    // Right click
+    // Expand
+    // Verify expanded
+  });
+
+
+  test('Disable', async function () {
+  });
+
+
+  test('Enable', async function () {
+  });
+
+  test('Add Comment', async function () {
+  });
+
+  test('Remove Comment', async function () {
+  });
   // Teardown entire suite after test are done running
   suiteTeardown(async function () {
     await browser.deleteSession();

--- a/tests/browser/test/basic_playground_test.js
+++ b/tests/browser/test/basic_playground_test.js
@@ -13,6 +13,7 @@ const {
   testSetup,
   testFileLocations,
   dragNthBlockFromFlyout,
+  contextMenuSelect,
 } = require('./test_setup');
 
 let browser;
@@ -61,9 +62,8 @@ suite('Right Clicking on Blocks', function (done) {
   });
 
   test('Collapse', async function () {
+    await browser.refresh();
     const block = await dragNthBlockFromFlyout(browser, 'Loops', 0, 20, 20);
-    await block.click({button: 2});
-    await new Promise((resolve) => setTimeout(resolve, 2000)); // 2 sec
 
     const blockId = block.id;
     let isCollapsed = await browser.execute((blockId) => {
@@ -71,35 +71,65 @@ suite('Right Clicking on Blocks', function (done) {
     }, blockId);
     chai.assert.isFalse(isCollapsed);
 
-    const collapse = await browser.$('div=Collapse Block');
-    await collapse.click();
-
-    await new Promise((resolve) => setTimeout(resolve, 2000)); // 2 sec
+    await contextMenuSelect(browser, block, 'Collapse Block');
 
     isCollapsed = await browser.execute((blockId) => {
       return Blockly.getMainWorkspace().getBlockById(blockId).isCollapsed();
     }, blockId);
 
     chai.assert.isTrue(isCollapsed);
-    // TODO: assert that the text of the block is correct, maybe.
   });
 
   test('Expand', async function () {
-    // Drag out block
-    // Right click
-    // Collapse
-    // Right click
-    // Expand
-    // Verify expanded
+    await browser.refresh();
+    const block = await dragNthBlockFromFlyout(browser, 'Loops', 0, 20, 20);
+
+    await contextMenuSelect(browser, block, 'Collapse Block');
+    await contextMenuSelect(browser, block, 'Expand Block');
+
+    // Verify.
+    const blockId = block.id;
+    const isCollapsed = await browser.execute((blockId) => {
+      return Blockly.getMainWorkspace().getBlockById(blockId).isCollapsed();
+    }, blockId);
+    chai.assert.isFalse(isCollapsed);
   });
 
-  test('Disable', async function () {});
+  test('Disable', async function () {
+    await browser.refresh();
+    const block = await dragNthBlockFromFlyout(browser, 'Loops', 0, 20, 20);
 
-  test('Enable', async function () {});
+    const blockId = block.id;
+    let isEnabled = await browser.execute((blockId) => {
+      return Blockly.getMainWorkspace().getBlockById(blockId).isEnabled();
+    }, blockId);
+    chai.assert.isTrue(isEnabled);
 
-  test('Add Comment', async function () {});
+    await contextMenuSelect(browser, block, 'Disable Block');
 
-  test('Remove Comment', async function () {});
+    await new Promise((resolve) => setTimeout(resolve, 2000)); // 2 sec
+
+    isEnabled = await browser.execute((blockId) => {
+      return Blockly.getMainWorkspace().getBlockById(blockId).isEnabled();
+    }, blockId);
+    chai.assert.isFalse(isEnabled);
+  });
+
+  test('Enable', async function () {
+    await browser.refresh();
+    const block = await dragNthBlockFromFlyout(browser, 'Loops', 0, 20, 20);
+
+    const blockId = block.id;
+    await contextMenuSelect(browser, block, 'Disable Block');
+    await contextMenuSelect(browser, block, 'Enable Block');
+
+    const isEnabled = await browser.execute((blockId) => {
+      return Blockly.getMainWorkspace().getBlockById(blockId).isEnabled();
+    }, blockId);
+
+    chai.assert.isTrue(isEnabled);
+  });
+
   // Teardown entire suite after test are done running
   suiteTeardown(async function () {
     await browser.deleteSession();

--- a/tests/browser/test/basic_playground_test.js
+++ b/tests/browser/test/basic_playground_test.js
@@ -9,7 +9,11 @@
  */
 
 const chai = require('chai');
-const {testSetup, testFileLocations, dragNthBlockFromFlyout} = require('./test_setup');
+const {
+  testSetup,
+  testFileLocations,
+  dragNthBlockFromFlyout,
+} = require('./test_setup');
 
 let browser;
 suite('Testing Connecting Blocks', function (done) {
@@ -47,7 +51,6 @@ suite('Testing Connecting Blocks', function (done) {
   });
 });
 
-
 suite('Right Clicking on Blocks', function (done) {
   // Setting timeout to unlimited as the webdriver takes a longer time to run than most mocha test
   this.timeout(0);
@@ -61,12 +64,12 @@ suite('Right Clicking on Blocks', function (done) {
     const block = await dragNthBlockFromFlyout(browser, 'Loops', 0, 20, 20);
     await block.click({button: 2});
     await new Promise((resolve) => setTimeout(resolve, 2000)); // 2 sec
-    
+
     const blockId = block.id;
-  let isCollapsed = await browser.execute((blockId) => {
-    return Blockly.getMainWorkspace().getBlockById(blockId).isCollapsed();
-  }, blockId);
-  chai.assert.isFalse(isCollapsed);
+    let isCollapsed = await browser.execute((blockId) => {
+      return Blockly.getMainWorkspace().getBlockById(blockId).isCollapsed();
+    }, blockId);
+    chai.assert.isFalse(isCollapsed);
 
     const collapse = await browser.$('div=Collapse Block');
     await collapse.click();
@@ -77,10 +80,10 @@ suite('Right Clicking on Blocks', function (done) {
       return Blockly.getMainWorkspace().getBlockById(blockId).isCollapsed();
     }, blockId);
 
-  chai.assert.isTrue(isCollapsed);
+    chai.assert.isTrue(isCollapsed);
+    // TODO: assert that the text of the block is correct, maybe.
   });
 
-  
   test('Expand', async function () {
     // Drag out block
     // Right click
@@ -90,19 +93,13 @@ suite('Right Clicking on Blocks', function (done) {
     // Verify expanded
   });
 
+  test('Disable', async function () {});
 
-  test('Disable', async function () {
-  });
+  test('Enable', async function () {});
 
+  test('Add Comment', async function () {});
 
-  test('Enable', async function () {
-  });
-
-  test('Add Comment', async function () {
-  });
-
-  test('Remove Comment', async function () {
-  });
+  test('Remove Comment', async function () {});
   // Teardown entire suite after test are done running
   suiteTeardown(async function () {
     await browser.deleteSession();

--- a/tests/browser/test/basic_playground_test.js
+++ b/tests/browser/test/basic_playground_test.js
@@ -16,6 +16,18 @@ const {
   contextMenuSelect,
 } = require('./test_setup');
 
+async function getIsCollapsed(browser, blockId) {
+  return await browser.execute((blockId) => {
+    return Blockly.getMainWorkspace().getBlockById(blockId).isCollapsed();
+  }, blockId);
+}
+
+async function getIsEnabled(browser, blockId) {
+  return await browser.execute((blockId) => {
+    return Blockly.getMainWorkspace().getBlockById(blockId).isEnabled();
+  }, blockId);
+}
+
 let browser;
 suite('Testing Connecting Blocks', function (done) {
   // Setting timeout to unlimited as the webdriver takes a longer time to run than most mocha test
@@ -66,16 +78,12 @@ suite('Right Clicking on Blocks', function (done) {
     const block = await dragNthBlockFromFlyout(browser, 'Loops', 0, 20, 20);
 
     const blockId = block.id;
-    let isCollapsed = await browser.execute((blockId) => {
-      return Blockly.getMainWorkspace().getBlockById(blockId).isCollapsed();
-    }, blockId);
+    let isCollapsed = await getIsCollapsed(browser, blockId);
     chai.assert.isFalse(isCollapsed);
 
     await contextMenuSelect(browser, block, 'Collapse Block');
 
-    isCollapsed = await browser.execute((blockId) => {
-      return Blockly.getMainWorkspace().getBlockById(blockId).isCollapsed();
-    }, blockId);
+    isCollapsed = await getIsCollapsed(browser, blockId);
 
     chai.assert.isTrue(isCollapsed);
   });
@@ -89,9 +97,7 @@ suite('Right Clicking on Blocks', function (done) {
 
     // Verify.
     const blockId = block.id;
-    const isCollapsed = await browser.execute((blockId) => {
-      return Blockly.getMainWorkspace().getBlockById(blockId).isCollapsed();
-    }, blockId);
+    const isCollapsed = await getIsCollapsed(browser, blockId);
     chai.assert.isFalse(isCollapsed);
   });
 
@@ -100,18 +106,14 @@ suite('Right Clicking on Blocks', function (done) {
     const block = await dragNthBlockFromFlyout(browser, 'Loops', 0, 20, 20);
 
     const blockId = block.id;
-    let isEnabled = await browser.execute((blockId) => {
-      return Blockly.getMainWorkspace().getBlockById(blockId).isEnabled();
-    }, blockId);
+    let isEnabled = await getIsEnabled(browser, blockId);
     chai.assert.isTrue(isEnabled);
 
     await contextMenuSelect(browser, block, 'Disable Block');
 
     await new Promise((resolve) => setTimeout(resolve, 2000)); // 2 sec
 
-    isEnabled = await browser.execute((blockId) => {
-      return Blockly.getMainWorkspace().getBlockById(blockId).isEnabled();
-    }, blockId);
+    isEnabled = await getIsEnabled(browser, blockId);
     chai.assert.isFalse(isEnabled);
   });
 
@@ -123,10 +125,7 @@ suite('Right Clicking on Blocks', function (done) {
     await contextMenuSelect(browser, block, 'Disable Block');
     await contextMenuSelect(browser, block, 'Enable Block');
 
-    const isEnabled = await browser.execute((blockId) => {
-      return Blockly.getMainWorkspace().getBlockById(blockId).isEnabled();
-    }, blockId);
-
+    const isEnabled = await getIsEnabled(browser, blockId);
     chai.assert.isTrue(isEnabled);
   });
 

--- a/tests/browser/test/procedure_test.js
+++ b/tests/browser/test/procedure_test.js
@@ -82,7 +82,7 @@ suite('Testing Connecting Blocks', function (done) {
       'Text',
       'text_print'
     );
-    await printFlyout.dragAndDrop({x: 50, y: 20});
+    await printFlyout.dragAndDrop({x: 50, y: 0});
     await new Promise((resolve) => setTimeout(resolve, 2000)); // 2 sec
     const print = await getSelectedBlockElement(browser);
 

--- a/tests/browser/test/test_setup.js
+++ b/tests/browser/test/test_setup.js
@@ -200,17 +200,13 @@ async function connect(
   await draggedBlock.dragAndDrop(delta);
 }
 
-async function dragNthBlockFromFlyout(browser, categoryName, n, x, y) { 
-    const flyoutBlock = await getNthBlockOfCategory(
-    browser,
-    categoryName,
-    n
-  );
+async function dragNthBlockFromFlyout(browser, categoryName, n, x, y) {
+  const flyoutBlock = await getNthBlockOfCategory(browser, categoryName, n);
   await new Promise((resolve) => setTimeout(resolve, 2000)); // 2 sec
   await flyoutBlock.dragAndDrop({x: x, y: y});
   await new Promise((resolve) => setTimeout(resolve, 2000)); // 2 sec
   return await getSelectedBlockElement(browser);
-};
+}
 
 module.exports = {
   testSetup,

--- a/tests/browser/test/test_setup.js
+++ b/tests/browser/test/test_setup.js
@@ -200,6 +200,18 @@ async function connect(
   await draggedBlock.dragAndDrop(delta);
 }
 
+async function dragNthBlockFromFlyout(browser, categoryName, n, x, y) { 
+    const flyoutBlock = await getNthBlockOfCategory(
+    browser,
+    categoryName,
+    n
+  );
+  await new Promise((resolve) => setTimeout(resolve, 2000)); // 2 sec
+  await flyoutBlock.dragAndDrop({x: x, y: y});
+  await new Promise((resolve) => setTimeout(resolve, 2000)); // 2 sec
+  return await getSelectedBlockElement(browser);
+};
+
 module.exports = {
   testSetup,
   testFileLocations,
@@ -209,5 +221,6 @@ module.exports = {
   getCategory,
   getNthBlockOfCategory,
   getBlockTypeFromCategory,
+  dragNthBlockFromFlyout,
   connect,
 };

--- a/tests/browser/test/test_setup.js
+++ b/tests/browser/test/test_setup.js
@@ -208,6 +208,14 @@ async function dragNthBlockFromFlyout(browser, categoryName, n, x, y) {
   return await getSelectedBlockElement(browser);
 }
 
+async function contextMenuSelect(browser, block, itemText) {
+  await block.click({button: 2});
+  await new Promise((resolve) => setTimeout(resolve, 2000)); // 2 sec
+  const item = await browser.$(`div=${itemText}`);
+  await item.click();
+  await new Promise((resolve) => setTimeout(resolve, 2000)); // 2 sec
+}
+
 module.exports = {
   testSetup,
   testFileLocations,
@@ -219,4 +227,5 @@ module.exports = {
   getBlockTypeFromCategory,
   dragNthBlockFromFlyout,
   connect,
+  contextMenuSelect,
 };

--- a/tests/browser/test/test_setup.js
+++ b/tests/browser/test/test_setup.js
@@ -202,18 +202,30 @@ async function connect(
 
 async function dragNthBlockFromFlyout(browser, categoryName, n, x, y) {
   const flyoutBlock = await getNthBlockOfCategory(browser, categoryName, n);
-  await new Promise((resolve) => setTimeout(resolve, 2000)); // 2 sec
+  await browser.pause(2000);
   await flyoutBlock.dragAndDrop({x: x, y: y});
-  await new Promise((resolve) => setTimeout(resolve, 2000)); // 2 sec
+  await browser.pause(2000);
+  return await getSelectedBlockElement(browser);
+}
+
+async function dragBlockTypeFromFlyout(browser, categoryName, type, x, y) {
+  const flyoutBlock = await getBlockTypeFromCategory(
+    browser,
+    categoryName,
+    type
+  );
+  await browser.pause(2000);
+  await flyoutBlock.dragAndDrop({x: x, y: y});
+  await browser.pause(2000);
   return await getSelectedBlockElement(browser);
 }
 
 async function contextMenuSelect(browser, block, itemText) {
   await block.click({button: 2});
-  await new Promise((resolve) => setTimeout(resolve, 2000)); // 2 sec
+  await browser.pause(2000);
   const item = await browser.$(`div=${itemText}`);
   await item.click();
-  await new Promise((resolve) => setTimeout(resolve, 2000)); // 2 sec
+  await browser.pause(2000);
 }
 
 module.exports = {


### PR DESCRIPTION
## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [x] I ran `npm run format` and `npm run lint`

## The details

### Proposed Changes
Adds tests for collapsing/expanding and disabling/enabling blocks through the right-click menu.

Adds a helper function to right-click on the given block and click on the menu item with the given text.

### Documentation

### Additional Information

For now I'm just refreshing the browser at the beginning of each test to keep them hermetic, but that should happen in a `setup` function instead.