### PR TITLE
fix: dedeprecate render functions

### DIFF
--- a/core/block_svg.ts
+++ b/core/block_svg.ts
@@ -1548,13 +1548,8 @@ export class BlockSvg
   /**
    * Immediately lays out and reflows a block based on its contents and
    * settings.
-   *
-   * @deprecated Renders are triggered automatically when the block is modified
-   *     (e.g. fields are modified or inputs are added). Any calls to render()
-   *     are no longer necessary. To be removed in v11.
    */
   render() {
-    deprecation.warn('Blockly.BlockSvg.prototype.render', 'v10', 'v11');
     this.queueRender();
     renderManagement.triggerQueuedRenders();
   }

--- a/core/workspace_svg.ts
+++ b/core/workspace_svg.ts
@@ -78,7 +78,6 @@ import * as Xml from './xml.js';
 import {ZoomControls} from './zoom_controls.js';
 import {ContextMenuOption} from './contextmenu_registry.js';
 import * as renderManagement from './render_management.js';
-import * as deprecation from './utils/deprecation.js';
 
 /** Margin around the top/bottom/left/right after a zoomToFit call. */
 const ZOOM_TO_FIT_MARGIN = 20;
@@ -1232,13 +1231,8 @@ export class WorkspaceSvg extends Workspace implements IASTNodeLocationSvg {
 
   /**
    * Render all blocks in workspace.
-   *
-   * @deprecated Renders are triggered automatically when the block is modified
-   *     (e.g. fields are modified or inputs are added). Any calls to render()
-   *     are no longer necessary. To be removed in v11.
    */
   render() {
-    deprecation.warn('Blockly.WorkspaceSvg.prototype.render', 'v10', 'v11');
     // Generate list of all blocks.
     const blocks = this.getAllBlocks(false);
     // Render each block.


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [X] I ran `npm run format` and `npm run lint`

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes N/A

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->

Dedeprecates `render` on the block and workspace.

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
See here: https://github.com/google/blockly/pull/7355#issuecomment-1666203356

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->
N/A

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->
N/A

### Additional Information

<!-- Anything else we should know? -->
N/A
