### PR TITLE
feat: make ICopyable generic and update clipboard APIs

### DIFF
--- a/core/block_svg.ts
+++ b/core/block_svg.ts
@@ -70,7 +70,11 @@ import {BlockCopyData, BlockPaster} from './clipboard/block_paster.js';
  */
 export class BlockSvg
   extends Block
-  implements IASTNodeLocationSvg, IBoundedElement, ICopyable, IDraggable
+  implements
+    IASTNodeLocationSvg,
+    IBoundedElement,
+    ICopyable<BlockCopyData>,
+    IDraggable
 {
   /**
    * Constant for identifying rows that are to be rendered inline.

--- a/core/blockly.ts
+++ b/core/blockly.ts
@@ -140,7 +140,7 @@ import {ICollapsibleToolboxItem} from './interfaces/i_collapsible_toolbox_item.j
 import {IComponent} from './interfaces/i_component.js';
 import {IConnectionChecker} from './interfaces/i_connection_checker.js';
 import {IContextMenu} from './interfaces/i_contextmenu.js';
-import {ICopyable} from './interfaces/i_copyable.js';
+import {ICopyable, isCopyable} from './interfaces/i_copyable.js';
 import {IDeletable} from './interfaces/i_deletable.js';
 import {IDeleteArea} from './interfaces/i_delete_area.js';
 import {IDragTarget} from './interfaces/i_drag_target.js';
@@ -592,7 +592,7 @@ export {IComponent};
 export {IConnectionChecker};
 export {IContextMenu};
 export {icons};
-export {ICopyable};
+export {ICopyable, isCopyable};
 export {IDeletable};
 export {IDeleteArea};
 export {IDragTarget};

--- a/core/clipboard.ts
+++ b/core/clipboard.ts
@@ -24,6 +24,7 @@ let stashedWorkspace: WorkspaceSvg | null = null;
  * Copy a copyable element onto the local clipboard.
  *
  * @param toCopy The copyable element to be copied.
+ * @deprecated v11. Use `myCopyable.toCopyData()` instead. To be removed v12.
  * @internal
  */
 export function copy<T extends ICopyData>(toCopy: ICopyable<T>): T | null {
@@ -112,12 +113,21 @@ function pasteFromData<T extends ICopyData>(
  *
  * @param toDuplicate The element to be duplicated.
  * @returns The element that was duplicated, or null if the duplication failed.
+ * @deprecated v11. Use
+ *     `Blockly.clipboard.paste(myCopyable.toCopyData(), myWorkspace)` instead.
+ *     To be removed v12.
  * @internal
  */
 export function duplicate<
   U extends ICopyData,
   T extends ICopyable<U> & IHasWorkspace,
 >(toDuplicate: T): T | null {
+  deprecation.warn(
+    'Blockly.clipboard.duplicate',
+    'v11',
+    'v12',
+    'Blockly.clipboard.paste(myCopyable.toCopyData(), myWorkspace)',
+  );
   return TEST_ONLY.duplicateInternal(toDuplicate);
 }
 
@@ -128,12 +138,6 @@ function duplicateInternal<
   U extends ICopyData,
   T extends ICopyable<U> & IHasWorkspace,
 >(toDuplicate: T): T | null {
-  deprecation.warn(
-    'Blockly.clipboard.duplicate',
-    'v11',
-    'v12',
-    'Blockly.clipboard.paste(myCopyable.toCopyData(), myWorkspace)',
-  );
   const data = toDuplicate.toCopyData();
   if (!data) return null;
   return paste(data, toDuplicate.workspace) as T;

--- a/core/clipboard.ts
+++ b/core/clipboard.ts
@@ -13,6 +13,7 @@ import * as globalRegistry from './registry.js';
 import {WorkspaceSvg} from './workspace_svg.js';
 import * as registry from './clipboard/registry.js';
 import {Coordinate} from './utils/coordinate.js';
+import * as deprecation from './utils/deprecation.js';
 
 /** Metadata about the object that is currently on the clipboard. */
 let stashedCopyData: ICopyData | null = null;
@@ -20,12 +21,18 @@ let stashedCopyData: ICopyData | null = null;
 let stashedWorkspace: WorkspaceSvg | null = null;
 
 /**
- * Copy a block or workspace comment onto the local clipboard.
+ * Copy a copyable element onto the local clipboard.
  *
- * @param toCopy Block or Workspace Comment to be copied.
+ * @param toCopy The copyable element to be copied.
  * @internal
  */
 export function copy<T extends ICopyData>(toCopy: ICopyable<T>): T | null {
+  deprecation.warn(
+    'Blockly.clipboard.copy',
+    'v11',
+    'v12',
+    'myCopyable.toCopyData()',
+  );
   return TEST_ONLY.copyInternal(toCopy);
 }
 
@@ -34,7 +41,7 @@ export function copy<T extends ICopyData>(toCopy: ICopyable<T>): T | null {
  */
 function copyInternal<T extends ICopyData>(toCopy: ICopyable<T>): T | null {
   const data = toCopy.toCopyData();
-  stashedCopyData = data; // Necessary for propery typing. This is why state sucks.
+  stashedCopyData = data;
   stashedWorkspace = (toCopy as any).workspace ?? null;
   return data;
 }
@@ -101,11 +108,10 @@ function pasteFromData<T extends ICopyData>(
 }
 
 /**
- * Duplicate this block and its children, or a workspace comment.
+ * Duplicate this copy-paste-able element.
  *
- * @param toDuplicate Block or Workspace Comment to be duplicated.
- * @returns The block or workspace comment that was duplicated, or null if the
- *     duplication failed.
+ * @param toDuplicate The element to be duplicated.
+ * @returns The element that was duplicated, or null if the duplication failed.
  * @internal
  */
 export function duplicate<
@@ -122,15 +128,13 @@ function duplicateInternal<
   U extends ICopyData,
   T extends ICopyable<U> & IHasWorkspace,
 >(toDuplicate: T): T | null {
-  const oldCopyData = stashedCopyData;
-  const oldWorkspace = stashedWorkspace;
-
-  const data = copy(toDuplicate);
-
-  // I hate side effects.
-  stashedCopyData = oldCopyData;
-  stashedWorkspace = oldWorkspace;
-
+  deprecation.warn(
+    'Blockly.clipboard.duplicate',
+    'v11',
+    'v12',
+    'Blockly.clipboard.paste(myCopyable.toCopyData(), myWorkspace)',
+  );
+  const data = toDuplicate.toCopyData();
   if (!data) return null;
   return paste(data, toDuplicate.workspace) as T;
 }

--- a/core/clipboard.ts
+++ b/core/clipboard.ts
@@ -72,7 +72,7 @@ function pasteFromData<T extends ICopyData>(
     globalRegistry
       .getObject(globalRegistry.Type.PASTER, copyData.paster, false)
       ?.paste(copyData, workspace, coordinate) ?? null
-  );
+  ) as ICopyable<T> | null;
 }
 
 /**

--- a/core/clipboard.ts
+++ b/core/clipboard.ts
@@ -40,8 +40,11 @@ function copyInternal<T extends ICopyData>(toCopy: ICopyable<T>): T | null {
 }
 
 /**
- * Paste a block or workspace comment on to the main workspace.
+ * Paste a pasteable element into the workspace.
  *
+ * @param copyData The data to paste into the workspace.
+ * @param workspace The workspace to paste the data into.
+ * @param coordinate The location to paste the thing at.
  * @returns The pasted thing if the paste was successful, null otherwise.
  */
 export function paste<T extends ICopyData>(
@@ -49,7 +52,23 @@ export function paste<T extends ICopyData>(
   workspace: WorkspaceSvg,
   coordinate?: Coordinate,
 ): ICopyable<T> | null;
+
+/**
+ * Pastes the last copied ICopyable into the workspace.
+ *
+ * @returns the pasted thing if the paste was successful, null otherwise.
+ */
 export function paste(): ICopyable<ICopyData> | null;
+
+/**
+ * Pastes the given data into the workspace, or the last copied ICopyable if
+ * no data is passed.
+ *
+ * @param copyData The data to paste into the workspace.
+ * @param workspace The workspace to paste the data into.
+ * @param coordinate The location to paste the thing at.
+ * @returns The pasted thing if the paste was successful, null otherwise.
+ */
 export function paste<T extends ICopyData>(
   copyData?: T,
   workspace?: WorkspaceSvg,
@@ -62,17 +81,23 @@ export function paste<T extends ICopyData>(
   return pasteFromData(copyData, workspace, coordinate);
 }
 
+/**
+ * Paste a pasteable element into the workspace.
+ *
+ * @param copyData The data to paste into the workspace.
+ * @param workspace The workspace to paste the data into.
+ * @param coordinate The location to paste the thing at.
+ * @returns The pasted thing if the paste was successful, null otherwise.
+ */
 function pasteFromData<T extends ICopyData>(
   copyData: T,
   workspace: WorkspaceSvg,
   coordinate?: Coordinate,
 ): ICopyable<T> | null {
   workspace = workspace.getRootWorkspace() ?? workspace;
-  return (
-    globalRegistry
-      .getObject(globalRegistry.Type.PASTER, copyData.paster, false)
-      ?.paste(copyData, workspace, coordinate) ?? null
-  ) as ICopyable<T> | null;
+  return (globalRegistry
+    .getObject(globalRegistry.Type.PASTER, copyData.paster, false)
+    ?.paste(copyData, workspace, coordinate) ?? null) as ICopyable<T> | null;
 }
 
 /**
@@ -104,8 +129,8 @@ function duplicateInternal<
 
   // I hate side effects.
   stashedCopyData = oldCopyData;
-  stashedWorkspace = oldWorkspace
-  
+  stashedWorkspace = oldWorkspace;
+
   if (!data) return null;
   return paste(data, toDuplicate.workspace) as T;
 }

--- a/core/clipboard/registry.ts
+++ b/core/clipboard/registry.ts
@@ -14,7 +14,7 @@ import * as registry from '../registry.js';
  * @param type The type of the paster to register, e.g. 'block', 'comment', etc.
  * @param paster The paster to register.
  */
-export function register<U extends ICopyData, T extends ICopyable>(
+export function register<U extends ICopyData, T extends ICopyable<U>>(
   type: string,
   paster: IPaster<U, T>,
 ) {

--- a/core/common.ts
+++ b/core/common.ts
@@ -9,9 +9,9 @@ goog.declareModuleId('Blockly.common');
 
 /* eslint-disable-next-line no-unused-vars */
 import type {Block} from './block.js';
+import {ISelectable} from './blockly.js';
 import {BlockDefinition, Blocks} from './blocks.js';
 import type {Connection} from './connection.js';
-import type {ICopyable} from './interfaces/i_copyable.js';
 import type {Workspace} from './workspace.js';
 import type {WorkspaceSvg} from './workspace_svg.js';
 
@@ -88,12 +88,12 @@ export function setMainWorkspace(workspace: Workspace) {
 /**
  * Currently selected copyable object.
  */
-let selected: ICopyable | null = null;
+let selected: ISelectable | null = null;
 
 /**
  * Returns the currently selected copyable object.
  */
-export function getSelected(): ICopyable | null {
+export function getSelected(): ISelectable | null {
   return selected;
 }
 
@@ -105,7 +105,7 @@ export function getSelected(): ICopyable | null {
  * @param newSelection The newly selected block.
  * @internal
  */
-export function setSelected(newSelection: ICopyable | null) {
+export function setSelected(newSelection: ISelectable | null) {
   selected = newSelection;
 }
 

--- a/core/interfaces/i_copyable.ts
+++ b/core/interfaces/i_copyable.ts
@@ -9,13 +9,13 @@ goog.declareModuleId('Blockly.ICopyable');
 
 import type {ISelectable} from './i_selectable.js';
 
-export interface ICopyable extends ISelectable {
+export interface ICopyable<T extends ICopyData> extends ISelectable {
   /**
    * Encode for copying.
    *
    * @returns Copy metadata.
    */
-  toCopyData(): ICopyData | null;
+  toCopyData(): T | null;
 }
 
 export namespace ICopyable {

--- a/core/interfaces/i_copyable.ts
+++ b/core/interfaces/i_copyable.ts
@@ -25,3 +25,8 @@ export namespace ICopyable {
 }
 
 export type ICopyData = ICopyable.ICopyData;
+
+/** @returns true if the given object is copyable. */
+export function isCopyable(obj: any): obj is ICopyable<ICopyData> {
+  return obj.toCopyData !== undefined;
+}

--- a/core/interfaces/i_paster.ts
+++ b/core/interfaces/i_paster.ts
@@ -9,7 +9,7 @@ import {WorkspaceSvg} from '../workspace_svg.js';
 import {ICopyable, ICopyData} from './i_copyable.js';
 
 /** An object that can paste data into a workspace. */
-export interface IPaster<U extends ICopyData, T extends ICopyable> {
+export interface IPaster<U extends ICopyData, T extends ICopyable<U>> {
   paste(
     copyData: U,
     workspace: WorkspaceSvg,
@@ -18,6 +18,8 @@ export interface IPaster<U extends ICopyData, T extends ICopyable> {
 }
 
 /** @returns True if the given object is a paster. */
-export function isPaster(obj: any): obj is IPaster<ICopyData, ICopyable> {
+export function isPaster(
+  obj: any,
+): obj is IPaster<ICopyData, ICopyable<ICopyData>> {
   return obj.paste !== undefined;
 }

--- a/core/registry.ts
+++ b/core/registry.ts
@@ -100,7 +100,7 @@ export class Type<_T> {
   static ICON = new Type<IIcon>('icon');
 
   /** @internal */
-  static PASTER = new Type<IPaster<ICopyData, ICopyable>>('paster');
+  static PASTER = new Type<IPaster<ICopyData, ICopyable<ICopyData>>>('paster');
 }
 
 /**

--- a/core/shortcut_items.ts
+++ b/core/shortcut_items.ts
@@ -11,7 +11,7 @@ import {BlockSvg} from './block_svg.js';
 import * as clipboard from './clipboard.js';
 import * as common from './common.js';
 import {Gesture} from './gesture.js';
-import type {ICopyable} from './interfaces/i_copyable.js';
+import {isCopyable} from './interfaces/i_copyable.js';
 import {KeyboardShortcut, ShortcutRegistry} from './shortcut_registry.js';
 import {KeyCodes} from './utils/keycodes.js';
 import type {WorkspaceSvg} from './workspace_svg.js';
@@ -114,7 +114,9 @@ export function registerCopy() {
       // AnyDuringMigration because:  Property 'hideChaff' does not exist on
       // type 'Workspace'.
       (workspace as AnyDuringMigration).hideChaff();
-      clipboard.copy(common.getSelected() as ICopyable);
+      const selected = common.getSelected();
+      if (!selected || !isCopyable(selected)) return false;
+      clipboard.copy(selected);
       return true;
     },
     keyCodes: [ctrlC, altC, metaC],
@@ -152,10 +154,7 @@ export function registerCut() {
     },
     callback() {
       const selected = common.getSelected();
-      if (!selected) {
-        // Shouldn't happen but appeases the type system
-        return false;
-      }
+      if (!selected || !isCopyable(selected)) return false;
       clipboard.copy(selected);
       (selected as BlockSvg).checkAndDelete();
       return true;

--- a/core/workspace_comment_svg.ts
+++ b/core/workspace_comment_svg.ts
@@ -51,7 +51,7 @@ const TEXTAREA_OFFSET = 2;
  */
 export class WorkspaceCommentSvg
   extends WorkspaceComment
-  implements IBoundedElement, IBubble, ICopyable
+  implements IBoundedElement, IBubble, ICopyable<WorkspaceCommentCopyData>
 {
   /**
    * The width and height to use to size a workspace comment when it is first

--- a/core/workspace_svg.ts
+++ b/core/workspace_svg.ts
@@ -36,7 +36,7 @@ import {Gesture} from './gesture.js';
 import {Grid} from './grid.js';
 import type {IASTNodeLocationSvg} from './interfaces/i_ast_node_location_svg.js';
 import type {IBoundedElement} from './interfaces/i_bounded_element.js';
-import type {ICopyable} from './interfaces/i_copyable.js';
+import type {ICopyData, ICopyable} from './interfaces/i_copyable.js';
 import type {IDragTarget} from './interfaces/i_drag_target.js';
 import type {IFlyout} from './interfaces/i_flyout.js';
 import type {IMetricsManager} from './interfaces/i_metrics_manager.js';
@@ -1300,7 +1300,7 @@ export class WorkspaceSvg extends Workspace implements IASTNodeLocationSvg {
    */
   paste(
     state: AnyDuringMigration | Element | DocumentFragment,
-  ): ICopyable | null {
+  ): ICopyable<ICopyData> | null {
     if (!this.rendered || (!state['type'] && !state['tagName'])) {
       return null;
     }

--- a/tests/mocha/clipboard_test.js
+++ b/tests/mocha/clipboard_test.js
@@ -1,0 +1,35 @@
+/**
+ * @license
+ * Copyright 2019 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+goog.declareModuleId('Blockly.test.clipboard');
+
+import {
+  sharedTestSetup,
+  sharedTestTeardown,
+} from './test_helpers/setup_teardown.js';
+
+suite('Clipboard', function () {
+  setup(function () {
+    this.clock = sharedTestSetup.call(this, {fireEventsNow: false}).clock;
+    this.workspace = new Blockly.WorkspaceSvg(new Blockly.Options({}));
+  });
+
+  teardown(function () {
+    sharedTestTeardown.call(this);
+  });
+
+  test('a paster registered with a given type is called when pasting that type', function () {
+    const paster = {
+      paste: sinon.stub().returns(null),
+    };
+    Blockly.clipboard.registry.register('test-paster', paster);
+
+    Blockly.clipboard.paste({paster: 'test-paster'}, this.workspace);
+    chai.assert.isTrue(paster.paste.calledOnce);
+
+    Blockly.clipboard.registry.unregister('test-paster');
+  });
+});

--- a/tests/mocha/index.html
+++ b/tests/mocha/index.html
@@ -38,6 +38,7 @@
           'Blockly.test.astNode',
           'Blockly.test.blockJson',
           'Blockly.test.blocks',
+          'Blockly.test.clipboard',
           'Blockly.test.comments',
           'Blockly.test.commentDeserialization',
           'Blockly.test.connectionChecker',


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [ ] I branched from develop
- [ ] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [X] I ran `npm run format` and `npm run lint`

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #7337

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
* Updates the `ICopyable` interface to be generic.
* Updates the `clipboard` APIs to take in data instead of being stateful.
* Makes `paste` public. Everything else remains internal.

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
* More informative typing.
* State is the worst.
* Necessary if we want people to paste things by passing in data.

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->
Now that the methods aren't stateful anymore, I could test the API boundary between the clipboard and pasters :D

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->
N/A

### Additional Information

<!-- Anything else we should know? -->
N/A

## Deprecations

`Blockly.clipboard.copy` and `Blockly.clipboard.duplicate` have both been deprecated. These were marked `@internal` so if you are conforming to Blockly's API, you should not be accessing them anyway.

`Blockly.clipboard.copy` can be replaced with calling `toCopyData` on the element you want to copy.

`Blockly.clipboard.duplicate` can be replaced by calling `Blockly.clipboard.paste(myElement.toCopyData(), myWorkspace)`.