### PR TITLE
feat: add basic pasters

### DIFF
--- a/core/clipboard/block_paster.ts
+++ b/core/clipboard/block_paster.ts
@@ -1,0 +1,31 @@
+/**
+ * @license
+ * Copyright 2023 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {BlockSvg} from '../block_svg.js';
+import {CopyData} from '../interfaces/i_copyable';
+import {IPaster} from '../interfaces/i_paster.js';
+import {State, append} from '../serialization/blocks';
+import {Coordinate} from '../utils/coordinate.js';
+import {WorkspaceSvg} from '../workspace_svg.js';
+
+export class BlockPaster implements IPaster<BlockCopyData, BlockSvg> {
+  paste(
+    copyData: BlockCopyData,
+    workspace: WorkspaceSvg,
+    coordinate?: Coordinate,
+  ): BlockSvg | null {
+    if (!workspace.isCapacityAvailable(copyData.typeCounts!)) return null;
+
+    const state = copyData.saveInfo as State;
+    if (coordinate) {
+      state['x'] = coordinate.x;
+      state['y'] = coordinate.y;
+    }
+    return append(state, workspace, {recordUndo: true}) as BlockSvg;
+  }
+}
+
+export interface BlockCopyData extends CopyData {}

--- a/core/clipboard/workspace_comment_paster.ts
+++ b/core/clipboard/workspace_comment_paster.ts
@@ -1,0 +1,30 @@
+/**
+ * @license
+ * Copyright 2023 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {IPaster} from '../interfaces/i_paster.js';
+import {CopyData} from '../interfaces/i_copyable.js';
+import {Coordinate} from '../utils/coordinate.js';
+import {WorkspaceSvg} from '../workspace_svg.js';
+import {WorkspaceCommentSvg} from '../workspace_comment_svg.js';
+
+export class WorkspaceCommentPaster
+  implements IPaster<WorkspaceCommentCopyData, WorkspaceCommentSvg>
+{
+  paste(
+    copyData: WorkspaceCommentCopyData,
+    workspace: WorkspaceSvg,
+    coordinate?: Coordinate,
+  ): WorkspaceCommentSvg {
+    const state = copyData.saveInfo as Element;
+    if (coordinate) {
+      state.setAttribute('x', `${coordinate.x}`);
+      state.setAttribute('y', `${coordinate.y}`);
+    }
+    return WorkspaceCommentSvg.fromXmlRendered(state, workspace);
+  }
+}
+
+export interface WorkspaceCommentCopyData extends CopyData {}

--- a/core/interfaces/i_paster.ts
+++ b/core/interfaces/i_paster.ts
@@ -1,0 +1,23 @@
+/**
+ * @license
+ * Copyright 2023 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {Coordinate} from '../utils/coordinate.js';
+import {WorkspaceSvg} from '../workspace_svg.js';
+import {ICopyable, CopyData} from './i_copyable.js';
+
+/** An object that can paste data into a workspace. */
+export interface IPaster<U extends CopyData, T extends ICopyable> {
+  paste(
+    copyData: U,
+    workspace: WorkspaceSvg,
+    coordinate?: Coordinate,
+  ): T | null;
+}
+
+/** @returns True if the given object is a paster. */
+export function isPaster(obj: any): obj is IPaster<CopyData, ICopyable> {
+  return obj.paste !== undefined;
+}


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [ ] I branched from develop
- [ ] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [X] I ran `npm run format` and `npm run lint`

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #7336 

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
Add an IPaster interface and pasters for blocks and workspace comments.

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
Work toward having separate pasters for separate objects so that we can easily add new pastable objects.

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->
N/A - This is just using the serialization system so no need to test it separately. I'll add tests for the integration between the clipboard and the pasters when I get to that point! (I.e. to make sure the correct APIs are getting called).

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->
N/A

### Additional Information

<!-- Anything else we should know? -->

Currently these are not actually used anywhere :P I'm going to wire them in in a future PR.
