### PR TITLE
Revert "fix: insertion marker's next blocks are real blocks"

### DIFF
--- a/core/insertion_marker_manager.ts
+++ b/core/insertion_marker_manager.ts
@@ -225,12 +225,7 @@ export class InsertionMarkerManager {
     eventUtils.disable();
     let result: BlockSvg;
     try {
-      const blockJson = blocks.save(sourceBlock, {
-        addCoordinates: false,
-        addInputBlocks: false,
-        addNextBlocks: false,
-        doFullSerialization: false,
-      });
+      const blockJson = blocks.save(sourceBlock);
       if (!blockJson) {
         throw new Error('Failed to serialize source block.');
       }


### PR DESCRIPTION
Reverts google/blockly#7384

See https://github.com/google/blockly-samples/issues/1856#issuecomment-1690637093 for context on why we are rolling back the change to make insertion markers use JSON serialization.

Full steps:
- (**Current step**) Roll back google/blockly#7384 
- Roll back https://github.com/google/blockly/pull/7364
- Patch release
- Decide whether this was a breaking change
- Roll forward this change and https://github.com/google/blockly/pull/7364 together for the next major release
