### PR TITLE
chore: make ordered argument optional for workspace_svg functions

### DIFF
--- a/core/workspace_svg.ts
+++ b/core/workspace_svg.ts
@@ -2255,7 +2255,7 @@ export class WorkspaceSvg extends Workspace implements IASTNodeLocationSvg {
    * @param ordered Sort the list if true.
    * @returns Array of blocks.
    */
-  override getAllBlocks(ordered: boolean): BlockSvg[] {
+  override getAllBlocks(ordered = false): BlockSvg[] {
     return super.getAllBlocks(ordered) as BlockSvg[];
   }
 
@@ -2266,7 +2266,7 @@ export class WorkspaceSvg extends Workspace implements IASTNodeLocationSvg {
    * @param ordered Sort the list if true.
    * @returns The top-level block objects.
    */
-  override getTopBlocks(ordered: boolean): BlockSvg[] {
+  override getTopBlocks(ordered = false): BlockSvg[] {
     return super.getTopBlocks(ordered) as BlockSvg[];
   }
 


### PR DESCRIPTION


## The basics
Fast follow to https://github.com/google/blockly/pull/7424 that also makes it optional for workspace_svg functions.