### PR TITLE
chore(tests): update generator test blocks to use forBlock

### DIFF
--- a/tests/generators/unittest_dart.js
+++ b/tests/generators/unittest_dart.js
@@ -9,7 +9,7 @@
  */
 'use strict';
 
-dartGenerator['unittest_main'] = function(block) {
+dartGenerator.forBlock['unittest_main'] = function(block) {
   // Container for unit tests.
   var resultsVar = dartGenerator.nameDB_.getName('unittestResults',
       Blockly.Names.DEVELOPER_VARIABLE_TYPE);
@@ -59,7 +59,7 @@ dartGenerator['unittest_main'] = function(block) {
   return code;
 };
 
-dartGenerator['unittest_main'].defineAssert_ = function() {
+function dartDefineAssert() {
   var resultsVar = dartGenerator.nameDB_.getName('unittestResults',
       Blockly.Names.DEVELOPER_VARIABLE_TYPE);
   var functionName = dartGenerator.provideFunction_(
@@ -96,7 +96,7 @@ dartGenerator['unittest_main'].defineAssert_ = function() {
   return functionName;
 };
 
-dartGenerator['unittest_assertequals'] = function(block) {
+dartGenerator.forBlock['unittest_assertequals'] = function(block) {
   // Asserts that a value equals another value.
   var message = dartGenerator.valueToCode(block, 'MESSAGE',
       dartGenerator.ORDER_NONE) || '';
@@ -104,11 +104,11 @@ dartGenerator['unittest_assertequals'] = function(block) {
       dartGenerator.ORDER_NONE) || 'null';
   var expected = dartGenerator.valueToCode(block, 'EXPECTED',
       dartGenerator.ORDER_NONE) || 'null';
-  return dartGenerator['unittest_main'].defineAssert_() +
+  return dartDefineAssert() +
       '(' + actual + ', ' + expected + ', ' + message + ');\n';
 };
 
-dartGenerator['unittest_assertvalue'] = function(block) {
+dartGenerator.forBlock['unittest_assertvalue'] = function(block) {
   // Asserts that a value is true, false, or null.
   var message = dartGenerator.valueToCode(block, 'MESSAGE',
       dartGenerator.ORDER_NONE) || '';
@@ -122,11 +122,11 @@ dartGenerator['unittest_assertvalue'] = function(block) {
   } else if (expected === 'NULL') {
     expected = 'null';
   }
-  return dartGenerator['unittest_main'].defineAssert_() +
+  return dartDefineAssert() +
       '(' + actual + ', ' + expected + ', ' + message + ');\n';
 };
 
-dartGenerator['unittest_fail'] = function(block) {
+dartGenerator.forBlock['unittest_fail'] = function(block) {
   // Always assert an error.
   var resultsVar = dartGenerator.nameDB_.getName('unittestResults',
       Blockly.Names.DEVELOPER_VARIABLE_TYPE);
@@ -144,7 +144,7 @@ dartGenerator['unittest_fail'] = function(block) {
   return functionName + '(' + message + ');\n';
 };
 
-dartGenerator['unittest_adjustindex'] = function(block) {
+dartGenerator.forBlock['unittest_adjustindex'] = function(block) {
   var index = dartGenerator.valueToCode(block, 'INDEX',
       dartGenerator.ORDER_ADDITIVE) || '0';
   // Adjust index if using one-based indexing.

--- a/tests/generators/unittest_javascript.js
+++ b/tests/generators/unittest_javascript.js
@@ -9,7 +9,7 @@
  */
 'use strict';
 
-javascriptGenerator['unittest_main'] = function(block) {
+javascriptGenerator.forBlock['unittest_main'] = function(block) {
   // Container for unit tests.
   var resultsVar = javascriptGenerator.nameDB_.getName('unittestResults',
       Blockly.Names.DEVELOPER_VARIABLE_TYPE);
@@ -60,7 +60,7 @@ javascriptGenerator['unittest_main'] = function(block) {
   return code;
 };
 
-javascriptGenerator['unittest_main'].defineAssert_ = function(block) {
+function javascriptDefineAssert() {
   var resultsVar = javascriptGenerator.nameDB_.getName('unittestResults',
       Blockly.Names.DEVELOPER_VARIABLE_TYPE);
   var functionName = javascriptGenerator.provideFunction_(
@@ -100,7 +100,7 @@ javascriptGenerator['unittest_main'].defineAssert_ = function(block) {
   return functionName;
 };
 
-javascriptGenerator['unittest_assertequals'] = function(block) {
+javascriptGenerator.forBlock['unittest_assertequals'] = function(block) {
   // Asserts that a value equals another value.
   var message = javascriptGenerator.valueToCode(block, 'MESSAGE',
       javascriptGenerator.ORDER_NONE) || '';
@@ -108,11 +108,11 @@ javascriptGenerator['unittest_assertequals'] = function(block) {
       javascriptGenerator.ORDER_NONE) || 'null';
   var expected = javascriptGenerator.valueToCode(block, 'EXPECTED',
       javascriptGenerator.ORDER_NONE) || 'null';
-  return javascriptGenerator['unittest_main'].defineAssert_() +
+  return javascriptDefineAssert() +
       '(' + actual + ', ' + expected + ', ' + message + ');\n';
 };
 
-javascriptGenerator['unittest_assertvalue'] = function(block) {
+javascriptGenerator.forBlock['unittest_assertvalue'] = function(block) {
   // Asserts that a value is true, false, or null.
   var message = javascriptGenerator.valueToCode(block, 'MESSAGE',
       javascriptGenerator.ORDER_NONE) || '';
@@ -126,11 +126,11 @@ javascriptGenerator['unittest_assertvalue'] = function(block) {
   } else if (expected === 'NULL') {
     expected = 'null';
   }
-  return javascriptGenerator['unittest_main'].defineAssert_() +
+  return javascriptDefineAssert() +
       '(' + actual + ', ' + expected + ', ' + message + ');\n';
 };
 
-javascriptGenerator['unittest_fail'] = function(block) {
+javascriptGenerator.forBlock['unittest_fail'] = function(block) {
   // Always assert an error.
   var resultsVar = javascriptGenerator.nameDB_.getName('unittestResults',
       Blockly.Names.DEVELOPER_VARIABLE_TYPE);
@@ -148,7 +148,7 @@ javascriptGenerator['unittest_fail'] = function(block) {
   return functionName + '(' + message + ');\n';
 };
 
-javascriptGenerator['unittest_adjustindex'] = function(block) {
+javascriptGenerator.forBlock['unittest_adjustindex'] = function(block) {
   var index = javascriptGenerator.valueToCode(block, 'INDEX',
       javascriptGenerator.ORDER_ADDITION) || '0';
   // Adjust index if using one-based indexing.

--- a/tests/generators/unittest_lua.js
+++ b/tests/generators/unittest_lua.js
@@ -9,7 +9,7 @@
  */
 'use strict';
 
-luaGenerator['unittest_main'] = function(block) {
+luaGenerator.forBlock['unittest_main'] = function(block) {
   // Container for unit tests.
   var resultsVar = luaGenerator.nameDB_.getName('unittestResults',
       Blockly.Names.DEVELOPER_VARIABLE_TYPE);
@@ -58,7 +58,7 @@ luaGenerator['unittest_main'] = function(block) {
   return code;
 };
 
-luaGenerator['unittest_main'].defineAssert_ = function(block) {
+function luaDefineAssert() {
   var resultsVar = luaGenerator.nameDB_.getName('unittestResults',
       Blockly.Names.DEVELOPER_VARIABLE_TYPE);
   var functionName = luaGenerator.provideFunction_(
@@ -106,7 +106,7 @@ luaGenerator['unittest_main'].defineAssert_ = function(block) {
   return functionName;
 };
 
-luaGenerator['unittest_assertequals'] = function(block) {
+luaGenerator.forBlock['unittest_assertequals'] = function(block) {
   // Asserts that a value equals another value.
   var message = luaGenerator.valueToCode(block, 'MESSAGE',
       luaGenerator.ORDER_NONE) || '';
@@ -114,11 +114,11 @@ luaGenerator['unittest_assertequals'] = function(block) {
       luaGenerator.ORDER_NONE) || 'nil';
   var expected = luaGenerator.valueToCode(block, 'EXPECTED',
       luaGenerator.ORDER_NONE) || 'nil';
-  return luaGenerator['unittest_main'].defineAssert_() +
+  return luaDefineAssert() +
       '(' + actual + ', ' + expected + ', ' + message + ')\n';
 };
 
-luaGenerator['unittest_assertvalue'] = function(block) {
+luaGenerator.forBlock['unittest_assertvalue'] = function(block) {
   // Asserts that a value is true, false, or null.
   var message = luaGenerator.valueToCode(block, 'MESSAGE',
       luaGenerator.ORDER_NONE) || '';
@@ -132,11 +132,11 @@ luaGenerator['unittest_assertvalue'] = function(block) {
   } else if (expected == 'NULL') {
     expected = 'nil';
   }
-  return luaGenerator.unittest_main.defineAssert_() +
+  return luaDefineAssert() +
       '(' + actual + ', ' + expected + ', ' + message + ')\n';
 };
 
-luaGenerator['unittest_fail'] = function(block) {
+luaGenerator.forBlock['unittest_fail'] = function(block) {
   // Always assert an error.
   var resultsVar = luaGenerator.nameDB_.getName('unittestResults',
       Blockly.Names.DEVELOPER_VARIABLE_TYPE);
@@ -153,7 +153,7 @@ luaGenerator['unittest_fail'] = function(block) {
   return functionName + '(' + message + ')\n';
 };
 
-luaGenerator['unittest_adjustindex'] = function(block) {
+luaGenerator.forBlock['unittest_adjustindex'] = function(block) {
   var index = luaGenerator.valueToCode(block, 'INDEX',
       luaGenerator.ORDER_ADDITIVE) || '0';
   if (Blockly.utils.string.isNumber(index)) {

--- a/tests/generators/unittest_php.js
+++ b/tests/generators/unittest_php.js
@@ -9,7 +9,7 @@
  */
 'use strict';
 
-phpGenerator['unittest_main'] = function(block) {
+phpGenerator.forBlock['unittest_main'] = function(block) {
   // Container for unit tests.
   var resultsVar = phpGenerator.nameDB_.getName('unittestResults',
       Blockly.Names.DEVELOPER_VARIABLE_TYPE);
@@ -60,7 +60,7 @@ phpGenerator['unittest_main'] = function(block) {
   return code;
 };
 
-phpGenerator['unittest_main'].defineAssert_ = function(block) {
+function phpDefineAssert() {
   var resultsVar = phpGenerator.nameDB_.getName('unittestResults',
       Blockly.Names.DEVELOPER_VARIABLE_TYPE);
   var functionName = phpGenerator.provideFunction_(
@@ -86,7 +86,7 @@ phpGenerator['unittest_main'].defineAssert_ = function(block) {
   return functionName;
 };
 
-phpGenerator['unittest_assertequals'] = function(block) {
+phpGenerator.forBlock['unittest_assertequals'] = function(block) {
   // Asserts that a value equals another value.
   var message = phpGenerator.valueToCode(block, 'MESSAGE',
     phpGenerator.ORDER_NONE) || '';
@@ -94,11 +94,11 @@ phpGenerator['unittest_assertequals'] = function(block) {
           phpGenerator.ORDER_NONE) || 'null';
   var expected = phpGenerator.valueToCode(block, 'EXPECTED',
           phpGenerator.ORDER_NONE) || 'null';
-  return phpGenerator['unittest_main'].defineAssert_() +
+  return phpDefineAssert() +
       '(' + actual + ', ' + expected + ', ' + message + ');\n';
 };
 
-phpGenerator['unittest_assertvalue'] = function(block) {
+phpGenerator.forBlock['unittest_assertvalue'] = function(block) {
   // Asserts that a value is true, false, or null.
   var message = phpGenerator.valueToCode(block, 'MESSAGE',
     phpGenerator.ORDER_NONE) || '';
@@ -112,11 +112,11 @@ phpGenerator['unittest_assertvalue'] = function(block) {
   } else if (expected == 'NULL') {
       expected = 'null';
   }
-  return phpGenerator['unittest_main'].defineAssert_() +
+  return phpDefineAssert() +
       '(' + actual + ', ' + expected + ', ' + message + ');\n';
 };
 
-phpGenerator['unittest_fail'] = function(block) {
+phpGenerator.forBlock['unittest_fail'] = function(block) {
   // Always assert an error.
   var resultsVar = phpGenerator.nameDB_.getName('unittestResults',
       Blockly.Names.DEVELOPER_VARIABLE_TYPE);
@@ -135,7 +135,7 @@ phpGenerator['unittest_fail'] = function(block) {
   return functionName + '(' + message + ');\n';
 };
 
-phpGenerator['unittest_adjustindex'] = function(block) {
+phpGenerator.forBlock['unittest_adjustindex'] = function(block) {
   var index = phpGenerator.valueToCode(block, 'INDEX',
       phpGenerator.ORDER_ADDITION) || '0';
   // Adjust index if using one-based indexing.

--- a/tests/generators/unittest_python.js
+++ b/tests/generators/unittest_python.js
@@ -9,7 +9,7 @@
  */
 'use strict';
 
-pythonGenerator['unittest_main'] = function(block) {
+pythonGenerator.forBlock['unittest_main'] = function(block) {
   // Container for unit tests.
   var resultsVar = pythonGenerator.nameDB_.getName('unittestResults',
       Blockly.Names.DEVELOPER_VARIABLE_TYPE);
@@ -56,7 +56,7 @@ pythonGenerator['unittest_main'] = function(block) {
   return code;
 };
 
-pythonGenerator['unittest_main'].defineAssert_ = function() {
+function pythonDefineAssert() {
   var resultsVar = pythonGenerator.nameDB_.getName('unittestResults',
       Blockly.Names.DEVELOPER_VARIABLE_TYPE);
   var functionName = pythonGenerator.provideFunction_(
@@ -74,7 +74,7 @@ pythonGenerator['unittest_main'].defineAssert_ = function() {
   return functionName;
 };
 
-pythonGenerator['unittest_assertequals'] = function(block) {
+pythonGenerator.forBlock['unittest_assertequals'] = function(block) {
   // Asserts that a value equals another value.
   var message = pythonGenerator.valueToCode(block, 'MESSAGE',
       pythonGenerator.ORDER_NONE) || '';
@@ -82,11 +82,11 @@ pythonGenerator['unittest_assertequals'] = function(block) {
       pythonGenerator.ORDER_NONE) || 'None';
   var expected = pythonGenerator.valueToCode(block, 'EXPECTED',
       pythonGenerator.ORDER_NONE) || 'None';
-  return pythonGenerator['unittest_main'].defineAssert_() +
+  return pythonDefineAssert() +
       '(' + actual + ', ' + expected + ', ' + message + ')\n';
 };
 
-pythonGenerator['unittest_assertvalue'] = function(block) {
+pythonGenerator.forBlock['unittest_assertvalue'] = function(block) {
   // Asserts that a value is true, false, or null.
   var message = pythonGenerator.valueToCode(block, 'MESSAGE',
       pythonGenerator.ORDER_NONE) || '';
@@ -100,11 +100,11 @@ pythonGenerator['unittest_assertvalue'] = function(block) {
   } else if (expected == 'NULL') {
     expected = 'None';
   }
-  return pythonGenerator['unittest_main'].defineAssert_() +
+  return pythonDefineAssert() +
       '(' + actual + ', ' + expected + ', ' + message + ')\n';
 };
 
-pythonGenerator['unittest_fail'] = function(block) {
+pythonGenerator.forBlock['unittest_fail'] = function(block) {
   // Always assert an error.
   var resultsVar = pythonGenerator.nameDB_.getName('unittestResults',
       Blockly.Names.DEVELOPER_VARIABLE_TYPE);
@@ -119,7 +119,7 @@ pythonGenerator['unittest_fail'] = function(block) {
   return functionName + '(' + message + ')\n';
 };
 
-pythonGenerator['unittest_adjustindex'] = function(block) {
+pythonGenerator.forBlock['unittest_adjustindex'] = function(block) {
   var index = pythonGenerator.valueToCode(block, 'INDEX',
       pythonGenerator.ORDER_ADDITIVE) || '0';
   // Adjust index if using one-based indexing.


### PR DESCRIPTION
## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [x] I ran `npm run format` and `npm run lint`

## The details
### Resolves

Fixes https://github.com/google/blockly/issues/7303

### Proposed Changes

- Update how per-block generators are defined to use `forBlock`, as described in https://github.com/google/blockly/pull/7150
- Move the `defineAssert` functions off the `unittest_main` generator objects, and make sure their names don't collide when loaded in the same page.

#### Behavior Before Change

Lots of deprecation warnings, but everything works.

#### Behavior After Change

No deprecation warnings, and everything still works.

### Reason for Changes

Respond to deprecation.