### PR TITLE
feat: make field `initView` and `initModel` more accessible

### DIFF
--- a/core/block.ts
+++ b/core/block.ts
@@ -366,8 +366,8 @@ export class Block implements IASTNodeLocation, IDeletable {
    * change).
    */
   initModel() {
-    for (let i = 0, input; (input = this.inputList[i]); i++) {
-      for (let j = 0, field; (field = input.fieldRow[j]); j++) {
+    for (const input of this.inputList) {
+      for (const field of input.fieldRow) {
         if (field.initModel) {
           field.initModel();
         }

--- a/core/field.ts
+++ b/core/field.ts
@@ -321,10 +321,8 @@ export abstract class Field<T = any>
 
   /**
    * Create the block UI for this field.
-   *
-   * @internal
    */
-  initView() {
+  protected initView() {
     this.createBorderRect_();
     this.createTextElement_();
   }
@@ -332,8 +330,6 @@ export abstract class Field<T = any>
   /**
    * Initializes the model of the field after it has been installed on a block.
    * No-op by default.
-   *
-   * @internal
    */
   initModel() {}
 

--- a/core/field_angle.ts
+++ b/core/field_angle.ts
@@ -165,8 +165,6 @@ export class FieldAngle extends FieldInput<number> {
 
   /**
    * Create the block UI for this field.
-   *
-   * @internal
    */
   override initView() {
     super.initView();

--- a/core/field_checkbox.ts
+++ b/core/field_checkbox.ts
@@ -110,8 +110,6 @@ export class FieldCheckbox extends Field<CheckboxBool> {
 
   /**
    * Create the block UI for this checkbox.
-   *
-   * @internal
    */
   override initView() {
     super.initView();

--- a/core/field_colour.ts
+++ b/core/field_colour.ts
@@ -163,8 +163,6 @@ export class FieldColour extends Field<string> {
 
   /**
    * Create the block UI for this colour field.
-   *
-   * @internal
    */
   override initView() {
     this.size_ = new Size(

--- a/core/field_dropdown.ts
+++ b/core/field_dropdown.ts
@@ -185,8 +185,6 @@ export class FieldDropdown extends Field<string> {
 
   /**
    * Create the block UI for this dropdown.
-   *
-   * @internal
    */
   override initView() {
     if (this.shouldAddBorderRect_()) {

--- a/core/field_image.ts
+++ b/core/field_image.ts
@@ -29,13 +29,13 @@ export class FieldImage extends Field<string> {
    */
   private static readonly Y_PADDING = 1;
   protected override size_: Size;
-  private readonly imageHeight: number;
+  protected readonly imageHeight: number;
 
   /** The function to be called when this field is clicked. */
   private clickHandler: ((p1: FieldImage) => void) | null = null;
 
   /** The rendered field's image element. */
-  private imageElement: SVGImageElement | null = null;
+  protected imageElement: SVGImageElement | null = null;
 
   /**
    * Editable fields usually show some sort of UI indicating they are

--- a/core/field_image.ts
+++ b/core/field_image.ts
@@ -135,8 +135,6 @@ export class FieldImage extends Field<string> {
 
   /**
    * Create the block UI for this image.
-   *
-   * @internal
    */
   override initView() {
     this.imageElement = dom.createSvgElement(

--- a/core/field_input.ts
+++ b/core/field_input.ts
@@ -141,7 +141,6 @@ export abstract class FieldInput<T extends InputTypes> extends Field<
     }
   }
 
-  /** @internal */
   override initView() {
     const block = this.getSourceBlock();
     if (!block) {

--- a/core/field_label.ts
+++ b/core/field_label.ts
@@ -69,8 +69,6 @@ export class FieldLabel extends Field<string> {
 
   /**
    * Create block UI for this label.
-   *
-   * @internal
    */
   override initView() {
     this.createTextElement_();

--- a/core/field_multilineinput.ts
+++ b/core/field_multilineinput.ts
@@ -152,8 +152,6 @@ export class FieldMultilineInput extends FieldTextInput {
 
   /**
    * Create the block UI for this field.
-   *
-   * @internal
    */
   override initView() {
     this.createBorderRect_();

--- a/core/field_variable.ts
+++ b/core/field_variable.ts
@@ -130,8 +130,6 @@ export class FieldVariable extends FieldDropdown {
    * Initialize the model for this field if it has not already been initialized.
    * If the value has not been set to a variable by the first render, we make up
    * a variable rather than let the value be invalid.
-   *
-   * @internal
    */
   override initModel() {
     const block = this.getSourceBlock();


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [x] I ran `npm run format` and `npm run lint`

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes inconsistency in our API. The `init` method on a field is `@sealed` and `@internal`. The documentation says to override `initView` and `initModel` instead. However, those methods were also marked `@internal` meaning they couldn't actually be overridden.

### Proposed Changes

- Make `initView` protected because it's only used inside subclasses of fields
- Make `initModel` public because it's also used from within block serialization code
- Refactor usage of `initModel` in block serialization code because the old style of for loop was causing the field to be typed as `any` which breaks reference searching. Now, "find all references" will actually find them all.
- Makes `imageElement` and `imageHeight` protected in `field_image`. Having the image element be `@internal` makes the image field almost impossible to subclass. If you want to use dynamic image fields that can change images, you have to subclass the image field.

#### Behavior Before Change

- Unable to subclass certain fields effectively

#### Behavior After Change

- Able to subclass fields and change their dom structure

### Reason for Changes

- Improving documentation and making our API more consistent
- Code.org needs to be able to subclass image field for dynamic images

### Test Coverage

All tests pass and manually tested serialization in playground.

### Documentation

These methods will be included in the next documentation update through api-documenter

### Additional Information

<!-- Anything else we should know? -->
