### PR TITLE
feat: add added the ability to customize the color of  for each blocks

### DIFF
--- a/core/block_svg.ts
+++ b/core/block_svg.ts
@@ -246,6 +246,15 @@ export class BlockSvg
   }
 
   /**
+   * Get the field_label colour of a block.
+   *
+   * @returns #RRGGBB string.
+   */
+  getColourFieldLabel(): string | undefined {
+    return this.style.colourFieldLabel;
+  }
+
+  /**
    * Selects this block. Highlights the block visually and fires a select event
    * if the block is not already selected.
    */

--- a/core/field_label.ts
+++ b/core/field_label.ts
@@ -126,7 +126,10 @@ export class FieldLabel extends Field<string> {
     return new this(text, undefined, options);
   }
 
-  applyColour() {
+  /**
+   * Update field's textElement_ color.
+   */
+  override applyColour() {
     const style = (this.sourceBlock_ as BlockSvg).style;
     if (this.textElement_) {
       this.textElement_.style.fill = this.sourceBlock_?.isEnabled()

--- a/core/field_label.ts
+++ b/core/field_label.ts
@@ -17,6 +17,7 @@ import * as dom from './utils/dom.js';
 import {Field, FieldConfig} from './field.js';
 import * as fieldRegistry from './field_registry.js';
 import * as parsing from './utils/parsing.js';
+import {BlockSvg} from './block_svg.js';
 
 /**
  * Class for a non-editable, non-serializable text field.
@@ -123,6 +124,15 @@ export class FieldLabel extends Field<string> {
     // `this` might be a subclass of FieldLabel if that class doesn't override
     // the static fromJson method.
     return new this(text, undefined, options);
+  }
+
+  applyColour() {
+    const style = (this.sourceBlock_ as BlockSvg).style;
+    if (this.textElement_) {
+      this.textElement_.style.fill = this.sourceBlock_?.isEnabled()
+        ? style.colourFieldLabel
+        : '#ffffff';
+    }
   }
 }
 

--- a/core/renderers/common/constants.ts
+++ b/core/renderers/common/constants.ts
@@ -642,6 +642,9 @@ export class ConstantProvider {
     valid.colourTertiary = valid['colourTertiary']
       ? parsing.parseBlockColour(valid['colourTertiary']).hex
       : this.generateTertiaryColour_(valid.colourPrimary);
+    valid.colourFieldLabel = valid['colourFieldLabel']
+      ? parsing.parseBlockColour(valid['colourFieldLabel']).hex
+      : '#ffffff';
 
     valid.hat = valid['hat'] || '';
     return valid;

--- a/core/theme.ts
+++ b/core/theme.ts
@@ -194,6 +194,7 @@ export namespace Theme {
     colourPrimary: string;
     colourSecondary: string;
     colourTertiary: string;
+    colourFieldLabel: string;
     hat: string;
   }
 

--- a/tests/mocha/theme_test.js
+++ b/tests/mocha/theme_test.js
@@ -50,6 +50,7 @@ suite('Theme', function () {
         'colourPrimary': '#aaaaaa',
         'colourSecondary': '#bbbbbb',
         'colourTertiary': '#cccccc',
+        'colourFieldLabel': '#dddddd',
         'hat': 'cap',
       },
     };
@@ -61,12 +62,14 @@ suite('Theme', function () {
         'colourPrimary': '#aaaaaa',
         'colourSecondary': '#bbbbbb',
         'colourTertiary': '#cccccc',
+        'colourFieldLabel': '#dddddd',
         'hat': 'cap',
       },
       'styleTwo': {
         'colourPrimary': '#000000',
         'colourSecondary': '#999999',
         'colourTertiary': '#4d4d4d',
+        'colourFieldLabel': '#0f0f0f',
         'hat': '',
       },
     };
@@ -171,6 +174,7 @@ suite('Theme', function () {
         'colourPrimary': '#000000',
         'colourSecondary': '#999999',
         'colourTertiary': '#4d4d4d',
+        'colourFieldLabel': '#ffffff',
         'hat': '',
       };
       stringifyAndCompare(
@@ -185,6 +189,7 @@ suite('Theme', function () {
         'colourPrimary': '#000000',
         'colourSecondary': '#999999',
         'colourTertiary': '#4d4d4d',
+        'colourFieldLabel': '#ffffff',
         'hat': '',
       };
       stringifyAndCompare(
@@ -201,6 +206,7 @@ suite('Theme', function () {
         'colourPrimary': '#012345',
         'colourSecondary': '#99a7b5',
         'colourTertiary': '#4d657d',
+        'colourFieldLabel': '#ffffff',
         'hat': '',
       };
       stringifyAndCompare(
@@ -214,12 +220,14 @@ suite('Theme', function () {
         'colourPrimary': '#aaaaaa',
         'colourSecondary': '#bbbbbb',
         'colourTertiary': '#cccccc',
+        'colourFieldLabel': '#dddddd',
         'hat': 'cap',
       };
       const expectedOutput = {
         'colourPrimary': '#aaaaaa',
         'colourSecondary': '#bbbbbb',
         'colourTertiary': '#cccccc',
+        'colourFieldLabel': '#dddddd',
         'hat': 'cap',
       };
       stringifyAndCompare(
@@ -233,11 +241,13 @@ suite('Theme', function () {
         'colourPrimary': '20',
         'colourSecondary': '40',
         'colourTertiary': '60',
+        'colourFieldLabel': '60',
       };
       const expectedOutput = {
         'colourPrimary': '#a5745b',
         'colourSecondary': '#a58c5b',
         'colourTertiary': '#a5a55b',
+        'colourFieldLabel': '#a5a55b',
         'hat': '',
       };
       stringifyAndCompare(
@@ -254,6 +264,7 @@ suite('Theme', function () {
         'colourPrimary': '#a5745b',
         'colourSecondary': '#dbc7bd',
         'colourTertiary': '#c09e8c',
+        'colourFieldLabel': '#ffffff',
         'hat': '',
       };
       stringifyAndCompare(
@@ -267,11 +278,13 @@ suite('Theme', function () {
         'colourPrimary': 'red',
         'colourSecondary': 'white',
         'colourTertiary': 'blue',
+        'colourFieldLabel': 'black',
       };
       const expectedOutput = {
         'colourPrimary': '#ff0000',
         'colourSecondary': '#ffffff',
         'colourTertiary': '#0000ff',
+        'colourFieldLabel': '#000000',
         'hat': '',
       };
       stringifyAndCompare(
@@ -288,6 +301,7 @@ suite('Theme', function () {
         'colourPrimary': '#000000',
         'colourSecondary': '#999999',
         'colourTertiary': '#4d4d4d',
+        'colourFieldLabel': '#ffffff',
         'hat': '',
       };
       stringifyAndCompare(


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Added the ability to customize the color of field_labels for each block. 
### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
Override applyColour for field_label and add colourFieldLabel in BlockStyle interface.

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
This provides a wider range of customization options, using colors such as white or yellow with `field_labels` written in black, for example. If the block is disabled, the text color is white.


### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->
Change tests in theme_test.js file for include colourFieldLabel in expectedOutput. 

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->
Update BlockStyle (add explanation of colourFieldLabel)  and FieldLabe (add explanation of applyColour ) .

### Additional Information

<!-- Anything else we should know? -->
