### PR TITLE
fix: refactor CopyData interface to have the correct structure

### DIFF
--- a/core/block_svg.ts
+++ b/core/block_svg.ts
@@ -37,7 +37,7 @@ import {FieldLabel} from './field_label.js';
 import type {Input} from './inputs/input.js';
 import type {IASTNodeLocationSvg} from './interfaces/i_ast_node_location_svg.js';
 import type {IBoundedElement} from './interfaces/i_bounded_element.js';
-import type {ICopyData, ICopyable} from './interfaces/i_copyable.js';
+import type {ICopyable} from './interfaces/i_copyable.js';
 import type {IDraggable} from './interfaces/i_draggable.js';
 import {IIcon} from './interfaces/i_icon.js';
 import * as internalConstants from './internal_constants.js';
@@ -62,6 +62,7 @@ import type {WorkspaceSvg} from './workspace_svg.js';
 import * as renderManagement from './render_management.js';
 import * as deprecation from './utils/deprecation.js';
 import {IconType} from './icons/icon_types.js';
+import {BlockCopyData, BlockPaster} from './clipboard/block_paster.js';
 
 /**
  * Class for a block's SVG representation.
@@ -823,18 +824,17 @@ export class BlockSvg
    * Encode a block for copying.
    *
    * @returns Copy metadata, or null if the block is an insertion marker.
-   * @internal
    */
-  toCopyData(): ICopyData | null {
+  toCopyData(): BlockCopyData | null {
     if (this.isInsertionMarker_) {
       return null;
     }
     return {
+      paster: BlockPaster.TYPE,
       saveInfo: blocks.save(this, {
         addCoordinates: true,
         addNextBlocks: false,
       }) as blocks.State,
-      source: this.workspace,
       typeCounts: common.getBlockTypeCounts(this, true),
     };
   }

--- a/core/block_svg.ts
+++ b/core/block_svg.ts
@@ -831,7 +831,7 @@ export class BlockSvg
     }
     return {
       paster: BlockPaster.TYPE,
-      saveInfo: blocks.save(this, {
+      blockState: blocks.save(this, {
         addCoordinates: true,
         addNextBlocks: false,
       }) as blocks.State,

--- a/core/block_svg.ts
+++ b/core/block_svg.ts
@@ -37,7 +37,7 @@ import {FieldLabel} from './field_label.js';
 import type {Input} from './inputs/input.js';
 import type {IASTNodeLocationSvg} from './interfaces/i_ast_node_location_svg.js';
 import type {IBoundedElement} from './interfaces/i_bounded_element.js';
-import type {CopyData, ICopyable} from './interfaces/i_copyable.js';
+import type {ICopyData, ICopyable} from './interfaces/i_copyable.js';
 import type {IDraggable} from './interfaces/i_draggable.js';
 import {IIcon} from './interfaces/i_icon.js';
 import * as internalConstants from './internal_constants.js';
@@ -825,7 +825,7 @@ export class BlockSvg
    * @returns Copy metadata, or null if the block is an insertion marker.
    * @internal
    */
-  toCopyData(): CopyData | null {
+  toCopyData(): ICopyData | null {
     if (this.isInsertionMarker_) {
       return null;
     }

--- a/core/clipboard.ts
+++ b/core/clipboard.ts
@@ -7,12 +7,12 @@
 import * as goog from '../closure/goog/goog.js';
 goog.declareModuleId('Blockly.clipboard');
 
-import type {CopyData, ICopyable} from './interfaces/i_copyable.js';
+import type {ICopyData, ICopyable} from './interfaces/i_copyable.js';
 import {BlockPaster} from './clipboard/block_paster.js';
 import * as registry from './clipboard/registry.js';
 
 /** Metadata about the object that is currently on the clipboard. */
-let copyData: CopyData | null = null;
+let copyData: ICopyData | null = null;
 
 /**
  * Copy a block or workspace comment onto the local clipboard.

--- a/core/clipboard.ts
+++ b/core/clipboard.ts
@@ -9,10 +9,14 @@ goog.declareModuleId('Blockly.clipboard');
 
 import type {ICopyData, ICopyable} from './interfaces/i_copyable.js';
 import {BlockPaster} from './clipboard/block_paster.js';
+import * as globalRegistry from './registry.js';
+import {WorkspaceSvg} from './workspace_svg.js';
 import * as registry from './clipboard/registry.js';
 
 /** Metadata about the object that is currently on the clipboard. */
 let copyData: ICopyData | null = null;
+
+let source: WorkspaceSvg | null = null;
 
 /**
  * Copy a block or workspace comment onto the local clipboard.
@@ -29,6 +33,7 @@ export function copy(toCopy: ICopyable) {
  */
 function copyInternal(toCopy: ICopyable) {
   copyData = toCopy.toCopyData();
+  source = (toCopy as any).workspace ?? null;
 }
 
 /**
@@ -43,17 +48,16 @@ export function paste(): ICopyable | null {
   }
   // Pasting always pastes to the main workspace, even if the copy
   // started in a flyout workspace.
-  let workspace = copyData.source;
-  if (workspace.isFlyout) {
+  let workspace = source;
+  if (workspace?.isFlyout) {
     workspace = workspace.targetWorkspace!;
   }
-  if (
-    copyData.typeCounts &&
-    workspace.isCapacityAvailable(copyData.typeCounts)
-  ) {
-    return workspace.paste(copyData.saveInfo);
-  }
-  return null;
+  if (!workspace) return null;
+  return (
+    globalRegistry
+      .getObject(globalRegistry.Type.PASTER, copyData.paster, false)
+      ?.paste(copyData, workspace) ?? null
+  );
 }
 
 /**
@@ -74,8 +78,11 @@ export function duplicate(toDuplicate: ICopyable): ICopyable | null {
 function duplicateInternal(toDuplicate: ICopyable): ICopyable | null {
   const oldCopyData = copyData;
   copy(toDuplicate);
+  if (!copyData || !source) return null;
   const pastedThing =
-    toDuplicate.toCopyData()?.source?.paste(copyData!.saveInfo) ?? null;
+    globalRegistry
+      .getObject(globalRegistry.Type.PASTER, copyData.paster, false)
+      ?.paste(copyData, source) ?? null;
   copyData = oldCopyData;
   return pastedThing;
 }

--- a/core/clipboard/block_paster.ts
+++ b/core/clipboard/block_paster.ts
@@ -23,15 +23,17 @@ export class BlockPaster implements IPaster<BlockCopyData, BlockSvg> {
     if (!workspace.isCapacityAvailable(copyData.typeCounts!)) return null;
 
     if (coordinate) {
-      copyData.saveInfo['x'] = coordinate.x;
-      copyData.saveInfo['y'] = coordinate.y;
+      copyData.blockState['x'] = coordinate.x;
+      copyData.blockState['y'] = coordinate.y;
     }
-    return append(copyData.saveInfo, workspace, {recordUndo: true}) as BlockSvg;
+    return append(copyData.blockState, workspace, {
+      recordUndo: true,
+    }) as BlockSvg;
   }
 }
 
 export interface BlockCopyData extends ICopyData {
-  saveInfo: State;
+  blockState: State;
   typeCounts: {[key: string]: number};
 }
 

--- a/core/clipboard/block_paster.ts
+++ b/core/clipboard/block_paster.ts
@@ -6,7 +6,7 @@
 
 import {BlockSvg} from '../block_svg.js';
 import {registry} from '../clipboard.js';
-import {CopyData} from '../interfaces/i_copyable.js';
+import {ICopyData} from '../interfaces/i_copyable.js';
 import {IPaster} from '../interfaces/i_paster.js';
 import {State, append} from '../serialization/blocks.js';
 import {Coordinate} from '../utils/coordinate.js';
@@ -31,6 +31,6 @@ export class BlockPaster implements IPaster<BlockCopyData, BlockSvg> {
   }
 }
 
-export interface BlockCopyData extends CopyData {}
+export interface BlockCopyData extends ICopyData {}
 
 registry.register(BlockPaster.TYPE, new BlockPaster());

--- a/core/clipboard/block_paster.ts
+++ b/core/clipboard/block_paster.ts
@@ -5,7 +5,7 @@
  */
 
 import {BlockSvg} from '../block_svg.js';
-import {registry} from '../clipboard.js';
+import * as registry from './registry.js';
 import {ICopyData} from '../interfaces/i_copyable.js';
 import {IPaster} from '../interfaces/i_paster.js';
 import {State, append} from '../serialization/blocks.js';

--- a/core/clipboard/block_paster.ts
+++ b/core/clipboard/block_paster.ts
@@ -22,15 +22,17 @@ export class BlockPaster implements IPaster<BlockCopyData, BlockSvg> {
   ): BlockSvg | null {
     if (!workspace.isCapacityAvailable(copyData.typeCounts!)) return null;
 
-    const state = copyData.saveInfo as State;
     if (coordinate) {
-      state['x'] = coordinate.x;
-      state['y'] = coordinate.y;
+      copyData.saveInfo['x'] = coordinate.x;
+      copyData.saveInfo['y'] = coordinate.y;
     }
-    return append(state, workspace, {recordUndo: true}) as BlockSvg;
+    return append(copyData.saveInfo, workspace, {recordUndo: true}) as BlockSvg;
   }
 }
 
-export interface BlockCopyData extends ICopyData {}
+export interface BlockCopyData extends ICopyData {
+  saveInfo: State;
+  typeCounts: {[key: string]: number};
+}
 
 registry.register(BlockPaster.TYPE, new BlockPaster());

--- a/core/clipboard/registry.ts
+++ b/core/clipboard/registry.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {ICopyable, CopyData} from '../interfaces/i_copyable.js';
+import {ICopyable, ICopyData} from '../interfaces/i_copyable.js';
 import type {IPaster} from '../interfaces/i_paster.js';
 import * as registry from '../registry.js';
 
@@ -14,7 +14,7 @@ import * as registry from '../registry.js';
  * @param type The type of the paster to register, e.g. 'block', 'comment', etc.
  * @param paster The paster to register.
  */
-export function register<U extends CopyData, T extends ICopyable>(
+export function register<U extends ICopyData, T extends ICopyable>(
   type: string,
   paster: IPaster<U, T>,
 ) {

--- a/core/clipboard/workspace_comment_paster.ts
+++ b/core/clipboard/workspace_comment_paster.ts
@@ -5,7 +5,7 @@
  */
 
 import {IPaster} from '../interfaces/i_paster.js';
-import {CopyData} from '../interfaces/i_copyable.js';
+import {ICopyData} from '../interfaces/i_copyable.js';
 import {Coordinate} from '../utils/coordinate.js';
 import {WorkspaceSvg} from '../workspace_svg.js';
 import {WorkspaceCommentSvg} from '../workspace_comment_svg.js';
@@ -30,6 +30,6 @@ export class WorkspaceCommentPaster
   }
 }
 
-export interface WorkspaceCommentCopyData extends CopyData {}
+export interface WorkspaceCommentCopyData extends ICopyData {}
 
 registry.register(WorkspaceCommentPaster.TYPE, new WorkspaceCommentPaster());

--- a/core/clipboard/workspace_comment_paster.ts
+++ b/core/clipboard/workspace_comment_paster.ts
@@ -22,15 +22,18 @@ export class WorkspaceCommentPaster
     coordinate?: Coordinate,
   ): WorkspaceCommentSvg {
     if (coordinate) {
-      copyData.saveInfo.setAttribute('x', `${coordinate.x}`);
-      copyData.saveInfo.setAttribute('y', `${coordinate.y}`);
+      copyData.commentState.setAttribute('x', `${coordinate.x}`);
+      copyData.commentState.setAttribute('y', `${coordinate.y}`);
     }
-    return WorkspaceCommentSvg.fromXmlRendered(copyData.saveInfo, workspace);
+    return WorkspaceCommentSvg.fromXmlRendered(
+      copyData.commentState,
+      workspace,
+    );
   }
 }
 
 export interface WorkspaceCommentCopyData extends ICopyData {
-  saveInfo: Element;
+  commentState: Element;
 }
 
 registry.register(WorkspaceCommentPaster.TYPE, new WorkspaceCommentPaster());

--- a/core/clipboard/workspace_comment_paster.ts
+++ b/core/clipboard/workspace_comment_paster.ts
@@ -9,7 +9,7 @@ import {ICopyData} from '../interfaces/i_copyable.js';
 import {Coordinate} from '../utils/coordinate.js';
 import {WorkspaceSvg} from '../workspace_svg.js';
 import {WorkspaceCommentSvg} from '../workspace_comment_svg.js';
-import {registry} from '../clipboard.js';
+import * as registry from './registry.js';
 
 export class WorkspaceCommentPaster
   implements IPaster<WorkspaceCommentCopyData, WorkspaceCommentSvg>

--- a/core/clipboard/workspace_comment_paster.ts
+++ b/core/clipboard/workspace_comment_paster.ts
@@ -21,15 +21,16 @@ export class WorkspaceCommentPaster
     workspace: WorkspaceSvg,
     coordinate?: Coordinate,
   ): WorkspaceCommentSvg {
-    const state = copyData.saveInfo as Element;
     if (coordinate) {
-      state.setAttribute('x', `${coordinate.x}`);
-      state.setAttribute('y', `${coordinate.y}`);
+      copyData.saveInfo.setAttribute('x', `${coordinate.x}`);
+      copyData.saveInfo.setAttribute('y', `${coordinate.y}`);
     }
-    return WorkspaceCommentSvg.fromXmlRendered(state, workspace);
+    return WorkspaceCommentSvg.fromXmlRendered(copyData.saveInfo, workspace);
   }
 }
 
-export interface WorkspaceCommentCopyData extends ICopyData {}
+export interface WorkspaceCommentCopyData extends ICopyData {
+  saveInfo: Element;
+}
 
 registry.register(WorkspaceCommentPaster.TYPE, new WorkspaceCommentPaster());

--- a/core/interfaces/i_copyable.ts
+++ b/core/interfaces/i_copyable.ts
@@ -17,15 +17,15 @@ export interface ICopyable extends ISelectable {
    * @returns Copy metadata.
    * @internal
    */
-  toCopyData(): CopyData | null;
+  toCopyData(): ICopyData | null;
 }
 
 export namespace ICopyable {
-  export interface CopyData {
+  export interface ICopyData {
     saveInfo: Object | Element;
     source: WorkspaceSvg;
     typeCounts: {[key: string]: number} | null;
   }
 }
 
-export type CopyData = ICopyable.CopyData;
+export type ICopyData = ICopyable.ICopyData;

--- a/core/interfaces/i_copyable.ts
+++ b/core/interfaces/i_copyable.ts
@@ -7,7 +7,6 @@
 import * as goog from '../../closure/goog/goog.js';
 goog.declareModuleId('Blockly.ICopyable');
 
-import type {WorkspaceSvg} from '../workspace_svg.js';
 import type {ISelectable} from './i_selectable.js';
 
 export interface ICopyable extends ISelectable {
@@ -15,16 +14,13 @@ export interface ICopyable extends ISelectable {
    * Encode for copying.
    *
    * @returns Copy metadata.
-   * @internal
    */
   toCopyData(): ICopyData | null;
 }
 
 export namespace ICopyable {
   export interface ICopyData {
-    saveInfo: Object | Element;
-    source: WorkspaceSvg;
-    typeCounts: {[key: string]: number} | null;
+    paster: string;
   }
 }
 

--- a/core/interfaces/i_paster.ts
+++ b/core/interfaces/i_paster.ts
@@ -6,10 +6,10 @@
 
 import {Coordinate} from '../utils/coordinate.js';
 import {WorkspaceSvg} from '../workspace_svg.js';
-import {ICopyable, CopyData} from './i_copyable.js';
+import {ICopyable, ICopyData} from './i_copyable.js';
 
 /** An object that can paste data into a workspace. */
-export interface IPaster<U extends CopyData, T extends ICopyable> {
+export interface IPaster<U extends ICopyData, T extends ICopyable> {
   paste(
     copyData: U,
     workspace: WorkspaceSvg,
@@ -18,6 +18,6 @@ export interface IPaster<U extends CopyData, T extends ICopyable> {
 }
 
 /** @returns True if the given object is a paster. */
-export function isPaster(obj: any): obj is IPaster<CopyData, ICopyable> {
+export function isPaster(obj: any): obj is IPaster<ICopyData, ICopyable> {
   return obj.paste !== undefined;
 }

--- a/core/registry.ts
+++ b/core/registry.ts
@@ -23,7 +23,7 @@ import type {Renderer} from './renderers/common/renderer.js';
 import type {Theme} from './theme.js';
 import type {ToolboxItem} from './toolbox/toolbox_item.js';
 import {IPaster} from './interfaces/i_paster.js';
-import {CopyData, ICopyable} from './interfaces/i_copyable.js';
+import {ICopyData, ICopyable} from './interfaces/i_copyable.js';
 
 /**
  * A map of maps. With the keys being the type and name of the class we are
@@ -100,7 +100,7 @@ export class Type<_T> {
   static ICON = new Type<IIcon>('icon');
 
   /** @internal */
-  static PASTER = new Type<IPaster<CopyData, ICopyable>>('paster');
+  static PASTER = new Type<IPaster<ICopyData, ICopyable>>('paster');
 }
 
 /**

--- a/core/workspace_comment_svg.ts
+++ b/core/workspace_comment_svg.ts
@@ -23,7 +23,7 @@ import type {CommentMove} from './events/events_comment_move.js';
 import * as eventUtils from './events/utils.js';
 import type {IBoundedElement} from './interfaces/i_bounded_element.js';
 import type {IBubble} from './interfaces/i_bubble.js';
-import type {CopyData, ICopyable} from './interfaces/i_copyable.js';
+import type {ICopyData, ICopyable} from './interfaces/i_copyable.js';
 import * as Touch from './touch.js';
 import {Coordinate} from './utils/coordinate.js';
 import * as dom from './utils/dom.js';
@@ -568,7 +568,7 @@ export class WorkspaceCommentSvg
    * @returns Copy metadata.
    * @internal
    */
-  toCopyData(): CopyData {
+  toCopyData(): ICopyData {
     return {
       saveInfo: this.toXmlWithXY(),
       source: this.workspace,

--- a/core/workspace_comment_svg.ts
+++ b/core/workspace_comment_svg.ts
@@ -574,7 +574,7 @@ export class WorkspaceCommentSvg
   toCopyData(): WorkspaceCommentCopyData {
     return {
       paster: WorkspaceCommentPaster.TYPE,
-      saveInfo: this.toXmlWithXY(),
+      commentState: this.toXmlWithXY(),
     };
   }
 

--- a/core/workspace_comment_svg.ts
+++ b/core/workspace_comment_svg.ts
@@ -23,7 +23,7 @@ import type {CommentMove} from './events/events_comment_move.js';
 import * as eventUtils from './events/utils.js';
 import type {IBoundedElement} from './interfaces/i_bounded_element.js';
 import type {IBubble} from './interfaces/i_bubble.js';
-import type {ICopyData, ICopyable} from './interfaces/i_copyable.js';
+import type {ICopyable} from './interfaces/i_copyable.js';
 import * as Touch from './touch.js';
 import {Coordinate} from './utils/coordinate.js';
 import * as dom from './utils/dom.js';
@@ -32,6 +32,10 @@ import {Svg} from './utils/svg.js';
 import * as svgMath from './utils/svg_math.js';
 import {WorkspaceComment} from './workspace_comment.js';
 import type {WorkspaceSvg} from './workspace_svg.js';
+import {
+  WorkspaceCommentCopyData,
+  WorkspaceCommentPaster,
+} from './clipboard/workspace_comment_paster.js';
 
 /** Size of the resize icon. */
 const RESIZE_SIZE = 8;
@@ -566,13 +570,11 @@ export class WorkspaceCommentSvg
    * Encode a comment for copying.
    *
    * @returns Copy metadata.
-   * @internal
    */
-  toCopyData(): ICopyData {
+  toCopyData(): WorkspaceCommentCopyData {
     return {
+      paster: WorkspaceCommentPaster.TYPE,
       saveInfo: this.toXmlWithXY(),
-      source: this.workspace,
-      typeCounts: null,
     };
   }
 


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [ ] I branched from develop
- [ ] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [X] I ran `npm run format` and `npm run lint`

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Work on #7337 

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
Changes the `CopyData` interface to `ICopyData` and changes it to only require the `paster: string;` property.

Updates everything using this type/downstream APIs to conform to the new interface.

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
Working toward more flexible copy pasting.

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->
Should be covered by existing tests!

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->
N/A

### Additional Information

<!-- Anything else we should know? -->
Best to review commit-wise due to renames =)
