### PR TITLE
fix: block change serialization

### DIFF
--- a/core/events/events_block_change.ts
+++ b/core/events/events_block_change.ts
@@ -205,7 +205,7 @@ export class BlockChange extends BlockBase {
    */
   static getExtraBlockState_(block: BlockSvg): string {
     if (block.saveExtraState) {
-      const state = block.saveExtraState(false);
+      const state = block.saveExtraState(true);
       return state ? JSON.stringify(state) : '';
     } else if (block.mutationToDom) {
       const state = block.mutationToDom();


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [X] I ran `npm run format` and `npm run lint`

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes N/A

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
Switches change events (i.e. for mutations) to use full serialization.

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
I am reasonably sure this is the behavior it should have. But I needed to do a lot of playing with the shared procedure blocks to be confident.

Events are built for two use cases:
  1) Notifying the developer when things happen.
  2) Mirroring workspaces.

If we don't do full serialization then (1) breaks. E.g. in the shared procedure blocks change events will not be fired when the blocks mutate because their extra state isn't changing (their just serializing the same procedure ID). (2) is still fine because mirroring the procedure model updates updates the blocks.

With full serialization, (2) is a bit tricky because you need to mirror the changes to blocks and makes sure /not/ to mirror the changes to data models. If you mirror both, the block will be mirrored and create a new data model, and then the original data model will be mirrored (so you end up with an extra data model).

Note that we can't have the block create a data model with the same ID because we don't want copy-pasted blocks to point at the same procedure model as their originator.

Also note that the trickiness /currently/ applies to the released code where `doFullSerialization` doesn't exist. This change doesn't make mirroring better or worse than the released code. But it does make it trickier than the unreleased code :P

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->
N/A

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->
N/A

### Additional Information

<!-- Anything else we should know? -->
N/A
