### PR TITLE
chore(tests): add basic delete tests

### DIFF
--- a/core/flyout_base.ts
+++ b/core/flyout_base.ts
@@ -784,7 +784,7 @@ export abstract class Flyout extends DeleteArea implements IFlyout {
         }
         block = blocks.appendInternal(
           blockInfo as blocks.State,
-          this.workspace_
+          this.workspace_,
         );
       }
     }

--- a/core/xml.ts
+++ b/core/xml.ts
@@ -566,7 +566,7 @@ export function domToBlock(xmlBlock: Element, workspace: Workspace): Block {
  */
 export function domToBlockInternal(
   xmlBlock: Element,
-  workspace: Workspace
+  workspace: Workspace,
 ): Block {
   // Create top-level block.
   eventUtils.disable();

--- a/tests/browser/test/delete_blocks_test.js
+++ b/tests/browser/test/delete_blocks_test.js
@@ -1,91 +1,102 @@
+/**
+ * @license
+ * Copyright 2023 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 const chai = require('chai');
-const {testSetup, testFileLocations, getBlockTypeFromCategory, getSelectedBlockElement, getBlockTypeFromWorkspace, getAllBlocks, getBlockElementById, contextMenuSelect} = require('./test_setup');
+const {
+  testSetup,
+  testFileLocations,
+  getAllBlocks,
+  getBlockElementById,
+  contextMenuSelect,
+} = require('./test_setup');
 const {Key} = require('webdriverio');
 
-let browser;
-const firstBlockId = "/q5Q_1$kf`gSEFU9C7vK"
+const firstBlockId = 'root_block';
 const startBlocks = {
-  "blocks": {
-    "languageVersion": 0,
-    "blocks": [
+  blocks: {
+    languageVersion: 0,
+    blocks: [
       {
-        "type": "text_print",
-        "id": firstBlockId,
-        "x": 63,
-        "y": 88,
-        "inputs": {
-          "TEXT": {
-            "shadow": {
-              "type": "text",
-              "id": "]2?G%L#p9Vgca{zd6#JB",
-              "fields": {
-                "TEXT": "1"
-              }
-            }
-          }
-        },
-        "next": {
-          "block": {
-            "type": "text_print",
-            "id": "FyV$;[AN7G5frPOrpXg@",
-            "inputs": {
-              "TEXT": {
-                "shadow": {
-                  "type": "text",
-                  "id": "3q[_v5rA3sl/Vw$*:jGp",
-                  "fields": {
-                    "TEXT": "2"
-                  }
-                },
-                "block": {
-                  "type": "text_trim",
-                  "id": "o1O*0%]Vq-4/Nh}2j|wF",
-                  "fields": {
-                    "MODE": "BOTH"
-                  },
-                  "inputs": {
-                    "TEXT": {
-                      "shadow": {
-                        "type": "text",
-                        "id": "A878E^l0J%Hm3iu,j3eV",
-                        "fields": {
-                          "TEXT": "abc"
-                        }
-                      },
-                      "block": {
-                        "type": "text",
-                        "id": "Bma#)g!^Nm_TMHry#ve}",
-                        "fields": {
-                          "TEXT": "hello"
-                        }
-                      }
-                    }
-                  }
-                }
-              }
+        type: 'text_print',
+        id: firstBlockId,
+        x: 63,
+        y: 88,
+        inputs: {
+          TEXT: {
+            shadow: {
+              type: 'text',
+              id: 'text_shadow',
+              fields: {
+                TEXT: '1',
+              },
             },
-            "next": {
-              "block": {
-                "type": "text_print",
-                "id": "{s3Ci:xp;NCsV0(_9ofD",
-                "inputs": {
-                  "TEXT": {
-                    "shadow": {
-                      "type": "text",
-                      "id": "_zw:|_*p~3itPhy#O*4I",
-                      "fields": {
-                        "TEXT": "3"
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    ]
-  }
+          },
+        },
+        next: {
+          block: {
+            type: 'text_print',
+            id: 'second_block',
+            inputs: {
+              TEXT: {
+                shadow: {
+                  type: 'text',
+                  id: 'second_text_shadow',
+                  fields: {
+                    TEXT: '2',
+                  },
+                },
+                block: {
+                  type: 'text_trim',
+                  id: 'trim_block',
+                  fields: {
+                    MODE: 'BOTH',
+                  },
+                  inputs: {
+                    TEXT: {
+                      shadow: {
+                        type: 'text',
+                        id: 'text_to_trim_shadow',
+                        fields: {
+                          TEXT: 'abc',
+                        },
+                      },
+                      block: {
+                        type: 'text',
+                        id: 'text_to_trim_real',
+                        fields: {
+                          TEXT: 'hello',
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+            next: {
+              block: {
+                type: 'text_print',
+                id: 'third_block',
+                inputs: {
+                  TEXT: {
+                    shadow: {
+                      type: 'text',
+                      id: 'third_text_shadow',
+                      fields: {
+                        TEXT: '3',
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    ],
+  },
 };
 const pauseLength = 20;
 
@@ -95,88 +106,118 @@ suite('Delete blocks', function (done) {
 
   // Setup Selenium for all of the tests
   suiteSetup(async function () {
-    browser = await testSetup(testFileLocations.playground);
+    this.browser = await testSetup(testFileLocations.PLAYGROUND);
   });
 
   // Clear the workspace and load the start blocks before each test
-  setup(async function() {
-    await browser.execute(() => {
+  setup(async function () {
+    await this.browser.execute(() => {
       // Clear the workspace manually so we can ensure it's clear before moving on to the next test.
       Blockly.getMainWorkspace().clear();
     });
     // Wait for the workspace to be cleared of blocks (no blocks found on main workspace)
-    await browser.$('.blocklySvg .blocklyWorkspace > .blocklyBlockCanvas > .blocklyDraggable').waitForExist({timeout: 2000, reverse: true});
+    await this.browser
+      .$(
+        '.blocklySvg .blocklyWorkspace > .blocklyBlockCanvas > .blocklyDraggable',
+      )
+      .waitForExist({timeout: 2000, reverse: true});
 
     // Load the start blocks
-    await browser.execute((blocks) => {
+    await this.browser.execute((blocks) => {
       Blockly.serialization.workspaces.load(blocks, Blockly.getMainWorkspace());
     }, startBlocks);
     // Wait for there to be a block on the main workspace before continuing
-    (await getBlockElementById(browser, firstBlockId)).waitForExist({timeout: 2000});
+    (await getBlockElementById(this.browser, firstBlockId)).waitForExist({
+      timeout: 2000,
+    });
   });
 
   test('Delete block using backspace key', async function () {
-    const before = await getAllBlocks(this.browser).length;
+    const before = (await getAllBlocks(this.browser)).length;
     // Get first print block, click to select it, and delete it using backspace key.
-    const block = (await getBlockElementById(browser, firstBlockId)).$('.blocklyPath');
+    const block = (await getBlockElementById(this.browser, firstBlockId)).$(
+      '.blocklyPath',
+    );
     await block.click();
-    await browser.keys([Key.Backspace]);
-    const after = await getAllBlocks(this.browser).length;
-    chai.assert.equal(before-2, after, 'Expected there to be two fewer blocks after deletion of block and shadow');
+    await this.browser.keys([Key.Backspace]);
+    const after = (await getAllBlocks(this.browser)).length;
+    chai.assert.equal(
+      before - 2,
+      after,
+      'Expected there to be two fewer blocks after deletion of block and shadow',
+    );
   });
 
   test('Delete block using delete key', async function () {
-    const before = await getAllBlocks(this.browser).length;
+    const before = (await getAllBlocks(this.browser)).length;
     // Get first print block, click to select it, and delete it using delete key.
-    const block = (await getBlockElementById(browser, firstBlockId)).$('.blocklyPath');
+    const block = (await getBlockElementById(this.browser, firstBlockId)).$(
+      '.blocklyPath',
+    );
     await block.click();
-    await browser.keys([Key.Delete]);
-    const after = await getAllBlocks(this.browser).length;
-    chai.assert.equal(before-2, after, 'Expected there to be two fewer blocks after deletion of block and shadow');
+    await this.browser.keys([Key.Delete]);
+    const after = (await getAllBlocks(this.browser)).length;
+    chai.assert.equal(
+      before - 2,
+      after,
+      'Expected there to be two fewer blocks after deletion of block and shadow',
+    );
   });
 
   test('Delete block using context menu', async function () {
-    const before = await getAllBlocks(this.browser).length;
+    const before = (await getAllBlocks(this.browser)).length;
     // Get first print block, click to select it, and delete it using context menu.
-    const block = (await getBlockElementById(browser, firstBlockId)).$('.blocklyPath');
-    await contextMenuSelect(browser, block, 'Delete 2 Blocks');
-    const after = await getAllBlocks(this.browser).length;
-    chai.assert.equal(before-2, after, 'Expected there to be two fewer blocks after deletion of block and shadow');
+    const block = (await getBlockElementById(this.browser, firstBlockId)).$(
+      '.blocklyPath',
+    );
+    await contextMenuSelect(this.browser, block, 'Delete 2 Blocks');
+    const after = (await getAllBlocks(this.browser)).length;
+    chai.assert.equal(
+      before - 2,
+      after,
+      'Expected there to be two fewer blocks after deletion of block and shadow',
+    );
   });
 
   test('Undo block deletion', async function () {
-    const before = await getAllBlocks(this.browser).length;
+    const before = (await getAllBlocks(this.browser)).length;
     // Get first print block, click to select it, and delete it using backspace key.
-    const block = (await getBlockElementById(browser, firstBlockId)).$('.blocklyPath');
+    const block = (await getBlockElementById(this.browser, firstBlockId)).$(
+      '.blocklyPath',
+    );
     await block.click();
-    await browser.keys([Key.Backspace]);
-    await browser.pause(pauseLength);
+    await this.browser.keys([Key.Backspace]);
+    await this.browser.pause(pauseLength);
     // Undo
-    await browser.keys([Key.Ctrl, 'Z']);
-    const after = await getAllBlocks(this.browser).length;
-    chai.assert.equal(before, after, 'Expected there to be the original number of blocks after undoing a delete');
+    await this.browser.keys([Key.Ctrl, 'Z']);
+    const after = (await getAllBlocks(this.browser)).length;
+    chai.assert.equal(
+      before,
+      after,
+      'Expected there to be the original number of blocks after undoing a delete',
+    );
   });
 
   test('Redo block deletion', async function () {
-    const before = await getAllBlocks(this.browser).length;
+    const before = (await getAllBlocks(this.browser)).length;
     // Get first print block, click to select it, and delete it using backspace key.
-    const block = (await getBlockElementById(browser, firstBlockId)).$('.blocklyPath');
+    const block = (await getBlockElementById(this.browser, firstBlockId)).$(
+      '.blocklyPath',
+    );
     await block.click();
-    await browser.keys([Key.Backspace]);
-    await browser.pause(pauseLength);
+    await this.browser.keys([Key.Backspace]);
+    await this.browser.pause(pauseLength);
     // Undo
-    await browser.keys([Key.Ctrl, 'Z']);
-    await browser.pause(pauseLength);
+    await this.browser.keys([Key.Ctrl, 'Z']);
+    await this.browser.pause(pauseLength);
     // Redo
-    await browser.keys([Key.Ctrl, Key.Shift, 'Z']);
-    await browser.pause(pauseLength);
-    const after = await getAllBlocks(this.browser).length;
-    chai.assert.equal(before-2, after, 'Expected there to be fewer blocks after undoing and redoing a delete');
-  });
-  
-
-  // Teardown entire suite after test are done running
-  suiteTeardown(async function () {
-    await browser.deleteSession();
+    await this.browser.keys([Key.Ctrl, Key.Shift, 'Z']);
+    await this.browser.pause(pauseLength);
+    const after = (await getAllBlocks(this.browser)).length;
+    chai.assert.equal(
+      before - 2,
+      after,
+      'Expected there to be fewer blocks after undoing and redoing a delete',
+    );
   });
 });

--- a/tests/browser/test/delete_blocks_test.js
+++ b/tests/browser/test/delete_blocks_test.js
@@ -1,0 +1,182 @@
+const chai = require('chai');
+const {testSetup, testFileLocations, getBlockTypeFromCategory, getSelectedBlockElement, getBlockTypeFromWorkspace, getAllBlocks, getBlockElementById, contextMenuSelect} = require('./test_setup');
+const {Key} = require('webdriverio');
+
+let browser;
+const firstBlockId = "/q5Q_1$kf`gSEFU9C7vK"
+const startBlocks = {
+  "blocks": {
+    "languageVersion": 0,
+    "blocks": [
+      {
+        "type": "text_print",
+        "id": firstBlockId,
+        "x": 63,
+        "y": 88,
+        "inputs": {
+          "TEXT": {
+            "shadow": {
+              "type": "text",
+              "id": "]2?G%L#p9Vgca{zd6#JB",
+              "fields": {
+                "TEXT": "1"
+              }
+            }
+          }
+        },
+        "next": {
+          "block": {
+            "type": "text_print",
+            "id": "FyV$;[AN7G5frPOrpXg@",
+            "inputs": {
+              "TEXT": {
+                "shadow": {
+                  "type": "text",
+                  "id": "3q[_v5rA3sl/Vw$*:jGp",
+                  "fields": {
+                    "TEXT": "2"
+                  }
+                },
+                "block": {
+                  "type": "text_trim",
+                  "id": "o1O*0%]Vq-4/Nh}2j|wF",
+                  "fields": {
+                    "MODE": "BOTH"
+                  },
+                  "inputs": {
+                    "TEXT": {
+                      "shadow": {
+                        "type": "text",
+                        "id": "A878E^l0J%Hm3iu,j3eV",
+                        "fields": {
+                          "TEXT": "abc"
+                        }
+                      },
+                      "block": {
+                        "type": "text",
+                        "id": "Bma#)g!^Nm_TMHry#ve}",
+                        "fields": {
+                          "TEXT": "hello"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "next": {
+              "block": {
+                "type": "text_print",
+                "id": "{s3Ci:xp;NCsV0(_9ofD",
+                "inputs": {
+                  "TEXT": {
+                    "shadow": {
+                      "type": "text",
+                      "id": "_zw:|_*p~3itPhy#O*4I",
+                      "fields": {
+                        "TEXT": "3"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    ]
+  }
+};
+const pauseLength = 20;
+
+suite('Delete blocks', function (done) {
+  // Setting timeout to unlimited as the webdriver takes a longer time to run than most mocha test
+  this.timeout(0);
+
+  // Setup Selenium for all of the tests
+  suiteSetup(async function () {
+    browser = await testSetup(testFileLocations.playground);
+  });
+
+  // Clear the workspace and load the start blocks before each test
+  setup(async function() {
+    await browser.execute(() => {
+      // Clear the workspace manually so we can ensure it's clear before moving on to the next test.
+      Blockly.getMainWorkspace().clear();
+    });
+    // Wait for the workspace to be cleared of blocks (no blocks found on main workspace)
+    await browser.$('.blocklySvg .blocklyWorkspace > .blocklyBlockCanvas > .blocklyDraggable').waitForExist({timeout: 2000, reverse: true});
+
+    // Load the start blocks
+    await browser.execute((blocks) => {
+      Blockly.serialization.workspaces.load(blocks, Blockly.getMainWorkspace());
+    }, startBlocks);
+    // Wait for there to be a block on the main workspace before continuing
+    (await getBlockElementById(browser, firstBlockId)).waitForExist({timeout: 2000});
+  });
+
+  test('Delete block using backspace key', async function () {
+    const before = await getAllBlocks(this.browser).length;
+    // Get first print block, click to select it, and delete it using backspace key.
+    const block = (await getBlockElementById(browser, firstBlockId)).$('.blocklyPath');
+    await block.click();
+    await browser.keys([Key.Backspace]);
+    const after = await getAllBlocks(this.browser).length;
+    chai.assert.equal(before-2, after, 'Expected there to be two fewer blocks after deletion of block and shadow');
+  });
+
+  test('Delete block using delete key', async function () {
+    const before = await getAllBlocks(this.browser).length;
+    // Get first print block, click to select it, and delete it using delete key.
+    const block = (await getBlockElementById(browser, firstBlockId)).$('.blocklyPath');
+    await block.click();
+    await browser.keys([Key.Delete]);
+    const after = await getAllBlocks(this.browser).length;
+    chai.assert.equal(before-2, after, 'Expected there to be two fewer blocks after deletion of block and shadow');
+  });
+
+  test('Delete block using context menu', async function () {
+    const before = await getAllBlocks(this.browser).length;
+    // Get first print block, click to select it, and delete it using context menu.
+    const block = (await getBlockElementById(browser, firstBlockId)).$('.blocklyPath');
+    await contextMenuSelect(browser, block, 'Delete 2 Blocks');
+    const after = await getAllBlocks(this.browser).length;
+    chai.assert.equal(before-2, after, 'Expected there to be two fewer blocks after deletion of block and shadow');
+  });
+
+  test('Undo block deletion', async function () {
+    const before = await getAllBlocks(this.browser).length;
+    // Get first print block, click to select it, and delete it using backspace key.
+    const block = (await getBlockElementById(browser, firstBlockId)).$('.blocklyPath');
+    await block.click();
+    await browser.keys([Key.Backspace]);
+    await browser.pause(pauseLength);
+    // Undo
+    await browser.keys([Key.Ctrl, 'Z']);
+    const after = await getAllBlocks(this.browser).length;
+    chai.assert.equal(before, after, 'Expected there to be the original number of blocks after undoing a delete');
+  });
+
+  test('Redo block deletion', async function () {
+    const before = await getAllBlocks(this.browser).length;
+    // Get first print block, click to select it, and delete it using backspace key.
+    const block = (await getBlockElementById(browser, firstBlockId)).$('.blocklyPath');
+    await block.click();
+    await browser.keys([Key.Backspace]);
+    await browser.pause(pauseLength);
+    // Undo
+    await browser.keys([Key.Ctrl, 'Z']);
+    await browser.pause(pauseLength);
+    // Redo
+    await browser.keys([Key.Ctrl, Key.Shift, 'Z']);
+    await browser.pause(pauseLength);
+    const after = await getAllBlocks(this.browser).length;
+    chai.assert.equal(before-2, after, 'Expected there to be fewer blocks after undoing and redoing a delete');
+  });
+  
+
+  // Teardown entire suite after test are done running
+  suiteTeardown(async function () {
+    await browser.deleteSession();
+  });
+});


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [x] I ran `npm run format` and `npm run lint`

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #7275 

### Proposed Changes

Adds basic tests for deleting blocks in various ways.
Adds a helper to get the number of blocks on the workspace since this is a common metric used for assertions.

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage

Future tests include checking the heal stack behavior, deleting blocks that are on top of a shadow block, etc. I designed the start blocks with these cases in mind.

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

I used different start blocks than noted in the testing doc because the c-shaped blocks were giving me a headache, and they were a lot more complicated than they needed to be for this set of tests.
