### PR TITLE
chore(tests): fix delete tests

### DIFF
--- a/tests/browser/test/delete_blocks_test.js
+++ b/tests/browser/test/delete_blocks_test.js
@@ -167,9 +167,7 @@ suite('Delete blocks', function (done) {
   test('Delete block using context menu', async function () {
     const before = (await getAllBlocks(this.browser)).length;
     // Get first print block, click to select it, and delete it using context menu.
-    const block = (await getBlockElementById(this.browser, firstBlockId)).$(
-      '.blocklyPath',
-    );
+    const block = await getBlockElementById(this.browser, firstBlockId);
     await contextMenuSelect(this.browser, block, 'Delete 2 Blocks');
     const after = (await getAllBlocks(this.browser)).length;
     chai.assert.equal(

--- a/tests/browser/test/delete_blocks_test.js
+++ b/tests/browser/test/delete_blocks_test.js
@@ -98,7 +98,7 @@ const startBlocks = {
     ],
   },
 };
-const pauseLength = 20;
+const pauseLength = 200;
 
 suite('Delete blocks', function (done) {
   // Setting timeout to unlimited as the webdriver takes a longer time to run than most mocha test


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [x] I ran `npm run format` and `npm run lint`

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes delete tests broken in ci

### Proposed Changes

- Increases pause length from 20ms to 200ms.. i guess 20 was too short. I tried to avoid pauses in favor of `waitForExist`s but you have to pause after typing keys
- Fixes context menu test. I had previously changed the helper to click on the text on the block, but I was already passing in a child element in my test which wasn't compatible with the new helper.

#### Behavior Before Change

<!--TODO: Image, gif or explanation of behavior before this pull request. -->

#### Behavior After Change

<!--TODO: Image, gif or explanation of behavior after this pull request. -->

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage

Passes 3x on CI now so hopefully less flaky?

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
