### PR TITLE
fix: Correct errors in `HSV_SATURATION`, `HSV_VALUE` accessors

### DIFF
--- a/core/main.js
+++ b/core/main.js
@@ -32,8 +32,8 @@ Object.defineProperties(Blockly, {
    * Must be in the range of 0 (inclusive) to 1 (exclusive).
    * @name Blockly.HSV_SATURATION
    * @type {number}
-   * @deprecated Use Blockly.colour.getHsvSaturation() / .setHsvSaturation(
-   *     instead.  (July 2023)
+   * @deprecated Use Blockly.utils.colour.getHsvSaturation() /
+   *     .setHsvSaturation() instead.  (July 2023)
    * @suppress {checkTypes}
    */
   HSV_SATURATION: {
@@ -42,7 +42,7 @@ Object.defineProperties(Blockly, {
         'Blockly.HSV_SATURATION',
         'version 10',
         'version 11',
-        'Blockly.colour.getHsvSaturation()'
+        'Blockly.utils.colour.getHsvSaturation()'
       );
       return colour.getHsvSaturation();
     },
@@ -51,7 +51,7 @@ Object.defineProperties(Blockly, {
         'Blockly.HSV_SATURATION',
         'version 10',
         'version 11',
-        'Blockly.colour.setHsvSaturation()'
+        'Blockly.utils.colour.setHsvSaturation()'
       );
       colour.setHsvSaturation(newValue);
     },
@@ -61,7 +61,7 @@ Object.defineProperties(Blockly, {
    * Must be in the range of 0 (inclusive) to 1 (exclusive).
    * @name Blockly.HSV_VALUE
    * @type {number}
-   * @deprecated Use Blockly.colour.getHsvValue() / .setHsvValue instead.
+   * @deprecated Use Blockly.utils.colour.getHsvValue() / .setHsvValue instead.
    *     (July 2023)
    * @suppress {checkTypes}
    */
@@ -71,7 +71,7 @@ Object.defineProperties(Blockly, {
         'Blockly.HSV_VALUE',
         'version 10',
         'version 11',
-        'Blockly.colour.getHsvValue()'
+        'Blockly.utils.colour.getHsvValue()'
       );
       return colour.getHsvValue();
     },
@@ -80,7 +80,7 @@ Object.defineProperties(Blockly, {
         'Blockly.HSV_VALUE',
         'version 10',
         'version 11',
-        'Blockly.colour.setHsvValue()'
+        'Blockly.utils.colour.setHsvValue()'
       );
       colour.setHsvValue(newValue);
     },

--- a/scripts/migration/renamings.json5
+++ b/scripts/migration/renamings.json5
@@ -1577,5 +1577,23 @@
     },
   ],
 
+  '10.0.1': [
+    {
+      oldName: 'Blockly',
+      exports: {
+        HSV_SATURATION: {
+          newModule: 'Blockly.utils.colour',
+          getMethod: 'getHsvSaturation',
+          setMethod: 'setHsvSaturation',
+        },
+        HSV_VALUE: {
+          newModule: 'Blockly.utils.colour',
+          getMethod: 'getHsvValue',
+          setMethod: 'setHsvValue',
+        },
+      },
+    },
+  ],
+
   'develop': [],
 }


### PR DESCRIPTION
## The basics

- [X] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [X] I ran `npm run format` and `npm run lint`

## The details
### Resolves

Fixes [error noted in comment on #7249](https://github.com/google/blockly/pull/7249#issuecomment-1638645810).

### Proposed Changes

* Change `Blockly.colour.*` to `Blockly.utils.colour.*` in `core/main.js`.
* Add entries to `scripts/migration/renamings.json5` for `HSV_SATURATION` and `HSV_VALUE`

#### Behaviour Before Change

Accessors worked correctly but deprecation messages were misleading.

#### Behaviour After Change

Accessors work and produce less misleading deprecation messages.

### Reason for Changes

It's not nice to confuse people.

It's nice to make developer's lives easier.

### Additional Information

This change should be cherry-picked into the next patch release.