### PR TITLE
feat: Replace getValue check with getVariable for variable fields.

### DIFF
--- a/core/block.ts
+++ b/core/block.ts
@@ -51,6 +51,7 @@ import {EndRowInput} from './inputs/end_row_input.js';
 import {ValueInput} from './inputs/value_input.js';
 import {StatementInput} from './inputs/statement_input.js';
 import {IconType} from './icons/icon_types.js';
+import { deprecation } from './utils.js';
 
 /**
  * Class for one block.
@@ -1122,6 +1123,12 @@ export class Block implements IASTNodeLocation, IDeletable {
         // as their value. Deprecated, implement Field.getVariable() instead.
         // When this is removed, the continue keyword above can be removed too.
         if (field.referencesVariables()) {
+          deprecation.warn(
+            'Blockly.Field.referencesVariables',
+            'version 10',
+            'version 11',
+            'Blockly.Field.getVariable()',
+          );
           vars.push(field.getValue() as string);
         }
       }
@@ -1170,6 +1177,12 @@ export class Block implements IASTNodeLocation, IDeletable {
           field.referencesVariables() &&
           variable.getId() === field.getValue()
         ) {
+          deprecation.warn(
+            'Blockly.Field.referencesVariables',
+            'version 10',
+            'version 11',
+            'Blockly.Field.getVariable()',
+          );
           field.refreshVariableName();
         }
       }
@@ -1197,6 +1210,12 @@ export class Block implements IASTNodeLocation, IDeletable {
         // Field.setVariable() instead. When this is removed, the continue
         // keyword above can be removed too.
         if (field.referencesVariables() && oldId === field.getValue()) {
+          deprecation.warn(
+            'Blockly.Field.referencesVariables',
+            'version 10',
+            'version 11',
+            'Blockly.Field.setVariable()',
+          );
           field.setValue(newId);
         }
       }

--- a/core/block.ts
+++ b/core/block.ts
@@ -1113,8 +1113,10 @@ export class Block implements IASTNodeLocation, IDeletable {
     for (let i = 0, input; (input = this.inputList[i]); i++) {
       for (let j = 0, field; (field = input.fieldRow[j]); j++) {
         if (field.referencesVariables()) {
-          // NOTE: This only applies to `FieldVariable`, a `Field<string>`
-          vars.push(field.getValue() as string);
+          const variable = field.getVariable();
+          if (variable) {
+            vars.push(variable.getId());
+          }
         }
       }
     }
@@ -1129,18 +1131,11 @@ export class Block implements IASTNodeLocation, IDeletable {
    */
   getVarModels(): VariableModel[] {
     const vars = [];
-    for (let i = 0, input; (input = this.inputList[i]); i++) {
-      for (let j = 0, field; (field = input.fieldRow[j]); j++) {
-        if (field.referencesVariables()) {
-          const model = this.workspace.getVariableById(
-            field.getValue() as string,
-          );
-          // Check if the variable actually exists (and isn't just a potential
-          // variable).
-          if (model) {
-            vars.push(model);
-          }
-        }
+    for (const id of this.getVars()) {
+      const model = this.workspace.getVariableById(id);
+      // Check if the variable exists (and isn't just a potential variable).
+      if (model) {
+        vars.push(model);
       }
     }
     return vars;
@@ -1158,7 +1153,7 @@ export class Block implements IASTNodeLocation, IDeletable {
       for (let j = 0, field; (field = input.fieldRow[j]); j++) {
         if (
           field.referencesVariables() &&
-          variable.getId() === field.getValue()
+          variable.getId() === field.getVariable()?.getId()
         ) {
           field.refreshVariableName();
         }
@@ -1177,7 +1172,10 @@ export class Block implements IASTNodeLocation, IDeletable {
   renameVarById(oldId: string, newId: string) {
     for (let i = 0, input; (input = this.inputList[i]); i++) {
       for (let j = 0, field; (field = input.fieldRow[j]); j++) {
-        if (field.referencesVariables() && oldId === field.getValue()) {
+        if (
+          field.referencesVariables() &&
+          oldId === field.getVariable()?.getId()
+        ) {
           field.setValue(newId);
         }
       }

--- a/core/block.ts
+++ b/core/block.ts
@@ -51,7 +51,7 @@ import {EndRowInput} from './inputs/end_row_input.js';
 import {ValueInput} from './inputs/value_input.js';
 import {StatementInput} from './inputs/statement_input.js';
 import {IconType} from './icons/icon_types.js';
-import { deprecation } from './utils.js';
+import {deprecation} from './utils.js';
 
 /**
  * Class for one block.

--- a/core/field.ts
+++ b/core/field.ts
@@ -1271,7 +1271,7 @@ export abstract class Field<T = any>
    *
    * @deprecated Implement `Blockly.Block.getVariable` instead. If you do,
    *             ensure this method returns false, indicating that
-   *             To be removed in v??. 
+   *             To be removed in v11. 
    * @returns    True if this field has any variable references.
    */
   referencesVariables(): boolean {

--- a/core/field.ts
+++ b/core/field.ts
@@ -42,6 +42,7 @@ import * as utilsXml from './utils/xml.js';
 import * as WidgetDiv from './widgetdiv.js';
 import type {WorkspaceSvg} from './workspace_svg.js';
 import {ISerializable} from './interfaces/i_serializable.js';
+import {VariableModel} from './variable_model.js';
 
 /**
  * A function that is called to validate changes to the field's value before
@@ -1273,6 +1274,16 @@ export abstract class Field<T = any>
    */
   referencesVariables(): boolean {
     return false;
+  }
+
+  /**
+   * Get the variable model if this field refers to one.
+   *
+   * @returns The field's variable, or null if none exists.
+   * @internal
+   */
+  getVariable(): VariableModel | null {
+    return null;
   }
 
   /**

--- a/core/field.ts
+++ b/core/field.ts
@@ -1269,8 +1269,10 @@ export abstract class Field<T = any>
    * to be handled differently during serialization and deserialization.
    * Subclasses may override this.
    *
-   * @returns True if this field has any variable references.
-   * @internal
+   * @deprecated Implement `Blockly.Block.getVariable` instead. If you do,
+   *             ensure this method returns false, indicating that
+   *             To be removed in v??. 
+   * @returns    True if this field has any variable references.
    */
   referencesVariables(): boolean {
     return false;
@@ -1280,10 +1282,17 @@ export abstract class Field<T = any>
    * Get the variable model if this field refers to one.
    *
    * @returns The field's variable, or null if none exists.
-   * @internal
    */
   getVariable(): VariableModel | null {
     return null;
+  }
+
+  /**
+   * Sets or clears the variable model.
+   *
+   * @param variable The variable to set or null to clear.
+   */
+  setVariable(_variable: VariableModel | null) {
   }
 
   /**

--- a/core/field.ts
+++ b/core/field.ts
@@ -1271,7 +1271,7 @@ export abstract class Field<T = any>
    *
    * @deprecated Implement `Blockly.Block.getVariable` instead. If you do,
    *             ensure this method returns false, indicating that
-   *             To be removed in v11. 
+   *             To be removed in v11.
    * @returns    True if this field has any variable references.
    */
   referencesVariables(): boolean {
@@ -1290,10 +1290,10 @@ export abstract class Field<T = any>
   /**
    * Sets or clears the variable model.
    *
-   * @param variable The variable to set or null to clear.
+   * @param _variable The variable to set or null to clear.
    */
-  setVariable(_variable: VariableModel | null) {
-  }
+  setVariable(_variable: VariableModel | null) {}
+  // NOP
 
   /**
    * Refresh the variable name referenced by this field if this field references

--- a/core/field_variable.ts
+++ b/core/field_variable.ts
@@ -527,7 +527,7 @@ export class FieldVariable extends FieldDropdown {
    *
    * @deprecated `Blockly.Block.getVariable` returns a a variable, which is
    *             an equivalent indicator for returning true from here.
-   *             To be removed in v??.
+   *             To be removed in v11.
    * @returns True.
    */
   override referencesVariables(): boolean {

--- a/core/field_variable.ts
+++ b/core/field_variable.ts
@@ -312,7 +312,7 @@ export class FieldVariable extends FieldDropdown {
    * @returns The selected variable, or null if none was selected.
    * @internal
    */
-  getVariable(): VariableModel | null {
+  override getVariable(): VariableModel | null {
     return this.variable;
   }
 

--- a/core/field_variable.ts
+++ b/core/field_variable.ts
@@ -288,10 +288,34 @@ export class FieldVariable extends FieldDropdown {
   /**
    * Get the variable's ID.
    *
+   * It is recommended to use `getVariable()` instead.
+   *
    * @returns Current variable's ID.
    */
   override getValue(): string | null {
     return this.variable ? this.variable.getId() : null;
+  }
+
+  /**
+   * Set the variable by ID.
+   *
+   * It is recommended to use `setVariable()` instead.
+   *
+   * @param newValue New value.
+   * @param fireChangeEvent Whether to fire a change event. Defaults to true.
+   *     Should usually be true unless the change will be reported some other
+   *     way, e.g. an intermediate field change event.
+   */
+  override setValue(newValue: AnyDuringMigration, fireChangeEvent = true) {
+    // Although getVariable/setVariable are used to get/set the variable,
+    // the ID is kept as the field's value for backwards compatibility.
+    super.setValue(newValue, fireChangeEvent);
+
+    const block = this.getSourceBlock();
+    if (!block) {
+      throw new UnattachedFieldError();
+    }
+    this.variable = Variables.getVariable(block.workspace, newValue as string);
   }
 
   /**
@@ -324,6 +348,11 @@ export class FieldVariable extends FieldDropdown {
   override setVariable(variable: VariableModel | null) {
     this.variable = variable;
     this.refreshVariableName();
+
+    // Although getVariable/setVariable are used to get/set the variable,
+    // the ID is kept as the field's value for backwards compatibility.
+    // This also ensures events are fired when the variable is changed.
+    super.setValue(variable?.getId());
   }
 
   /**

--- a/core/field_variable.ts
+++ b/core/field_variable.ts
@@ -317,6 +317,16 @@ export class FieldVariable extends FieldDropdown {
   }
 
   /**
+   * Sets or clears the variable model.
+   *
+   * @param variable The variable to set or null to clear.
+   */
+  override setVariable(variable: VariableModel | null) {
+    this.variable = variable;
+    this.refreshVariableName();
+  }
+
+  /**
    * Gets the validation function for this field, or null if not set.
    * Returns null if the variable is not set, because validators should not
    * run on the initial setValue call, because the field won't be attached to
@@ -515,8 +525,10 @@ export class FieldVariable extends FieldDropdown {
    * Overrides referencesVariables(), indicating this field refers to a
    * variable.
    *
+   * @deprecated `Blockly.Block.getVariable` returns a a variable, which is
+   *             an equivalent indicator for returning true from here.
+   *             To be removed in v??.
    * @returns True.
-   * @internal
    */
   override referencesVariables(): boolean {
     return true;

--- a/tests/mocha/field_variable_test.js
+++ b/tests/mocha/field_variable_test.js
@@ -137,6 +137,7 @@ suite('Variable Fields', function () {
       const fieldVariable = new Blockly.FieldVariable('name1');
       chai.assert.equal(fieldVariable.getText(), '');
       chai.assert.isNull(fieldVariable.getValue());
+      chai.assert.isNull(fieldVariable.getVariable());
     });
   });
 
@@ -571,10 +572,12 @@ suite('Variable Fields', function () {
         },
         this.workspace,
       );
-      const variable = block.getField('VAR').getVariable();
+      const field = block.getField('VAR');
+      const variable = field.getVariable();
       chai.assert.equal(variable.name, 'test');
       chai.assert.equal(variable.type, '');
       chai.assert.equal(variable.getId(), 'id1');
+      chai.assert.equal(variable.getId(), field.getValue());
     });
 
     test('Name, untyped', function () {


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes `block.getVars` currently detecting only variables in `FieldVariable`, as indicated by the (now deleted) note:

```
// NOTE: This only applies to `FieldVariable`, a `Field<string>`
```

### Proposed Changes

There seems to be a hook intended for this already --- `getVariable()` --- but it isn't used everywhere.

The proposal is to replace `field.getValue()` check with `field.getVariable()?.getId()` or similar in `block.getVars` and related methods.

To make this work, also make `getVariable` available on fields. This matches `referencesVariables` and `refreshVariableName` prototypes being available on fields already.

### Reason for Changes

Getting a variable using `getValue` applies only to `FieldVariable`. There was a note to indicate this; this replaces it with the relevant check. This ensures that variables can be used with fields other than dropdowns, as seems to be the intention.

### Test Coverage

Added a test for `field_variable` to verify that `getValue` matches the `id` obtained from the variable.

### Documentation

`getVariable` is now available on fields.

### Additional Information

This is somewhere between a fix and a feature (I marked it as `feat` because of the added property). A use case could be a text field that declares a variable. For example to have a dedicated declare variable block instead of a "create variable" button.


