### PR TITLE
fix: disposing workspace comments.

### DIFF
--- a/core/workspace_comment_svg.ts
+++ b/core/workspace_comment_svg.ts
@@ -144,9 +144,7 @@ export class WorkspaceCommentSvg
     }
 
     dom.removeNode(this.svgGroup);
-    // Dispose of any rendered components
-    this.disposeInternal();
-
+    
     eventUtils.disable();
     super.dispose();
     eventUtils.enable();
@@ -987,11 +985,6 @@ export class WorkspaceCommentSvg
 
     // Allow the contents to resize.
     this.resizeComment();
-  }
-
-  /** Dispose of any rendered comment components. */
-  private disposeInternal() {
-    this.disposed_ = true;
   }
 
   /**

--- a/core/workspace_comment_svg.ts
+++ b/core/workspace_comment_svg.ts
@@ -144,7 +144,7 @@ export class WorkspaceCommentSvg
     }
 
     dom.removeNode(this.svgGroup);
-    
+
     eventUtils.disable();
     super.dispose();
     eventUtils.enable();

--- a/tests/mocha/workspace_comment_test.js
+++ b/tests/mocha/workspace_comment_test.js
@@ -6,7 +6,6 @@
 
 goog.declareModuleId('Blockly.test.workspaceComment');
 
-import {WorkspaceComment} from '../../build/src/core/workspace_comment.js';
 import {
   sharedTestSetup,
   sharedTestTeardown,
@@ -156,6 +155,19 @@ suite('Workspace comment', function () {
   suite('dispose', function () {
     test('Called twice', function () {
       const comment = new Blockly.WorkspaceComment(
+        this.workspace,
+        'comment text',
+        0,
+        0,
+        'comment id'
+      );
+      comment.dispose();
+      // Nothing should go wrong the second time dispose is called.
+      comment.dispose();
+    });
+
+    test('WorkspaceCommentSvg disposed', function () {
+      const comment = new Blockly.WorkspaceCommentSvg(
         this.workspace,
         'comment text',
         0,


### PR DESCRIPTION
## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [x] I ran `npm run format` and `npm run lint`

## The details
### Resolves

Fixes https://github.com/google/blockly/issues/7177

### Proposed Changes

Makes it the sole responsibility of the WorkspaceComment superclass to mark the comment as disposed, instead of letting the subclass mark it as disposed before the superclass has a chance to handle disposing it.

#### Behavior Before Change

The superclass's dispose method did not actually run, and the comment would not be completely disposed.

#### Behavior After Change

Deleting a comment now fully disposes it.

### Test Coverage

Previously there was test coverage for disposing WorkspaceComment, but not for disposing WorkspaceCommentSvg. I added a method testing the latter.
