### PR TITLE
fix: do not create extra shadow blocks when mirroring events

### DIFF
--- a/core/events/events_block_create.ts
+++ b/core/events/events_block_create.ts
@@ -138,6 +138,7 @@ export class BlockCreate extends BlockBase {
           'the constructor, or call fromJson',
       );
     }
+    if (allShadowBlocks(workspace, this.ids)) return;
     if (forward) {
       blocks.append(this.json, workspace);
     } else {
@@ -154,6 +155,26 @@ export class BlockCreate extends BlockBase {
     }
   }
 }
+/**
+ * Returns true if all blocks in the list are shadow blocks. If so, that means
+ * the top-level block being created is a shadow block. This only happens when a
+ * block that was covering up a shadow block is removed. We don't need to create
+ * an additional block in that case because the original block still has its
+ * shadow block.
+ *
+ * @param workspace Workspace to check for blocks
+ * @param ids A list of block ids that were created in this event
+ * @returns True if all block ids in the list are shadow blocks
+ */
+const allShadowBlocks = function (
+  workspace: Workspace,
+  ids: string[],
+): boolean {
+  const shadows = ids
+    .map((id) => workspace.getBlockById(id))
+    .filter((block) => block && block.isShadow());
+  return shadows.length === ids.length;
+};
 
 export interface BlockCreateJson extends BlockBaseJson {
   xml: string;

--- a/tests/mocha/event_block_create_test.js
+++ b/tests/mocha/event_block_create_test.js
@@ -56,6 +56,42 @@ suite('Block Create Event', function () {
     chai.assert.equal(event.xml.tagName, 'shadow');
   });
 
+  test('Does not create extra shadow blocks', function () {
+    const shadowId = 'shadow_block';
+    const blockJson = {
+      'type': 'math_arithmetic',
+      'id': 'parent_with_shadow',
+      'fields': {'OP': 'ADD'},
+      'inputs': {
+        'A': {
+          'shadow': {
+            'type': 'math_number',
+            'id': shadowId,
+            'fields': {'NUM': 1},
+          },
+        },
+      },
+    };
+
+    // If there is a shadow block on the workspace and then we get
+    // a block create event with the same ID as the shadow block,
+    // this represents a block that had been covering a shadow block
+    // being removed.
+    Blockly.serialization.blocks.append(blockJson, this.workspace);
+    const shadowBlock = this.workspace.getBlockById(shadowId);
+    const blocksBefore = this.workspace.getAllBlocks();
+
+    const event = new Blockly.Events.BlockCreate(shadowBlock);
+    event.run(true);
+
+    const blocksAfter = this.workspace.getAllBlocks();
+    chai.assert.deepEqual(
+      blocksAfter,
+      blocksBefore,
+      'No new blocks should be created from an event that only creates shadow blocks',
+    );
+  });
+
   suite('Serialization', function () {
     test('events round-trip through JSON', function () {
       const block = this.workspace.newBlock('row_block', 'block_id');


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #7310 

### Proposed Changes

If the Create event only has shadow blocks that already exist in the workspace, don't run anything in the event. This is because shadow block handling is done already when a block is disconnected or deleted. These types of events only happen when a block covering a shadow block is moved or deleted.

#### Behavior Before Change

When mirroring events across a workspace, extra block that has the same data as the shadow block is created.

#### Behavior After Change

No extra blocks created when mirroring events.

### Reason for Changes

bugs

### Test Coverage

- Added a unit test. 
- Linked my build into the mirror demo and tested manually. Also tested undo, redo, etc.

### Documentation

no

### Additional Information
