### PR TITLE
chore: clean up measurement code in mini workspace bubble

### DIFF
--- a/core/bubbles/mini_workspace_bubble.ts
+++ b/core/bubbles/mini_workspace_bubble.ts
@@ -218,12 +218,10 @@ export class MiniWorkspaceBubble extends Bubble {
    * Calculates the size of the mini workspace for use in resizing the bubble.
    */
   private calculateWorkspaceSize(): Size {
-    // TODO (#7104): Clean this up to be more readable and unified for RTL
-    //     vs LTR.
-    const canvas = this.miniWorkspace.getCanvas();
-    const workspaceSize = canvas.getBBox();
-    let width = workspaceSize.width + workspaceSize.x;
+    const workspaceSize = this.miniWorkspace.getCanvas().getBBox();
+    let width = workspaceSize.width + MiniWorkspaceBubble.MARGIN;
     let height = workspaceSize.height + MiniWorkspaceBubble.MARGIN;
+
     const flyout = this.miniWorkspace.getFlyout();
     if (flyout) {
       const flyoutScrollMetrics = flyout
@@ -233,10 +231,6 @@ export class MiniWorkspaceBubble extends Bubble {
       height = Math.max(height, flyoutScrollMetrics.height + 20);
       width += flyout.getWidth();
     }
-    if (this.miniWorkspace.RTL) {
-      width = -workspaceSize.x;
-    }
-    width += MiniWorkspaceBubble.MARGIN;
     return new Size(width, height);
   }
 


### PR DESCRIPTION
## The basics

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

Part of https://github.com/google/blockly/issues/7104

### Proposed Changes

Stop adding extra margin to mini workspace bubbles (mutator bubbles). Make the margin the same in RTL and LTR.

#### Behavior Before Change
RTL:
![image](https://github.com/google/blockly/assets/13686399/65b38d85-58bb-47b8-9789-ffbfbdf8887a)

LTR:
![image](https://github.com/google/blockly/assets/13686399/1f53da5d-d438-4702-b145-932e0ca5b125)


#### Behavior After Change

RTL:
![image](https://github.com/google/blockly/assets/13686399/60df25b5-5eaa-402e-b761-757049fce2f0)

LTR:
![image](https://github.com/google/blockly/assets/13686399/da324dfb-2587-40ab-87b4-695236e36995)

### Reason for Changes

Could not find a reason for the previous inconsistency.

### Test Coverage

Opened mutators in LTR and RTL modes and dragged blocks around inside the mutator bubbles to make them change size.

### Documentation
None

