### PR TITLE
feat: make ordered argument optional for workspace.getAllBlocks

### DIFF
--- a/core/workspace.ts
+++ b/core/workspace.ts
@@ -206,7 +206,7 @@ export class Workspace implements IASTNodeLocation {
    * @param ordered Sort the list if true.
    * @returns The top-level block objects.
    */
-  getTopBlocks(ordered: boolean): Block[] {
+  getTopBlocks(ordered = false): Block[] {
     // Copy the topBlocks list.
     const blocks = new Array<Block>().concat(this.topBlocks);
     if (ordered && blocks.length > 1) {
@@ -247,7 +247,7 @@ export class Workspace implements IASTNodeLocation {
    * @param ordered Sort the list if true.
    * @returns The blocks of the given type.
    */
-  getBlocksByType(type: string, ordered: boolean): Block[] {
+  getBlocksByType(type: string, ordered = false): Block[] {
     if (!this.typedBlocksDB.has(type)) {
       return [];
     }
@@ -307,7 +307,7 @@ export class Workspace implements IASTNodeLocation {
    * @returns The top-level comment objects.
    * @internal
    */
-  getTopComments(ordered: boolean): WorkspaceComment[] {
+  getTopComments(ordered = false): WorkspaceComment[] {
     // Copy the topComments list.
     const comments = new Array<WorkspaceComment>().concat(this.topComments);
     if (ordered && comments.length > 1) {
@@ -323,7 +323,7 @@ export class Workspace implements IASTNodeLocation {
    * @param ordered Sort the list if true.
    * @returns Array of blocks.
    */
-  getAllBlocks(ordered?: boolean): Block[] {
+  getAllBlocks(ordered = false): Block[] {
     let blocks: Block[];
     if (ordered) {
       // Slow, but ordered.

--- a/core/workspace.ts
+++ b/core/workspace.ts
@@ -323,7 +323,7 @@ export class Workspace implements IASTNodeLocation {
    * @param ordered Sort the list if true.
    * @returns Array of blocks.
    */
-  getAllBlocks(ordered: boolean): Block[] {
+  getAllBlocks(ordered?: boolean): Block[] {
     let blocks: Block[];
     if (ordered) {
       // Slow, but ordered.


### PR DESCRIPTION
If you're using typescript then you know how frustrating it is to always add a param when calling workspace.getAllBlocks(). That's why I think it's a good idea to make it optional. If a value is not passed, it will use `false` as default.