### PR TITLE
refactor(tests): Use `import` instead of `goog.bootstrap` to load Blockly in mocha tests

### DIFF
--- a/scripts/gulpfiles/build_tasks.js
+++ b/scripts/gulpfiles/build_tasks.js
@@ -691,10 +691,8 @@ async function buildShims() {
   // ESM, but fortunately we don't attempt to import or require this
   // file from node.js - we only feed it to Closure Compiler, which
   // uses the type information in deps.js rather than package.json.
-  await fsPromises.writeFile(
-    path.join(BUILD_DIR, 'package.json'),
-    '{"type": "module"}'
-  );
+  const TMP_PACKAGE_JSON = path.join(BUILD_DIR, 'package.json');
+  await fsPromises.writeFile(TMP_PACKAGE_JSON, '{"type": "module"}');
 
   // Import each entrypoint module, enumerate its exports, and write
   // a shim to load the chunk either by importing the entrypoint
@@ -723,6 +721,8 @@ ${Object.keys(exports).map((name) => `  ${name},`).join('\n')}
 );
 `);
   }));
+
+  await fsPromises.rm(TMP_PACKAGE_JSON);
 }
 
 

--- a/scripts/gulpfiles/build_tasks.js
+++ b/scripts/gulpfiles/build_tasks.js
@@ -22,7 +22,7 @@ const closureCompiler = require('google-closure-compiler').gulp();
 const argv = require('yargs').argv;
 const {rimraf} = require('rimraf');
 
-const {BUILD_DIR, DEPS_FILE, RELEASE_DIR, TEST_DEPS_FILE, TSC_OUTPUT_DIR, TYPINGS_BUILD_DIR} = require('./config');
+const {BUILD_DIR, DEPS_FILE, RELEASE_DIR, TSC_OUTPUT_DIR, TYPINGS_BUILD_DIR} = require('./config');
 const {getPackageJson} = require('./helper_tasks');
 
 const {posixPath, quote} = require('../helpers');
@@ -305,35 +305,16 @@ function buildJavaScript(done) {
  * This task updates DEPS_FILE (deps.js), used by the debug module
  * loader (via bootstrap.js) when loading Blockly in uncompiled mode.
  *
- * Also updates TEST_DEPS_FILE (deps.mocha.js), used by the mocha test
- * suite.
- *
  * Prerequisite: buildJavaScript.
  */
 function buildDeps() {
   const roots = [
     path.join(TSC_OUTPUT_DIR, 'closure', 'goog', 'base.js'),
     TSC_OUTPUT_DIR,
-    'tests/mocha',
   ];
 
   /** Maximum buffer size, in bytes for child process stdout/stderr. */
   const MAX_BUFFER_SIZE = 10 * 1024 * 1024;
-
-  /**
-   * Filter a string to extract lines containing (or not containing) the
-   * specified target string.
-   *
-   * @param {string} text Text to filter.
-   * @param {string} target String to search for.
-   * @param {boolean?} exclude If true, extract only non-matching lines.
-   * @returns {string} Filtered text.
-   */
-  function filter(text, target, exclude) {
-    return text.split('\n')
-        .filter((line) => Boolean(line.match(target)) !== Boolean(exclude))
-        .join('\n');
-  }
 
   /**
    * Log unexpected diagnostics, after removing expected warnings.
@@ -374,9 +355,7 @@ error message above, try running:
           } else {
             log(stderr);
             // Anything not about mocha goes in DEPS_FILE.
-            fs.writeFileSync(DEPS_FILE, filter(stdout, 'tests/mocha', true));
-            // Anything about mocha does in TEST_DEPS_FILE.
-            fs.writeFileSync(TEST_DEPS_FILE, filter(stdout, 'tests/mocha'));
+            fs.writeFileSync(DEPS_FILE, stdout);
             resolve();
           }
         });

--- a/scripts/gulpfiles/config.js
+++ b/scripts/gulpfiles/config.js
@@ -28,9 +28,6 @@ exports.BUILD_DIR = 'build';
 // Dependencies file (used by bootstrap.js in uncompiled mode):
 exports.DEPS_FILE = path.join(exports.BUILD_DIR, 'deps.js');
 
-// Mocha test dependencies file (used by tests/mocha/index.html):
-exports.TEST_DEPS_FILE = path.join(exports.BUILD_DIR, 'deps.mocha.js');
-
 // Directory to write typings output to.
 exports.TYPINGS_BUILD_DIR = path.join(exports.BUILD_DIR, 'declarations');
 

--- a/tests/mocha/astnode_test.js
+++ b/tests/mocha/astnode_test.js
@@ -4,9 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as goog from '../../build/src/closure/goog/goog.js';
-goog.declareModuleId('Blockly.test.astNode');
-
 import {ASTNode} from '../../build/src/core/keyboard_nav/ast_node.js';
 import {
   sharedTestSetup,

--- a/tests/mocha/astnode_test.js
+++ b/tests/mocha/astnode_test.js
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import * as goog from '../../build/src/closure/goog/goog.js';
 goog.declareModuleId('Blockly.test.astNode');
 
 import {ASTNode} from '../../build/src/core/keyboard_nav/ast_node.js';

--- a/tests/mocha/block_json_test.js
+++ b/tests/mocha/block_json_test.js
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import * as goog from '../../build/src/closure/goog/goog.js';
 goog.declareModuleId('Blockly.test.blockJson');
 
 import {Align} from '../../build/src/core/inputs/align.js';

--- a/tests/mocha/block_json_test.js
+++ b/tests/mocha/block_json_test.js
@@ -4,9 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as goog from '../../build/src/closure/goog/goog.js';
-goog.declareModuleId('Blockly.test.blockJson');
-
 import {Align} from '../../build/src/core/inputs/align.js';
 import {
   sharedTestSetup,

--- a/tests/mocha/block_test.js
+++ b/tests/mocha/block_test.js
@@ -4,9 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as goog from '../../build/src/closure/goog/goog.js';
-goog.declareModuleId('Blockly.test.blocks');
-
 import {ConnectionType} from '../../build/src/core/connection_type.js';
 import {createDeprecationWarningStub} from './test_helpers/warnings.js';
 import {createRenderedBlock} from './test_helpers/block_definitions.js';

--- a/tests/mocha/block_test.js
+++ b/tests/mocha/block_test.js
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import * as goog from '../../build/src/closure/goog/goog.js';
 goog.declareModuleId('Blockly.test.blocks');
 
 import {ConnectionType} from '../../build/src/core/connection_type.js';

--- a/tests/mocha/blocks/lists_test.js
+++ b/tests/mocha/blocks/lists_test.js
@@ -4,9 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as goog from '../../../build/src/closure/goog/goog.js';
-goog.declareModuleId('Blockly.test.lists');
-
 import {runSerializationTestSuite} from '../test_helpers/serialization.js';
 import {
   sharedTestSetup,

--- a/tests/mocha/blocks/lists_test.js
+++ b/tests/mocha/blocks/lists_test.js
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import * as goog from '../../../build/src/closure/goog/goog.js';
 goog.declareModuleId('Blockly.test.lists');
 
 import {runSerializationTestSuite} from '../test_helpers/serialization.js';

--- a/tests/mocha/blocks/logic_ternary_test.js
+++ b/tests/mocha/blocks/logic_ternary_test.js
@@ -4,9 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as goog from '../../../build/src/closure/goog/goog.js';
-goog.declareModuleId('Blockly.test.logicTernary');
-
 import * as eventUtils from '../../../build/src/core/events/utils.js';
 import {runSerializationTestSuite} from '../test_helpers/serialization.js';
 import {

--- a/tests/mocha/blocks/logic_ternary_test.js
+++ b/tests/mocha/blocks/logic_ternary_test.js
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import * as goog from '../../../build/src/closure/goog/goog.js';
 goog.declareModuleId('Blockly.test.logicTernary');
 
 import * as eventUtils from '../../../build/src/core/events/utils.js';

--- a/tests/mocha/blocks/procedures_test.js
+++ b/tests/mocha/blocks/procedures_test.js
@@ -4,9 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as goog from '../../../build/src/closure/goog/goog.js';
-goog.declareModuleId('Blockly.test.procedures');
-
 import * as Blockly from '../../../build/src/core/blockly.js';
 import {
   assertCallBlockStructure,

--- a/tests/mocha/blocks/procedures_test.js
+++ b/tests/mocha/blocks/procedures_test.js
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import * as goog from '../../../build/src/closure/goog/goog.js';
 goog.declareModuleId('Blockly.test.procedures');
 
 import * as Blockly from '../../../build/src/core/blockly.js';

--- a/tests/mocha/blocks/variables_test.js
+++ b/tests/mocha/blocks/variables_test.js
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import * as goog from '../../../build/src/closure/goog/goog.js';
 goog.declareModuleId('Blockly.test.variables');
 
 import {

--- a/tests/mocha/blocks/variables_test.js
+++ b/tests/mocha/blocks/variables_test.js
@@ -4,9 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as goog from '../../../build/src/closure/goog/goog.js';
-goog.declareModuleId('Blockly.test.variables');
-
 import {
   sharedTestSetup,
   sharedTestTeardown,

--- a/tests/mocha/clipboard_test.js
+++ b/tests/mocha/clipboard_test.js
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import * as goog from '../../build/src/closure/goog/goog.js';
 goog.declareModuleId('Blockly.test.clipboard');
 
 import {

--- a/tests/mocha/clipboard_test.js
+++ b/tests/mocha/clipboard_test.js
@@ -4,9 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as goog from '../../build/src/closure/goog/goog.js';
-goog.declareModuleId('Blockly.test.clipboard');
-
 import {
   sharedTestSetup,
   sharedTestTeardown,

--- a/tests/mocha/comment_deserialization_test.js
+++ b/tests/mocha/comment_deserialization_test.js
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import * as goog from '../../build/src/closure/goog/goog.js';
 goog.declareModuleId('Blockly.test.commentDeserialization');
 
 import {

--- a/tests/mocha/comment_deserialization_test.js
+++ b/tests/mocha/comment_deserialization_test.js
@@ -4,9 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as goog from '../../build/src/closure/goog/goog.js';
-goog.declareModuleId('Blockly.test.commentDeserialization');
-
 import {
   sharedTestSetup,
   sharedTestTeardown,

--- a/tests/mocha/comment_test.js
+++ b/tests/mocha/comment_test.js
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import * as goog from '../../build/src/closure/goog/goog.js';
 goog.declareModuleId('Blockly.test.comments');
 
 import {assertEventFired} from './test_helpers/events.js';

--- a/tests/mocha/comment_test.js
+++ b/tests/mocha/comment_test.js
@@ -4,9 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as goog from '../../build/src/closure/goog/goog.js';
-goog.declareModuleId('Blockly.test.comments');
-
 import {assertEventFired} from './test_helpers/events.js';
 import * as eventUtils from '../../build/src/core/events/utils.js';
 import {

--- a/tests/mocha/connection_checker_test.js
+++ b/tests/mocha/connection_checker_test.js
@@ -4,9 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as goog from '../../build/src/closure/goog/goog.js';
-goog.declareModuleId('Blockly.test.connectionChecker');
-
 import {ConnectionType} from '../../build/src/core/connection_type.js';
 import {
   sharedTestSetup,

--- a/tests/mocha/connection_checker_test.js
+++ b/tests/mocha/connection_checker_test.js
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import * as goog from '../../build/src/closure/goog/goog.js';
 goog.declareModuleId('Blockly.test.connectionChecker');
 
 import {ConnectionType} from '../../build/src/core/connection_type.js';

--- a/tests/mocha/connection_db_test.js
+++ b/tests/mocha/connection_db_test.js
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import * as goog from '../../build/src/closure/goog/goog.js';
 goog.declareModuleId('Blockly.test.connectionDb');
 
 import {ConnectionType} from '../../build/src/core/connection_type.js';

--- a/tests/mocha/connection_db_test.js
+++ b/tests/mocha/connection_db_test.js
@@ -4,9 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as goog from '../../build/src/closure/goog/goog.js';
-goog.declareModuleId('Blockly.test.connectionDb');
-
 import {ConnectionType} from '../../build/src/core/connection_type.js';
 import {
   sharedTestSetup,

--- a/tests/mocha/connection_test.js
+++ b/tests/mocha/connection_test.js
@@ -4,9 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as goog from '../../build/src/closure/goog/goog.js';
-goog.declareModuleId('Blockly.test.connection');
-
 import {
   createGenUidStubWithReturns,
   sharedTestSetup,

--- a/tests/mocha/connection_test.js
+++ b/tests/mocha/connection_test.js
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import * as goog from '../../build/src/closure/goog/goog.js';
 goog.declareModuleId('Blockly.test.connection');
 
 import {

--- a/tests/mocha/contextmenu_items_test.js
+++ b/tests/mocha/contextmenu_items_test.js
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import * as goog from '../../build/src/closure/goog/goog.js';
 goog.declareModuleId('Blockly.test.contextMenuItem');
 
 import {

--- a/tests/mocha/contextmenu_items_test.js
+++ b/tests/mocha/contextmenu_items_test.js
@@ -4,9 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as goog from '../../build/src/closure/goog/goog.js';
-goog.declareModuleId('Blockly.test.contextMenuItem');
-
 import {
   sharedTestSetup,
   sharedTestTeardown,

--- a/tests/mocha/cursor_test.js
+++ b/tests/mocha/cursor_test.js
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import * as goog from '../../build/src/closure/goog/goog.js';
 goog.declareModuleId('Blockly.test.cursor');
 
 import {

--- a/tests/mocha/cursor_test.js
+++ b/tests/mocha/cursor_test.js
@@ -4,9 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as goog from '../../build/src/closure/goog/goog.js';
-goog.declareModuleId('Blockly.test.cursor');
-
 import {
   sharedTestSetup,
   sharedTestTeardown,

--- a/tests/mocha/dropdowndiv_test.js
+++ b/tests/mocha/dropdowndiv_test.js
@@ -4,9 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as goog from '../../build/src/closure/goog/goog.js';
-goog.declareModuleId('Blockly.test.dropdown');
-
 import {
   sharedTestSetup,
   sharedTestTeardown,

--- a/tests/mocha/dropdowndiv_test.js
+++ b/tests/mocha/dropdowndiv_test.js
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import * as goog from '../../build/src/closure/goog/goog.js';
 goog.declareModuleId('Blockly.test.dropdown');
 
 import {

--- a/tests/mocha/event_block_change_test.js
+++ b/tests/mocha/event_block_change_test.js
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import * as goog from '../../build/src/closure/goog/goog.js';
 goog.declareModuleId('Blockly.test.eventBlockChange');
 
 import {

--- a/tests/mocha/event_block_change_test.js
+++ b/tests/mocha/event_block_change_test.js
@@ -4,9 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as goog from '../../build/src/closure/goog/goog.js';
-goog.declareModuleId('Blockly.test.eventBlockChange');
-
 import {
   sharedTestSetup,
   sharedTestTeardown,

--- a/tests/mocha/event_block_create_test.js
+++ b/tests/mocha/event_block_create_test.js
@@ -4,9 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as goog from '../../build/src/closure/goog/goog.js';
-goog.declareModuleId('Blockly.test.eventBlockCreate');
-
 import {assertEventFired} from './test_helpers/events.js';
 import * as eventUtils from '../../build/src/core/events/utils.js';
 import {

--- a/tests/mocha/event_block_create_test.js
+++ b/tests/mocha/event_block_create_test.js
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import * as goog from '../../build/src/closure/goog/goog.js';
 goog.declareModuleId('Blockly.test.eventBlockCreate');
 
 import {assertEventFired} from './test_helpers/events.js';

--- a/tests/mocha/event_block_delete_test.js
+++ b/tests/mocha/event_block_delete_test.js
@@ -4,9 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as goog from '../../build/src/closure/goog/goog.js';
-goog.declareModuleId('Blockly.test.eventBlockDelete');
-
 import {defineRowBlock} from './test_helpers/block_definitions.js';
 import {
   sharedTestSetup,

--- a/tests/mocha/event_block_delete_test.js
+++ b/tests/mocha/event_block_delete_test.js
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import * as goog from '../../build/src/closure/goog/goog.js';
 goog.declareModuleId('Blockly.test.eventBlockDelete');
 
 import {defineRowBlock} from './test_helpers/block_definitions.js';

--- a/tests/mocha/event_block_drag_test.js
+++ b/tests/mocha/event_block_drag_test.js
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import * as goog from '../../build/src/closure/goog/goog.js';
 goog.declareModuleId('Blockly.test.eventBlockDrag');
 
 import {defineRowBlock} from './test_helpers/block_definitions.js';

--- a/tests/mocha/event_block_drag_test.js
+++ b/tests/mocha/event_block_drag_test.js
@@ -4,9 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as goog from '../../build/src/closure/goog/goog.js';
-goog.declareModuleId('Blockly.test.eventBlockDrag');
-
 import {defineRowBlock} from './test_helpers/block_definitions.js';
 import {
   sharedTestSetup,

--- a/tests/mocha/event_block_field_intermediate_change_test.js
+++ b/tests/mocha/event_block_field_intermediate_change_test.js
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import * as goog from '../../build/src/closure/goog/goog.js';
 goog.declareModuleId('Blockly.test.eventBlockFieldIntermediateChange');
 
 import {

--- a/tests/mocha/event_block_field_intermediate_change_test.js
+++ b/tests/mocha/event_block_field_intermediate_change_test.js
@@ -4,9 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as goog from '../../build/src/closure/goog/goog.js';
-goog.declareModuleId('Blockly.test.eventBlockFieldIntermediateChange');
-
 import {
   sharedTestSetup,
   sharedTestTeardown,

--- a/tests/mocha/event_block_move_test.js
+++ b/tests/mocha/event_block_move_test.js
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import * as goog from '../../build/src/closure/goog/goog.js';
 goog.declareModuleId('Blockly.test.eventBlockMove');
 
 import {defineRowBlock} from './test_helpers/block_definitions.js';

--- a/tests/mocha/event_block_move_test.js
+++ b/tests/mocha/event_block_move_test.js
@@ -4,9 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as goog from '../../build/src/closure/goog/goog.js';
-goog.declareModuleId('Blockly.test.eventBlockMove');
-
 import {defineRowBlock} from './test_helpers/block_definitions.js';
 import {
   sharedTestSetup,

--- a/tests/mocha/event_bubble_open_test.js
+++ b/tests/mocha/event_bubble_open_test.js
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import * as goog from '../../build/src/closure/goog/goog.js';
 goog.declareModuleId('Blockly.test.eventBubbleOpen');
 
 import {defineMutatorBlocks} from './test_helpers/block_definitions.js';

--- a/tests/mocha/event_bubble_open_test.js
+++ b/tests/mocha/event_bubble_open_test.js
@@ -4,9 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as goog from '../../build/src/closure/goog/goog.js';
-goog.declareModuleId('Blockly.test.eventBubbleOpen');
-
 import {defineMutatorBlocks} from './test_helpers/block_definitions.js';
 import {
   sharedTestSetup,

--- a/tests/mocha/event_click_test.js
+++ b/tests/mocha/event_click_test.js
@@ -4,9 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as goog from '../../build/src/closure/goog/goog.js';
-goog.declareModuleId('Blockly.test.eventClick');
-
 import {defineRowBlock} from './test_helpers/block_definitions.js';
 import {
   sharedTestSetup,

--- a/tests/mocha/event_click_test.js
+++ b/tests/mocha/event_click_test.js
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import * as goog from '../../build/src/closure/goog/goog.js';
 goog.declareModuleId('Blockly.test.eventClick');
 
 import {defineRowBlock} from './test_helpers/block_definitions.js';

--- a/tests/mocha/event_comment_change_test.js
+++ b/tests/mocha/event_comment_change_test.js
@@ -4,9 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as goog from '../../build/src/closure/goog/goog.js';
-goog.declareModuleId('Blockly.test.eventCommentChange');
-
 import {
   sharedTestSetup,
   sharedTestTeardown,

--- a/tests/mocha/event_comment_change_test.js
+++ b/tests/mocha/event_comment_change_test.js
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import * as goog from '../../build/src/closure/goog/goog.js';
 goog.declareModuleId('Blockly.test.eventCommentChange');
 
 import {

--- a/tests/mocha/event_comment_create_test.js
+++ b/tests/mocha/event_comment_create_test.js
@@ -4,9 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as goog from '../../build/src/closure/goog/goog.js';
-goog.declareModuleId('Blockly.test.eventCommentCreate');
-
 import {
   sharedTestSetup,
   sharedTestTeardown,

--- a/tests/mocha/event_comment_create_test.js
+++ b/tests/mocha/event_comment_create_test.js
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import * as goog from '../../build/src/closure/goog/goog.js';
 goog.declareModuleId('Blockly.test.eventCommentCreate');
 
 import {

--- a/tests/mocha/event_comment_delete_test.js
+++ b/tests/mocha/event_comment_delete_test.js
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import * as goog from '../../build/src/closure/goog/goog.js';
 goog.declareModuleId('Blockly.test.eventCommentDelete');
 
 import {

--- a/tests/mocha/event_comment_delete_test.js
+++ b/tests/mocha/event_comment_delete_test.js
@@ -4,9 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as goog from '../../build/src/closure/goog/goog.js';
-goog.declareModuleId('Blockly.test.eventCommentDelete');
-
 import {
   sharedTestSetup,
   sharedTestTeardown,

--- a/tests/mocha/event_comment_move_test.js
+++ b/tests/mocha/event_comment_move_test.js
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import * as goog from '../../build/src/closure/goog/goog.js';
 goog.declareModuleId('Blockly.test.eventCommentMove');
 
 import {

--- a/tests/mocha/event_comment_move_test.js
+++ b/tests/mocha/event_comment_move_test.js
@@ -4,9 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as goog from '../../build/src/closure/goog/goog.js';
-goog.declareModuleId('Blockly.test.eventCommentMove');
-
 import {
   sharedTestSetup,
   sharedTestTeardown,

--- a/tests/mocha/event_marker_move_test.js
+++ b/tests/mocha/event_marker_move_test.js
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import * as goog from '../../build/src/closure/goog/goog.js';
 goog.declareModuleId('Blockly.test.eventMarkerMove');
 
 import {defineRowBlock} from './test_helpers/block_definitions.js';

--- a/tests/mocha/event_marker_move_test.js
+++ b/tests/mocha/event_marker_move_test.js
@@ -4,9 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as goog from '../../build/src/closure/goog/goog.js';
-goog.declareModuleId('Blockly.test.eventMarkerMove');
-
 import {defineRowBlock} from './test_helpers/block_definitions.js';
 import {
   sharedTestSetup,

--- a/tests/mocha/event_selected_test.js
+++ b/tests/mocha/event_selected_test.js
@@ -4,9 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as goog from '../../build/src/closure/goog/goog.js';
-goog.declareModuleId('Blockly.test.eventSelected');
-
 import {defineRowBlock} from './test_helpers/block_definitions.js';
 import {
   sharedTestSetup,

--- a/tests/mocha/event_selected_test.js
+++ b/tests/mocha/event_selected_test.js
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import * as goog from '../../build/src/closure/goog/goog.js';
 goog.declareModuleId('Blockly.test.eventSelected');
 
 import {defineRowBlock} from './test_helpers/block_definitions.js';

--- a/tests/mocha/event_test.js
+++ b/tests/mocha/event_test.js
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import * as goog from '../../build/src/closure/goog/goog.js';
 goog.declareModuleId('Blockly.test.event');
 
 import * as Blockly from '../../build/src/core/blockly.js';

--- a/tests/mocha/event_test.js
+++ b/tests/mocha/event_test.js
@@ -4,9 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as goog from '../../build/src/closure/goog/goog.js';
-goog.declareModuleId('Blockly.test.event');
-
 import * as Blockly from '../../build/src/core/blockly.js';
 import {ASTNode} from '../../build/src/core/keyboard_nav/ast_node.js';
 import {

--- a/tests/mocha/event_theme_change_test.js
+++ b/tests/mocha/event_theme_change_test.js
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import * as goog from '../../build/src/closure/goog/goog.js';
 goog.declareModuleId('Blockly.test.eventThemeChange');
 
 import {

--- a/tests/mocha/event_theme_change_test.js
+++ b/tests/mocha/event_theme_change_test.js
@@ -4,9 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as goog from '../../build/src/closure/goog/goog.js';
-goog.declareModuleId('Blockly.test.eventThemeChange');
-
 import {
   sharedTestSetup,
   sharedTestTeardown,

--- a/tests/mocha/event_toolbox_item_select_test.js
+++ b/tests/mocha/event_toolbox_item_select_test.js
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import * as goog from '../../build/src/closure/goog/goog.js';
 goog.declareModuleId('Blockly.test.eventToolboxItemSelect');
 
 import {

--- a/tests/mocha/event_toolbox_item_select_test.js
+++ b/tests/mocha/event_toolbox_item_select_test.js
@@ -4,9 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as goog from '../../build/src/closure/goog/goog.js';
-goog.declareModuleId('Blockly.test.eventToolboxItemSelect');
-
 import {
   sharedTestSetup,
   sharedTestTeardown,

--- a/tests/mocha/event_trashcan_open_test.js
+++ b/tests/mocha/event_trashcan_open_test.js
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import * as goog from '../../build/src/closure/goog/goog.js';
 goog.declareModuleId('Blockly.test.eventTrashcanOpen');
 
 import {

--- a/tests/mocha/event_trashcan_open_test.js
+++ b/tests/mocha/event_trashcan_open_test.js
@@ -4,9 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as goog from '../../build/src/closure/goog/goog.js';
-goog.declareModuleId('Blockly.test.eventTrashcanOpen');
-
 import {
   sharedTestSetup,
   sharedTestTeardown,

--- a/tests/mocha/event_var_create_test.js
+++ b/tests/mocha/event_var_create_test.js
@@ -4,9 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as goog from '../../build/src/closure/goog/goog.js';
-goog.declareModuleId('Blockly.test.eventVarCreate');
-
 import {
   sharedTestSetup,
   sharedTestTeardown,

--- a/tests/mocha/event_var_create_test.js
+++ b/tests/mocha/event_var_create_test.js
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import * as goog from '../../build/src/closure/goog/goog.js';
 goog.declareModuleId('Blockly.test.eventVarCreate');
 
 import {

--- a/tests/mocha/event_var_delete_test.js
+++ b/tests/mocha/event_var_delete_test.js
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import * as goog from '../../build/src/closure/goog/goog.js';
 goog.declareModuleId('Blockly.test.eventVarDelete');
 
 import {

--- a/tests/mocha/event_var_delete_test.js
+++ b/tests/mocha/event_var_delete_test.js
@@ -4,9 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as goog from '../../build/src/closure/goog/goog.js';
-goog.declareModuleId('Blockly.test.eventVarDelete');
-
 import {
   sharedTestSetup,
   sharedTestTeardown,

--- a/tests/mocha/event_var_rename_test.js
+++ b/tests/mocha/event_var_rename_test.js
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import * as goog from '../../build/src/closure/goog/goog.js';
 goog.declareModuleId('Blockly.test.eventVarRename');
 
 import {

--- a/tests/mocha/event_var_rename_test.js
+++ b/tests/mocha/event_var_rename_test.js
@@ -4,9 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as goog from '../../build/src/closure/goog/goog.js';
-goog.declareModuleId('Blockly.test.eventVarRename');
-
 import {
   sharedTestSetup,
   sharedTestTeardown,

--- a/tests/mocha/event_viewport_test.js
+++ b/tests/mocha/event_viewport_test.js
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import * as goog from '../../build/src/closure/goog/goog.js';
 goog.declareModuleId('Blockly.test.eventViewportChange');
 
 import {

--- a/tests/mocha/event_viewport_test.js
+++ b/tests/mocha/event_viewport_test.js
@@ -4,9 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as goog from '../../build/src/closure/goog/goog.js';
-goog.declareModuleId('Blockly.test.eventViewportChange');
-
 import {
   sharedTestSetup,
   sharedTestTeardown,

--- a/tests/mocha/extensions_test.js
+++ b/tests/mocha/extensions_test.js
@@ -4,9 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as goog from '../../build/src/closure/goog/goog.js';
-goog.declareModuleId('Blockly.test.extensions');
-
 import {
   sharedTestSetup,
   sharedTestTeardown,

--- a/tests/mocha/extensions_test.js
+++ b/tests/mocha/extensions_test.js
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import * as goog from '../../build/src/closure/goog/goog.js';
 goog.declareModuleId('Blockly.test.extensions');
 
 import {

--- a/tests/mocha/field_angle_test.js
+++ b/tests/mocha/field_angle_test.js
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import * as goog from '../../build/src/closure/goog/goog.js';
 goog.declareModuleId('Blockly.test.fieldAngle');
 
 import * as Blockly from '../../build/src/core/blockly.js';

--- a/tests/mocha/field_angle_test.js
+++ b/tests/mocha/field_angle_test.js
@@ -4,9 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as goog from '../../build/src/closure/goog/goog.js';
-goog.declareModuleId('Blockly.test.fieldAngle');
-
 import * as Blockly from '../../build/src/core/blockly.js';
 import {
   assertFieldValue,

--- a/tests/mocha/field_checkbox_test.js
+++ b/tests/mocha/field_checkbox_test.js
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import * as goog from '../../build/src/closure/goog/goog.js';
 goog.declareModuleId('Blockly.test.fieldCheckbox');
 
 import * as Blockly from '../../build/src/core/blockly.js';

--- a/tests/mocha/field_checkbox_test.js
+++ b/tests/mocha/field_checkbox_test.js
@@ -4,9 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as goog from '../../build/src/closure/goog/goog.js';
-goog.declareModuleId('Blockly.test.fieldCheckbox');
-
 import * as Blockly from '../../build/src/core/blockly.js';
 import {
   assertFieldValue,

--- a/tests/mocha/field_colour_test.js
+++ b/tests/mocha/field_colour_test.js
@@ -4,9 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as goog from '../../build/src/closure/goog/goog.js';
-goog.declareModuleId('Blockly.test.fieldColour');
-
 import * as Blockly from '../../build/src/core/blockly.js';
 import {
   assertFieldValue,

--- a/tests/mocha/field_colour_test.js
+++ b/tests/mocha/field_colour_test.js
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import * as goog from '../../build/src/closure/goog/goog.js';
 goog.declareModuleId('Blockly.test.fieldColour');
 
 import * as Blockly from '../../build/src/core/blockly.js';

--- a/tests/mocha/field_dropdown_test.js
+++ b/tests/mocha/field_dropdown_test.js
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import * as goog from '../../build/src/closure/goog/goog.js';
 goog.declareModuleId('Blockly.test.fieldDropdown');
 
 import * as Blockly from '../../build/src/core/blockly.js';

--- a/tests/mocha/field_dropdown_test.js
+++ b/tests/mocha/field_dropdown_test.js
@@ -4,9 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as goog from '../../build/src/closure/goog/goog.js';
-goog.declareModuleId('Blockly.test.fieldDropdown');
-
 import * as Blockly from '../../build/src/core/blockly.js';
 import {
   assertFieldValue,

--- a/tests/mocha/field_image_test.js
+++ b/tests/mocha/field_image_test.js
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import * as goog from '../../build/src/closure/goog/goog.js';
 goog.declareModuleId('Blockly.test.fieldImage');
 
 import * as Blockly from '../../build/src/core/blockly.js';

--- a/tests/mocha/field_image_test.js
+++ b/tests/mocha/field_image_test.js
@@ -4,9 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as goog from '../../build/src/closure/goog/goog.js';
-goog.declareModuleId('Blockly.test.fieldImage');
-
 import * as Blockly from '../../build/src/core/blockly.js';
 import {
   assertFieldValue,

--- a/tests/mocha/field_label_serializable_test.js
+++ b/tests/mocha/field_label_serializable_test.js
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import * as goog from '../../build/src/closure/goog/goog.js';
 goog.declareModuleId('Blockly.test.fieldLabelSerialization');
 
 import * as Blockly from '../../build/src/core/blockly.js';

--- a/tests/mocha/field_label_serializable_test.js
+++ b/tests/mocha/field_label_serializable_test.js
@@ -4,9 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as goog from '../../build/src/closure/goog/goog.js';
-goog.declareModuleId('Blockly.test.fieldLabelSerialization');
-
 import * as Blockly from '../../build/src/core/blockly.js';
 import {
   assertFieldValue,

--- a/tests/mocha/field_label_test.js
+++ b/tests/mocha/field_label_test.js
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import * as goog from '../../build/src/closure/goog/goog.js';
 goog.declareModuleId('Blockly.test.fieldLabel');
 
 import * as Blockly from '../../build/src/core/blockly.js';

--- a/tests/mocha/field_label_test.js
+++ b/tests/mocha/field_label_test.js
@@ -4,9 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as goog from '../../build/src/closure/goog/goog.js';
-goog.declareModuleId('Blockly.test.fieldLabel');
-
 import * as Blockly from '../../build/src/core/blockly.js';
 import {
   assertFieldValue,

--- a/tests/mocha/field_multilineinput_test.js
+++ b/tests/mocha/field_multilineinput_test.js
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import * as goog from '../../build/src/closure/goog/goog.js';
 goog.declareModuleId('Blockly.test.fieldMultiline');
 
 import * as Blockly from '../../build/src/core/blockly.js';

--- a/tests/mocha/field_multilineinput_test.js
+++ b/tests/mocha/field_multilineinput_test.js
@@ -4,9 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as goog from '../../build/src/closure/goog/goog.js';
-goog.declareModuleId('Blockly.test.fieldMultiline');
-
 import * as Blockly from '../../build/src/core/blockly.js';
 import {
   assertFieldValue,

--- a/tests/mocha/field_number_test.js
+++ b/tests/mocha/field_number_test.js
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import * as goog from '../../build/src/closure/goog/goog.js';
 goog.declareModuleId('Blockly.test.fieldNumber');
 
 import * as Blockly from '../../build/src/core/blockly.js';

--- a/tests/mocha/field_number_test.js
+++ b/tests/mocha/field_number_test.js
@@ -4,9 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as goog from '../../build/src/closure/goog/goog.js';
-goog.declareModuleId('Blockly.test.fieldNumber');
-
 import * as Blockly from '../../build/src/core/blockly.js';
 import {
   assertFieldValue,

--- a/tests/mocha/field_registry_test.js
+++ b/tests/mocha/field_registry_test.js
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import * as goog from '../../build/src/closure/goog/goog.js';
 goog.declareModuleId('Blockly.test.fieldRegistry');
 
 import * as Blockly from '../../build/src/core/blockly.js';

--- a/tests/mocha/field_registry_test.js
+++ b/tests/mocha/field_registry_test.js
@@ -4,9 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as goog from '../../build/src/closure/goog/goog.js';
-goog.declareModuleId('Blockly.test.fieldRegistry');
-
 import * as Blockly from '../../build/src/core/blockly.js';
 import {createDeprecationWarningStub} from './test_helpers/warnings.js';
 import {

--- a/tests/mocha/field_test.js
+++ b/tests/mocha/field_test.js
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import * as goog from '../../build/src/closure/goog/goog.js';
 goog.declareModuleId('Blockly.test.fieldTest');
 
 import * as Blockly from '../../build/src/core/blockly.js';

--- a/tests/mocha/field_test.js
+++ b/tests/mocha/field_test.js
@@ -4,9 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as goog from '../../build/src/closure/goog/goog.js';
-goog.declareModuleId('Blockly.test.fieldTest');
-
 import * as Blockly from '../../build/src/core/blockly.js';
 import {
   addBlockTypeToCleanup,

--- a/tests/mocha/field_textinput_test.js
+++ b/tests/mocha/field_textinput_test.js
@@ -4,9 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as goog from '../../build/src/closure/goog/goog.js';
-goog.declareModuleId('Blockly.test.fieldTextInput');
-
 import * as Blockly from '../../build/src/core/blockly.js';
 import {
   assertFieldValue,

--- a/tests/mocha/field_textinput_test.js
+++ b/tests/mocha/field_textinput_test.js
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import * as goog from '../../build/src/closure/goog/goog.js';
 goog.declareModuleId('Blockly.test.fieldTextInput');
 
 import * as Blockly from '../../build/src/core/blockly.js';

--- a/tests/mocha/field_variable_test.js
+++ b/tests/mocha/field_variable_test.js
@@ -4,9 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as goog from '../../build/src/closure/goog/goog.js';
-goog.declareModuleId('Blockly.test.fieldVariable');
-
 import * as Blockly from '../../build/src/core/blockly.js';
 import {
   assertFieldValue,

--- a/tests/mocha/field_variable_test.js
+++ b/tests/mocha/field_variable_test.js
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import * as goog from '../../build/src/closure/goog/goog.js';
 goog.declareModuleId('Blockly.test.fieldVariable');
 
 import * as Blockly from '../../build/src/core/blockly.js';

--- a/tests/mocha/flyout_test.js
+++ b/tests/mocha/flyout_test.js
@@ -4,9 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as goog from '../../build/src/closure/goog/goog.js';
-goog.declareModuleId('Blockly.test.flyout');
-
 import {
   sharedTestSetup,
   sharedTestTeardown,

--- a/tests/mocha/flyout_test.js
+++ b/tests/mocha/flyout_test.js
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import * as goog from '../../build/src/closure/goog/goog.js';
 goog.declareModuleId('Blockly.test.flyout');
 
 import {

--- a/tests/mocha/generator_test.js
+++ b/tests/mocha/generator_test.js
@@ -4,9 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as goog from '../../build/src/closure/goog/goog.js';
-goog.declareModuleId('Blockly.test.generator');
-
 import * as Blockly from '../../build/src/core/blockly.js';
 import {DartGenerator} from '../../build/src/generators/dart/dart_generator.js';
 import {JavascriptGenerator} from '../../build/src/generators/javascript/javascript_generator.js';

--- a/tests/mocha/generator_test.js
+++ b/tests/mocha/generator_test.js
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import * as goog from '../../build/src/closure/goog/goog.js';
 goog.declareModuleId('Blockly.test.generator');
 
 import * as Blockly from '../../build/src/core/blockly.js';

--- a/tests/mocha/gesture_test.js
+++ b/tests/mocha/gesture_test.js
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import * as goog from '../../build/src/closure/goog/goog.js';
 goog.declareModuleId('Blockly.test.gesture');
 
 import {assertEventFired, assertEventNotFired} from './test_helpers/events.js';

--- a/tests/mocha/gesture_test.js
+++ b/tests/mocha/gesture_test.js
@@ -4,9 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as goog from '../../build/src/closure/goog/goog.js';
-goog.declareModuleId('Blockly.test.gesture');
-
 import {assertEventFired, assertEventNotFired} from './test_helpers/events.js';
 import {defineBasicBlockWithField} from './test_helpers/block_definitions.js';
 import {dispatchPointerEvent} from './test_helpers/user_input.js';

--- a/tests/mocha/icon_test.js
+++ b/tests/mocha/icon_test.js
@@ -4,9 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as goog from '../../build/src/closure/goog/goog.js';
-goog.declareModuleId('Blockly.test.icon');
-
 import {
   sharedTestSetup,
   sharedTestTeardown,

--- a/tests/mocha/icon_test.js
+++ b/tests/mocha/icon_test.js
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import * as goog from '../../build/src/closure/goog/goog.js';
 goog.declareModuleId('Blockly.test.icon');
 
 import {

--- a/tests/mocha/index.html
+++ b/tests/mocha/index.html
@@ -130,6 +130,22 @@
     </script>
     <script src="../bootstrap.js"></script>
 
+    <script type="module">
+      // Wait for Blockly to finish loading before running tests.
+      import '../bootstrap_done.mjs';
+
+      let runner = mocha.run(function (failures) {
+        var failureDiv = document.getElementById('failureCount');
+        failureDiv.setAttribute('tests_failed', failures);
+      });
+      runner.on('fail', function (test, err) {
+        const msg = document.createElement('p');
+        msg.textContent = `"${test.fullTitle()}" failed: ${err.message}`;
+        const div = document.getElementById('failureMessages');
+        div.appendChild(msg);
+      });
+    </script>
+
     <div id="blocklyDiv"></div>
 
     <xml
@@ -203,20 +219,5 @@
       <block type="test_field_block"></block>
     </xml>
 
-    <script type="module">
-      // Wait for Blockly to finish loading before running tests.
-      import '../bootstrap_done.mjs';
-
-      let runner = mocha.run(function (failures) {
-        var failureDiv = document.getElementById('failureCount');
-        failureDiv.setAttribute('tests_failed', failures);
-      });
-      runner.on('fail', function (test, err) {
-        const msg = document.createElement('p');
-        msg.textContent = `"${test.fullTitle()}" failed: ${err.message}`;
-        const div = document.getElementById('failureMessages');
-        div.appendChild(msg);
-      });
-    </script>
   </body>
 </html>

--- a/tests/mocha/index.html
+++ b/tests/mocha/index.html
@@ -29,110 +29,111 @@
         ui: 'tdd',
         failZero: true,
       });
-
-      var BLOCKLY_BOOTSTRAP_OPTIONS = {
-        loadCompressed: false,
-        depsFiles: ['build/deps.js', 'build/deps.mocha.js'],
-        requires: [
-          // Test modules.
-          'Blockly.test.astNode',
-          'Blockly.test.blockJson',
-          'Blockly.test.blocks',
-          'Blockly.test.clipboard',
-          'Blockly.test.comments',
-          'Blockly.test.commentDeserialization',
-          'Blockly.test.connectionChecker',
-          'Blockly.test.connectionDb',
-          'Blockly.test.connection',
-          'Blockly.test.contextMenuItem',
-          'Blockly.test.cursor',
-          'Blockly.test.dropdown',
-          'Blockly.test.event',
-          'Blockly.test.eventBlockChange',
-          'Blockly.test.eventBlockCreate',
-          'Blockly.test.eventBlockDelete',
-          'Blockly.test.eventBlockDrag',
-          'Blockly.test.eventBlockFieldIntermediateChange',
-          'Blockly.test.eventBlockMove',
-          'Blockly.test.eventBubbleOpen',
-          'Blockly.test.eventClick',
-          'Blockly.test.eventCommentChange',
-          'Blockly.test.eventCommentCreate',
-          'Blockly.test.eventCommentDelete',
-          'Blockly.test.eventCommentMove',
-          'Blockly.test.eventMarkerMove',
-          'Blockly.test.eventSelected',
-          'Blockly.test.eventThemeChange',
-          'Blockly.test.eventToolboxItemSelect',
-          'Blockly.test.eventTrashcanOpen',
-          'Blockly.test.eventVarCreate',
-          'Blockly.test.eventVarDelete',
-          'Blockly.test.eventVarRename',
-          'Blockly.test.eventViewportChange',
-          'Blockly.test.extensions',
-          'Blockly.test.fieldAngle',
-          'Blockly.test.fieldCheckbox',
-          'Blockly.test.fieldColour',
-          'Blockly.test.fieldDropdown',
-          'Blockly.test.fieldImage',
-          'Blockly.test.fieldLabelSerialization',
-          'Blockly.test.fieldLabel',
-          'Blockly.test.fieldMultiline',
-          'Blockly.test.fieldNumber',
-          'Blockly.test.fieldRegistry',
-          'Blockly.test.fieldTest',
-          'Blockly.test.fieldTextInput',
-          'Blockly.test.fieldVariable',
-          'Blockly.test.flyout',
-          'Blockly.test.generator',
-          'Blockly.test.gesture',
-          'Blockly.test.icon',
-          'Blockly.test.input',
-          'Blockly.test.insertionMarker',
-          'Blockly.test.insertionMarkerManager',
-          'Blockly.test.jsoDeserialization',
-          'Blockly.test.jsoSerialization',
-          'Blockly.test.json',
-          'Blockly.test.keydown',
-          'Blockly.test.lists',
-          'Blockly.test.logicTernary',
-          'Blockly.test.metrics',
-          'Blockly.test.mutator',
-          'Blockly.test.names',
-          'Blockly.test.procedureMap',
-          'Blockly.test.procedures',
-          'Blockly.test.registry',
-          'Blockly.test.renderManagement',
-          'Blockly.test.serialization',
-          'Blockly.test.shortcutRegistry',
-          'Blockly.test.touch',
-          'Blockly.test.theme',
-          'Blockly.test.toolbox',
-          'Blockly.test.tooltip',
-          'Blockly.test.trashcan',
-          'Blockly.test.utils',
-          'Blockly.test.variableMap',
-          'Blockly.test.variableModel',
-          'Blockly.test.variables',
-          'Blockly.test.widgetDiv',
-          'Blockly.test.workspaceComment',
-          'Blockly.test.workspaceSvg',
-          'Blockly.test.workspace',
-          'Blockly.test.xml',
-          'Blockly.test.zoomControls',
-        ],
-        scripts: [
-          'build/msg/en.js',
-          'tests/playgrounds/screenshot.js',
-          'node_modules/@blockly/dev-tools/dist/index.js',
-        ],
-      };
     </script>
-    <script src="../bootstrap.js"></script>
 
     <script type="module">
-      // Wait for Blockly to finish loading before running tests.
-      import '../bootstrap_done.mjs';
+      import {loadScript} from '../scripts/load.mjs';
+
+      // Load Blockly in uncompressed mode.
+      import * as Blockly from '../../build/blockly.loader.mjs';
+      import '../../build/blocks.loader.mjs';
+      import {javascriptGenerator} from '../../build/javascript.loader.mjs';
+
+      // Import tests.
+      import './astnode_test.js';
+      import './block_json_test.js';
+      import './block_test.js';
+      import './clipboard_test.js';
+      import './comment_test.js';
+      import './comment_deserialization_test.js';
+      import './connection_checker_test.js';
+      import './connection_db_test.js';
+      import './connection_test.js';
+      import './contextmenu_items_test.js';
+      import './cursor_test.js';
+      import './dropdowndiv_test.js';
+      import './event_test.js';
+      import './event_block_change_test.js';
+      import './event_block_create_test.js';
+      import './event_block_delete_test.js';
+      import './event_block_drag_test.js';
+      import './event_block_field_intermediate_change_test.js';
+      import './event_block_move_test.js';
+      import './event_bubble_open_test.js';
+      import './event_click_test.js';
+      import './event_comment_change_test.js';
+      import './event_comment_create_test.js';
+      import './event_comment_delete_test.js';
+      import './event_comment_move_test.js';
+      import './event_marker_move_test.js';
+      import './event_selected_test.js';
+      import './event_theme_change_test.js';
+      import './event_toolbox_item_select_test.js';
+      import './event_trashcan_open_test.js';
+      import './event_var_create_test.js';
+      import './event_var_delete_test.js';
+      import './event_var_rename_test.js';
+      import './event_viewport_test.js';
+      import './extensions_test.js';
+      import './field_angle_test.js';
+      import './field_checkbox_test.js';
+      import './field_colour_test.js';
+      import './field_dropdown_test.js';
+      import './field_image_test.js';
+      import './field_label_serializable_test.js';
+      import './field_label_test.js';
+      import './field_multilineinput_test.js';
+      import './field_number_test.js';
+      import './field_registry_test.js';
+      import './field_test.js';
+      import './field_textinput_test.js';
+      import './field_variable_test.js';
+      import './flyout_test.js';
+      import './generator_test.js';
+      import './gesture_test.js';
+      import './icon_test.js';
+      import './input_test.js';
+      import './insertion_marker_test.js';
+      import './insertion_marker_manager_test.js';
+      import './jso_deserialization_test.js';
+      import './jso_serialization_test.js';
+      import './json_test.js';
+      import './keydown_test.js';
+      import './blocks/lists_test.js';
+      import './blocks/logic_ternary_test.js';
+      import './metrics_test.js';
+      import './mutator_test.js';
+      import './names_test.js';
+      import './procedure_map_test.js';
+      import './blocks/procedures_test.js';
+      import './registry_test.js';
+      import './render_management_test.js';
+      import './serializer_test.js';
+      import './shortcut_registry_test.js';
+      import './touch_test.js';
+      import './theme_test.js';
+      import './toolbox_test.js';
+      import './tooltip_test.js';
+      import './trashcan_test.js';
+      import './utils_test.js';
+      import './variable_map_test.js';
+      import './variable_model_test.js';
+      import './blocks/variables_test.js';
+      import './widget_div_test.js';
+      import './workspace_comment_test.js';
+      import './workspace_svg_test.js';
+      import './workspace_test.js';
+      import './xml_test.js';
+      import './zoom_controls_test.js';
+
+      // Make Blockly and generators available via global scope.
+      globalThis.Blockly = Blockly;
+      globalThis.javascriptGenerator = javascriptGenerator;
+
+      // Load additional scripts.
+      await loadScript('../../build/msg/en.js');
+      await loadScript('../playgrounds/screenshot.js');
+      await loadScript('../../node_modules/@blockly/dev-tools/dist/index.js');
 
       let runner = mocha.run(function (failures) {
         var failureDiv = document.getElementById('failureCount');
@@ -218,6 +219,5 @@
       style="display: none">
       <block type="test_field_block"></block>
     </xml>
-
   </body>
 </html>

--- a/tests/mocha/input_test.js
+++ b/tests/mocha/input_test.js
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import * as goog from '../../build/src/closure/goog/goog.js';
 goog.declareModuleId('Blockly.test.input');
 
 import {

--- a/tests/mocha/input_test.js
+++ b/tests/mocha/input_test.js
@@ -4,9 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as goog from '../../build/src/closure/goog/goog.js';
-goog.declareModuleId('Blockly.test.input');
-
 import {
   sharedTestSetup,
   sharedTestTeardown,

--- a/tests/mocha/insertion_marker_manager_test.js
+++ b/tests/mocha/insertion_marker_manager_test.js
@@ -4,9 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as goog from '../../build/src/closure/goog/goog.js';
-goog.declareModuleId('Blockly.test.insertionMarkerManager');
-
 import {
   sharedTestSetup,
   sharedTestTeardown,

--- a/tests/mocha/insertion_marker_manager_test.js
+++ b/tests/mocha/insertion_marker_manager_test.js
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import * as goog from '../../build/src/closure/goog/goog.js';
 goog.declareModuleId('Blockly.test.insertionMarkerManager');
 
 import {

--- a/tests/mocha/insertion_marker_test.js
+++ b/tests/mocha/insertion_marker_test.js
@@ -4,9 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as goog from '../../build/src/closure/goog/goog.js';
-goog.declareModuleId('Blockly.test.insertionMarker');
-
 import {
   sharedTestSetup,
   sharedTestTeardown,

--- a/tests/mocha/insertion_marker_test.js
+++ b/tests/mocha/insertion_marker_test.js
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import * as goog from '../../build/src/closure/goog/goog.js';
 goog.declareModuleId('Blockly.test.insertionMarker');
 
 import {

--- a/tests/mocha/jso_deserialization_test.js
+++ b/tests/mocha/jso_deserialization_test.js
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import * as goog from '../../build/src/closure/goog/goog.js';
 goog.declareModuleId('Blockly.test.jsoDeserialization');
 
 import {

--- a/tests/mocha/jso_deserialization_test.js
+++ b/tests/mocha/jso_deserialization_test.js
@@ -4,9 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as goog from '../../build/src/closure/goog/goog.js';
-goog.declareModuleId('Blockly.test.jsoDeserialization');
-
 import {
   sharedTestSetup,
   sharedTestTeardown,

--- a/tests/mocha/jso_serialization_test.js
+++ b/tests/mocha/jso_serialization_test.js
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import * as goog from '../../build/src/closure/goog/goog.js';
 goog.declareModuleId('Blockly.test.jsoSerialization');
 
 import * as Blockly from '../../build/src/core/blockly.js';

--- a/tests/mocha/jso_serialization_test.js
+++ b/tests/mocha/jso_serialization_test.js
@@ -4,9 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as goog from '../../build/src/closure/goog/goog.js';
-goog.declareModuleId('Blockly.test.jsoSerialization');
-
 import * as Blockly from '../../build/src/core/blockly.js';
 import {
   createGenUidStubWithReturns,

--- a/tests/mocha/json_test.js
+++ b/tests/mocha/json_test.js
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import * as goog from '../../build/src/closure/goog/goog.js';
 goog.declareModuleId('Blockly.test.json');
 
 import {

--- a/tests/mocha/json_test.js
+++ b/tests/mocha/json_test.js
@@ -4,9 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as goog from '../../build/src/closure/goog/goog.js';
-goog.declareModuleId('Blockly.test.json');
-
 import {
   addMessageToCleanup,
   sharedTestSetup,

--- a/tests/mocha/keydown_test.js
+++ b/tests/mocha/keydown_test.js
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import * as goog from '../../build/src/closure/goog/goog.js';
 goog.declareModuleId('Blockly.test.keydown');
 
 import * as Blockly from '../../build/src/core/blockly.js';

--- a/tests/mocha/keydown_test.js
+++ b/tests/mocha/keydown_test.js
@@ -4,9 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as goog from '../../build/src/closure/goog/goog.js';
-goog.declareModuleId('Blockly.test.keydown');
-
 import * as Blockly from '../../build/src/core/blockly.js';
 import {createKeyDownEvent} from './test_helpers/user_input.js';
 import {defineStackBlock} from './test_helpers/block_definitions.js';

--- a/tests/mocha/metrics_test.js
+++ b/tests/mocha/metrics_test.js
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import * as goog from '../../build/src/closure/goog/goog.js';
 goog.declareModuleId('Blockly.test.metrics');
 
 import {

--- a/tests/mocha/metrics_test.js
+++ b/tests/mocha/metrics_test.js
@@ -4,9 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as goog from '../../build/src/closure/goog/goog.js';
-goog.declareModuleId('Blockly.test.metrics');
-
 import {
   sharedTestSetup,
   sharedTestTeardown,

--- a/tests/mocha/mutator_test.js
+++ b/tests/mocha/mutator_test.js
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import * as goog from '../../build/src/closure/goog/goog.js';
 goog.declareModuleId('Blockly.test.mutator');
 
 import {

--- a/tests/mocha/mutator_test.js
+++ b/tests/mocha/mutator_test.js
@@ -4,9 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as goog from '../../build/src/closure/goog/goog.js';
-goog.declareModuleId('Blockly.test.mutator');
-
 import {
   sharedTestSetup,
   sharedTestTeardown,

--- a/tests/mocha/names_test.js
+++ b/tests/mocha/names_test.js
@@ -4,9 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as goog from '../../build/src/closure/goog/goog.js';
-goog.declareModuleId('Blockly.test.names');
-
 import {
   sharedTestSetup,
   sharedTestTeardown,

--- a/tests/mocha/names_test.js
+++ b/tests/mocha/names_test.js
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import * as goog from '../../build/src/closure/goog/goog.js';
 goog.declareModuleId('Blockly.test.names');
 
 import {

--- a/tests/mocha/procedure_map_test.js
+++ b/tests/mocha/procedure_map_test.js
@@ -15,6 +15,7 @@ import {
 } from './test_helpers/events.js';
 import {MockProcedureModel} from './test_helpers/procedures.js';
 
+import * as goog from '../../build/src/closure/goog/goog.js';
 goog.declareModuleId('Blockly.test.procedureMap');
 
 suite('Procedure Map', function () {

--- a/tests/mocha/procedure_map_test.js
+++ b/tests/mocha/procedure_map_test.js
@@ -15,9 +15,6 @@ import {
 } from './test_helpers/events.js';
 import {MockProcedureModel} from './test_helpers/procedures.js';
 
-import * as goog from '../../build/src/closure/goog/goog.js';
-goog.declareModuleId('Blockly.test.procedureMap');
-
 suite('Procedure Map', function () {
   setup(function () {
     sharedTestSetup.call(this);

--- a/tests/mocha/registry_test.js
+++ b/tests/mocha/registry_test.js
@@ -4,9 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as goog from '../../build/src/closure/goog/goog.js';
-goog.declareModuleId('Blockly.test.registry');
-
 import {assertWarnings} from './test_helpers/warnings.js';
 import {
   sharedTestSetup,

--- a/tests/mocha/registry_test.js
+++ b/tests/mocha/registry_test.js
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import * as goog from '../../build/src/closure/goog/goog.js';
 goog.declareModuleId('Blockly.test.registry');
 
 import {assertWarnings} from './test_helpers/warnings.js';

--- a/tests/mocha/render_management_test.js
+++ b/tests/mocha/render_management_test.js
@@ -4,9 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as goog from '../../build/src/closure/goog/goog.js';
-goog.declareModuleId('Blockly.test.renderManagement');
-
 import {
   sharedTestSetup,
   sharedTestTeardown,

--- a/tests/mocha/render_management_test.js
+++ b/tests/mocha/render_management_test.js
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import * as goog from '../../build/src/closure/goog/goog.js';
 goog.declareModuleId('Blockly.test.renderManagement');
 
 import {

--- a/tests/mocha/serializer_test.js
+++ b/tests/mocha/serializer_test.js
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import * as goog from '../../build/src/closure/goog/goog.js';
 goog.declareModuleId('Blockly.test.serialization');
 
 import * as Blockly from '../../build/src/core/blockly.js';

--- a/tests/mocha/serializer_test.js
+++ b/tests/mocha/serializer_test.js
@@ -4,9 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as goog from '../../build/src/closure/goog/goog.js';
-goog.declareModuleId('Blockly.test.serialization');
-
 import * as Blockly from '../../build/src/core/blockly.js';
 import {
   TestCase,

--- a/tests/mocha/shortcut_registry_test.js
+++ b/tests/mocha/shortcut_registry_test.js
@@ -4,9 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as goog from '../../build/src/closure/goog/goog.js';
-goog.declareModuleId('Blockly.test.shortcutRegistry');
-
 import {createKeyDownEvent} from './test_helpers/user_input.js';
 import {
   sharedTestSetup,

--- a/tests/mocha/shortcut_registry_test.js
+++ b/tests/mocha/shortcut_registry_test.js
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import * as goog from '../../build/src/closure/goog/goog.js';
 goog.declareModuleId('Blockly.test.shortcutRegistry');
 
 import {createKeyDownEvent} from './test_helpers/user_input.js';

--- a/tests/mocha/test_helpers/block_definitions.js
+++ b/tests/mocha/test_helpers/block_definitions.js
@@ -4,9 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as goog from '../../../build/src/closure/goog/goog.js';
-goog.declareModuleId('Blockly.test.helpers.blockDefinitions');
-
 export function defineEmptyBlock(name = 'empty_block') {
   Blockly.defineBlocksWithJsonArray([
     {

--- a/tests/mocha/test_helpers/block_definitions.js
+++ b/tests/mocha/test_helpers/block_definitions.js
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import * as goog from '../../../build/src/closure/goog/goog.js';
 goog.declareModuleId('Blockly.test.helpers.blockDefinitions');
 
 export function defineEmptyBlock(name = 'empty_block') {

--- a/tests/mocha/test_helpers/code_generation.js
+++ b/tests/mocha/test_helpers/code_generation.js
@@ -5,9 +5,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as goog from '../../../build/src/closure/goog/goog.js';
-goog.declareModuleId('Blockly.test.helpers.codeGeneration');
-
 import {runTestSuites} from './common.js';
 
 /**

--- a/tests/mocha/test_helpers/code_generation.js
+++ b/tests/mocha/test_helpers/code_generation.js
@@ -5,6 +5,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import * as goog from '../../../build/src/closure/goog/goog.js';
 goog.declareModuleId('Blockly.test.helpers.codeGeneration');
 
 import {runTestSuites} from './common.js';

--- a/tests/mocha/test_helpers/common.js
+++ b/tests/mocha/test_helpers/common.js
@@ -4,9 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as goog from '../../../build/src/closure/goog/goog.js';
-goog.declareModuleId('Blockly.test.helpers.common');
-
 /**
  * Test case configuration.
  * @record

--- a/tests/mocha/test_helpers/common.js
+++ b/tests/mocha/test_helpers/common.js
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import * as goog from '../../../build/src/closure/goog/goog.js';
 goog.declareModuleId('Blockly.test.helpers.common');
 
 /**

--- a/tests/mocha/test_helpers/events.js
+++ b/tests/mocha/test_helpers/events.js
@@ -4,9 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as goog from '../../../build/src/closure/goog/goog.js';
-goog.declareModuleId('Blockly.test.helpers.events');
-
 /**
  * Creates spy for workspace fireChangeListener
  * @param {!Blockly.Workspace} workspace The workspace to spy fireChangeListener

--- a/tests/mocha/test_helpers/events.js
+++ b/tests/mocha/test_helpers/events.js
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import * as goog from '../../../build/src/closure/goog/goog.js';
 goog.declareModuleId('Blockly.test.helpers.events');
 
 /**

--- a/tests/mocha/test_helpers/fields.js
+++ b/tests/mocha/test_helpers/fields.js
@@ -4,9 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as goog from '../../../build/src/closure/goog/goog.js';
-goog.declareModuleId('Blockly.test.helpers.fields');
-
 import {runTestCases, TestCase} from './common.js';
 
 /**

--- a/tests/mocha/test_helpers/fields.js
+++ b/tests/mocha/test_helpers/fields.js
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import * as goog from '../../../build/src/closure/goog/goog.js';
 goog.declareModuleId('Blockly.test.helpers.fields');
 
 import {runTestCases, TestCase} from './common.js';

--- a/tests/mocha/test_helpers/procedures.js
+++ b/tests/mocha/test_helpers/procedures.js
@@ -3,8 +3,6 @@
  * Copyright 2020 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
-import * as goog from '../../../build/src/closure/goog/goog.js';
-goog.declareModuleId('Blockly.test.helpers.procedures');
 
 import {ConnectionType} from '../../../build/src/core/connection_type.js';
 import {VariableModel} from '../../../build/src/core/variable_model.js';

--- a/tests/mocha/test_helpers/procedures.js
+++ b/tests/mocha/test_helpers/procedures.js
@@ -3,6 +3,7 @@
  * Copyright 2020 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
+import * as goog from '../../../build/src/closure/goog/goog.js';
 goog.declareModuleId('Blockly.test.helpers.procedures');
 
 import {ConnectionType} from '../../../build/src/core/connection_type.js';

--- a/tests/mocha/test_helpers/serialization.js
+++ b/tests/mocha/test_helpers/serialization.js
@@ -110,25 +110,7 @@ export const runSerializationTestSuite = (testCases) => {
     });
     suite('xml round-trip', function () {
       setup(function () {
-        // The genUid is undergoing change as part of the 2021Q3
-        // goog.module migration:
-        //
-        // - It is being moved from Blockly.utils to
-        //   Blockly.utils.idGenerator (which itself is being renamed
-        //   from IdGenerator).
-        // - For compatibility with changes to the module system (from
-        //   goog.provide to goog.module and in future to ES modules),
-        //   .genUid is now a wrapper around .TEST_ONLY.genUid, which
-        //   can be safely stubbed by sinon or other similar
-        //   frameworks in a way that will continue to work.
-        if (Blockly.utils.idGenerator && Blockly.utils.idGenerator.TEST_ONLY) {
-          sinon
-            .stub(Blockly.utils.idGenerator.TEST_ONLY, 'genUid')
-            .returns('1');
-        } else {
-          // Fall back to stubbing original version on Blockly.utils.
-          sinon.stub(Blockly.utils, 'genUid').returns('1');
-        }
+        sinon.stub(Blockly.utils.idGenerator.TEST_ONLY, 'genUid').returns('1');
       });
 
       teardown(function () {

--- a/tests/mocha/test_helpers/serialization.js
+++ b/tests/mocha/test_helpers/serialization.js
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import * as goog from '../../../build/src/closure/goog/goog.js';
 goog.declareModuleId('Blockly.test.helpers.serialization');
 
 import {runTestCases} from './common.js';

--- a/tests/mocha/test_helpers/serialization.js
+++ b/tests/mocha/test_helpers/serialization.js
@@ -4,9 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as goog from '../../../build/src/closure/goog/goog.js';
-goog.declareModuleId('Blockly.test.helpers.serialization');
-
 import {runTestCases} from './common.js';
 
 /**

--- a/tests/mocha/test_helpers/setup_teardown.js
+++ b/tests/mocha/test_helpers/setup_teardown.js
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import * as goog from '../../../build/src/closure/goog/goog.js';
 goog.declareModuleId('Blockly.test.helpers.setupTeardown');
 
 import * as eventUtils from '../../../build/src/core/events/utils.js';

--- a/tests/mocha/test_helpers/setup_teardown.js
+++ b/tests/mocha/test_helpers/setup_teardown.js
@@ -4,9 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as goog from '../../../build/src/closure/goog/goog.js';
-goog.declareModuleId('Blockly.test.helpers.setupTeardown');
-
 import * as eventUtils from '../../../build/src/core/events/utils.js';
 
 /**

--- a/tests/mocha/test_helpers/toolbox_definitions.js
+++ b/tests/mocha/test_helpers/toolbox_definitions.js
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import * as goog from '../../../build/src/closure/goog/goog.js';
 goog.declareModuleId('Blockly.test.helpers.toolboxDefinitions');
 
 /**

--- a/tests/mocha/test_helpers/toolbox_definitions.js
+++ b/tests/mocha/test_helpers/toolbox_definitions.js
@@ -4,9 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as goog from '../../../build/src/closure/goog/goog.js';
-goog.declareModuleId('Blockly.test.helpers.toolboxDefinitions');
-
 /**
  * Get JSON for a toolbox that contains categories.
  * @return {Blockly.utils.toolbox.ToolboxJson} The array holding information

--- a/tests/mocha/test_helpers/user_input.js
+++ b/tests/mocha/test_helpers/user_input.js
@@ -4,9 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as goog from '../../../build/src/closure/goog/goog.js';
-goog.declareModuleId('Blockly.test.helpers.userInput');
-
 import {KeyCodes} from '../../../build/src/core/utils/keycodes.js';
 
 /**

--- a/tests/mocha/test_helpers/user_input.js
+++ b/tests/mocha/test_helpers/user_input.js
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import * as goog from '../../../build/src/closure/goog/goog.js';
 goog.declareModuleId('Blockly.test.helpers.userInput');
 
 import {KeyCodes} from '../../../build/src/core/utils/keycodes.js';

--- a/tests/mocha/test_helpers/variables.js
+++ b/tests/mocha/test_helpers/variables.js
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import * as goog from '../../../build/src/closure/goog/goog.js';
 goog.declareModuleId('Blockly.test.helpers.variables');
 
 /**

--- a/tests/mocha/test_helpers/variables.js
+++ b/tests/mocha/test_helpers/variables.js
@@ -4,9 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as goog from '../../../build/src/closure/goog/goog.js';
-goog.declareModuleId('Blockly.test.helpers.variables');
-
 /**
  * Check if a variable with the given values exists.
  * @param {Blockly.Workspace|Blockly.VariableMap} container The workspace  or

--- a/tests/mocha/test_helpers/warnings.js
+++ b/tests/mocha/test_helpers/warnings.js
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import * as goog from '../../../build/src/closure/goog/goog.js';
 goog.declareModuleId('Blockly.test.helpers.warnings');
 
 /**

--- a/tests/mocha/test_helpers/warnings.js
+++ b/tests/mocha/test_helpers/warnings.js
@@ -4,9 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as goog from '../../../build/src/closure/goog/goog.js';
-goog.declareModuleId('Blockly.test.helpers.warnings');
-
 /**
  * Captures the strings sent to console.warn() when calling a function.
  * Copies from core.

--- a/tests/mocha/test_helpers/workspace.js
+++ b/tests/mocha/test_helpers/workspace.js
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import * as goog from '../../../build/src/closure/goog/goog.js';
 goog.declareModuleId('Blockly.test.helpers.workspace');
 
 import {assertVariableValues} from './variables.js';

--- a/tests/mocha/test_helpers/workspace.js
+++ b/tests/mocha/test_helpers/workspace.js
@@ -4,9 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as goog from '../../../build/src/closure/goog/goog.js';
-goog.declareModuleId('Blockly.test.helpers.workspace');
-
 import {assertVariableValues} from './variables.js';
 import {assertWarnings} from './warnings.js';
 import * as eventUtils from '../../../build/src/core/events/utils.js';

--- a/tests/mocha/theme_test.js
+++ b/tests/mocha/theme_test.js
@@ -4,9 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as goog from '../../build/src/closure/goog/goog.js';
-goog.declareModuleId('Blockly.test.theme');
-
 import {assertEventFired} from './test_helpers/events.js';
 import * as eventUtils from '../../build/src/core/events/utils.js';
 import {

--- a/tests/mocha/theme_test.js
+++ b/tests/mocha/theme_test.js
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import * as goog from '../../build/src/closure/goog/goog.js';
 goog.declareModuleId('Blockly.test.theme');
 
 import {assertEventFired} from './test_helpers/events.js';

--- a/tests/mocha/toolbox_test.js
+++ b/tests/mocha/toolbox_test.js
@@ -4,9 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as goog from '../../build/src/closure/goog/goog.js';
-goog.declareModuleId('Blockly.test.toolbox');
-
 import {defineStackBlock} from './test_helpers/block_definitions.js';
 import {
   sharedTestSetup,

--- a/tests/mocha/toolbox_test.js
+++ b/tests/mocha/toolbox_test.js
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import * as goog from '../../build/src/closure/goog/goog.js';
 goog.declareModuleId('Blockly.test.toolbox');
 
 import {defineStackBlock} from './test_helpers/block_definitions.js';

--- a/tests/mocha/tooltip_test.js
+++ b/tests/mocha/tooltip_test.js
@@ -4,9 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as goog from '../../build/src/closure/goog/goog.js';
-goog.declareModuleId('Blockly.test.tooltip');
-
 import {
   sharedTestSetup,
   sharedTestTeardown,

--- a/tests/mocha/tooltip_test.js
+++ b/tests/mocha/tooltip_test.js
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import * as goog from '../../build/src/closure/goog/goog.js';
 goog.declareModuleId('Blockly.test.tooltip');
 
 import {

--- a/tests/mocha/touch_test.js
+++ b/tests/mocha/touch_test.js
@@ -4,9 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as goog from '../../build/src/closure/goog/goog.js';
-goog.declareModuleId('Blockly.test.touch');
-
 import {
   sharedTestSetup,
   sharedTestTeardown,

--- a/tests/mocha/touch_test.js
+++ b/tests/mocha/touch_test.js
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import * as goog from '../../build/src/closure/goog/goog.js';
 goog.declareModuleId('Blockly.test.touch');
 
 import {

--- a/tests/mocha/trashcan_test.js
+++ b/tests/mocha/trashcan_test.js
@@ -4,9 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as goog from '../../build/src/closure/goog/goog.js';
-goog.declareModuleId('Blockly.test.trashcan');
-
 import {assertEventFired, assertEventNotFired} from './test_helpers/events.js';
 import {
   sharedTestSetup,

--- a/tests/mocha/trashcan_test.js
+++ b/tests/mocha/trashcan_test.js
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import * as goog from '../../build/src/closure/goog/goog.js';
 goog.declareModuleId('Blockly.test.trashcan');
 
 import {assertEventFired, assertEventNotFired} from './test_helpers/events.js';

--- a/tests/mocha/utils_test.js
+++ b/tests/mocha/utils_test.js
@@ -4,9 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as goog from '../../build/src/closure/goog/goog.js';
-goog.declareModuleId('Blockly.test.utils');
-
 import {
   sharedTestSetup,
   sharedTestTeardown,

--- a/tests/mocha/utils_test.js
+++ b/tests/mocha/utils_test.js
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import * as goog from '../../build/src/closure/goog/goog.js';
 goog.declareModuleId('Blockly.test.utils');
 
 import {

--- a/tests/mocha/variable_map_test.js
+++ b/tests/mocha/variable_map_test.js
@@ -4,9 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as goog from '../../build/src/closure/goog/goog.js';
-goog.declareModuleId('Blockly.test.variableMap');
-
 import {assertVariableValues} from './test_helpers/variables.js';
 import {
   createGenUidStubWithReturns,

--- a/tests/mocha/variable_map_test.js
+++ b/tests/mocha/variable_map_test.js
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import * as goog from '../../build/src/closure/goog/goog.js';
 goog.declareModuleId('Blockly.test.variableMap');
 
 import {assertVariableValues} from './test_helpers/variables.js';

--- a/tests/mocha/variable_model_test.js
+++ b/tests/mocha/variable_model_test.js
@@ -4,9 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as goog from '../../build/src/closure/goog/goog.js';
-goog.declareModuleId('Blockly.test.variableModel');
-
 import {
   sharedTestSetup,
   sharedTestTeardown,

--- a/tests/mocha/variable_model_test.js
+++ b/tests/mocha/variable_model_test.js
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import * as goog from '../../build/src/closure/goog/goog.js';
 goog.declareModuleId('Blockly.test.variableModel');
 
 import {

--- a/tests/mocha/widget_div_test.js
+++ b/tests/mocha/widget_div_test.js
@@ -4,9 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as goog from '../../build/src/closure/goog/goog.js';
-goog.declareModuleId('Blockly.test.widgetDiv');
-
 import {
   sharedTestSetup,
   sharedTestTeardown,

--- a/tests/mocha/widget_div_test.js
+++ b/tests/mocha/widget_div_test.js
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import * as goog from '../../build/src/closure/goog/goog.js';
 goog.declareModuleId('Blockly.test.widgetDiv');
 
 import {

--- a/tests/mocha/workspace_comment_test.js
+++ b/tests/mocha/workspace_comment_test.js
@@ -4,9 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as goog from '../../build/src/closure/goog/goog.js';
-goog.declareModuleId('Blockly.test.workspaceComment');
-
 import {
   sharedTestSetup,
   sharedTestTeardown,

--- a/tests/mocha/workspace_comment_test.js
+++ b/tests/mocha/workspace_comment_test.js
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import * as goog from '../../build/src/closure/goog/goog.js';
 goog.declareModuleId('Blockly.test.workspaceComment');
 
 import {

--- a/tests/mocha/workspace_svg_test.js
+++ b/tests/mocha/workspace_svg_test.js
@@ -4,9 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as goog from '../../build/src/closure/goog/goog.js';
-goog.declareModuleId('Blockly.test.workspaceSvg');
-
 import {
   assertEventFired,
   assertEventNotFired,

--- a/tests/mocha/workspace_svg_test.js
+++ b/tests/mocha/workspace_svg_test.js
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import * as goog from '../../build/src/closure/goog/goog.js';
 goog.declareModuleId('Blockly.test.workspaceSvg');
 
 import {

--- a/tests/mocha/workspace_test.js
+++ b/tests/mocha/workspace_test.js
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import * as goog from '../../build/src/closure/goog/goog.js';
 goog.declareModuleId('Blockly.test.workspace');
 
 import {assertVariableValues} from './test_helpers/variables.js';

--- a/tests/mocha/workspace_test.js
+++ b/tests/mocha/workspace_test.js
@@ -4,9 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as goog from '../../build/src/closure/goog/goog.js';
-goog.declareModuleId('Blockly.test.workspace');
-
 import {assertVariableValues} from './test_helpers/variables.js';
 import {
   sharedTestSetup,

--- a/tests/mocha/xml_test.js
+++ b/tests/mocha/xml_test.js
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import * as goog from '../../build/src/closure/goog/goog.js';
 goog.declareModuleId('Blockly.test.xml');
 
 import {

--- a/tests/mocha/xml_test.js
+++ b/tests/mocha/xml_test.js
@@ -4,9 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as goog from '../../build/src/closure/goog/goog.js';
-goog.declareModuleId('Blockly.test.xml');
-
 import {
   addBlockTypeToCleanup,
   createGenUidStubWithReturns,

--- a/tests/mocha/zoom_controls_test.js
+++ b/tests/mocha/zoom_controls_test.js
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import * as goog from '../../build/src/closure/goog/goog.js';
 goog.declareModuleId('Blockly.test.zoomControls');
 
 import {assertEventFired, assertEventNotFired} from './test_helpers/events.js';

--- a/tests/mocha/zoom_controls_test.js
+++ b/tests/mocha/zoom_controls_test.js
@@ -4,9 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as goog from '../../build/src/closure/goog/goog.js';
-goog.declareModuleId('Blockly.test.zoomControls');
-
 import {assertEventFired, assertEventNotFired} from './test_helpers/events.js';
 import * as eventUtils from '../../build/src/core/events/utils.js';
 import {


### PR DESCRIPTION
## The basics

- [X] I branched from develop
- [X] My pull request is against develop
- [X] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)
- [X] I ran `npm run format` and `npm run lint`

## The details
### Resolves

Part of #6858.

### Proposed Changes

* Have the `buildShims` task clean up after itself.

  We need to create a `build/package.json` file to allow node.js to load `build/src/core/blockly.js` and the other chunk entry points as ES modules (it otherwise forcibly assumes `.js` means CJS even if one is trying to `import` the file rather than `require` it, unless `package.json` says `{"type": "module"}`), but this interferes with `scripts/migration/js2ts` doing a `require('build/deps.js')`, since `deps.js` is _not_ an ES module.

* Temporarily add missing `import`s of `closure/goog/goog.js` to modules in `tests/mocha/` (see de9499b for rationale).

* Migrate `tests/mocha/index.html` to `import` the loader shims instead of using `bootstrap.js`.
  * It now uses `import` to load Blockly, the library blocks and the JavaScript generator via the shims create in PR #7380.  Because the mocha tests have always been run in uncompressed mode it could instead directly import the chunk entry point s (e.g. `build/src/core/blockly.js`), but using the shims allows us to optionally run the tests in compressed mode as well.  At the moment they do not all pass, because several tests directly import individual modules from `core/`, which is not compatible with `blockly_compressed.js`, but #7224 is tracking work that would resolve this problem.
  * It also now uses `import` to load the individual test files that were originally `goog.require()`ed and more recently loaded via `bootstrap.js`.
  * It uses `loadScript` (from `tests/scripts/load.mjs`) to load various additional scripts including `en.js`.

* Remove code from `build_tasks.js` that generates `tests/deps.mocha.js`, since it was only needed by the bootstrap code now deleted from `tests/mocha/index.html`.

* Remove `goog.declareModuleId` calls (and added `import`s) from all `tests/mocha/**/*.js`.

* Remove some dead code from `tests/mocha/test_helpers/serialization.js`.

#### Behaviour Before Change

Mocha tests run and 2994/2994 (100%) tests pass in uncompressed mode.

#### Behaviour After Change

Mocha tests run and 2994/2994 (100%) tests pass in uncompressed mode.

Moreover, tests can optionally be run in compressed mode, with 2174/2994 (97%) passing.

### Reason for Changes

Remove dependency on `bootstrap.js` so it and the Closure debug module loader can be deleted.

### Test Coverage

Unchanged.

### Additional Info

Due to the large number of files touched it may be easier to review commit-by-commit.