### PR TITLE
feat: have the trashcan hide scrollbars when the flyout opens

### DIFF
--- a/core/trashcan.ts
+++ b/core/trashcan.ts
@@ -306,6 +306,7 @@ export class Trashcan
     setTimeout(() => {
       this.flyout?.show(contents);
       blocklyStyle.cursor = '';
+      this.workspace.scrollbar?.setVisible(false);
     }, 10);
     this.fireUiEvent(true);
   }
@@ -316,6 +317,7 @@ export class Trashcan
       return;
     }
     this.flyout?.hide();
+    this.workspace.scrollbar?.setVisible(true);
     this.fireUiEvent(false);
     this.workspace.recordDragTargets();
   }


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [X] I ran `npm run format` and `npm run lint`

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes N/A
Related to https://github.com/google/blockly-samples/issues/1841

### Proposed Changes
Temporarily hide the scrollbars in the main workspace while the trashcan flyout is open.
<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->

### Reason for Changes
Having multiple sets of overlapping scrollbars is confusing to users.
<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->
Manually tested that scrollbars are hidden.

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->
N/A

### Additional Information

<!-- Anything else we should know? -->
N/A