### PR TITLE
fix: Preemptively fix API change in NDB.

### DIFF
--- a/appengine/storage.py
+++ b/appengine/storage.py
@@ -44,9 +44,9 @@ def xmlToKey(xml_content):
   # Store XML and return a generated key.
   xml_hash = int(hashlib.sha1(xml_content.encode("utf-8")).hexdigest(), 16)
   xml_hash = int(xml_hash % (2 ** 64) - (2 ** 63))
-  lookup_query = Xml.query(Xml.xml_hash == xml_hash)
   client = ndb.Client()
   with client.context():
+    lookup_query = Xml.query(Xml.xml_hash == xml_hash)
     lookup_result = lookup_query.get()
     if lookup_result:
       xml_key = lookup_result.key.string_id()


### PR DESCRIPTION
Glockenspiel broke due to 'query' now being required within a client context.  This change fixed Glockenspiel.  Blockly samples doesn't appear to be broken yet, but Glockenspiel broke at midnight yesterday.

Similar change being made to Blockly Games.

google.cloud.ndb.exceptions.ContextError
No current context. NDB calls must be made in context established by google.cloud.ndb.Client.context.
Traceback (most recent call last): File "/layers/google.python.pip/pip/lib/python3.7/site-packages/gunicorn/workers/gthread.py", line 271, in handle keepalive = self.handle_request(req, conn) File "/layers/google.python.pip/pip/lib/python3.7/site-packages/gunicorn/workers/gthread.py", line 323, in handle_request respiter = self.wsgi(environ, resp.start_response) File "/srv/main.py", line 42, in app return [storage.app](http://storage.app/)(environ, start_response) File "/srv/storage.py", line 89, in app out = xmlToKey(forms["xml"].value) File "/srv/storage.py", line 47, in xmlToKey lookup_query = Xml.query(Xml.xml_hash == xml_hash) File "/layers/google.python.pip/pip/lib/python3.7/site-packages/google/cloud/ndb/utils.py", line 118, in wrapper return wrapped(*args, **new_kwargs) File "/layers/google.python.pip/pip/lib/python3.7/site-packages/google/cloud/ndb/model.py", line 5545, in _query default_options=kwargs["default_options"], File "/layers/google.python.pip/pip/lib/python3.7/site-packages/google/cloud/ndb/query.py", line 1384, in __init__ database = context_module.get_context().client.database or None File "/layers/google.python.pip/pip/lib/python3.7/site-packages/google/cloud/ndb/context.py", line 118, in get_context raise exceptions.ContextError() google.cloud.ndb.exceptions.ContextError: No current context. NDB calls must be made in context established by google.cloud.ndb.Client.context.