### PR TITLE
fix: dragging blocks within a zoomed mutator

### DIFF
--- a/core/bubbles/mini_workspace_bubble.ts
+++ b/core/bubbles/mini_workspace_bubble.ts
@@ -65,6 +65,9 @@ export class MiniWorkspaceBubble extends Bubble {
     );
     workspaceOptions.parentWorkspace = this.workspace;
     this.miniWorkspace = this.newWorkspaceSvg(new Options(workspaceOptions));
+    // TODO (#7422): Change this to `internalIsMiniWorkspace` or something. Not
+    //   all mini workspaces are necessarily mutators.
+    this.miniWorkspace.internalIsMutator = true;
     const background = this.miniWorkspace.createDom('blocklyMutatorBackground');
     this.svgDialog.appendChild(background);
     if (options.languageTree) {


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #7421 

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
Sets `internalIsMutator` on the mini workspace bubble workspace.

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
Makes it so that dragging behaves correctly.

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->
Manually tested dragging with a zoomed workspace.

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->
N/A

### Additional Information

<!-- Anything else we should know? -->
N/A