### PR TITLE
fix: bumping copied objects

### DIFF
--- a/core/clipboard/block_paster.ts
+++ b/core/clipboard/block_paster.ts
@@ -32,9 +32,7 @@ export class BlockPaster implements IPaster<BlockCopyData, BlockSvg> {
     eventUtils.disable();
     let block;
     try {
-      block = append(copyData.blockState, workspace, {
-        recordUndo: true,
-      }) as BlockSvg;
+      block = append(copyData.blockState, workspace) as BlockSvg;
       moveBlockToNotConflict(block);
     } finally {
       eventUtils.enable();
@@ -54,9 +52,12 @@ export class BlockPaster implements IPaster<BlockCopyData, BlockSvg> {
  * Moves the given block to a location where it does not: (1) overlap exactly
  * with any other blocks, or (2) look like it is connected to any other blocks.
  *
+ * Exported for testing.
+ *
  * @param block The block to move to an unambiguous location.
+ * @internal
  */
-function moveBlockToNotConflict(block: BlockSvg) {
+export function moveBlockToNotConflict(block: BlockSvg) {
   const workspace = block.workspace;
   const snapRadius = config.snapRadius;
   const coord = block.getRelativeToSurfaceXY();

--- a/core/clipboard/block_paster.ts
+++ b/core/clipboard/block_paster.ts
@@ -11,6 +11,8 @@ import {IPaster} from '../interfaces/i_paster.js';
 import {State, append} from '../serialization/blocks.js';
 import {Coordinate} from '../utils/coordinate.js';
 import {WorkspaceSvg} from '../workspace_svg.js';
+import * as eventUtils from '../events/utils.js';
+import {config} from '../config.js';
 
 export class BlockPaster implements IPaster<BlockCopyData, BlockSvg> {
   static TYPE = 'block';
@@ -26,10 +28,87 @@ export class BlockPaster implements IPaster<BlockCopyData, BlockSvg> {
       copyData.blockState['x'] = coordinate.x;
       copyData.blockState['y'] = coordinate.y;
     }
-    return append(copyData.blockState, workspace, {
-      recordUndo: true,
-    }) as BlockSvg;
+
+    eventUtils.disable();
+    let block;
+    try {
+      block = append(copyData.blockState, workspace, {
+        recordUndo: true,
+      }) as BlockSvg;
+      moveBlockToNotConflict(block);
+    } finally {
+      eventUtils.enable();
+    }
+
+    if (!block) return block;
+
+    if (eventUtils.isEnabled() && !block.isShadow()) {
+      eventUtils.fire(new (eventUtils.get(eventUtils.BLOCK_CREATE))(block));
+    }
+    block.select();
+    return block;
   }
+}
+
+/**
+ * Moves the given block to a location where it does not: (1) overlap exactly
+ * with any other blocks, or (2) look like it is connected to any other blocks.
+ *
+ * @param block The block to move to an unambiguous location.
+ */
+function moveBlockToNotConflict(block: BlockSvg) {
+  const workspace = block.workspace;
+  const snapRadius = config.snapRadius;
+  const coord = block.getRelativeToSurfaceXY();
+  const offset = new Coordinate(0, 0);
+  // getRelativeToSurfaceXY is really expensive, so we want to cache this.
+  const otherCoords = workspace
+    .getAllBlocks(false)
+    .filter((otherBlock) => otherBlock.id != block.id)
+    .map((b) => b.getRelativeToSurfaceXY());
+
+  while (
+    blockOverlapsOtherExactly(Coordinate.sum(coord, offset), otherCoords) ||
+    blockIsInSnapRadius(block, offset, snapRadius)
+  ) {
+    if (workspace.RTL) {
+      offset.translate(-snapRadius, snapRadius * 2);
+    } else {
+      offset.translate(snapRadius, snapRadius * 2);
+    }
+  }
+
+  block!.moveTo(Coordinate.sum(coord, offset));
+}
+
+/**
+ * @returns true if the given block coordinates are less than a delta of 1 from
+ *     any of the other coordinates.
+ */
+function blockOverlapsOtherExactly(
+  coord: Coordinate,
+  otherCoords: Coordinate[],
+): boolean {
+  return otherCoords.some(
+    (otherCoord) =>
+      Math.abs(otherCoord.x - coord.x) <= 1 &&
+      Math.abs(otherCoord.y - coord.y) <= 1,
+  );
+}
+
+/**
+ * @returns true if the given block (when offset by the given amount) is close
+ *     enough to any other connections (within the snap radius) that it looks
+ *     like they could connect.
+ */
+function blockIsInSnapRadius(
+  block: BlockSvg,
+  offset: Coordinate,
+  snapRadius: number,
+): boolean {
+  return block
+    .getConnections_(false)
+    .some((connection) => !!connection.closest(snapRadius, offset).connection);
 }
 
 export interface BlockCopyData extends ICopyData {

--- a/core/clipboard/workspace_comment_paster.ts
+++ b/core/clipboard/workspace_comment_paster.ts
@@ -21,9 +21,15 @@ export class WorkspaceCommentPaster
     workspace: WorkspaceSvg,
     coordinate?: Coordinate,
   ): WorkspaceCommentSvg {
+    const state = copyData.commentState;
     if (coordinate) {
-      copyData.commentState.setAttribute('x', `${coordinate.x}`);
-      copyData.commentState.setAttribute('y', `${coordinate.y}`);
+      state.setAttribute('x', `${coordinate.x}`);
+      state.setAttribute('y', `${coordinate.y}`);
+    } else {
+      const x = parseInt(state.getAttribute('x') ?? '0') + 50;
+      const y = parseInt(state.getAttribute('y') ?? '0') + 50;
+      state.setAttribute('x', `${x}`);
+      state.setAttribute('y', `${y}`);
     }
     return WorkspaceCommentSvg.fromXmlRendered(
       copyData.commentState,

--- a/core/serialization/blocks.ts
+++ b/core/serialization/blocks.ts
@@ -396,7 +396,9 @@ export function appendInternal(
   const block = appendPrivate(state, workspace, {parentConnection, isShadow});
 
   eventUtils.enable();
-  eventUtils.fire(new (eventUtils.get(eventUtils.BLOCK_CREATE))(block));
+  if (eventUtils.isEnabled()) {
+    eventUtils.fire(new (eventUtils.get(eventUtils.BLOCK_CREATE))(block));
+  }
   eventUtils.setGroup(existingGroup);
   eventUtils.setRecordUndo(prevRecordUndo);
 

--- a/core/workspace_svg.ts
+++ b/core/workspace_svg.ts
@@ -1388,6 +1388,10 @@ export class WorkspaceSvg extends Workspace implements IASTNodeLocationSvg {
             for (let i = 0, connection; (connection = connections[i]); i++) {
               const neighbour = connection.closest(
                 config.snapRadius,
+                // TODO: This code doesn't work because it's passing an absolute
+                //     coordinate instead of a relative coordinate. Need to
+                //     figure out if I'm deprecating this function or if I
+                //     need to fix this.
                 new Coordinate(blockX, blockY),
               );
               if (neighbour.connection) {

--- a/core/workspace_svg.ts
+++ b/core/workspace_svg.ts
@@ -1445,6 +1445,9 @@ export class WorkspaceSvg extends Workspace implements IASTNodeLocationSvg {
         // with any blocks.
         commentX += 50;
         commentY += 50;
+        // TODO: This code doesn't work because it's using absolute coords
+        //    where relative coords are expected. Need to figure out what I'm
+        //    doing with this function and if I need to fix it.
         comment.moveBy(commentX, commentY);
       }
     } finally {

--- a/tests/mocha/clipboard_test.js
+++ b/tests/mocha/clipboard_test.js
@@ -114,4 +114,23 @@ suite('Clipboard', function () {
       });
     });
   });
+
+  suite('pasting comments', function () {
+    test('pasted comments are bumped to not overlap', function () {
+      Blockly.Xml.domToWorkspace(
+        Blockly.utils.xml.textToDom(
+          '<xml><comment id="test" x=10 y=10/></xml>',
+        ),
+        this.workspace,
+      );
+      const comment = this.workspace.getTopComments(false)[0];
+      const data = comment.toCopyData();
+
+      const newComment = Blockly.clipboard.paste(data, this.workspace);
+      chai.assert.deepEqual(
+        newComment.getRelativeToSurfaceXY(),
+        new Blockly.utils.Coordinate(60, 60),
+      );
+    });
+  });
 });

--- a/tests/mocha/test_helpers/events.js
+++ b/tests/mocha/test_helpers/events.js
@@ -149,13 +149,10 @@ export function assertEventFired(
   expectedWorkspaceId,
   expectedBlockId,
 ) {
-  expectedProperties = Object.assign(
-    {
-      workspaceId: expectedWorkspaceId,
-      blockId: expectedBlockId,
-    },
-    expectedProperties,
-  );
+  const baseProps = {};
+  if (expectedWorkspaceId) baseProps.workspaceId = expectedWorkspaceId;
+  if (expectedBlockId) baseProps.blockId = expectedBlockId;
+  expectedProperties = Object.assign(baseProps, expectedProperties);
   const expectedEvent = sinon.match
     .instanceOf(instanceType)
     .and(sinon.match(expectedProperties));


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [ ] I branched from develop
- [ ] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [X] I ran `npm run format` and `npm run lint`

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes N/A

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
Adds logic to bump pasted blocks out of the way of other blocks.
Adds logic to bump pasted comments out of the way of their original comment.

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
Pasting blocks directly on top of other blocks or within the snap radius of other connections is confusing to the end user.

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->
Added a test to make sure block create events are being fired.
Added tests to make sure the bumping is working correctly.

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->
N/A

### Additional Information

<!-- Anything else we should know? -->
Dependent on #7348 
