### PR TITLE
chore: fix docs in FieldImage

### DIFF
--- a/core/field.ts
+++ b/core/field.ts
@@ -79,9 +79,7 @@ export abstract class Field<T = any>
    * the prototype.
    *
    * Example:
-   * ```typescript
-   * FieldImage.prototype.DEFAULT_VALUE = null;
-   * ```
+   * `FieldImage.prototype.DEFAULT_VALUE = null;`
    */
   DEFAULT_VALUE: T | null = null;
 


### PR DESCRIPTION
## The basics

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [x] I ran `npm run format` and `npm run lint`

## The details
### Resolves

Fixes https://github.com/google/blockly/issues/7315 by switching to single-backtick for a code snippet that is inside of a markdown table.

### Proposed Changes

Use single backticks instead of triple backticks.

### Reason for Changes

Fixes bad rendering in our documentation pages.

### Additional Information

Tested by running `npm run package && npm run docs` and making sure that the change is propagated correctly.