### PR TITLE
fix: add compose and decompose errors to mutator icon

### DIFF
--- a/core/icons/mutator_icon.ts
+++ b/core/icons/mutator_icon.ts
@@ -227,7 +227,11 @@ export class MutatorIcon extends Icon implements IHasBubble {
 
   /** Decomposes the source block to create blocks in the mini workspace. */
   private createRootBlock() {
-    this.rootBlock = this.sourceBlock.decompose!(
+    if (!this.sourceBlock.decompose) {
+      throw new Error(
+          'Blocks with mutator icons must include a decompose method');
+    }
+    this.rootBlock = this.sourceBlock.decompose(
       this.miniWorkspaceBubble!.getWorkspace()
     )!;
 
@@ -290,12 +294,16 @@ export class MutatorIcon extends Icon implements IHasBubble {
   /** Recomposes the source block based on changes to the mini workspace. */
   private recomposeSourceBlock() {
     if (!this.rootBlock) return;
+    if (!this.sourceBlock.compose) {
+      throw new Error(
+          'Blocks with mutator icons must include a compose method');
+    }
 
     const existingGroup = eventUtils.getGroup();
     if (!existingGroup) eventUtils.setGroup(true);
 
     const oldExtraState = BlockChange.getExtraBlockState_(this.sourceBlock);
-    this.sourceBlock.compose!(this.rootBlock);
+    this.sourceBlock.compose(this.rootBlock);
     const newExtraState = BlockChange.getExtraBlockState_(this.sourceBlock);
 
     if (oldExtraState !== newExtraState) {

--- a/core/icons/mutator_icon.ts
+++ b/core/icons/mutator_icon.ts
@@ -229,7 +229,8 @@ export class MutatorIcon extends Icon implements IHasBubble {
   private createRootBlock() {
     if (!this.sourceBlock.decompose) {
       throw new Error(
-          'Blocks with mutator icons must include a decompose method');
+        'Blocks with mutator icons must include a decompose method'
+      );
     }
     this.rootBlock = this.sourceBlock.decompose(
       this.miniWorkspaceBubble!.getWorkspace()
@@ -296,7 +297,8 @@ export class MutatorIcon extends Icon implements IHasBubble {
     if (!this.rootBlock) return;
     if (!this.sourceBlock.compose) {
       throw new Error(
-          'Blocks with mutator icons must include a compose method');
+        'Blocks with mutator icons must include a compose method'
+      );
     }
 
     const existingGroup = eventUtils.getGroup();


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [X] I ran `npm run format` and `npm run lint`

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes https://github.com/google/blockly/issues/7288

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
Adds clearer error throwing to the mutator. Throws if necessary methods do not exist.

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->
N/A Can add unit tests if desired.

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->
N/A

### Additional Information

<!-- Anything else we should know? -->
N/A
