### PR TITLE
fix(build): Fix import of parent chunk's shim

### DIFF
--- a/scripts/gulpfiles/build_tasks.js
+++ b/scripts/gulpfiles/build_tasks.js
@@ -705,7 +705,9 @@ async function buildShims() {
         path.posix.join(RELEASE_DIR, `${chunk.name}${COMPILED_SUFFIX}.js`);
     const shimPath = path.join(BUILD_DIR, `${chunk.name}.loader.mjs`);
     const parentImport =
-        chunk.parent ? `import ${quote(`./${chunk.parent.name}.mjs`)};` : '';
+        chunk.parent ?
+        `import ${quote(`./${chunk.parent.name}.loader.mjs`)};` :
+        '';
     const exports = await import(`../../${modulePath}`);
 
     await fsPromises.writeFile(shimPath,


### PR DESCRIPTION
## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [X] I ran `npm run format` and `npm run lint`

## The details
### Resolves

Fixes error when loading playgrounds.

### Proposed Changes

Have dependent chunks import `blockly.loader.mjs` instead of `blockly.mjs`.

#### Behaviour Before Change

Trying to load playgrounds gives console error:

```
GET http://127.0.0.1:8080/build/blockly.mjs net::ERR_ABORTED 404 (Not Found)               javascript.loader.mjs:2
```


#### Behavior After Change

Loading playgrounds works correctly.

### Reason for Changes

In PR #7380 [it was suggested](https://github.com/google/blockly/pull/7380#discussion_r1291667037) that the shims be renamed from (e.g.) `blockly.mjs` to `blockly.loader.mjs`, and in commit 6f930f5 this was duly done, but alas one place was overlooked.

The problem was not spotted in local testing because the `blockly.mjs` module that the blocks and generators chunks were attempting to import did still exist on disk, left over from before the change was made.

Running `npm run clean` would have revealed the issue but alas that was not done.

