### PR TITLE
chore: upgrade keyboard shortcuts and context menus to use non-deprecated APIs

### DIFF
--- a/core/contextmenu.ts
+++ b/core/contextmenu.ts
@@ -297,7 +297,9 @@ export function commentDuplicateOption(
     text: Msg['DUPLICATE_COMMENT'],
     enabled: true,
     callback: function () {
-      clipboard.duplicate(comment);
+      const data = comment.toCopyData();
+      if (!data) return;
+      clipboard.paste(data, comment.workspace);
     },
   };
   return duplicateOption;

--- a/core/contextmenu_items.ts
+++ b/core/contextmenu_items.ts
@@ -331,9 +331,10 @@ export function registerDuplicate() {
       return 'hidden';
     },
     callback(scope: Scope) {
-      if (scope.block) {
-        clipboard.duplicate(scope.block);
-      }
+      if (!scope.block) return;
+      const data = scope.block.toCopyData();
+      if (!data) return;
+      clipboard.paste(data, scope.block.workspace);
     },
     scopeType: ContextMenuRegistry.ScopeType.BLOCK,
     id: 'blockDuplicate',

--- a/core/shortcut_items.ts
+++ b/core/shortcut_items.ts
@@ -112,6 +112,8 @@ export function registerCopy() {
       );
     },
     callback(workspace, e) {
+      // Prevent the default copy behavior, which may beep or otherwise indicate
+      // an error due to the lack of a selection.
       e.preventDefault();
       workspace.hideChaff();
       const selected = common.getSelected();

--- a/core/shortcut_registry.ts
+++ b/core/shortcut_registry.ts
@@ -15,7 +15,7 @@ goog.declareModuleId('Blockly.ShortcutRegistry');
 
 import {KeyCodes} from './utils/keycodes.js';
 import * as object from './utils/object.js';
-import { WorkspaceSvg } from './workspace_svg.js';
+import {WorkspaceSvg} from './workspace_svg.js';
 
 /**
  * Class for the registry of keyboard shortcuts. This is intended to be a

--- a/core/shortcut_registry.ts
+++ b/core/shortcut_registry.ts
@@ -15,7 +15,7 @@ goog.declareModuleId('Blockly.ShortcutRegistry');
 
 import {KeyCodes} from './utils/keycodes.js';
 import * as object from './utils/object.js';
-import type {Workspace} from './workspace.js';
+import { WorkspaceSvg } from './workspace_svg.js';
 
 /**
  * Class for the registry of keyboard shortcuts. This is intended to be a
@@ -224,7 +224,7 @@ export class ShortcutRegistry {
    * @param e The key down event.
    * @returns True if the event was handled, false otherwise.
    */
-  onKeyDown(workspace: Workspace, e: KeyboardEvent): boolean {
+  onKeyDown(workspace: WorkspaceSvg, e: KeyboardEvent): boolean {
     const key = this.serializeKeyEvent_(e);
     const shortcutNames = this.getShortcutNamesByKeyCode(key);
     if (!shortcutNames) {
@@ -346,9 +346,9 @@ export class ShortcutRegistry {
 
 export namespace ShortcutRegistry {
   export interface KeyboardShortcut {
-    callback?: (p1: Workspace, p2: Event, p3: KeyboardShortcut) => boolean;
+    callback?: (p1: WorkspaceSvg, p2: Event, p3: KeyboardShortcut) => boolean;
     name: string;
-    preconditionFn?: (p1: Workspace) => boolean;
+    preconditionFn?: (p1: WorkspaceSvg) => boolean;
     metadata?: object;
     keyCodes?: (number | string)[];
     allowCollision?: boolean;

--- a/tests/mocha/contextmenu_items_test.js
+++ b/tests/mocha/contextmenu_items_test.js
@@ -419,13 +419,13 @@ suite('Context Menu Items', function () {
         );
       });
 
-      test('Calls duplicate', function () {
-        const spy = sinon.spy(Blockly.clipboard.TEST_ONLY, 'duplicateInternal');
-
+      test('the block is duplicated', function () {
         this.duplicateOption.callback(this.scope);
-
-        sinon.assert.calledOnce(spy);
-        sinon.assert.calledWith(spy, this.block);
+        chai.assert.equal(
+          this.workspace.getTopBlocks(false).length,
+          2,
+          'Expected a second block',
+        );
       });
 
       test('Has correct label', function () {

--- a/tests/mocha/keydown_test.js
+++ b/tests/mocha/keydown_test.js
@@ -30,7 +30,7 @@ suite('Key Down', function () {
    */
   function setSelectedBlock(workspace) {
     defineStackBlock();
-    const block = workspace.newBlock('stack_block')
+    const block = workspace.newBlock('stack_block');
     Blockly.common.setSelected(block);
     return block;
   }

--- a/tests/mocha/keydown_test.js
+++ b/tests/mocha/keydown_test.js
@@ -26,10 +26,13 @@ suite('Key Down', function () {
   /**
    * Creates a block and sets it as Blockly.selected.
    * @param {Blockly.Workspace} workspace The workspace to create a new block on.
+   * @return {Blockly.Block} The block being selected.
    */
   function setSelectedBlock(workspace) {
     defineStackBlock();
-    Blockly.common.setSelected(workspace.newBlock('stack_block'));
+    const block = workspace.newBlock('stack_block')
+    Blockly.common.setSelected(block);
+    return block;
   }
 
   /**
@@ -109,8 +112,8 @@ suite('Key Down', function () {
 
   suite('Copy', function () {
     setup(function () {
-      setSelectedBlock(this.workspace);
-      this.copySpy = sinon.spy(Blockly.clipboard.TEST_ONLY, 'copyInternal');
+      this.block = setSelectedBlock(this.workspace);
+      this.copySpy = sinon.spy(this.block, 'toCopyData');
       this.hideChaffSpy = sinon.spy(
         Blockly.WorkspaceSvg.prototype,
         'hideChaff',


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [ ] I branched from develop
- [ ] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [X] I ran `npm run format` and `npm run lint`

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #7338 

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
Upgrades keyboard shortcuts and context menu items to use `toCopyData` instead of `copy` and `duplicate`

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
Deprecation warnings are sad :/

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->

Manually tested that copying, pasting, cutting, and duplicating works for blocks and workspace comments.

Workspace comments only support duplicating.

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->
N/A

### Additional Information

<!-- Anything else we should know? -->

Dependent on #7349 
