### PR TITLE
docs: remove @internal tag from isDragTowardWorkspace method jsdoc in…

### DIFF
--- a/core/flyout_horizontal.ts
+++ b/core/flyout_horizontal.ts
@@ -306,7 +306,6 @@ export class HorizontalFlyout extends Flyout {
    * @param currentDragDeltaXY How far the pointer has moved from the position
    *     at mouse down, in pixel units.
    * @returns True if the drag is toward the workspace.
-   * @internal
    */
   override isDragTowardWorkspace(currentDragDeltaXY: Coordinate): boolean {
     const dx = currentDragDeltaXY.x;

--- a/core/flyout_vertical.ts
+++ b/core/flyout_vertical.ts
@@ -274,7 +274,6 @@ export class VerticalFlyout extends Flyout {
    * @param currentDragDeltaXY How far the pointer has moved from the position
    *     at mouse down, in pixel units.
    * @returns True if the drag is toward the workspace.
-   * @internal
    */
   override isDragTowardWorkspace(currentDragDeltaXY: Coordinate): boolean {
     const dx = currentDragDeltaXY.x;


### PR DESCRIPTION
… FlyoutVertical and FlyoutHorizontal

## The basics


- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

Fixes https://github.com/google/blockly/issues/7462

### Proposed Changes

Remove @internal tag from isDragTowardWorkSpace method in horizontal and vertical flyouts

#### Behavior Before Change

The @internal tag exists in the jsdoc for horizontal and vertical flyouts

#### Behavior After Change

The horizontal and vertical flyouts do not have @internal tag in isDragTowardWorkspace jsdoc

### Reason for Changes

More info in associated issue

### Test Coverage

N/A - works locally and builds without errors

### Documentation

N/A

### Additional Information

N/A
