### PR TITLE
release: v10.0.1

### DIFF
--- a/core/main.js
+++ b/core/main.js
@@ -13,9 +13,79 @@
 
 goog.module('Blockly.main');
 
-/** @suppress {extraRequire} */
-goog.require('Blockly');
+const Blockly = goog.require('Blockly');
 const Msg = goog.require('Blockly.Msg');
+const colour = goog.require('Blockly.utils.colour');
+const deprecation = goog.require('Blockly.utils.deprecation');
+
+/*
+ * Aliased functions and properties that used to be on the Blockly namespace.
+ * Everything in this section is deprecated. Both external and internal code
+ * should avoid using these functions and use the designated replacements.
+ * Everything in this section will be removed in a future version of Blockly.
+ */
+
+// Add accessors for properties on Blockly that have now been deprecated.
+Object.defineProperties(Blockly, {
+  /**
+   * The richness of block colours, regardless of the hue.
+   * Must be in the range of 0 (inclusive) to 1 (exclusive).
+   * @name Blockly.HSV_SATURATION
+   * @type {number}
+   * @deprecated Use Blockly.colour.getHsvSaturation() / .setHsvSaturation(
+   *     instead.  (July 2023)
+   * @suppress {checkTypes}
+   */
+  HSV_SATURATION: {
+    get: function () {
+      deprecation.warn(
+        'Blockly.HSV_SATURATION',
+        'version 10',
+        'version 11',
+        'Blockly.colour.getHsvSaturation()'
+      );
+      return colour.getHsvSaturation();
+    },
+    set: function (newValue) {
+      deprecation.warn(
+        'Blockly.HSV_SATURATION',
+        'version 10',
+        'version 11',
+        'Blockly.colour.setHsvSaturation()'
+      );
+      colour.setHsvSaturation(newValue);
+    },
+  },
+  /**
+   * The intensity of block colours, regardless of the hue.
+   * Must be in the range of 0 (inclusive) to 1 (exclusive).
+   * @name Blockly.HSV_VALUE
+   * @type {number}
+   * @deprecated Use Blockly.colour.getHsvValue() / .setHsvValue instead.
+   *     (July 2023)
+   * @suppress {checkTypes}
+   */
+  HSV_VALUE: {
+    get: function () {
+      deprecation.warn(
+        'Blockly.HSV_VALUE',
+        'version 10',
+        'version 11',
+        'Blockly.colour.getHsvValue()'
+      );
+      return colour.getHsvValue();
+    },
+    set: function (newValue) {
+      deprecation.warn(
+        'Blockly.HSV_VALUE',
+        'version 10',
+        'version 11',
+        'Blockly.colour.setHsvValue()'
+      );
+      colour.setHsvValue(newValue);
+    },
+  },
+});
 
 // If Blockly is compiled with ADVANCED_COMPILATION and/or loaded as a
 // CJS or ES module there will not be a Blockly global variable

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "blockly",
-  "version": "10.0.0",
+  "version": "10.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "blockly",
-      "version": "10.0.0",
+      "version": "10.0.1",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blockly",
-  "version": "10.0.0",
+  "version": "10.0.1",
   "description": "Blockly is a library for building visual programming editors.",
   "keywords": [
     "blockly"


### PR DESCRIPTION
## The basics

- [x] I branched from master
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [x] I ran `npm run format` and `npm run lint`

## The details
### Resolves

Developer errors/confusion caused by the removal of `HSV_SATURATION` and `HSV_VALUE` by PR #7077 despite them not having previously been formally deprecated

### Proposed Changes

* cherry-pick: a677355 to pull in #7249


