### PR TITLE
fix: have icons use the new render management system

### DIFF
--- a/core/block_svg.ts
+++ b/core/block_svg.ts
@@ -59,7 +59,7 @@ import * as svgMath from './utils/svg_math.js';
 import {WarningIcon} from './icons/warning_icon.js';
 import type {Workspace} from './workspace.js';
 import type {WorkspaceSvg} from './workspace_svg.js';
-import {queueRender} from './render_management.js';
+import * as renderManagement from './render_management.js';
 import * as deprecation from './utils/deprecation.js';
 import {IconType} from './icons/icon_types.js';
 
@@ -983,8 +983,8 @@ export class BlockSvg
       icon.initView(this.createIconPointerDownListener(icon));
       icon.applyColour();
       icon.updateEditable();
-      // TODO: Change this based on #7068.
-      this.render();
+      this.queueRender();
+      renderManagement.triggerQueuedRenders();
       this.bumpNeighbours();
     }
 
@@ -1012,8 +1012,8 @@ export class BlockSvg
     if (type.equals(MutatorIcon.TYPE)) this.mutator = null;
 
     if (this.rendered) {
-      // TODO: Change this based on #7068.
-      this.render();
+      this.queueRender();
+      renderManagement.triggerQueuedRenders();
       this.bumpNeighbours();
     }
     return removed;
@@ -1542,7 +1542,7 @@ export class BlockSvg
    * @internal
    */
   queueRender(): Promise<void> {
-    return queueRender(this);
+    return renderManagement.queueRender(this);
   }
 
   /**

--- a/tests/mocha/block_test.js
+++ b/tests/mocha/block_test.js
@@ -1468,7 +1468,7 @@ suite('Blocks', function () {
         this.block = this.workspace.newBlock('stack_block');
         this.block.initSvg();
         this.block.render();
-        this.renderSpy = sinon.spy(this.block, 'render');
+        this.renderSpy = sinon.spy(this.block, 'queueRender');
       });
 
       teardown(function () {
@@ -1513,7 +1513,7 @@ suite('Blocks', function () {
         this.block = this.workspace.newBlock('stack_block');
         this.block.initSvg();
         this.block.render();
-        this.renderSpy = sinon.spy(this.block, 'render');
+        this.renderSpy = sinon.spy(this.block, 'queueRender');
       });
 
       teardown(function () {


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [X] I ran `npm run format` and `npm run lint`

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Work on #7068 

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
1) Adds a new method to the render management system to immediately trigger any queued renders. This should only be used in cases where it's necessary for backwards compatibility (like this one).
2) Switches icon methods over to use the render management system (with the immediate trigger).
3) Adds dummy promises to the return value of all `setBubbleVisible` methods.

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
1) We need adding icons to trigger a render immediately so that if the bubbles are set to be visible immediately, they are positioned correctly. Eventually we want to move this to be promises-based (so setting the visibility will wait for any queued renders to finish first). But that is a breaking change.
2) This gets us one step closer to tearing out the old render management system.
3) This makes it easier for external devs to transition to the new promises based system.

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->

All tests pass! Also quickly tested `block.setCommentText('test'); block.getIcon('comment').setBubbleVisible(true);` in the browser console to reassure myself that it was indeed working.