### PR TITLE
feat: add the ability to toggle scrollbar visibility

### DIFF
--- a/core/scrollbar.ts
+++ b/core/scrollbar.ts
@@ -657,13 +657,25 @@ export class Scrollbar {
    * @param visible True if visible.
    */
   setVisible(visible: boolean) {
-    const visibilityChanged = visible !== this.isVisible();
-
     // Ideally this would also apply to scrollbar pairs, but that's a bigger
-    // headache (due to interactions with the corner square).
+    // headache (due to interactions with the corner square), and the fact
+    // that telling the pair to resize itself would cause circular dependencies.
     if (this.pair) {
       throw Error('Unable to toggle visibility of paired scrollbars.');
     }
+    this.setVisibleInternal(visible);
+  }
+
+  /**
+   * Set whether the scrollbar is visible. Bypasses checking whether this
+   * scrollbar is part of a pair so that it can be toggled by the scrollbar
+   * pair.
+   *
+   * @param visible True if visible.
+   * @internal
+   */
+  setVisibleInternal(visible: boolean) {
+    const visibilityChanged = visible !== this.isVisible();
     this.isHandleVisible = visible;
     if (visibilityChanged) {
       this.updateDisplay_();

--- a/core/scrollbar_pair.ts
+++ b/core/scrollbar_pair.ts
@@ -307,6 +307,16 @@ export class ScrollbarPair {
   }
 
   /**
+   * Sets the visibility of any existing scrollbars.
+   *
+   * @param visible True if visible.
+   */
+  setVisible(visible: boolean) {
+    if (this.hScroll) this.hScroll.setVisibleInternal(visible);
+    if (this.vScroll) this.vScroll.setVisibleInternal(visible);
+  }
+
+  /**
    * Recalculates the scrollbars' locations within their path and length.
    * This should be called when the contents of the workspace have changed.
    *


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [X] I ran `npm run format` and `npm run lint`

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes https://github.com/google/blockly/issues/6971

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
Adds a method to toggle the visibility of a scrollbar pair.

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
App inventor needs this to reduce clutter when opening flyouts.

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->
Manually tested that setting the scrollbar visibility hides the scrollbars.

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->
N/A

### Additional Information

<!-- Anything else we should know? -->
I thought about solving this in a bunch of different ways, but the only one that ended up working was adding the internal `setVisible` method.

Removing the `this.pair` check alone doesn't work because external devs can access the individual scrollbars and try to mess with them, so we will run into the corner-error that the comment references. And we can't fix that by by telling the scrollbar pair to update itself when an individual scrollbar gets hidden, because having a reference to the scrollbar pair would cause circular dependencies.
