### PR TITLE
fix: Call onFinishEditing_ for fields on mobile.

### DIFF
--- a/core/field_input.ts
+++ b/core/field_input.ts
@@ -316,6 +316,7 @@ export abstract class FieldInput<T extends InputTypes> extends Field<
         if (text !== null) {
           this.setValue(this.getValueFromEditorText_(text));
         }
+        this.onFinishEditing_(this.value_);
       },
     );
   }

--- a/msg/messages.js
+++ b/msg/messages.js
@@ -132,7 +132,7 @@ Blockly.Msg.REDO = 'Redo';
 
 // Variable renaming.
 /** @type {string} */
-/// prompt - This message is only seen in the Opera browser.  With most browsers, users can edit numeric values in blocks by just clicking and typing.  Opera does not allows this, so we have to open a new window and prompt users with this message to chanage a value.
+/// prompt - This message is seen on mobile devices and the Opera browser.  With most browsers, users can edit numeric values in blocks by just clicking and typing.  Opera does not allow this and mobile browsers may have issues with in-line textareas. So we prompt users with this message (usually a popup) to change a value.
 Blockly.Msg.CHANGE_VALUE_TITLE = 'Change value:';
 /** @type {string} */
 /// dropdown choice - When the user clicks on a variable block, this is one of the dropdown menu choices.  It is used to rename the current variable.  See [https://github.com/google/blockly/wiki/Variables#dropdown-menu https://github.com/google/blockly/wiki/Variables#dropdown-menu].


### PR DESCRIPTION
On the desktop, widgetDispose_ will call onFinishEditing_ on close.

This was missing in the mobile counterpart, so any cleanups in onFinishEditing_ would not be called.

Also update the message string comment while we are touching this code.

<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

On mobile, any cleanups in `onFinishEditing_` would not be called.

It is called in `widgetDispose_` but not in `showPromptEditor_`.

### Proposed Changes

Call `onFinishEditing_`  in `showPromptEditor_`.

### Reason for Changes

Make sure `onFinishEditing_` works consistently on mobile and desktop.

### Test Coverage

Tested on a playground hosted on desktop, viewed on Android mobile device on local network and verified that `onFinishEditing_` was not called before but is now.

### Documentation

Updated the docstring for the prompt translation.

### Additional Information
For consideration (though possibly not needed): Should  `showPromptEditor_` share more things with `widgetDispose_` like `forceRerender` and firing events or can we assume that `setValue` does that?
