### PR TITLE
fix: remove old `render` method

### DIFF
--- a/core/block_svg.ts
+++ b/core/block_svg.ts
@@ -1549,44 +1549,14 @@ export class BlockSvg
    * Immediately lays out and reflows a block based on its contents and
    * settings.
    *
-   * @param opt_bubble If false, just render this block.
-   *   If true, also render block's parent, grandparent, etc.  Defaults to true.
+   * @deprecated Renders are triggered automatically when the block is modified
+   *     (e.g. fields are modified or inputs are added). Any calls to render()
+   *     are no longer necessary. To be removed in v11.
    */
-  render(opt_bubble?: boolean) {
-    if (this.renderIsInProgress_) {
-      return; // Don't allow recursive renders.
-    }
-    this.renderIsInProgress_ = true;
-    try {
-      this.rendered = true;
-      dom.startTextWidthCache();
-
-      if (!this.isEnabled()) {
-        // Apply disabled styles if needed.
-        this.updateDisabled();
-      }
-
-      if (this.isCollapsed()) {
-        this.updateCollapsed_();
-      }
-      this.workspace.getRenderer().render(this);
-      this.updateConnectionAndIconLocations();
-
-      if (opt_bubble !== false) {
-        const parentBlock = this.getParent();
-        if (parentBlock) {
-          parentBlock.render(true);
-        } else {
-          // Top-most block. Fire an event to allow scrollbars to resize.
-          this.workspace.resizeContents();
-        }
-      }
-
-      dom.stopTextWidthCache();
-      this.updateMarkers_();
-    } finally {
-      this.renderIsInProgress_ = false;
-    }
+  render() {
+    deprecation.warn('Blockly.BlockSvg.prototype.render', 'v10', 'v11');
+    this.queueRender();
+    renderManagement.triggerQueuedRenders();
   }
 
   /**

--- a/core/flyout_base.ts
+++ b/core/flyout_base.ts
@@ -784,7 +784,7 @@ export abstract class Flyout extends DeleteArea implements IFlyout {
         }
         block = blocks.appendInternal(
           blockInfo as blocks.State,
-          this.workspace_
+          this.workspace_,
         );
       }
     }

--- a/core/workspace_svg.ts
+++ b/core/workspace_svg.ts
@@ -78,6 +78,7 @@ import * as Xml from './xml.js';
 import {ZoomControls} from './zoom_controls.js';
 import {ContextMenuOption} from './contextmenu_registry.js';
 import * as renderManagement from './render_management.js';
+import * as deprecation from './utils/deprecation.js';
 
 /** Margin around the top/bottom/left/right after a zoomToFit call. */
 const ZOOM_TO_FIT_MARGIN = 20;
@@ -1224,24 +1225,20 @@ export class WorkspaceSvg extends Workspace implements IASTNodeLocationSvg {
       // Currently does not support toolboxes in mutators.
       this.toolbox_.setVisible(isVisible);
     }
-    if (isVisible) {
-      const blocks = this.getAllBlocks(false);
-      // Tell each block on the workspace to mark its fields as dirty.
-      for (let i = blocks.length - 1; i >= 0; i--) {
-        blocks[i].markDirty();
-      }
-
-      this.render();
-      if (this.toolbox_) {
-        this.toolbox_.position();
-      }
-    } else {
+    if (!isVisible) {
       this.hideChaff(true);
     }
   }
 
-  /** Render all blocks in workspace. */
+  /**
+   * Render all blocks in workspace.
+   *
+   * @deprecated Renders are triggered automatically when the block is modified
+   *     (e.g. fields are modified or inputs are added). Any calls to render()
+   *     are no longer necessary. To be removed in v11.
+   */
   render() {
+    deprecation.warn('Blockly.WorkspaceSvg.prototype.render', 'v10', 'v11');
     // Generate list of all blocks.
     const blocks = this.getAllBlocks(false);
     // Render each block.

--- a/core/xml.ts
+++ b/core/xml.ts
@@ -566,7 +566,7 @@ export function domToBlock(xmlBlock: Element, workspace: Workspace): Block {
  */
 export function domToBlockInternal(
   xmlBlock: Element,
-  workspace: Workspace
+  workspace: Workspace,
 ): Block {
   // Create top-level block.
   eventUtils.disable();


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [X] I ran `npm run format` and `npm run lint`

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes N/A

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
Removes the last vestiges of the old render management system.

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
Less variants! 

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->
All tests pass. Smoke tested the playground and it looks good!

Also tested that hiding and showing the workspace works properly.

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->
N/A

### Additional Information

<!-- Anything else we should know? -->
Dependent on https://github.com/google/blockly/pull/7306 and https://github.com/google/blockly/pull/7307
