### PR TITLE
fix: make deserialization use the new render management system

### DIFF
--- a/core/connection.ts
+++ b/core/connection.ts
@@ -648,7 +648,7 @@ export class Connection implements IASTNodeLocationWithBlock {
     }
 
     if (shadowDom) {
-      blockShadow = Xml.domToBlock(shadowDom, parentBlock.workspace);
+      blockShadow = Xml.domToBlockInternal(shadowDom, parentBlock.workspace);
       if (attemptToConnect) {
         if (this.type === ConnectionType.INPUT_VALUE) {
           if (!blockShadow.outputConnection) {

--- a/core/contextmenu.ts
+++ b/core/contextmenu.ts
@@ -235,7 +235,7 @@ export function callbackFactory(block: Block, xml: Element): () => void {
     eventUtils.disable();
     let newBlock;
     try {
-      newBlock = Xml.domToBlock(xml, block.workspace!) as BlockSvg;
+      newBlock = Xml.domToBlockInternal(xml, block.workspace!) as BlockSvg;
       // Move the new block next to the old block.
       const xy = block.getRelativeToSurfaceXY();
       if (block.RTL) {

--- a/core/flyout_base.ts
+++ b/core/flyout_base.ts
@@ -36,6 +36,7 @@ import * as Variables from './variables.js';
 import {WorkspaceSvg} from './workspace_svg.js';
 import * as utilsXml from './utils/xml.js';
 import * as Xml from './xml.js';
+import * as renderManagement from './render_management.js';
 
 enum FlyoutItemType {
   BLOCK = 'block',
@@ -626,6 +627,8 @@ export abstract class Flyout extends DeleteArea implements IFlyout {
     const parsedContent = toolbox.convertFlyoutDefToJsonArray(flyoutDef);
     const flyoutInfo = this.createFlyoutInfo(parsedContent);
 
+    renderManagement.triggerQueuedRenders();
+
     this.layout_(flyoutInfo.contents, flyoutInfo.gaps);
 
     if (this.horizontalLayout) {
@@ -770,7 +773,7 @@ export abstract class Flyout extends DeleteArea implements IFlyout {
       ) as Element;
       block = this.getRecycledBlock(xml.getAttribute('type')!);
       if (!block) {
-        block = Xml.domToBlock(xml, this.workspace_);
+        block = Xml.domToBlockInternal(xml, this.workspace_);
       }
     } else {
       block = this.getRecycledBlock(blockInfo['type']!);
@@ -779,7 +782,10 @@ export abstract class Flyout extends DeleteArea implements IFlyout {
           blockInfo['enabled'] =
             blockInfo['disabled'] !== 'true' && blockInfo['disabled'] !== true;
         }
-        block = blocks.append(blockInfo as blocks.State, this.workspace_);
+        block = blocks.appendInternal(
+          blockInfo as blocks.State,
+          this.workspace_
+        );
       }
     }
 

--- a/core/serialization/blocks.ts
+++ b/core/serialization/blocks.ts
@@ -18,6 +18,7 @@ import * as registry from '../registry.js';
 import * as utilsXml from '../utils/xml.js';
 import type {Workspace} from '../workspace.js';
 import * as Xml from '../xml.js';
+import * as renderManagement from '../render_management.js';
 
 import {
   BadConnectionCheck,
@@ -349,7 +350,9 @@ export function append(
   workspace: Workspace,
   {recordUndo = false}: {recordUndo?: boolean} = {}
 ): Block {
-  return appendInternal(state, workspace, {recordUndo});
+  const block = appendInternal(state, workspace, {recordUndo});
+  if (workspace.rendered) renderManagement.triggerQueuedRenders();
+  return block;
 }
 
 /**
@@ -701,7 +704,8 @@ function initBlock(block: Block, rendered: boolean) {
     blockSvg.setConnectionTracking(false);
 
     blockSvg.initSvg();
-    blockSvg.render(false);
+    blockSvg.queueRender();
+
     // fixes #6076 JSO deserialization doesn't
     // set .iconXY_ property so here it will be set
     for (const icon of blockSvg.getIcons()) {

--- a/core/serialization/blocks.ts
+++ b/core/serialization/blocks.ts
@@ -705,6 +705,7 @@ function initBlock(block: Block, rendered: boolean) {
 
     blockSvg.initSvg();
     blockSvg.queueRender();
+    blockSvg.updateDisabled();
 
     // fixes #6076 JSO deserialization doesn't
     // set .iconXY_ property so here it will be set

--- a/core/workspace_svg.ts
+++ b/core/workspace_svg.ts
@@ -1349,7 +1349,7 @@ export class WorkspaceSvg extends Workspace implements IASTNodeLocationSvg {
       let blockX = 0;
       let blockY = 0;
       if (xmlBlock) {
-        block = Xml.domToBlock(xmlBlock, this) as BlockSvg;
+        block = Xml.domToBlockInternal(xmlBlock, this) as BlockSvg;
         blockX = parseInt(xmlBlock.getAttribute('x') ?? '0');
         if (this.RTL) {
           blockX = -blockX;

--- a/tests/mocha/flyout_test.js
+++ b/tests/mocha/flyout_test.js
@@ -27,7 +27,7 @@ import {
 
 suite('Flyout', function () {
   setup(function () {
-    sharedTestSetup.call(this);
+    this.clock = sharedTestSetup.call(this, {fireEventsNow: false}).clock;
     Blockly.defineBlocksWithJsonArray([
       {
         'type': 'basic_block',
@@ -48,6 +48,7 @@ suite('Flyout', function () {
   });
 
   teardown(function () {
+    this.clock.runAll();
     sharedTestTeardown.call(this);
   });
 


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [X] I ran `npm run format` and `npm run lint`

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #7290 

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
Changed both the JSON and XML deserialization systems to use the render queue, but trigger an immediate render.

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
Moving both sytems to use the render queue allows us to get rid of the old render management system. But I chose to make them trigger an immediate render (instead of waiting until the end of the frame) to ensure 100% backwards compatibility.

We could have people use the `finishQueuedRenders` method if they want to calculate things based on the size/position of the blocks after deserialization. However, as we discovered last time I was reorganizing stuff, that's technically a breaking change :/ And I think deserialization is a much more high-risk area for this kind of thing! (as opposed to like, adding an input to a block).

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->
* Verified that there is no performance impact for deserialization. The spaghetti tests ran in the same amount of time before and after this change.
* Verified that copying and pasting properly renders the block.
* Verified that setting shadows programatically properly renders the block.

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->
N/A

### Additional Information

<!-- Anything else we should know? -->
N/A

Dependent on: https://github.com/google/blockly/pull/7296