### PR TITLE
fix: removed X & Y from toolbox.ts and replaced movBy to moveTo

### DIFF
--- a/core/flyout_horizontal.ts
+++ b/core/flyout_horizontal.ts
@@ -14,13 +14,13 @@ goog.declareModuleId('Blockly.HorizontalFlyout');
 
 import * as browserEvents from './browser_events.js';
 import * as dropDownDiv from './dropdowndiv.js';
-import {Flyout, FlyoutItem} from './flyout_base.js';
-import type {FlyoutButton} from './flyout_button.js';
-import type {Options} from './options.js';
+import { Flyout, FlyoutItem } from './flyout_base.js';
+import type { FlyoutButton } from './flyout_button.js';
+import type { Options } from './options.js';
 import * as registry from './registry.js';
-import {Scrollbar} from './scrollbar.js';
-import type {Coordinate} from './utils/coordinate.js';
-import {Rect} from './utils/rect.js';
+import { Scrollbar } from './scrollbar.js';
+import { Coordinate } from './utils/coordinate.js';
+import { Rect } from './utils/rect.js';
 import * as toolbox from './utils/toolbox.js';
 import * as WidgetDiv from './widgetdiv.js';
 
@@ -41,7 +41,7 @@ export class HorizontalFlyout extends Flyout {
    * @param xyRatio Contains a y property which is a float between 0 and 1
    *     specifying the degree of scrolling and a similar x property.
    */
-  protected override setMetrics_(xyRatio: {x: number; y: number}) {
+  protected override setMetrics_(xyRatio: { x: number; y: number }) {
     if (!this.isVisible()) {
       return;
     }
@@ -285,7 +285,8 @@ export class HorizontalFlyout extends Flyout {
         } else {
           moveX = cursorX - tab;
         }
-        block!.moveBy(moveX, cursorY);
+        // No 'reason' provided since events are disabled.
+        block!.moveTo(new Coordinate(moveX, cursorY));
 
         const rect = this.createRect_(block!, moveX, cursorY, blockHW, i);
         cursorX += blockHW.width + gaps[i];

--- a/core/flyout_horizontal.ts
+++ b/core/flyout_horizontal.ts
@@ -14,13 +14,13 @@ goog.declareModuleId('Blockly.HorizontalFlyout');
 
 import * as browserEvents from './browser_events.js';
 import * as dropDownDiv from './dropdowndiv.js';
-import { Flyout, FlyoutItem } from './flyout_base.js';
-import type { FlyoutButton } from './flyout_button.js';
-import type { Options } from './options.js';
+import {Flyout, FlyoutItem} from './flyout_base.js';
+import type {FlyoutButton} from './flyout_button.js';
+import type {Options} from './options.js';
 import * as registry from './registry.js';
-import { Scrollbar } from './scrollbar.js';
-import { Coordinate } from './utils/coordinate.js';
-import { Rect } from './utils/rect.js';
+import {Scrollbar} from './scrollbar.js';
+import {Coordinate} from './utils/coordinate.js';
+import {Rect} from './utils/rect.js';
 import * as toolbox from './utils/toolbox.js';
 import * as WidgetDiv from './widgetdiv.js';
 
@@ -41,7 +41,7 @@ export class HorizontalFlyout extends Flyout {
    * @param xyRatio Contains a y property which is a float between 0 and 1
    *     specifying the degree of scrolling and a similar x property.
    */
-  protected override setMetrics_(xyRatio: { x: number; y: number }) {
+  protected override setMetrics_(xyRatio: {x: number; y: number}) {
     if (!this.isVisible()) {
       return;
     }

--- a/core/flyout_vertical.ts
+++ b/core/flyout_vertical.ts
@@ -374,7 +374,6 @@ export class VerticalFlyout extends Flyout {
             button.width -
             this.MARGIN -
             this.tabWidth_;
-          // No 'reason' provided since events are disabled.
           button.moveTo(x, y);
         }
       }

--- a/core/flyout_vertical.ts
+++ b/core/flyout_vertical.ts
@@ -14,13 +14,13 @@ goog.declareModuleId('Blockly.VerticalFlyout');
 
 import * as browserEvents from './browser_events.js';
 import * as dropDownDiv from './dropdowndiv.js';
-import {Flyout, FlyoutItem} from './flyout_base.js';
-import type {FlyoutButton} from './flyout_button.js';
-import type {Options} from './options.js';
+import { Flyout, FlyoutItem } from './flyout_base.js';
+import type { FlyoutButton } from './flyout_button.js';
+import type { Options } from './options.js';
 import * as registry from './registry.js';
-import {Scrollbar} from './scrollbar.js';
-import type {Coordinate} from './utils/coordinate.js';
-import {Rect} from './utils/rect.js';
+import { Scrollbar } from './scrollbar.js';
+import { Coordinate } from './utils/coordinate.js';
+import { Rect } from './utils/rect.js';
 import * as toolbox from './utils/toolbox.js';
 import * as WidgetDiv from './widgetdiv.js';
 
@@ -42,7 +42,7 @@ export class VerticalFlyout extends Flyout {
    * @param xyRatio Contains a y property which is a float between 0 and 1
    *     specifying the degree of scrolling and a similar x property.
    */
-  protected override setMetrics_(xyRatio: {x: number; y: number}) {
+  protected override setMetrics_(xyRatio: { x: number; y: number }) {
     if (!this.isVisible()) {
       return;
     }
@@ -246,7 +246,8 @@ export class VerticalFlyout extends Flyout {
         const moveX = block!.outputConnection
           ? cursorX - this.tabWidth_
           : cursorX;
-        block!.moveBy(moveX, cursorY);
+        // No 'reason' provided since events are disabled.
+        block!.moveTo(new Coordinate(moveX, cursorY));
 
         const rect = this.createRect_(
           block!,
@@ -357,7 +358,8 @@ export class VerticalFlyout extends Flyout {
           if (!block.outputConnection) {
             newX -= this.tabWidth_;
           }
-          block.moveBy(newX - oldX, 0);
+          // No 'reason' provided since events are disabled.
+          block.moveTo(new Coordinate(newX - oldX, 0));
         }
         if (this.rectMap_.has(block)) {
           this.moveRectToBlock_(this.rectMap_.get(block)!, block);
@@ -372,6 +374,7 @@ export class VerticalFlyout extends Flyout {
             button.width -
             this.MARGIN -
             this.tabWidth_;
+          // No 'reason' provided since events are disabled.
           button.moveTo(x, y);
         }
       }

--- a/core/flyout_vertical.ts
+++ b/core/flyout_vertical.ts
@@ -14,13 +14,13 @@ goog.declareModuleId('Blockly.VerticalFlyout');
 
 import * as browserEvents from './browser_events.js';
 import * as dropDownDiv from './dropdowndiv.js';
-import { Flyout, FlyoutItem } from './flyout_base.js';
-import type { FlyoutButton } from './flyout_button.js';
-import type { Options } from './options.js';
+import {Flyout, FlyoutItem} from './flyout_base.js';
+import type {FlyoutButton} from './flyout_button.js';
+import type {Options} from './options.js';
 import * as registry from './registry.js';
-import { Scrollbar } from './scrollbar.js';
-import { Coordinate } from './utils/coordinate.js';
-import { Rect } from './utils/rect.js';
+import {Scrollbar} from './scrollbar.js';
+import {Coordinate} from './utils/coordinate.js';
+import {Rect} from './utils/rect.js';
 import * as toolbox from './utils/toolbox.js';
 import * as WidgetDiv from './widgetdiv.js';
 
@@ -42,7 +42,7 @@ export class VerticalFlyout extends Flyout {
    * @param xyRatio Contains a y property which is a float between 0 and 1
    *     specifying the degree of scrolling and a similar x property.
    */
-  protected override setMetrics_(xyRatio: { x: number; y: number }) {
+  protected override setMetrics_(xyRatio: {x: number; y: number}) {
     if (!this.isVisible()) {
       return;
     }

--- a/core/utils/toolbox.ts
+++ b/core/utils/toolbox.ts
@@ -24,8 +24,6 @@ export interface BlockInfo {
   disabled?: string | boolean;
   enabled?: boolean;
   id?: string;
-  x?: number;
-  y?: number;
   collapsed?: boolean;
   inline?: boolean;
   data?: string;


### PR DESCRIPTION

<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [x] I ran `npm run format` and `npm run lint`

## The details

### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
- Fixes #6280 

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
The [BlockInfo type](https://github.com/google/blockly/blob/fa58cbaaf7456ab227c2214af5dd0e7025dc731c/core/utils/toolbox.ts#L19) should be updated to not include X and Y.
Blockly has two kinds of flyouts built-in, horizontal and vertical. You should update the layout logic in both of them.
The flyouts should be changed to use [moveTo](https://github.com/google/blockly/blob/fa58cbaaf7456ab227c2214af5dd0e7025dc731c/core/block_svg.ts#L414) [instead of moveBy](https://github.com/google/blockly/blob/61322294da70c770b32abb28b9d695af75f61a16/core/flyout_vertical.js#L250)

#### Behavior Before Change

The `BlockInfo type` was picking up the values of `x` and `y` henceforth the position of the Toolbox Element was getting changed.

#### Behavior After Change

After removing the `X` and `Y` from the `BlockInfo type` the Toolbox Element is now ignoring the value and introducing the chnage to the code in files 
- [core/flyout_horizontal.ts](https://github.com/google/blockly/pull/7333/files#diff-67129394789d0d6086c6c255000bb6db6c9a4ecfa66a3e3f8618a64b0f804d40)
- [core/flyout_vertical.ts](https://github.com/google/blockly/pull/7333/files#diff-b866da6441c5a41965db65339b45aaffa9036332a928bde9ba9e5f59823b14a3)

to use `moveTo` instead of `moveBy`

Ignoring the x and y properties on blocks would allow them to position correctly.
<!--TODO: Image, gif or explanation of behavior after this pull request. -->

### Reason for Changes

Because, the blocks were using the `relative coordinates` instead of the `absolute coordinates`
<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage

Browser which I used is MS Edge Version 115.0.1901.188 (Official build) (64-bit)

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

It's my first PR on this project, so I might make mistakes.
<!-- Anything else we should know? -->
