### PR TITLE
fix(tests): Make `.mocharc.js` independent of current working directory

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "start": "npm run build && concurrently -n tsc,server \"tsc --watch --preserveWatchOutput --outDir 'build/src' --declarationDir 'build/declarations'\" \"http-server ./ -s -o /tests/playground.html -c-1\"",
     "tsc": "gulp tsc",
     "test": "gulp test",
-    "test:browser": "npx mocha ./tests/browser/test --config ./tests/browser/test/.mocharc.js",
+    "test:browser": "cd tests/browser && npx mocha",
     "test:generators": "gulp testGenerators",
     "test:mocha:interactive": "http-server ./ -o /tests/mocha/index.html -c-1",
     "test:compile:advanced": "gulp buildAdvancedCompilationTest --debug",

--- a/tests/browser/.mocharc.js
+++ b/tests/browser/.mocharc.js
@@ -2,5 +2,5 @@
 
 module.exports = {
   ui: 'tdd',
-  require: 'tests/browser/test/hooks.js',
+  require: __dirname + '/test/hooks.js',
 };


### PR DESCRIPTION
## The basics

- [X] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [X] I ran `npm run format` and `npm run lint`

## The details
### Resolves

Fixes difficulties with running individual tests via `npx mocha path/to/test_file.js`

### Proposed Changes

Move `tests/browser/test/.mocharc.js` to `tests/browser` and use `__dirname` to make the `require` directive work regardless of where `mocha` is invoked from.

Simplify the `browser:test` script accordingly, taking advantage also of the mocha default of running all tests in the `test/` subdirectory.


#### Behaviour Before Change

It was necessary to be in the repository root, and specify `--config tests/browser/test/.mocharc.js` in order to successfully invoke `mocha` on any/all of the files in `tests/browser/test`.

#### Behaviour After Change

The previous way works, but it's also possible to `npx mocha path/to/test_file.js` from anywhere in `browser/tests/`

### Reason for Changes

Convenience when developing tests.

### Test Coverage

Unchanged.

