### PR TITLE
fix: insertion marker position when connection is resized (#7426)

### DIFF
--- a/core/block_svg.ts
+++ b/core/block_svg.ts
@@ -1515,38 +1515,13 @@ export class BlockSvg
    * or an insertion marker.
    *
    * @param sourceConnection The connection on the moving block's stack.
-   * @param targetConnection The connection that should stay stationary as this
-   *     block is positioned.
+   * @param originalOffsetToTarget The connection original offset to the target connection
+   * @param originalOffsetInBlock The connection original offset in its block
    * @internal
    */
   positionNearConnection(
     sourceConnection: RenderedConnection,
-    targetConnection: RenderedConnection,
-  ) {
-    // We only need to position the new block if it's before the existing one,
-    // otherwise its position is set by the previous block.
-    if (
-      sourceConnection.type === ConnectionType.NEXT_STATEMENT ||
-      sourceConnection.type === ConnectionType.INPUT_VALUE
-    ) {
-      const dx = targetConnection.x - sourceConnection.x;
-      const dy = targetConnection.y - sourceConnection.y;
-
-      this.moveBy(dx, dy);
-    }
-  }
-
-  /**
- * Reposition a block after its connection has been resized, to match exactly the target block position.
- * The block to position is usually either the first block in a dragged stack
- * or an insertion marker.
- *
- * @param sourceConnection The connection on the moving block's stack.
- * @param originalOffsetInBlock The connection original offset in its block, before the resize occured
- * @internal
- */
-  repositionAfterConnectionResize(
-    sourceConnection: RenderedConnection,
+    originalOffsetToTarget: {x: number; y: number},
     originalOffsetInBlock: Coordinate,
   ) {
     // We only need to position the new block if it's before the existing one,
@@ -1555,8 +1530,12 @@ export class BlockSvg
       sourceConnection.type === ConnectionType.NEXT_STATEMENT ||
       sourceConnection.type === ConnectionType.INPUT_VALUE
     ) {
-      const dx = originalOffsetInBlock.x - sourceConnection.getOffsetInBlock().x;
-      const dy = originalOffsetInBlock.y - sourceConnection.getOffsetInBlock().y;
+      // First move the block to match the orginal target connection position
+      let dx = originalOffsetToTarget.x;
+      let dy = originalOffsetToTarget.y;
+      // Then adjust its position according to the connection resize
+      dx +=  originalOffsetInBlock.x - sourceConnection.getOffsetInBlock().x;
+      dy +=  originalOffsetInBlock.y - sourceConnection.getOffsetInBlock().y;
 
       this.moveBy(dx, dy);
     }

--- a/core/block_svg.ts
+++ b/core/block_svg.ts
@@ -1537,6 +1537,32 @@ export class BlockSvg
   }
 
   /**
+ * Reposition a block after its connection has been resized, to match exactly the target block position.
+ * The block to position is usually either the first block in a dragged stack
+ * or an insertion marker.
+ *
+ * @param sourceConnection The connection on the moving block's stack.
+ * @param originalOffsetInBlock The connection original offset in its block, before the resize occured
+ * @internal
+ */
+  repositionAfterConnectionResize(
+    sourceConnection: RenderedConnection,
+    originalOffsetInBlock: Coordinate,
+  ) {
+    // We only need to position the new block if it's before the existing one,
+    // otherwise its position is set by the previous block.
+    if (
+      sourceConnection.type === ConnectionType.NEXT_STATEMENT ||
+      sourceConnection.type === ConnectionType.INPUT_VALUE
+    ) {
+      const dx = originalOffsetInBlock.x - sourceConnection.getOffsetInBlock().x;
+      const dy = originalOffsetInBlock.y - sourceConnection.getOffsetInBlock().y;
+
+      this.moveBy(dx, dy);
+    }
+  }
+
+  /**
    * Find all the blocks that are directly nested inside this one.
    * Includes value and statement inputs, as well as any following statement.
    * Excludes any connection on an output tab or any preceding statement.

--- a/core/block_svg.ts
+++ b/core/block_svg.ts
@@ -1534,8 +1534,8 @@ export class BlockSvg
       let dx = originalOffsetToTarget.x;
       let dy = originalOffsetToTarget.y;
       // Then adjust its position according to the connection resize
-      dx +=  originalOffsetInBlock.x - sourceConnection.getOffsetInBlock().x;
-      dy +=  originalOffsetInBlock.y - sourceConnection.getOffsetInBlock().y;
+      dx += originalOffsetInBlock.x - sourceConnection.getOffsetInBlock().x;
+      dy += originalOffsetInBlock.y - sourceConnection.getOffsetInBlock().y;
 
       this.moveBy(dx, dy);
     }

--- a/core/insertion_marker_manager.ts
+++ b/core/insertion_marker_manager.ts
@@ -614,12 +614,19 @@ export class InsertionMarkerManager {
     // Connect() also renders the insertion marker.
     imConn.connect(closest);
 
-    const originalOffsetToTarget = {x: closest.x - imConn.x, y: closest.y - imConn.y}
+    const originalOffsetToTarget = {
+      x: closest.x - imConn.x,
+      y: closest.y - imConn.y,
+    };
     const originalOffsetInBlock = imConn.getOffsetInBlock().clone();
     const imConnConst = imConn;
     renderManagement.finishQueuedRenders().then(() => {
       // Position so that the existing block doesn't move.
-      insertionMarker?.positionNearConnection(imConnConst, originalOffsetToTarget, originalOffsetInBlock);
+      insertionMarker?.positionNearConnection(
+        imConnConst,
+        originalOffsetToTarget,
+        originalOffsetInBlock,
+      );
       insertionMarker?.getSvgRoot().setAttribute('visibility', 'visible');
     });
 

--- a/core/insertion_marker_manager.ts
+++ b/core/insertion_marker_manager.ts
@@ -616,8 +616,11 @@ export class InsertionMarkerManager {
     // Connect() also renders the insertion marker.
     imConn.connect(closest);
 
+    let originalOffsetInBlock = imConn.getOffsetInBlock().clone();
+    const imConnConst = imConn;
     renderManagement.finishQueuedRenders().then(() => {
       insertionMarker?.getSvgRoot().setAttribute('visibility', 'visible');
+      insertionMarker?.repositionAfterConnectionResize(imConnConst, originalOffsetInBlock);
     });
 
     this.markerConnection = imConn;

--- a/core/insertion_marker_manager.ts
+++ b/core/insertion_marker_manager.ts
@@ -611,16 +611,16 @@ export class InsertionMarkerManager {
     insertionMarker.queueRender();
     renderManagement.triggerQueuedRenders();
 
-    // Position so that the existing block doesn't move.
-    insertionMarker.positionNearConnection(imConn, closest);
     // Connect() also renders the insertion marker.
     imConn.connect(closest);
 
-    let originalOffsetInBlock = imConn.getOffsetInBlock().clone();
+    const originalOffsetToTarget = {x: closest.x - imConn.x, y: closest.y - imConn.y}
+    const originalOffsetInBlock = imConn.getOffsetInBlock().clone();
     const imConnConst = imConn;
     renderManagement.finishQueuedRenders().then(() => {
+      // Position so that the existing block doesn't move.
+      insertionMarker?.positionNearConnection(imConnConst, originalOffsetToTarget, originalOffsetInBlock);
       insertionMarker?.getSvgRoot().setAttribute('visibility', 'visible');
-      insertionMarker?.repositionAfterConnectionResize(imConnConst, originalOffsetInBlock);
     });
 
     this.markerConnection = imConn;


### PR DESCRIPTION
## The basics

- [x ] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

Fixes https://github.com/google/blockly/issues/7426

### Proposed Changes

When positioning the insertion marker, take into account that its connection may have been resized.

### Reason for Changes

With these changes, when positioning the insertion marker, we ensure that the target connection will not move.

### Test Coverage

I tested in the playground with Zelos and Geras that insertion markers don't move target connections anymore, even if their connection have been resized.

### Documentation

N/A
