### PR TITLE
chore(tests): fix disable block tests

### DIFF
--- a/tests/browser/test/basic_playground_test.js
+++ b/tests/browser/test/basic_playground_test.js
@@ -125,6 +125,8 @@ suite('Disabling', function () {
 
   setup(async function () {
     await this.browser.refresh();
+    // Pause to allow refresh time to work.
+    await this.browser.pause(200);
   });
 
   test(

--- a/tests/browser/test/test_setup.js
+++ b/tests/browser/test/test_setup.js
@@ -396,7 +396,8 @@ async function dragBlockTypeFromFlyout(browser, categoryName, type, x, y) {
  * context menu item.
  *
  * @param browser The active WebdriverIO Browser object.
- * @param block The block to click, as an interactable element.
+ * @param block The block to click, as an interactable element. This block must
+ *    have text on it, because we use the text element as the click target.
  * @param itemText The display text of the context menu item to click.
  * @return A Promise that resolves when the actions are completed.
  */
@@ -406,6 +407,9 @@ async function contextMenuSelect(browser, block, itemText) {
   // (e.g. statement inputs).
   // Instead, we'll click directly on the first bit of text on the block.
   const clickEl = block.$('.blocklyText');
+
+  // Even though the element should definitely already exist,
+  // one specific test breaks if you remove this...
   await clickEl.waitForExist();
 
   await clickEl.click({button: 2});

--- a/tests/browser/test/test_setup.js
+++ b/tests/browser/test/test_setup.js
@@ -404,13 +404,11 @@ async function contextMenuSelect(browser, block, itemText) {
   // Clicking will always happen in the middle of the block's bounds
   // (including children) by default, which causes problems if it has holes
   // (e.g. statement inputs).
-  // Instead we want to click 10px from the left and 10px from the top.
-  const blockWidth = await block.getSize('width');
-  const blockHeight = await block.getSize('height');
-  const xOffset = -Math.round(blockWidth * 0.5) + 10;
-  const yOffset = -Math.round(blockHeight * 0.5) + 10;
+  // Instead, we'll click directly on the first bit of text on the block.
+  const clickEl = block.$('.blocklyText');
+  await clickEl.waitForExist();
 
-  await block.click({button: 2, x: xOffset, y: yOffset});
+  await clickEl.click({button: 2});
 
   const item = await browser.$(`div=${itemText}`);
   await item.waitForExist();


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [x] I ran `npm run format` and `npm run lint`

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes flaky disable tests

### Proposed Changes

- Instead of trying to do math about where to click on blocks, click on the first bit of text in the block instead, which won't have any holes
- Add a pause after calling `this.browser.refresh` in the disable tests. without this, the refresh is not complete when the next test starts, causing flakiness. this is in the [webdriver examples
](https://webdriver.io/docs/api/webdriver/#refresh)
#### Behavior Before Change

<!--TODO: Image, gif or explanation of behavior before this pull request. -->

#### Behavior After Change

<!--TODO: Image, gif or explanation of behavior after this pull request. -->

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage

I ran just the disable tests suite 20 times, and all the tests 8 times, to make sure they are no longer flaky.

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
