### PR TITLE
feat: add accessor for the workspace svg group

### DIFF
--- a/core/workspace_svg.ts
+++ b/core/workspace_svg.ts
@@ -694,6 +694,15 @@ export class WorkspaceSvg extends Workspace implements IASTNodeLocationSvg {
   }
 
   /**
+   * Returns the SVG group for the workspace.
+   *
+   * @returns The SVG group for the workspace.
+   */
+  getSvgGroup(): Element {
+    return this.svgGroup_;
+  }
+
+  /**
    * Get the SVG block canvas for the workspace.
    *
    * @returns The SVG group for the workspace.


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [X] I ran `npm run format` and `npm run lint`

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Work on #7157 

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
Adds public accessor for `svgGroup_`.

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
This is necessary for the scroll options plugin to add a wheel listener, and for the multiselect plugin to add a mouse enter listener.

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->
N/A

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->
N/A

### Additional Information

<!-- Anything else we should know? -->
I didn't make `getBlockCanvas` public because I realized the scroll options plugin is only using it to get the transform. I think we should either be able to use the metrics, or just `scrollX` and `scrollY` to do that instead.

App Inventor asked that I fix the `svgGroup_` issue this quarter so they don't need to worry about the multiselect plugin breaking (in this way) in the future.
