### PR TITLE
fix: make insertion markers use new render management system

### DIFF
--- a/core/insertion_marker_manager.ts
+++ b/core/insertion_marker_manager.ts
@@ -25,6 +25,7 @@ import type {IDragTarget} from './interfaces/i_drag_target.js';
 import type {RenderedConnection} from './rendered_connection.js';
 import type {Coordinate} from './utils/coordinate.js';
 import type {WorkspaceSvg} from './workspace_svg.js';
+import * as renderManagement from './render_management.js';
 
 /** Represents a nearby valid connection. */
 interface CandidateConnection {
@@ -608,18 +609,17 @@ export class InsertionMarkerManager {
 
     // Render disconnected from everything else so that we have a valid
     // connection location.
-    insertionMarker.render();
-    insertionMarker.rendered = true;
-    insertionMarker.getSvgRoot().setAttribute('visibility', 'visible');
+    insertionMarker.queueRender();
+    renderManagement.triggerQueuedRenders();
 
-    if (imConn && closest) {
-      // Position so that the existing block doesn't move.
-      insertionMarker.positionNearConnection(imConn, closest);
-    }
-    if (closest) {
-      // Connect() also renders the insertion marker.
-      imConn.connect(closest);
-    }
+    // Position so that the existing block doesn't move.
+    insertionMarker.positionNearConnection(imConn, closest);
+    // Connect() also renders the insertion marker.
+    imConn.connect(closest);
+
+    renderManagement.finishQueuedRenders().then(() => {
+      insertionMarker?.getSvgRoot().setAttribute('visibility', 'visible');
+    });
 
     this.markerConnection = imConn;
   }

--- a/core/workspace_svg.ts
+++ b/core/workspace_svg.ts
@@ -77,6 +77,7 @@ import {WorkspaceCommentSvg} from './workspace_comment_svg.js';
 import * as Xml from './xml.js';
 import {ZoomControls} from './zoom_controls.js';
 import {ContextMenuOption} from './contextmenu_registry.js';
+import * as renderManagement from './render_management.js';
 
 /** Margin around the top/bottom/left/right after a zoomToFit call. */
 const ZOOM_TO_FIT_MARGIN = 20;
@@ -1251,11 +1252,13 @@ export class WorkspaceSvg extends Workspace implements IASTNodeLocationSvg {
     if (this.currentGesture_) {
       const imList = this.currentGesture_.getInsertionMarkers();
       for (let i = 0; i < imList.length; i++) {
-        imList[i].render(false);
+        imList[i].queueRender();
       }
     }
 
-    this.markerManager.updateMarkers();
+    renderManagement
+      .finishQueuedRenders()
+      .then(() => void this.markerManager.updateMarkers());
   }
 
   /**


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [X] I ran `npm run format` and `npm run lint`

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes N/A

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
Makes is so that insertion markers use the new render management system.
### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
Necessary for tearing out the ~new~ old render management system.

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->
Manually tested that insertion markers appear and look correct.

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->
N/A

### Additional Information

<!-- Anything else we should know? -->
Dependent on https://github.com/google/blockly/pull/7296
