### PR TITLE
release: merge master back into develop for v10.0.2 release

### DIFF
--- a/core/generator.ts
+++ b/core/generator.ts
@@ -49,7 +49,7 @@ export class CodeGenerator {
    * legitimately appear in a function definition (or comment), and it must
    * not confuse the regular expression parser.
    */
-  protected FUNCTION_NAME_PLACEHOLDER_ = '{leCUI8hutHZI4480Dc}';
+  FUNCTION_NAME_PLACEHOLDER_ = '{leCUI8hutHZI4480Dc}';
   FUNCTION_NAME_PLACEHOLDER_REGEXP_: RegExp;
 
   /**
@@ -471,10 +471,7 @@ export class CodeGenerator {
    * @returns The actual name of the new function.  This may differ from
    *     desiredName if the former has already been taken by the user.
    */
-  protected provideFunction_(
-    desiredName: string,
-    code: string[] | string
-  ): string {
+  provideFunction_(desiredName: string, code: string[] | string): string {
     if (!this.definitions_[desiredName]) {
       const functionName = this.nameDB_!.getDistinctName(
         desiredName,

--- a/core/main.js
+++ b/core/main.js
@@ -32,8 +32,8 @@ Object.defineProperties(Blockly, {
    * Must be in the range of 0 (inclusive) to 1 (exclusive).
    * @name Blockly.HSV_SATURATION
    * @type {number}
-   * @deprecated Use Blockly.colour.getHsvSaturation() / .setHsvSaturation(
-   *     instead.  (July 2023)
+   * @deprecated Use Blockly.utils.colour.getHsvSaturation() /
+   *     .setHsvSaturation() instead.  (July 2023)
    * @suppress {checkTypes}
    */
   HSV_SATURATION: {
@@ -42,7 +42,7 @@ Object.defineProperties(Blockly, {
         'Blockly.HSV_SATURATION',
         'version 10',
         'version 11',
-        'Blockly.colour.getHsvSaturation()'
+        'Blockly.utils.colour.getHsvSaturation()'
       );
       return colour.getHsvSaturation();
     },
@@ -51,7 +51,7 @@ Object.defineProperties(Blockly, {
         'Blockly.HSV_SATURATION',
         'version 10',
         'version 11',
-        'Blockly.colour.setHsvSaturation()'
+        'Blockly.utils.colour.setHsvSaturation()'
       );
       colour.setHsvSaturation(newValue);
     },
@@ -61,7 +61,7 @@ Object.defineProperties(Blockly, {
    * Must be in the range of 0 (inclusive) to 1 (exclusive).
    * @name Blockly.HSV_VALUE
    * @type {number}
-   * @deprecated Use Blockly.colour.getHsvValue() / .setHsvValue instead.
+   * @deprecated Use Blockly.utils.colour.getHsvValue() / .setHsvValue instead.
    *     (July 2023)
    * @suppress {checkTypes}
    */
@@ -71,7 +71,7 @@ Object.defineProperties(Blockly, {
         'Blockly.HSV_VALUE',
         'version 10',
         'version 11',
-        'Blockly.colour.getHsvValue()'
+        'Blockly.utils.colour.getHsvValue()'
       );
       return colour.getHsvValue();
     },
@@ -80,7 +80,7 @@ Object.defineProperties(Blockly, {
         'Blockly.HSV_VALUE',
         'version 10',
         'version 11',
-        'Blockly.colour.setHsvValue()'
+        'Blockly.utils.colour.setHsvValue()'
       );
       colour.setHsvValue(newValue);
     },

--- a/generators/python/python_generator.js
+++ b/generators/python/python_generator.js
@@ -72,7 +72,7 @@ export class PythonGenerator extends CodeGenerator {
     // (foo.bar)() -> foo.bar()
     // (foo[0])() -> foo[0]()
     [Order.MEMBER, Order.FUNCTION_CALL],
-  
+
     // not (not foo) -> not not foo
     [Order.LOGICAL_NOT, Order.LOGICAL_NOT],
     // a and (b and c) -> a and b and c
@@ -80,7 +80,7 @@ export class PythonGenerator extends CodeGenerator {
     // a or (b or c) -> a or b or c
     [Order.LOGICAL_OR, Order.LOGICAL_OR]
   ];
-  
+
   constructor(name) {
     super(name ?? 'Python');
     this.isInitialized = false;
@@ -143,7 +143,7 @@ export class PythonGenerator extends CodeGenerator {
       'vars,xrange,zip'
     );
   }
-  
+
   /**
    * Initialise the database of variable names.
    * @param {!Workspace} workspace Workspace to generate code from.
@@ -151,22 +151,22 @@ export class PythonGenerator extends CodeGenerator {
    */
   init(workspace) {
     super.init(workspace);
-  
+
     /**
      * Empty loops or conditionals are not allowed in Python.
      */
     this.PASS = this.INDENT + 'pass\n';
-  
+
     if (!this.nameDB_) {
       this.nameDB_ = new Names(this.RESERVED_WORDS_);
     } else {
       this.nameDB_.reset();
     }
-  
+
     this.nameDB_.setVariableMap(workspace.getVariableMap());
     this.nameDB_.populateVariables(workspace);
     this.nameDB_.populateProcedures(workspace);
-  
+
     const defvars = [];
     // Add developer variables (not created or named by the user).
     const devVarList = Variables.allDeveloperVariables(workspace);
@@ -175,7 +175,7 @@ export class PythonGenerator extends CodeGenerator {
           this.nameDB_.getName(devVarList[i], Names.DEVELOPER_VARIABLE_TYPE) +
           ' = None');
     }
-  
+
     // Add user variables, but only ones that are being used.
     const variables = Variables.allUsedVarModels(workspace);
     for (let i = 0; i < variables.length; i++) {
@@ -183,11 +183,11 @@ export class PythonGenerator extends CodeGenerator {
           this.nameDB_.getName(variables[i].getId(), NameType.VARIABLE) +
           ' = None');
     }
-  
+
     this.definitions_['variables'] = defvars.join('\n');
     this.isInitialized = true;
   }
-  
+
   /**
    * Prepend the generated code with import statements and variable definitions.
    * @param {string} code Generated code.
@@ -208,12 +208,12 @@ export class PythonGenerator extends CodeGenerator {
     // Call Blockly.CodeGenerator's finish.
     code = super.finish(code);
     this.isInitialized = false;
-  
+
     this.nameDB_.reset();
     const allDefs = imports.join('\n') + '\n\n' + definitions.join('\n\n');
     return allDefs.replace(/\n\n+/g, '\n\n').replace(/\n*$/, '\n\n\n') + code;
   }
-  
+
   /**
    * Naked values are top-level blocks with outputs that aren't plugged into
    * anything.
@@ -223,7 +223,7 @@ export class PythonGenerator extends CodeGenerator {
   scrubNakedValue(line) {
     return line + '\n';
   }
-  
+
   /**
    * Encode a string as a properly escaped Python string, complete with quotes.
    * @param {string} string Text to encode.
@@ -232,7 +232,7 @@ export class PythonGenerator extends CodeGenerator {
    */
   quote_(string) {
     string = string.replace(/\\/g, '\\\\').replace(/\n/g, '\\\n');
-  
+
     // Follow the CPython behaviour of repr() for a non-byte string.
     let quote = '\'';
     if (string.indexOf('\'') !== -1) {
@@ -244,7 +244,7 @@ export class PythonGenerator extends CodeGenerator {
     }
     return quote + string + quote;
   }
-  
+
   /**
    * Encode a string as a properly escaped multiline Python string, complete
    * with quotes.
@@ -258,7 +258,7 @@ export class PythonGenerator extends CodeGenerator {
     // + '\n' +
     return lines.join(' + \'\\n\' + \n');
   }
-  
+
   /**
    * Common tasks for generating Python from blocks.
    * Handles comments for the specified block and any connected value blocks.
@@ -297,7 +297,7 @@ export class PythonGenerator extends CodeGenerator {
     const nextCode = opt_thisOnly ? '' : this.blockToCode(nextBlock);
     return commentCode + code + nextCode;
   }
-  
+
   /**
    * Gets a property and adjusts the value, taking into account indexing.
    * If a static int, casts to an integer, otherwise returns a code string.
@@ -315,7 +315,7 @@ export class PythonGenerator extends CodeGenerator {
     const defaultAtIndex = block.workspace.options.oneBasedIndex ? '1' : '0';
     const atOrder = delta ? this.ORDER_ADDITIVE : this.ORDER_NONE;
     let at = this.valueToCode(block, atId, atOrder) || defaultAtIndex;
-  
+
     if (stringUtils.isNumber(at)) {
       // If the index is a naked number, adjust it right now.
       at = parseInt(at, 10) + delta;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "blockly",
-  "version": "10.0.1",
+  "version": "10.0.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "blockly",
-      "version": "10.0.1",
+      "version": "10.0.2",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blockly",
-  "version": "10.0.1",
+  "version": "10.0.2",
   "description": "Blockly is a library for building visual programming editors.",
   "keywords": [
     "blockly"

--- a/scripts/migration/renamings.json5
+++ b/scripts/migration/renamings.json5
@@ -1577,5 +1577,23 @@
     },
   ],
 
+  '10.0.1': [
+    {
+      oldName: 'Blockly',
+      exports: {
+        HSV_SATURATION: {
+          newModule: 'Blockly.utils.colour',
+          getMethod: 'getHsvSaturation',
+          setMethod: 'setHsvSaturation',
+        },
+        HSV_VALUE: {
+          newModule: 'Blockly.utils.colour',
+          getMethod: 'getHsvValue',
+          setMethod: 'setHsvValue',
+        },
+      },
+    },
+  ],
+
   'develop': [],
 }

--- a/typings/dart.d.ts
+++ b/typings/dart.d.ts
@@ -4,4 +4,25 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+export enum Order {
+  ATOMIC = 0,         // 0 "" ...
+  UNARY_POSTFIX = 1,  // expr++ expr-- () [] . ?.
+  UNARY_PREFIX = 2,   // -expr !expr ~expr ++expr --expr
+  MULTIPLICATIVE = 3, // * / % ~/
+  ADDITIVE = 4,       // + -
+  SHIFT = 5,          // << >>
+  BITWISE_AND = 6,    // &
+  BITWISE_XOR = 7,    // ^
+  BITWISE_OR = 8,     // |
+  RELATIONAL = 9,     // >= > <= < as is is!
+  EQUALITY = 10,      // == !=
+  LOGICAL_AND = 11,   // &&
+  LOGICAL_OR = 12,    // ||
+  IF_NULL = 13,       // ??
+  CONDITIONAL = 14,   // expr ? expr : expr
+  CASCADE = 15,       // ..
+  ASSIGNMENT = 16,    // = *= /= ~/= %= += -= <<= >>= &= ^= |=
+  NONE = 99,          // (...)
+}
+
 export declare const dartGenerator: any;

--- a/typings/javascript.d.ts
+++ b/typings/javascript.d.ts
@@ -4,4 +4,42 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+export enum Order {
+  ATOMIC = 0,            // 0 "" ...
+  NEW = 1.1,             // new
+  MEMBER = 1.2,          // . []
+  FUNCTION_CALL = 2,     // ()
+  INCREMENT = 3,         // ++
+  DECREMENT = 3,         // --
+  BITWISE_NOT = 4.1,     // ~
+  UNARY_PLUS = 4.2,      // +
+  UNARY_NEGATION = 4.3,  // -
+  LOGICAL_NOT = 4.4,     // !
+  TYPEOF = 4.5,          // typeof
+  VOID = 4.6,            // void
+  DELETE = 4.7,          // delete
+  AWAIT = 4.8,           // await
+  EXPONENTIATION = 5.0,  // **
+  MULTIPLICATION = 5.1,  // *
+  DIVISION = 5.2,        // /
+  MODULUS = 5.3,         // %
+  SUBTRACTION = 6.1,     // -
+  ADDITION = 6.2,        // +
+  BITWISE_SHIFT = 7,     // << >> >>>
+  RELATIONAL = 8,        // < <= > >=
+  IN = 8,                // in
+  INSTANCEOF = 8,        // instanceof
+  EQUALITY = 9,          // == != === !==
+  BITWISE_AND = 10,      // &
+  BITWISE_XOR = 11,      // ^
+  BITWISE_OR = 12,       // |
+  LOGICAL_AND = 13,      // &&
+  LOGICAL_OR = 14,       // ||
+  CONDITIONAL = 15,      // ?:
+  ASSIGNMENT = 16,       // = += -= **= *= /= %= <<= >>= ...
+  YIELD = 17,            // yield
+  COMMA = 18,            // ,
+  NONE = 99,             // (...)
+}
+
 export declare const javascriptGenerator: any;

--- a/typings/lua.d.ts
+++ b/typings/lua.d.ts
@@ -4,4 +4,19 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+export enum Order {
+  ATOMIC = 0,    // literals
+  // The next level was not explicit in documentation and inferred by Ellen.
+  HIGH = 1,            // Function calls, tables[]
+  EXPONENTIATION = 2,  // ^
+  UNARY = 3,           // not # - ~
+  MULTIPLICATIVE = 4,  // * / %
+  ADDITIVE = 5,        // + -
+  CONCATENATION = 6,   // ..
+  RELATIONAL = 7,      // < > <=  >= ~= ==
+  AND = 8,             // and
+  OR = 9,              // or
+  NONE = 99,
+}
+
 export declare const luaGenerator: any;

--- a/typings/php.d.ts
+++ b/typings/php.d.ts
@@ -4,4 +4,44 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+export enum Order {
+  ATOMIC = 0,             // 0 "" ...
+  CLONE = 1,              // clone
+  NEW = 1,                // new
+  MEMBER = 2.1,           // []
+  FUNCTION_CALL = 2.2,    // ()
+  POWER = 3,              // **
+  INCREMENT = 4,          // ++
+  DECREMENT = 4,          // --
+  BITWISE_NOT = 4,        // ~
+  CAST = 4,               // (int) (float) (string) (array) ...
+  SUPPRESS_ERROR = 4,     // @
+  INSTANCEOF = 5,         // instanceof
+  LOGICAL_NOT = 6,        // !
+  UNARY_PLUS = 7.1,       // +
+  UNARY_NEGATION = 7.2,   // -
+  MULTIPLICATION = 8.1,   // *
+  DIVISION = 8.2,         // /
+  MODULUS = 8.3,          // %
+  ADDITION = 9.1,         // +
+  SUBTRACTION = 9.2,      // -
+  STRING_CONCAT = 9.3,    // .
+  BITWISE_SHIFT = 10,     // << >>
+  RELATIONAL = 11,        // < <= > >=
+  EQUALITY = 12,          // == != === !== <> <=>
+  REFERENCE = 13,         // &
+  BITWISE_AND = 13,       // &
+  BITWISE_XOR = 14,       // ^
+  BITWISE_OR = 15,        // |
+  LOGICAL_AND = 16,       // &&
+  LOGICAL_OR = 17,        // ||
+  IF_NULL = 18,           // ??
+  CONDITIONAL = 19,       // ?:
+  ASSIGNMENT = 20,        // = += -= *= /= %= <<= >>= ...
+  LOGICAL_AND_WEAK = 21,  // and
+  LOGICAL_XOR = 22,       // xor
+  LOGICAL_OR_WEAK = 23,   // or
+  NONE = 99,              // (...)
+}
+
 export declare const phpGenerator: any;

--- a/typings/python.d.ts
+++ b/typings/python.d.ts
@@ -4,4 +4,28 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+export enum Order {
+  ATOMIC = 0,             // 0 "" ...
+  COLLECTION = 1,         // tuples, lists, dictionaries
+  STRING_CONVERSION = 1,  // `expression...`
+  MEMBER = 2.1,           // . []
+  FUNCTION_CALL = 2.2,    // ()
+  EXPONENTIATION = 3,     // **
+  UNARY_SIGN = 4,         // + -
+  BITWISE_NOT = 4,        // ~
+  MULTIPLICATIVE = 5,     // * / // %
+  ADDITIVE = 6,           // + -
+  BITWISE_SHIFT = 7,      // << >>
+  BITWISE_AND = 8,        // &
+  BITWISE_XOR = 9,        // ^
+  BITWISE_OR = 10,        // |
+  RELATIONAL = 11,        // in, not in, is, is not, >, >=, <>, !=, ==
+  LOGICAL_NOT = 12,       // not
+  LOGICAL_AND = 13,       // and
+  LOGICAL_OR = 14,        // or
+  CONDITIONAL = 15,       // if else
+  LAMBDA = 16,            // lambda
+  NONE = 99,              // (...)
+}
+
 export declare const pythonGenerator: any;


### PR DESCRIPTION
* fix(generators): Changes to exports and access controls for TypeScript compatibility (#7295)

* fix(generators): Add missing declarations for Order enums

* chore(generators): Remove spurious whitespace

* fix(generators): Make provideFunction_ etc. public

  Remove the protected declaration on provideFunction_ and
  FUNCTION_NAME_PLACEHOLDER_ so they can be used from generator
  functions written in TypeScript.

  Not strictly part of #7283, but closely related and required to
  fixing the related issue google/blockly-samples#1785.

* chore(generators): format

(cherry picked from commit d503fbb409e58d80a3a4db89ec603532505e8663)

* fix: Correct errors in `HSV_SATURATION`, `HSV_VALUE` accessors (#7297)

* fix: Correct errors in HSV_SATURATION, HSV_VALUE accessors

  Fix the comment / message errors noted in
  https://github.com/google/blockly/pull/7249#issuecomment-1638645810

* chore: Add renamings for HSV_SATURATION, HSV_VALUE

(cherry picked from commit 1bc4f67d78cc88c15a4e55d7d102743db1e04a4c)

* release: Update version number to 10.0.2

---------

<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [x] I ran `npm run format` and `npm run lint`
