### PR TITLE
chore(tests): Add documentation to browser test helper functions

### DIFF
--- a/tests/browser/.eslintrc.json
+++ b/tests/browser/.eslintrc.json
@@ -13,7 +13,14 @@
     // Allow uncommented helper functions in tests.
     "require-jsdoc": ["off"],
     "prefer-rest-params": ["off"],
-    "no-invalid-this": ["off"]
+    "no-invalid-this": ["off"],
+    "valid-jsdoc": [
+      "error",
+      {
+        "requireReturnType": false,
+        "requireParamType": false
+      }
+    ]
   },
   "extends": "../../.eslintrc.js",
   "parserOptions": {

--- a/tests/browser/test/test_setup.js
+++ b/tests/browser/test/test_setup.js
@@ -91,8 +91,8 @@ async function getSelectedBlockId(browser) {
 }
 
 /**
- * @param {Browser} browser The active WebdriverIO Browser object.
- * @return {WebElement} The selected block's root SVG element, as an interactable
+ * @param browser The active WebdriverIO Browser object.
+ * @return The selected block's root SVG element, as an interactable
  *     browser element.
  */
 async function getSelectedBlockElement(browser) {

--- a/tests/browser/test/test_setup.js
+++ b/tests/browser/test/test_setup.js
@@ -145,7 +145,7 @@ async function getCategory(browser, categoryName) {
 /**
  * @param browser The active WebdriverIO Browser object.
  * @param categoryName The name of the toolbox category to search.
- * @param n Which block to select, indexed from the top of the category.
+ * @param n Which block to select, 0-indexed from the top of the category.
  * @return A Promise that resolves to the root element of the nth block in the
  *     given category.
  */


### PR DESCRIPTION
## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [x] I ran `npm run format` and `npm run lint`

## The details
### Resolves

Fixes lack of jsdoc.

### Proposed Changes

Change jsdoc rules for browser tests to not require types, because we don't have strong typing here (and do not intend to compile this code before running it).
Add jsdoc for functions in `test_helpers.js`.

#### Behavior Before Change

No change in test behaviour.

### Reason for Changes

Documentation!

### Test Coverage
These are tests.

### Documentation

This is documentation!

### Additional Information

I think I got the promises right but would appreciate a double-check.