### PR TITLE
fix(tests): wait for the workspace to render before starting test actions

### DIFF
--- a/tests/browser/test/test_setup.js
+++ b/tests/browser/test/test_setup.js
@@ -70,14 +70,19 @@ async function driverTeardown() {
 
 /**
  * Navigate to the correct URL for the test, using the shared driver.
- * @param {string} url The URL to open for the test.
+ * @param {string} playgroundUrl The URL to open for the test, which should be
+ *     a Blockly playground with a workspace.
  * @return A Promsie that resolves to a webdriverIO browser that tests can manipulate.
  */
-async function testSetup(url) {
+async function testSetup(playgroundUrl) {
   if (!driver) {
     await driverSetup();
   }
-  await driver.url(url);
+  await driver.url(playgroundUrl);
+  // Wait for the workspace to exist and be rendered.
+  await driver
+    .$('.blocklySvg .blocklyWorkspace > .blocklyBlockCanvas')
+    .waitForExist({timeout: 2000});
   return driver;
 }
 


### PR DESCRIPTION
## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [x] I ran `npm run format` and `npm run lint`

## The details
### Resolves

Fixes some tests that were flaky because the workspace wasn't always fully loaded.

### Proposed Changes

In the `testSetup` function that loads a URL, wait for the workspace's block canvas to exist before returning.

### Reason for Changes

The workspace must exist before the test actions start running. Checking for the block canvas is an easy test that uses standard webdriver APIs (`waitForExist` and selectors).
