### PR TITLE
fix: have rendered blocks render themselves on construction

### DIFF
--- a/blocks/lists.ts
+++ b/blocks/lists.ts
@@ -187,13 +187,11 @@ const LISTS_CREATE_WITH = {
     const containerBlock = workspace.newBlock(
       'lists_create_with_container',
     ) as ContainerBlock;
-    (containerBlock as BlockSvg).initSvg();
     let connection = containerBlock.getInput('STACK')!.connection;
     for (let i = 0; i < this.itemCount_; i++) {
       const itemBlock = workspace.newBlock(
         'lists_create_with_item',
       ) as ItemBlock;
-      (itemBlock as BlockSvg).initSvg();
       if (!itemBlock.previousConnection) {
         throw new Error('itemBlock has no previousConnection');
       }

--- a/blocks/logic.ts
+++ b/blocks/logic.ts
@@ -375,17 +375,14 @@ const CONTROLS_IF_MUTATOR_MIXIN = {
    */
   decompose: function (this: IfBlock, workspace: Workspace): ContainerBlock {
     const containerBlock = workspace.newBlock('controls_if_if');
-    (containerBlock as BlockSvg).initSvg();
     let connection = containerBlock.nextConnection!;
     for (let i = 1; i <= this.elseifCount_; i++) {
       const elseifBlock = workspace.newBlock('controls_if_elseif');
-      (elseifBlock as BlockSvg).initSvg();
       connection.connect(elseifBlock.previousConnection!);
       connection = elseifBlock.nextConnection!;
     }
     if (this.elseCount_) {
       const elseBlock = workspace.newBlock('controls_if_else');
-      (elseBlock as BlockSvg).initSvg();
       connection.connect(elseBlock.previousConnection!);
     }
     return containerBlock;

--- a/blocks/text.ts
+++ b/blocks/text.ts
@@ -792,13 +792,11 @@ const JOIN_MUTATOR_MIXIN = {
     const containerBlock = workspace.newBlock(
       'text_create_join_container',
     ) as BlockSvg;
-    containerBlock.initSvg();
     let connection = containerBlock.getInput('STACK')!.connection!;
     for (let i = 0; i < this.itemCount_; i++) {
       const itemBlock = workspace.newBlock(
         'text_create_join_item',
       ) as JoinItemBlock;
-      itemBlock.initSvg();
       connection.connect(itemBlock.previousConnection);
       connection = itemBlock.nextConnection;
     }

--- a/core/block_svg.ts
+++ b/core/block_svg.ts
@@ -187,6 +187,8 @@ export class BlockSvg
     this.svgGroup_.setAttribute('data-id', this.id);
 
     this.doInit_();
+    this.initSvg();
+    this.queueRender();
   }
 
   /**

--- a/core/blockly.ts
+++ b/core/blockly.ts
@@ -407,7 +407,6 @@ export const PROCEDURE_CATEGORY_NAME: string = Procedures.CATEGORY_NAME;
 // Context for why we need to monkey-patch in these functions (internal):
 //   https://docs.google.com/document/d/1MbO0LEA-pAyx1ErGLJnyUqTLrcYTo-5zga9qplnxeXo/edit?usp=sharing&resourcekey=0-5h_32-i-dHwHjf_9KYEVKg
 
-// clang-format off
 Workspace.prototype.newBlock = function (
   prototypeName: string,
   opt_id?: string,
@@ -460,7 +459,6 @@ Names.prototype.populateProcedures = function (
     this.getName(flattenedProcedures[i][0], Names.NameType.PROCEDURE);
   }
 };
-// clang-format on
 
 // Re-export submodules that no longer declareLegacyNamespace.
 export {browserEvents};

--- a/core/insertion_marker_manager.ts
+++ b/core/insertion_marker_manager.ts
@@ -275,7 +275,6 @@ export class InsertionMarkerManager {
       result.setCollapsed(sourceBlock.isCollapsed());
       result.setInputsInline(sourceBlock.getInputsInline());
 
-      result.initSvg();
       result.getSvgRoot().setAttribute('visibility', 'hidden');
     } finally {
       eventUtils.enable();

--- a/core/rendered_connection.ts
+++ b/core/rendered_connection.ts
@@ -534,20 +534,6 @@ export class RenderedConnection extends Connection {
   }
 
   /**
-   * Respawn the shadow block if there was one connected to the this connection.
-   * Render/rerender blocks as needed.
-   */
-  protected override respawnShadow_() {
-    super.respawnShadow_();
-    const blockShadow = this.targetBlock();
-    if (!blockShadow) {
-      return;
-    }
-    blockShadow.initSvg();
-    blockShadow.queueRender();
-  }
-
-  /**
    * Find all nearby compatible connections to this connection.
    * Type checking does not apply, since this function is used for bumping.
    *

--- a/core/serialization/blocks.ts
+++ b/core/serialization/blocks.ts
@@ -703,8 +703,6 @@ function initBlock(block: Block, rendered: boolean) {
     // operation to decrease load time.
     blockSvg.setConnectionTracking(false);
 
-    blockSvg.initSvg();
-    blockSvg.queueRender();
     blockSvg.updateDisabled();
 
     // fixes #6076 JSO deserialization doesn't

--- a/demos/blockfactory/blocks.js
+++ b/demos/blockfactory/blocks.js
@@ -365,12 +365,10 @@ Blockly.Blocks['field_dropdown'] = {
   decompose: function(workspace) {
     // Populate the mutator's dialog with this block's components.
     var containerBlock = workspace.newBlock('field_dropdown_container');
-    containerBlock.initSvg();
     var connection = containerBlock.getInput('STACK').connection;
     for (var i = 0; i < this.optionList_.length; i++) {
       var optionBlock = workspace.newBlock(
           'field_dropdown_option_' + this.optionList_[i]);
-      optionBlock.initSvg();
       connection.connect(optionBlock.previousConnection);
       connection = optionBlock.nextConnection;
     }
@@ -640,11 +638,9 @@ Blockly.Blocks['type_group'] = {
   decompose: function(workspace) {
     // Populate the mutator's dialog with this block's components.
     var containerBlock = workspace.newBlock('type_group_container');
-    containerBlock.initSvg();
     var connection = containerBlock.getInput('STACK').connection;
     for (var i = 0; i < this.typeCount_; i++) {
       var typeBlock = workspace.newBlock('type_group_item');
-      typeBlock.initSvg();
       connection.connect(typeBlock.previousConnection);
       connection = typeBlock.nextConnection;
     }

--- a/demos/blockfactory/blocks.js
+++ b/demos/blockfactory/blocks.js
@@ -64,30 +64,21 @@ Blockly.Blocks['factory_base'] = {
   spawnOutputShadow_: function(option) {
     // Helper method for deciding which type of outputs this block needs
     // to attach shadow blocks to.
+    const shadowState = {'type': 'type_null'};
     switch (option) {
       case 'LEFT':
-        this.connectOutputShadow_('OUTPUTTYPE');
+        this.getInput('OUTPUTTYPE').connection.setShadowState(shadowState);
         break;
       case 'TOP':
-        this.connectOutputShadow_('TOPTYPE');
+        this.getInput('TOPTYPE').connection.setShadowState(shadowState);
         break;
       case 'BOTTOM':
-        this.connectOutputShadow_('BOTTOMTYPE');
+        this.getInput('BOTTOMTYPE').connection.setShadowState(shadowState);
         break;
       case 'BOTH':
-        this.connectOutputShadow_('TOPTYPE');
-        this.connectOutputShadow_('BOTTOMTYPE');
+        this.getInput('TOPTYPE').connection.setShadowState(shadowState);
+        this.getInput('BOTTOMTYPE').connection.setShadowState(shadowState);
         break;
-    }
-  },
-  connectOutputShadow_: function(outputType) {
-    // Helper method to create & connect shadow block.
-    var type = this.workspace.newBlock('type_null');
-    type.setShadow(true);
-    type.outputConnection.connect(this.getInput(outputType).connection);
-    type.initSvg();
-    if (this.rendered) {
-      type.render();
     }
   },
   updateShape_: function(option) {

--- a/demos/blockfactory/factory.js
+++ b/demos/blockfactory/factory.js
@@ -227,8 +227,6 @@ BlockFactory.updatePreview = function() {
 
     // Create the preview block.
     var previewBlock = BlockFactory.previewWorkspace.newBlock(blockType);
-    previewBlock.initSvg();
-    previewBlock.render();
     previewBlock.setMovable(false);
     previewBlock.setDeletable(false);
     previewBlock.moveBy(15, 10);

--- a/tests/mocha/theme_test.js
+++ b/tests/mocha/theme_test.js
@@ -128,7 +128,7 @@ suite('Theme', function () {
     try {
       const blockStyles = createBlockStyles();
       const theme = new Blockly.Theme('themeName', blockStyles);
-      workspace = new Blockly.WorkspaceSvg(new Blockly.Options({}));
+      workspace = Blockly.inject('blocklyDiv', {});
       const blockA = workspace.newBlock('stack_block');
 
       blockA.setStyle = function () {


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [X] I ran `npm run format` and `npm run lint`

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Work on #5146

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
Makes it so that BlockSvgs automatically render themselves when they are constructed.

### Reason for Changes

Before this change external devs needed to call `initSvg` and `render` on their blocks if they were instantiating them via `workspace.newBlock`. But I deprecated `render` recently. This makes it so calling `render` is no longer necessary.

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->
Tested that loading the spaghetti code, and instantiating via `newBlock` both worked as expected.

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->
N/A

### Additional Information

<!-- Anything else we should know? -->
I decided to have these queue the render instead of rendering immediately. External devs calling `render` currently will trigger the immediate render, so this is non-breaking. And this way they can properly switch to using `finishQueuedRenders`.