### PR TITLE
chore: update PR template and add info for new contribs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -7,10 +7,7 @@
 
 <!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->
 
-- [ ] I branched from develop
-- [ ] My pull request is against develop
-- [ ] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
-- [ ] I ran `npm run format` and `npm run lint`
+- [ ] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)
 
 ## The details
 ### Resolves

--- a/.github/workflows/welcome_new_contributors.yml
+++ b/.github/workflows/welcome_new_contributors.yml
@@ -1,0 +1,37 @@
+on:
+  pull_request_target:
+    types:
+      - opened
+name: Welcome new contributors
+jobs:
+  welcome:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - uses: actions/first-interaction@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          pr-message: >
+            Welcome! It looks like this is your first pull request in blockly,
+            so here are a couple of tips:
+            
+              - You can find tips about contributing to Blockly and how to
+              validate your changes on our
+              [developer site](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change).
+
+              - All contributors must sign the Google Contributor License
+              Agreement (CLA). If the google-cla bot leaves a comment on this
+              PR, make sure you follow the instructions.
+
+              - We use [conventional commits](https://www.conventionalcommits.org/)
+              to make versioning the package easier. Make sure your commit
+              message is in the [proper format](https://developers.google.com/blockly/guides/contribute/get-started/commits)
+              or [learn how to fix it](https://developers.google.com/blockly/guides/contribute/get-started/commits#fixing_non-conventional_commits).
+              
+              - If any of the other checks on this PR fail, you can click on
+              them to learn why. It might be that your change caused a test
+              failure, or that you need to double-check the
+              [style guide](https://developers.google.com/blockly/guides/contribute/core/style_guide).
+
+            Thank you for opening this PR! A member of the Blockly team will review it soon.

--- a/.github/workflows/welcome_new_contributors.yml
+++ b/.github/workflows/welcome_new_contributors.yml
@@ -15,7 +15,7 @@ jobs:
           pr-message: >
             Welcome! It looks like this is your first pull request in blockly,
             so here are a couple of tips:
-            
+
               - You can find tips about contributing to Blockly and how to
               validate your changes on our
               [developer site](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change).

--- a/.github/workflows/welcome_new_contributors.yml
+++ b/.github/workflows/welcome_new_contributors.yml
@@ -13,7 +13,7 @@ jobs:
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           pr-message: >
-            Welcome! It looks like this is your first pull request in blockly,
+            Welcome! It looks like this is your first pull request in Blockly,
             so here are a couple of tips:
 
               - You can find tips about contributing to Blockly and how to


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [ ] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [ ] I ran `npm run format` and `npm run lint`

## The details
### Resolves



### Proposed Changes

- Removes all of the current checkboxes and replaces with a "I validated my changes" checkbox which covers testing, linting, and formatting (in the linked document)
- Added a new workflow that will comment on the first PR that is opened by a contributor. This lists some helpful resources and instructions.

### Reason for Changes

- Eliminated the "my PR is against develop" and "I branched from develop" because develop is now the default branch in the repo, so contributors would have to go out of their way to make that not true. I don't think we've seen a PR come in against master since we changed the default branch, but we used to (even with the checkbox)
- Eliminated "I ran format and lint" because we have checks for those. If you didn't run them, the checks will fail.
- Eliminated "My code conforms to the style guide" because linting should cover that. I did include a link to it in the new contributor message though.

I don't like checking all the boxes, and our team makes the overwhelming majority of PRs. So I prioritized streamlining PR creation, while still trying to provide helpful information to new contributors. Let me know if you think I didn't hit the right balance though.

### Documentation

Note: I also updated the style guide and sent a CL to Rachel for review.

### Additional Information

I also wrote another GitHub workflow that would simply add a comment if a PR is against master and not develop. I thought this might be useful because I feel like it can be easy to miss which branch is selected for a PR due to it being in small type at the top. I don't always remember to check. I decided against including it here since develop is the default branch, but I can do so if you think it would be useful. It's a really small/straightforward workflow.
