### PR TITLE
feat: Insertion marker json deserialization 7316

### DIFF
--- a/core/insertion_marker_manager.ts
+++ b/core/insertion_marker_manager.ts
@@ -22,6 +22,7 @@ import * as eventUtils from './events/utils.js';
 import type {IDeleteArea} from './interfaces/i_delete_area.js';
 import type {IDragTarget} from './interfaces/i_drag_target.js';
 import type {RenderedConnection} from './rendered_connection.js';
+import * as blocks from './serialization/blocks.js';
 import type {Coordinate} from './utils/coordinate.js';
 import type {WorkspaceSvg} from './workspace_svg.js';
 import * as renderManagement from './render_management.js';
@@ -225,10 +226,12 @@ export class InsertionMarkerManager {
     let result: BlockSvg;
     try {
       // 1. Serialize the source block to JSON
-      const blockJson = Blockly.serialization.blocks.save(sourceBlock);
-
+      const blockJson = blocks.save(sourceBlock);
+      if (!blockJson) {
+        throw new Error('Failed to serialize source block.');
+      }
       // 2. Deserialize the JSON back to a block in the same workspace
-      result = Blockly.serialization.blocks.append(blockJson, this.workspace);
+      result = blocks.append(blockJson, this.workspace) as BlockSvg;
 
       // Setting the result as an insertion marker
       result.setInsertionMarker(true);

--- a/core/insertion_marker_manager.ts
+++ b/core/insertion_marker_manager.ts
@@ -225,18 +225,14 @@ export class InsertionMarkerManager {
     eventUtils.disable();
     let result: BlockSvg;
     try {
-      // 1. Serialize the source block to JSON
       const blockJson = blocks.save(sourceBlock);
       if (!blockJson) {
         throw new Error('Failed to serialize source block.');
       }
-      // 2. Deserialize the JSON back to a block in the same workspace
       result = blocks.append(blockJson, this.workspace) as BlockSvg;
 
-      // Setting the result as an insertion marker
       result.setInsertionMarker(true);
 
-      // Initialize the SVG for rendering
       result.initSvg();
       result.getSvgRoot().setAttribute('visibility', 'hidden');
     } finally {

--- a/core/insertion_marker_manager.ts
+++ b/core/insertion_marker_manager.ts
@@ -18,7 +18,6 @@ import type {BlockSvg} from './block_svg.js';
 import * as common from './common.js';
 import {ComponentManager} from './component_manager.js';
 import {config} from './config.js';
-import * as constants from './constants.js';
 import * as eventUtils from './events/utils.js';
 import type {IDeleteArea} from './interfaces/i_delete_area.js';
 import type {IDragTarget} from './interfaces/i_drag_target.js';
@@ -42,16 +41,6 @@ interface CandidateConnection {
   local: RenderedConnection;
   radius: number;
 }
-
-/**
- * An error message to throw if the block created by createMarkerBlock_ is
- * missing any components.
- */
-const DUPLICATE_BLOCK_ERROR =
-  'The insertion marker ' +
-  'manager tried to create a marker but the result is missing %1. If ' +
-  'you are using a mutator, make sure your domToMutation method is ' +
-  'properly defined.';
 
 /**
  * Class that controls updates to connections during drags.  It is primarily


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [x] I ran `npm run format` and `npm run lint`

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
- Fixes #7316 

### Proposed Changes

Change the insertion marker `createMarkerBlock` code over to use **JSON serialization and deserialization**.

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->

#### Behavior Before Change

In Blockly's XML serialization, child blocks are represented using nested XML elements. This means that if a block has child blocks connected to it, those child blocks will be represented as nested XML elements within the XML element representing the parent block. The structure of the XML serialization mirrors the structure of the blocks in the workspace.

<!--TODO: Image, gif or explanation of behavior before this pull request. -->

#### Behavior After Change

The JSON serialization system in Blockly does something similar, but with a JSON structure instead of XML. The structure of the serialized data, whether XML or JSON, is designed to capture the hierarchical relationships between blocks and their connections.

<!--TODO: Image, gif or explanation of behavior after this pull request. -->

### Reason for Changes

Insertion markers duplicate the block being dragged, and then tell the duplicate to be an insertion marker.

Currently the duplication duplicates (ha) a lot of code from the serialization system. We think this is because in the past the XML system didn't have a good way to just serialize and deserialize a single block (without children). But the JSON system does have this!

- Sparked by this discussion: https://groups.google.com/g/blockly/c/gcvynl88QLY/m/shFyX4x0BwAJ

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
