### PR TITLE
feat: Export shape interfaces from ConstantProvider

### DIFF
--- a/core/renderers/common/block_rendering.ts
+++ b/core/renderers/common/block_rendering.ts
@@ -109,3 +109,14 @@ export {SquareCorner};
 export {StatementInput};
 export {TopRow};
 export {Types};
+
+export {
+  OutsideCorners,
+  InsideCorners,
+  StartHat,
+  Notch,
+  PuzzleTab,
+  JaggedTeeth,
+  BaseShape,
+  DynamicShape,
+} from './constants.js';

--- a/core/renderers/common/block_rendering.ts
+++ b/core/renderers/common/block_rendering.ts
@@ -32,7 +32,6 @@ import {StatementInput} from '../measurables/statement_input.js';
 import {TopRow} from '../measurables/top_row.js';
 import {Types} from '../measurables/types.js';
 
-import {ConstantProvider} from './constants.js';
 import {Drawer} from './drawer.js';
 import type {IPathObject} from './i_path_object.js';
 import {RenderInfo} from './info.js';
@@ -82,7 +81,6 @@ export function init(
 }
 export {BottomRow};
 export {Connection};
-export {ConstantProvider};
 export {Drawer};
 export {ExternalValueInput};
 export {Field};
@@ -119,4 +117,5 @@ export {
   JaggedTeeth,
   BaseShape,
   DynamicShape,
+  ConstantProvider,
 } from './constants.js';


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [x] I ran `npm run format` and `npm run lint`

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
- Fixes #7286 

### Proposed Changes

Export the shape interfaces defined in the ConstantProvider file from blockRendering, or the relevant namespace (geras, zelos) for the given renderer.
<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->

#### Behavior Before Change

External developers have to look at the source code to see what values they should return from custom rendering methods.
<!--TODO: Image, gif or explanation of behavior before this pull request. -->

#### Behavior After Change
After this change the External developers do not have to look at the source code for returning the custom rendering methods.
<!--TODO: Image, gif or explanation of behavior after this pull request. -->

### Reason for Changes

As the types related to shapes (e.g. `BasicShape`, `StartHat`, `Notch`, `PuzzleTab`) are not exported from `Blockly.blockRendering` which was making the bad developing experience for the external developers.

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
