### PR TITLE
fix(build): support running Blocky locally on Windows machines

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "publish:beta": "npm ci && gulp publishBeta",
     "recompile": "gulp recompile",
     "release": "gulp gitCreateRC",
-    "start": "npm run build && concurrently -n tsc,server \"tsc --watch --preserveWatchOutput --outDir 'build/src' --declarationDir 'build/declarations'\" \"http-server ./ -s -o /tests/playground.html -c-1\"",
+    "start": "npm run build && concurrently -n tsc,server \"tsc --watch --preserveWatchOutput --outDir \"build/src\" --declarationDir \"build/declarations\"\" \"http-server ./ -s -o /tests/playground.html -c-1\"",
     "tsc": "gulp tsc",
     "test": "gulp test",
     "test:browser": "npx mocha ./tests/browser/test --config ./tests/browser/test/.mocharc.js",

--- a/scripts/gulpfiles/build_tasks.js
+++ b/scripts/gulpfiles/build_tasks.js
@@ -15,7 +15,6 @@ gulp.sourcemaps = require('gulp-sourcemaps');
 
 const path = require('path');
 const fs = require('fs');
-const os = require('os');
 const {exec, execSync} = require('child_process');
 
 const closureCompiler = require('google-closure-compiler').gulp();
@@ -30,6 +29,13 @@ const {posixPath} = require('../helpers');
 ////////////////////////////////////////////////////////////
 //                        Build                           //
 ////////////////////////////////////////////////////////////
+
+/**
+ * Path to the python runtime.
+ * This will normalize the command across platforms (e.g. python3 on Linux and
+ * Mac, python on Windows).
+ */
+const PYTHON = process.platform === 'win32' ? 'python' : 'python3';
 
 /**
  * Suffix to add to compiled output files.
@@ -380,9 +386,8 @@ error message above, try running:
  * msg/messages.js.
  */
 function generateMessages(done) {
-  const pythonCmd = os.platform() === 'win32' ? 'python' : 'python3';
   // Run js_to_json.py
-  const jsToJsonCmd = `${pythonCmd} scripts/i18n/js_to_json.py \
+  const jsToJsonCmd = `${PYTHON} scripts/i18n/js_to_json.py \
       --input_file ${path.join('msg', 'messages.js')} \
       --output_dir ${path.join('msg', 'json')} \
       --quiet`;
@@ -421,8 +426,7 @@ function buildLangfiles(done) {
       !(new RegExp(/(keys|synonyms|qqq|constants)\.json$/).test(file)));
   json_files = json_files.map(file => path.join('msg', 'json', file));
 
-  const pythonCmd = os.platform() === 'win32' ? 'python' : 'python3';
-  const createMessagesCmd = `${pythonCmd} ./scripts/i18n/create_messages.py \
+  const createMessagesCmd = `${PYTHON} ./scripts/i18n/create_messages.py \
   --source_lang_file ${path.join('msg', 'json', 'en.json')} \
   --source_synonym_file ${path.join('msg', 'json', 'synonyms.json')} \
   --source_constants_file ${path.join('msg', 'json', 'constants.json')} \

--- a/scripts/gulpfiles/build_tasks.js
+++ b/scripts/gulpfiles/build_tasks.js
@@ -568,7 +568,7 @@ function getChunkOptions() {
     // known chunk entrypoints in chunkFiles.  N.B.: O(n*m).  :-(
     const chunk = chunks.find(
         chunk => chunkFiles.find(f => {
-          return f.endsWith("/" + chunk.entry.replaceAll("\\", "/"));
+          return f.endsWith('/' + chunk.entry.replaceAll('\\', '/'));
         }
         ));
     if (!chunk) throw new Error('Unable to identify chunk');

--- a/scripts/gulpfiles/build_tasks.js
+++ b/scripts/gulpfiles/build_tasks.js
@@ -568,7 +568,7 @@ function getChunkOptions() {
     // known chunk entrypoints in chunkFiles.  N.B.: O(n*m).  :-(
     const chunk = chunks.find(
         chunk => chunkFiles.find(f => {
-          return f.endsWith(path.sep.replace("\\", "/") + chunk.entry.replaceAll("\\", "/"));
+          return f.endsWith("/" + chunk.entry.replaceAll("\\", "/"));
         }
         ));
     if (!chunk) throw new Error('Unable to identify chunk');


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [x] I ran `npm run format` and `npm run lint`

## The details
### Resolves
#6864 and #7097 
<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes 

### Proposed Changes
Make building process compatible with machines run on windows. 

#### Behavior Before Change
When running `npm run start` errors occur as described in the bug reports above.

#### Behavior After Change
Running `npm run start` is working with no errors on Windows.

### Reason for Changes
Help developers who work on Windows machines to run blocky locally and potentially contribute to the codebase.

### Test Coverage
I did not create any tests. I tested the code on my Windows machine. 

### Documentation
I don't think any further documentation required for this change. Current documentation already asks users to run `npm run start`. The user does not need to do anything specific on Windows machines.

### Additional Information
No
