### PR TITLE
fix: remove specific warning text

### DIFF
--- a/core/block_svg.ts
+++ b/core/block_svg.ts
@@ -896,11 +896,10 @@ export class BlockSvg
    * Set this block's warning text.
    *
    * @param text The text, or null to delete.
-   * @param opt_id An optional ID for the warning text to be able to maintain
+   * @param id An optional ID for the warning text to be able to maintain
    *     multiple warnings.
    */
-  override setWarningText(text: string | null, opt_id?: string) {
-    const id = opt_id || '';
+  override setWarningText(text: string | null, id: string = '') {
     if (!id) {
       // Kill all previous pending processes, this edit supersedes them all.
       for (const timeout of this.warningTextDb.values()) {
@@ -931,8 +930,9 @@ export class BlockSvg
     }
 
     const icon = this.getIcon(WarningIcon.TYPE) as WarningIcon | undefined;
-    if (typeof text === 'string') {
+    if (text) {
       // Bubble up to add a warning on top-most collapsed block.
+      // TODO(#6020): This warning is never removed.
       let parent = this.getSurroundParent();
       let collapsedParent = null;
       while (parent) {
@@ -958,6 +958,9 @@ export class BlockSvg
       if (!id) {
         this.removeIcon(WarningIcon.TYPE);
       } else {
+        // Remove just this warning id's message.
+        icon.addMessage('', id);
+        // Then remove the entire icon if there is no longer any text.
         if (!icon.getText()) this.removeIcon(WarningIcon.TYPE);
       }
     }

--- a/tests/mocha/block_test.js
+++ b/tests/mocha/block_test.js
@@ -1612,6 +1612,83 @@ suite('Blocks', function () {
       });
     });
 
+    suite('Warning icons', function () {
+      setup(function () {
+        this.workspace = Blockly.inject('blocklyDiv');
+
+        this.block = this.workspace.newBlock('stack_block');
+        this.block.initSvg();
+        this.block.render();
+      });
+
+      test('Block with no warning text does not have warning icon', function () {
+        const icon = this.block.getIcon(Blockly.icons.WarningIcon.TYPE);
+        chai.assert.isUndefined(
+          icon,
+          'Block with no warning should not have warning icon',
+        );
+      });
+
+      test('Set warning text creates new icon if none existed', function () {
+        const text = 'Warning Text';
+        this.block.setWarningText(text);
+        const icon = this.block.getIcon(Blockly.icons.WarningIcon.TYPE);
+        chai.assert.equal(
+          icon.getText(),
+          text,
+          'Expected warning icon text to be set',
+        );
+      });
+
+      test('Set warning text adds text to existing icon if needed', function () {
+        const text1 = 'Warning Text 1';
+        const text2 = 'Warning Text 2';
+        this.block.setWarningText(text1, '1');
+        this.block.setWarningText(text2, '2');
+        const icon = this.block.getIcon(Blockly.icons.WarningIcon.TYPE);
+        chai.assert.equal(icon.getText(), `${text1}\n${text2}`);
+      });
+
+      test('Clearing all warning text deletes the warning icon', function () {
+        const text = 'Warning Text';
+        this.block.setWarningText(text);
+        this.block.setWarningText(null);
+        const icon = this.block.getIcon(Blockly.icons.WarningIcon.TYPE);
+        chai.assert.isUndefined(
+          icon,
+          'Expected warning icon to be undefined after deleting all warning text',
+        );
+      });
+
+      test('Clearing specific warning does not delete the icon if other warnings present', function () {
+        const text1 = 'Warning Text 1';
+        const text2 = 'Warning Text 2';
+        this.block.setWarningText(text1, '1');
+        this.block.setWarningText(text2, '2');
+        this.block.setWarningText(null, '1');
+        const icon = this.block.getIcon(Blockly.icons.WarningIcon.TYPE);
+        chai.assert.equal(
+          icon.getText(),
+          text2,
+          'Expected first warning text to be deleted',
+        );
+      });
+
+      test('Clearing specific warning removes icon if it was only warning present', function () {
+        const text1 = 'Warning Text 1';
+        const text2 = 'Warning Text 2';
+        this.block.setWarningText(text1, '1');
+        this.block.setWarningText(text2, '2');
+        this.block.setWarningText(null, '1');
+        this.block.setWarningText(null, '2');
+        const icon = this.block.getIcon(Blockly.icons.WarningIcon.TYPE);
+        chai.assert.isUndefined(
+          icon,
+          'Expected warning icon to be deleted after all warning text is cleared',
+        );
+      });
+    });
+
     suite('Bubbles and collapsing', function () {
       setup(function () {
         this.workspace = Blockly.inject('blocklyDiv');

--- a/tests/mocha/block_test.js
+++ b/tests/mocha/block_test.js
@@ -1621,6 +1621,10 @@ suite('Blocks', function () {
         this.block.render();
       });
 
+      teardown(function () {
+        workspaceTeardown.call(this, this.workspace);
+      });
+
       test('Block with no warning text does not have warning icon', function () {
         const icon = this.block.getIcon(Blockly.icons.WarningIcon.TYPE);
         chai.assert.isUndefined(

--- a/tests/mocha/block_test.js
+++ b/tests/mocha/block_test.js
@@ -1627,6 +1627,7 @@ suite('Blocks', function () {
 
       test('Block with no warning text does not have warning icon', function () {
         const icon = this.block.getIcon(Blockly.icons.WarningIcon.TYPE);
+
         chai.assert.isUndefined(
           icon,
           'Block with no warning should not have warning icon',
@@ -1635,7 +1636,9 @@ suite('Blocks', function () {
 
       test('Set warning text creates new icon if none existed', function () {
         const text = 'Warning Text';
+
         this.block.setWarningText(text);
+
         const icon = this.block.getIcon(Blockly.icons.WarningIcon.TYPE);
         chai.assert.equal(
           icon.getText(),
@@ -1647,8 +1650,10 @@ suite('Blocks', function () {
       test('Set warning text adds text to existing icon if needed', function () {
         const text1 = 'Warning Text 1';
         const text2 = 'Warning Text 2';
+
         this.block.setWarningText(text1, '1');
         this.block.setWarningText(text2, '2');
+
         const icon = this.block.getIcon(Blockly.icons.WarningIcon.TYPE);
         chai.assert.equal(icon.getText(), `${text1}\n${text2}`);
       });
@@ -1656,7 +1661,9 @@ suite('Blocks', function () {
       test('Clearing all warning text deletes the warning icon', function () {
         const text = 'Warning Text';
         this.block.setWarningText(text);
+
         this.block.setWarningText(null);
+
         const icon = this.block.getIcon(Blockly.icons.WarningIcon.TYPE);
         chai.assert.isUndefined(
           icon,
@@ -1667,9 +1674,11 @@ suite('Blocks', function () {
       test('Clearing specific warning does not delete the icon if other warnings present', function () {
         const text1 = 'Warning Text 1';
         const text2 = 'Warning Text 2';
+
         this.block.setWarningText(text1, '1');
         this.block.setWarningText(text2, '2');
         this.block.setWarningText(null, '1');
+
         const icon = this.block.getIcon(Blockly.icons.WarningIcon.TYPE);
         chai.assert.equal(
           icon.getText(),
@@ -1681,10 +1690,12 @@ suite('Blocks', function () {
       test('Clearing specific warning removes icon if it was only warning present', function () {
         const text1 = 'Warning Text 1';
         const text2 = 'Warning Text 2';
+
         this.block.setWarningText(text1, '1');
         this.block.setWarningText(text2, '2');
         this.block.setWarningText(null, '1');
         this.block.setWarningText(null, '2');
+
         const icon = this.block.getIcon(Blockly.icons.WarningIcon.TYPE);
         chai.assert.isUndefined(
           icon,


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [x] I ran `npm run format` and `npm run lint`

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #7362 

### Proposed Changes

- Adds tests for setting and removing warning tests.
- Fixes bug where you could not remove only one warning by id
- Fixes bug where if you call `setWarningText('')` on a collapsed block, it would remove the warning on that block, but **add** the "collapsed block contains warnings" to its parent

#### Behavior Before Change

Can't remove a warning by id

#### Behavior After Change

Can remove a warning by id

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage

Wrote unit tests before fixing bug. The ones about removing by id failed before this change, and now pass.

### Documentation

no
### Additional Information

for context: introduced in https://github.com/google/blockly/pull/7112 I believe
