### PR TITLE
Revert "feat: Insertion marker json deserialization 7316"

### DIFF
--- a/core/insertion_marker_manager.ts
+++ b/core/insertion_marker_manager.ts
@@ -18,11 +18,11 @@ import type {BlockSvg} from './block_svg.js';
 import * as common from './common.js';
 import {ComponentManager} from './component_manager.js';
 import {config} from './config.js';
+import * as constants from './constants.js';
 import * as eventUtils from './events/utils.js';
 import type {IDeleteArea} from './interfaces/i_delete_area.js';
 import type {IDragTarget} from './interfaces/i_drag_target.js';
 import type {RenderedConnection} from './rendered_connection.js';
-import * as blocks from './serialization/blocks.js';
 import type {Coordinate} from './utils/coordinate.js';
 import type {WorkspaceSvg} from './workspace_svg.js';
 import * as renderManagement from './render_management.js';
@@ -42,6 +42,16 @@ interface CandidateConnection {
   local: RenderedConnection;
   radius: number;
 }
+
+/**
+ * An error message to throw if the block created by createMarkerBlock_ is
+ * missing any components.
+ */
+const DUPLICATE_BLOCK_ERROR =
+  'The insertion marker ' +
+  'manager tried to create a marker but the result is missing %1. If ' +
+  'you are using a mutator, make sure your domToMutation method is ' +
+  'properly defined.';
 
 /**
  * Class that controls updates to connections during drags.  It is primarily
@@ -222,16 +232,48 @@ export class InsertionMarkerManager {
    * @returns The insertion marker that represents the given block.
    */
   private createMarkerBlock(sourceBlock: BlockSvg): BlockSvg {
+    const imType = sourceBlock.type;
+
     eventUtils.disable();
     let result: BlockSvg;
     try {
-      const blockJson = blocks.save(sourceBlock);
-      if (!blockJson) {
-        throw new Error('Failed to serialize source block.');
-      }
-      result = blocks.append(blockJson, this.workspace) as BlockSvg;
-
+      result = this.workspace.newBlock(imType);
       result.setInsertionMarker(true);
+      if (sourceBlock.saveExtraState) {
+        const state = sourceBlock.saveExtraState();
+        if (state && result.loadExtraState) {
+          result.loadExtraState(state);
+        }
+      } else if (sourceBlock.mutationToDom) {
+        const oldMutationDom = sourceBlock.mutationToDom();
+        if (oldMutationDom && result.domToMutation) {
+          result.domToMutation(oldMutationDom);
+        }
+      }
+      // Copy field values from the other block.  These values may impact the
+      // rendered size of the insertion marker.  Note that we do not care about
+      // child blocks here.
+      for (let i = 0; i < sourceBlock.inputList.length; i++) {
+        const sourceInput = sourceBlock.inputList[i];
+        if (sourceInput.name === constants.COLLAPSED_INPUT_NAME) {
+          continue; // Ignore the collapsed input.
+        }
+        const resultInput = result.inputList[i];
+        if (!resultInput) {
+          throw new Error(DUPLICATE_BLOCK_ERROR.replace('%1', 'an input'));
+        }
+        for (let j = 0; j < sourceInput.fieldRow.length; j++) {
+          const sourceField = sourceInput.fieldRow[j];
+          const resultField = resultInput.fieldRow[j];
+          if (!resultField) {
+            throw new Error(DUPLICATE_BLOCK_ERROR.replace('%1', 'a field'));
+          }
+          resultField.setValue(sourceField.getValue());
+        }
+      }
+
+      result.setCollapsed(sourceBlock.isCollapsed());
+      result.setInputsInline(sourceBlock.getInputsInline());
 
       result.initSvg();
       result.getSvgRoot().setAttribute('visibility', 'hidden');


### PR DESCRIPTION
Reverts google/blockly#7364

See https://github.com/google/blockly-samples/issues/1856#issuecomment-1690637093 for context on why we are rolling back the change to make insertion markers use JSON serialization.

Full steps:

- Roll back https://github.com/google/blockly/pull/7384
- (**Current step**) Roll back https://github.com/google/blockly/pull/7364
- Patch release
- Decide whether this was a breaking change
- Roll forward this change and https://github.com/google/blockly/pull/7429 together for the next major release