### PR TITLE
fix(tests): fix broken browser tests

### DIFF
--- a/tests/browser/test/.mocharc.js
+++ b/tests/browser/test/.mocharc.js
@@ -2,5 +2,4 @@
 
 module.exports = {
   ui: 'tdd',
-  reporter: 'landing',
 };

--- a/tests/browser/test/basic_block_test.js
+++ b/tests/browser/test/basic_block_test.js
@@ -14,7 +14,7 @@ const {
   testSetup,
   testFileLocations,
   getAllBlocks,
-  dragNthBlockFromFlyout
+  dragNthBlockFromFlyout,
 } = require('./test_setup');
 const {Key} = require('webdriverio');
 
@@ -34,13 +34,7 @@ suite('Basic block tests', function (done) {
 
   test('Drag three blocks into the workspace', async function () {
     for (let i = 1; i <= 3; i++) {
-      await dragNthBlockFromFlyout(
-        browser,
-        'Align',
-        0,
-        250,
-        50 * i
-      );
+      await dragNthBlockFromFlyout(browser, 'Align', 0, 250, 50 * i);
       chai.assert.equal(i, (await getAllBlocks(browser)).length);
     }
   });

--- a/tests/browser/test/basic_block_test.js
+++ b/tests/browser/test/basic_block_test.js
@@ -14,10 +14,7 @@ const {
   testSetup,
   testFileLocations,
   getAllBlocks,
-  getSelectedBlockElement,
-  switchRTL,
-  dragBlockTypeFromFlyout,
-  screenDirection,
+  dragNthBlockFromFlyout
 } = require('./test_setup');
 const {Key} = require('webdriverio');
 
@@ -37,14 +34,14 @@ suite('Basic block tests', function (done) {
 
   test('Drag three blocks into the workspace', async function () {
     for (let i = 1; i <= 3; i++) {
-      await dragBlockTypeFromFlyout(
+      await dragNthBlockFromFlyout(
         browser,
-        'Basic',
-        'test_basic_empty',
+        'Align',
+        0,
         250,
         50 * i
       );
-      chai.assert.equal((await getAllBlocks(browser)).length, i);
+      chai.assert.equal(i, (await getAllBlocks(browser)).length);
     }
   });
 

--- a/tests/browser/test/basic_block_test.js
+++ b/tests/browser/test/basic_block_test.js
@@ -35,7 +35,7 @@ suite('Basic block tests', function (done) {
   test('Drag three blocks into the workspace', async function () {
     for (let i = 1; i <= 3; i++) {
       await dragNthBlockFromFlyout(browser, 'Align', 0, 250, 50 * i);
-      chai.assert.equal(i, (await getAllBlocks(browser)).length);
+      chai.assert.equal((await getAllBlocks(browser)).length, i);
     }
   });
 

--- a/tests/browser/test/basic_playground_test.js
+++ b/tests/browser/test/basic_playground_test.js
@@ -182,7 +182,7 @@ suite('Disabling', function () {
         110,
         110
       );
-      await connect(browser, child, 'PREVIOUS', parent, 'IF0');
+      await connect(browser, child, 'PREVIOUS', parent, 'DO0');
 
       await contextMenuSelect(browser, parent, 'Disable Block');
 

--- a/tests/browser/test/test_setup.js
+++ b/tests/browser/test/test_setup.js
@@ -230,7 +230,6 @@ async function getLocationOfBlockConnection(browser, id, connectionName) {
         block.getRelativeToSurfaceXY(),
         connection.getOffsetInBlock()
       );
-      console.log(Blockly);
       return Blockly.utils.svgMath.wsToScreenCoordinates(
         Blockly.getMainWorkspace(),
         loc
@@ -346,9 +345,11 @@ async function contextMenuSelect(browser, block, itemText) {
   // Clicking will always happen in the middle of the block's bounds
   // (including children) by default, which causes problems if it has holes
   // (e.g. statement inputs).
-  // Instead we want to click 20% from the right and 5% from the top.
-  const xOffset = -Math.round((await block.getSize('width')) * 0.3);
-  const yOffset = -Math.round((await block.getSize('height')) * 0.45);
+  // Instead we want to click 10px from the left and 10px from the top.
+  const blockWidth = await block.getSize('width');
+  const blockHeight = await block.getSize('height');
+  const xOffset = -Math.round(blockWidth * 0.5) + 10;
+  const yOffset = -Math.round(blockHeight * 0.5) + 10;
 
   await block.click({button: 2, x: xOffset, y: yOffset});
   await browser.pause(100);
@@ -369,7 +370,6 @@ async function contextMenuSelect(browser, block, itemText) {
  */
 async function getAllBlocks(browser) {
   return browser.execute(() => {
-    // return Blockly.getMainWorkspace().getAllBlocks(false);
     return Blockly.getMainWorkspace()
       .getAllBlocks(false)
       .map((block) => ({


### PR DESCRIPTION
## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [x] I ran `npm run format` and `npm run lint`

## The details
### Resolves


### Proposed Changes

- Change offset math to offset by a fixed amount from top-left, rather than a percent
- Use correct input for one of the tests (`DO0` instead of `IF0`)
- Use a different category for one of the drag tests, because one of the blocks in the category was broken. That broken block is also fixed in a different PR/set of PRs.
- Switched from the 'landing' reporter, which the mocha documentation calls a 'gimmick', to one that prints the names of tests to the console as it runs.

#### Behavior Before Change

Tests worked for Beka but not for me

#### Behavior After Change

Hopefully tests work for everyone

### Reason for Changes