### PR TITLE
deprecate: workspace paste

### DIFF
--- a/core/workspace_svg.ts
+++ b/core/workspace_svg.ts
@@ -1295,6 +1295,12 @@ export class WorkspaceSvg extends Workspace implements IASTNodeLocationSvg {
   paste(
     state: AnyDuringMigration | Element | DocumentFragment,
   ): ICopyable<ICopyData> | null {
+    deprecation.warn(
+      'Blockly.WorkspaceSvg.prototype.paste',
+      'v11',
+      'v12',
+      'Blockly.clipboard.paste',
+    );
     if (!this.rendered || (!state['type'] && !state['tagName'])) {
       return null;
     }
@@ -1382,10 +1388,6 @@ export class WorkspaceSvg extends Workspace implements IASTNodeLocationSvg {
             for (let i = 0, connection; (connection = connections[i]); i++) {
               const neighbour = connection.closest(
                 config.snapRadius,
-                // TODO: This code doesn't work because it's passing an absolute
-                //     coordinate instead of a relative coordinate. Need to
-                //     figure out if I'm deprecating this function or if I
-                //     need to fix this.
                 new Coordinate(blockX, blockY),
               );
               if (neighbour.connection) {
@@ -1439,9 +1441,6 @@ export class WorkspaceSvg extends Workspace implements IASTNodeLocationSvg {
         // with any blocks.
         commentX += 50;
         commentY += 50;
-        // TODO: This code doesn't work because it's using absolute coords
-        //    where relative coords are expected. Need to figure out what I'm
-        //    doing with this function and if I need to fix it.
         comment.moveBy(commentX, commentY);
       }
     } finally {

--- a/core/workspace_svg.ts
+++ b/core/workspace_svg.ts
@@ -1291,6 +1291,8 @@ export class WorkspaceSvg extends Workspace implements IASTNodeLocationSvg {
    *
    * @param state The representation of the thing to paste.
    * @returns The pasted thing, or null if the paste was not successful.
+   * @deprecated v11. Use `Blockly.clipboard.paste` instead. To be removed in
+   *     v12.
    */
   paste(
     state: AnyDuringMigration | Element | DocumentFragment,

--- a/core/workspace_svg.ts
+++ b/core/workspace_svg.ts
@@ -1292,8 +1292,8 @@ export class WorkspaceSvg extends Workspace implements IASTNodeLocationSvg {
    *
    * @param state The representation of the thing to paste.
    * @returns The pasted thing, or null if the paste was not successful.
-   * @deprecated v11. Use `Blockly.clipboard.paste` instead. To be removed in
-   *     v12.
+   * @deprecated v10. Use `Blockly.clipboard.paste` instead. To be removed in
+   *     v11.
    */
   paste(
     state: AnyDuringMigration | Element | DocumentFragment,

--- a/core/workspace_svg.ts
+++ b/core/workspace_svg.ts
@@ -78,6 +78,7 @@ import * as Xml from './xml.js';
 import {ZoomControls} from './zoom_controls.js';
 import {ContextMenuOption} from './contextmenu_registry.js';
 import * as renderManagement from './render_management.js';
+import * as deprecation from './utils/deprecation.js';
 
 /** Margin around the top/bottom/left/right after a zoomToFit call. */
 const ZOOM_TO_FIT_MARGIN = 20;

--- a/core/workspace_svg.ts
+++ b/core/workspace_svg.ts
@@ -1300,8 +1300,8 @@ export class WorkspaceSvg extends Workspace implements IASTNodeLocationSvg {
   ): ICopyable<ICopyData> | null {
     deprecation.warn(
       'Blockly.WorkspaceSvg.prototype.paste',
+      'v10',
       'v11',
-      'v12',
       'Blockly.clipboard.paste',
     );
     if (!this.rendered || (!state['type'] && !state['tagName'])) {
@@ -1391,6 +1391,9 @@ export class WorkspaceSvg extends Workspace implements IASTNodeLocationSvg {
             for (let i = 0, connection; (connection = connections[i]); i++) {
               const neighbour = connection.closest(
                 config.snapRadius,
+                // This code doesn't work because it's passing absolute coords
+                // instead of relative coords. But we're deprecating the `paste`
+                // function anyway so we're not going to fix it.
                 new Coordinate(blockX, blockY),
               );
               if (neighbour.connection) {
@@ -1444,6 +1447,9 @@ export class WorkspaceSvg extends Workspace implements IASTNodeLocationSvg {
         // with any blocks.
         commentX += 50;
         commentY += 50;
+        // This code doesn't work because it's passing absolute coords
+        // instead of relative coords. But we're deprecating the `paste`
+        // function anyway so we're not going to fix it.
         comment.moveBy(commentX, commentY);
       }
     } finally {


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [ ] I branched from develop
- [x] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [X] I ran `npm run format` and `npm run lint`

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes N/A

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
Deprecates the `paste` function on the workspace.

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
This function is not maintainable. It is hard coded to deserialize block data and workspace comment data. It cannot be backwards compatibily updated to use the new paster system, because it doesn't takes in the save state instead of the `CopyData` directly.

I see no reason to maintain this when we have better functionality in `clipboard.paste`.

For now it will continue to work as it did before (no breaking changes). But it will be deleted in v12.

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->
N/A This is just a deprecation :P

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->
N/A

### Additional Information

<!-- Anything else we should know? -->
N/A
