### PR TITLE
fix(tests): contextMenuSelect sometimes clicks the wrong block

### DIFF
--- a/tests/browser/test/basic_playground_test.js
+++ b/tests/browser/test/basic_playground_test.js
@@ -72,33 +72,33 @@ suite('Right Clicking on Blocks', function () {
   });
 
   test('clicking the collapse option collapses the block', async function () {
-    await contextMenuSelect(this.browser, this.block.id, 'Collapse Block');
+    await contextMenuSelect(this.browser, this.block, 'Collapse Block');
     chai.assert.isTrue(await getIsCollapsed(this.browser, this.block.id));
   });
 
   // Assumes that
   test('clicking the expand option expands the block', async function () {
-    await contextMenuSelect(this.browser, this.block.id, 'Expand Block');
+    await contextMenuSelect(this.browser, this.block, 'Expand Block');
     chai.assert.isFalse(await getIsCollapsed(this.browser, this.block.id));
   });
 
   test('clicking the disable option disables the block', async function () {
-    await contextMenuSelect(this.browser, this.block.id, 'Disable Block');
+    await contextMenuSelect(this.browser, this.block, 'Disable Block');
     chai.assert.isTrue(await getIsDisabled(this.browser, this.block.id));
   });
 
   test('clicking the enable option enables the block', async function () {
-    await contextMenuSelect(this.browser, this.block.id, 'Enable Block');
+    await contextMenuSelect(this.browser, this.block, 'Enable Block');
     chai.assert.isFalse(await getIsDisabled(this.browser, this.block.id));
   });
 
   test('clicking the add comment option adds a comment to the block', async function () {
-    await contextMenuSelect(this.browser, this.block.id, 'Add Comment');
+    await contextMenuSelect(this.browser, this.block, 'Add Comment');
     chai.assert.equal(await getCommentText(this.browser, this.block.id), '');
   });
 
   test('clicking the remove comment option removes a comment from the block', async function () {
-    await contextMenuSelect(this.browser, this.block.id, 'Remove Comment');
+    await contextMenuSelect(this.browser, this.block, 'Remove Comment');
     chai.assert.isNull(await getCommentText(this.browser, this.block.id));
   });
 });
@@ -138,7 +138,7 @@ suite('Disabling', function () {
       );
       await connect(this.browser, child, 'OUTPUT', parent, 'IF0');
 
-      await contextMenuSelect(this.browser, parent.id, 'Disable Block');
+      await contextMenuSelect(this.browser, parent, 'Disable Block');
 
       chai.assert.isTrue(await getIsDisabled(this.browser, child.id));
     },
@@ -164,7 +164,7 @@ suite('Disabling', function () {
       );
       await connect(this.browser, child, 'PREVIOUS', parent, 'DO0');
 
-      await contextMenuSelect(this.browser, parent.id, 'Disable Block');
+      await contextMenuSelect(this.browser, parent, 'Disable Block');
 
       chai.assert.isTrue(await getIsDisabled(this.browser, child.id));
     },
@@ -190,7 +190,7 @@ suite('Disabling', function () {
       );
       await connect(this.browser, child, 'PREVIOUS', parent, 'NEXT');
 
-      await contextMenuSelect(this.browser, parent.id, 'Disable Block');
+      await contextMenuSelect(this.browser, parent, 'Disable Block');
 
       chai.assert.isFalse(await getIsDisabled(this.browser, child.id));
     },

--- a/tests/browser/test/basic_playground_test.js
+++ b/tests/browser/test/basic_playground_test.js
@@ -69,37 +69,36 @@ suite('Right Clicking on Blocks', function () {
   suiteSetup(async function () {
     this.browser = await testSetup(testFileLocations.PLAYGROUND);
     this.block = await dragNthBlockFromFlyout(this.browser, 'Loops', 0, 20, 20);
-    this.blockId = this.block.id;
   });
 
   test('clicking the collapse option collapses the block', async function () {
-    await contextMenuSelect(this.browser, this.block, 'Collapse Block');
-    chai.assert.isTrue(await getIsCollapsed(this.browser, this.blockId));
+    await contextMenuSelect(this.browser, this.block.id, 'Collapse Block');
+    chai.assert.isTrue(await getIsCollapsed(this.browser, this.block.id));
   });
 
   // Assumes that
   test('clicking the expand option expands the block', async function () {
-    await contextMenuSelect(this.browser, this.block, 'Expand Block');
-    chai.assert.isFalse(await getIsCollapsed(this.browser, this.blockId));
+    await contextMenuSelect(this.browser, this.block.id, 'Expand Block');
+    chai.assert.isFalse(await getIsCollapsed(this.browser, this.block.id));
   });
 
   test('clicking the disable option disables the block', async function () {
-    await contextMenuSelect(this.browser, this.block, 'Disable Block');
-    chai.assert.isTrue(await getIsDisabled(this.browser, this.blockId));
+    await contextMenuSelect(this.browser, this.block.id, 'Disable Block');
+    chai.assert.isTrue(await getIsDisabled(this.browser, this.block.id));
   });
 
   test('clicking the enable option enables the block', async function () {
-    await contextMenuSelect(this.browser, this.block, 'Enable Block');
+    await contextMenuSelect(this.browser, this.block.id, 'Enable Block');
     chai.assert.isFalse(await getIsDisabled(this.browser, this.block.id));
   });
 
   test('clicking the add comment option adds a comment to the block', async function () {
-    await contextMenuSelect(this.browser, this.block, 'Add Comment');
+    await contextMenuSelect(this.browser, this.block.id, 'Add Comment');
     chai.assert.equal(await getCommentText(this.browser, this.block.id), '');
   });
 
   test('clicking the remove comment option removes a comment from the block', async function () {
-    await contextMenuSelect(this.browser, this.block, 'Remove Comment');
+    await contextMenuSelect(this.browser, this.block.id, 'Remove Comment');
     chai.assert.isNull(await getCommentText(this.browser, this.block.id));
   });
 });
@@ -139,7 +138,7 @@ suite('Disabling', function () {
       );
       await connect(this.browser, child, 'OUTPUT', parent, 'IF0');
 
-      await contextMenuSelect(this.browser, parent, 'Disable Block');
+      await contextMenuSelect(this.browser, parent.id, 'Disable Block');
 
       chai.assert.isTrue(await getIsDisabled(this.browser, child.id));
     },
@@ -165,7 +164,7 @@ suite('Disabling', function () {
       );
       await connect(this.browser, child, 'PREVIOUS', parent, 'DO0');
 
-      await contextMenuSelect(this.browser, parent, 'Disable Block');
+      await contextMenuSelect(this.browser, parent.id, 'Disable Block');
 
       chai.assert.isTrue(await getIsDisabled(this.browser, child.id));
     },
@@ -191,7 +190,7 @@ suite('Disabling', function () {
       );
       await connect(this.browser, child, 'PREVIOUS', parent, 'NEXT');
 
-      await contextMenuSelect(this.browser, parent, 'Disable Block');
+      await contextMenuSelect(this.browser, parent.id, 'Disable Block');
 
       chai.assert.isFalse(await getIsDisabled(this.browser, child.id));
     },

--- a/tests/browser/test/delete_blocks_test.js
+++ b/tests/browser/test/delete_blocks_test.js
@@ -168,7 +168,7 @@ suite('Delete blocks', function (done) {
     const before = (await getAllBlocks(this.browser)).length;
     // Get first print block, click to select it, and delete it using context menu.
     const block = await getBlockElementById(this.browser, firstBlockId);
-    await contextMenuSelect(this.browser, block, 'Delete 2 Blocks');
+    await contextMenuSelect(this.browser, block.id, 'Delete 2 Blocks');
     const after = (await getAllBlocks(this.browser)).length;
     chai.assert.equal(
       before - 2,

--- a/tests/browser/test/delete_blocks_test.js
+++ b/tests/browser/test/delete_blocks_test.js
@@ -10,6 +10,7 @@ const {
   testFileLocations,
   getAllBlocks,
   getBlockElementById,
+  getClickableBlockElementById,
   contextMenuSelect,
   PAUSE_TIME,
 } = require('./test_setup');
@@ -132,13 +133,14 @@ suite('Delete blocks', function (done) {
     });
   });
 
-  test('Delete block using backspace key', async function () {
+  test.only('Delete block using backspace key', async function () {
     const before = (await getAllBlocks(this.browser)).length;
     // Get first print block, click to select it, and delete it using backspace key.
-    const block = (await getBlockElementById(this.browser, firstBlockId)).$(
-      '.blocklyPath',
-    );
-    await block.click();
+    // const block = (await getBlockElementById(this.browser, firstBlockId)).$(
+    //   '.blocklyPath',
+    // );
+    const clickEl = await getClickableBlockElementById(this.browser, firstBlockId);
+    await clickEl.click();
     await this.browser.keys([Key.Backspace]);
     const after = (await getAllBlocks(this.browser)).length;
     chai.assert.equal(

--- a/tests/browser/test/delete_blocks_test.js
+++ b/tests/browser/test/delete_blocks_test.js
@@ -133,12 +133,9 @@ suite('Delete blocks', function (done) {
     });
   });
 
-  test.only('Delete block using backspace key', async function () {
+  test('Delete block using backspace key', async function () {
     const before = (await getAllBlocks(this.browser)).length;
     // Get first print block, click to select it, and delete it using backspace key.
-    // const block = (await getBlockElementById(this.browser, firstBlockId)).$(
-    //   '.blocklyPath',
-    // );
     const clickEl = await getClickableBlockElementById(this.browser, firstBlockId);
     await clickEl.click();
     await this.browser.keys([Key.Backspace]);
@@ -153,10 +150,8 @@ suite('Delete blocks', function (done) {
   test('Delete block using delete key', async function () {
     const before = (await getAllBlocks(this.browser)).length;
     // Get first print block, click to select it, and delete it using delete key.
-    const block = (await getBlockElementById(this.browser, firstBlockId)).$(
-      '.blocklyPath',
-    );
-    await block.click();
+    const clickEl = await getClickableBlockElementById(this.browser, firstBlockId);
+    await clickEl.click();
     await this.browser.keys([Key.Delete]);
     const after = (await getAllBlocks(this.browser)).length;
     chai.assert.equal(
@@ -169,8 +164,7 @@ suite('Delete blocks', function (done) {
   test('Delete block using context menu', async function () {
     const before = (await getAllBlocks(this.browser)).length;
     // Get first print block, click to select it, and delete it using context menu.
-    const block = await getBlockElementById(this.browser, firstBlockId);
-    await contextMenuSelect(this.browser, block.id, 'Delete 2 Blocks');
+    await contextMenuSelect(this.browser, firstBlockId, 'Delete 2 Blocks');
     const after = (await getAllBlocks(this.browser)).length;
     chai.assert.equal(
       before - 2,
@@ -182,10 +176,8 @@ suite('Delete blocks', function (done) {
   test('Undo block deletion', async function () {
     const before = (await getAllBlocks(this.browser)).length;
     // Get first print block, click to select it, and delete it using backspace key.
-    const block = (await getBlockElementById(this.browser, firstBlockId)).$(
-      '.blocklyPath',
-    );
-    await block.click();
+    const clickEl = await getClickableBlockElementById(this.browser, firstBlockId);
+    await clickEl.click();
     await this.browser.keys([Key.Backspace]);
     await this.browser.pause(PAUSE_TIME);
     // Undo
@@ -201,10 +193,8 @@ suite('Delete blocks', function (done) {
   test('Redo block deletion', async function () {
     const before = (await getAllBlocks(this.browser)).length;
     // Get first print block, click to select it, and delete it using backspace key.
-    const block = (await getBlockElementById(this.browser, firstBlockId)).$(
-      '.blocklyPath',
-    );
-    await block.click();
+    const clickEl = await getClickableBlockElementById(this.browser, firstBlockId);
+    await clickEl.click();
     await this.browser.keys([Key.Backspace]);
     await this.browser.pause(PAUSE_TIME);
     // Undo

--- a/tests/browser/test/delete_blocks_test.js
+++ b/tests/browser/test/delete_blocks_test.js
@@ -136,7 +136,10 @@ suite('Delete blocks', function (done) {
   test('Delete block using backspace key', async function () {
     const before = (await getAllBlocks(this.browser)).length;
     // Get first print block, click to select it, and delete it using backspace key.
-    const clickEl = await getClickableBlockElementById(this.browser, firstBlockId);
+    const clickEl = await getClickableBlockElementById(
+      this.browser,
+      firstBlockId,
+    );
     await clickEl.click();
     await this.browser.keys([Key.Backspace]);
     const after = (await getAllBlocks(this.browser)).length;
@@ -150,7 +153,10 @@ suite('Delete blocks', function (done) {
   test('Delete block using delete key', async function () {
     const before = (await getAllBlocks(this.browser)).length;
     // Get first print block, click to select it, and delete it using delete key.
-    const clickEl = await getClickableBlockElementById(this.browser, firstBlockId);
+    const clickEl = await getClickableBlockElementById(
+      this.browser,
+      firstBlockId,
+    );
     await clickEl.click();
     await this.browser.keys([Key.Delete]);
     const after = (await getAllBlocks(this.browser)).length;
@@ -176,7 +182,10 @@ suite('Delete blocks', function (done) {
   test('Undo block deletion', async function () {
     const before = (await getAllBlocks(this.browser)).length;
     // Get first print block, click to select it, and delete it using backspace key.
-    const clickEl = await getClickableBlockElementById(this.browser, firstBlockId);
+    const clickEl = await getClickableBlockElementById(
+      this.browser,
+      firstBlockId,
+    );
     await clickEl.click();
     await this.browser.keys([Key.Backspace]);
     await this.browser.pause(PAUSE_TIME);
@@ -193,7 +202,10 @@ suite('Delete blocks', function (done) {
   test('Redo block deletion', async function () {
     const before = (await getAllBlocks(this.browser)).length;
     // Get first print block, click to select it, and delete it using backspace key.
-    const clickEl = await getClickableBlockElementById(this.browser, firstBlockId);
+    const clickEl = await getClickableBlockElementById(
+      this.browser,
+      firstBlockId,
+    );
     await clickEl.click();
     await this.browser.keys([Key.Backspace]);
     await this.browser.pause(PAUSE_TIME);

--- a/tests/browser/test/delete_blocks_test.js
+++ b/tests/browser/test/delete_blocks_test.js
@@ -10,7 +10,7 @@ const {
   testFileLocations,
   getAllBlocks,
   getBlockElementById,
-  getClickableBlockElementById,
+  getClickableBlockElement,
   contextMenuSelect,
   PAUSE_TIME,
 } = require('./test_setup');
@@ -131,14 +131,15 @@ suite('Delete blocks', function (done) {
     (await getBlockElementById(this.browser, firstBlockId)).waitForExist({
       timeout: 2000,
     });
+    this.firstBlock = await getBlockElementById(this.browser, firstBlockId);
   });
 
   test('Delete block using backspace key', async function () {
     const before = (await getAllBlocks(this.browser)).length;
     // Get first print block, click to select it, and delete it using backspace key.
-    const clickEl = await getClickableBlockElementById(
+    const clickEl = await getClickableBlockElement(
       this.browser,
-      firstBlockId,
+      this.firstBlock,
     );
     await clickEl.click();
     await this.browser.keys([Key.Backspace]);
@@ -153,9 +154,9 @@ suite('Delete blocks', function (done) {
   test('Delete block using delete key', async function () {
     const before = (await getAllBlocks(this.browser)).length;
     // Get first print block, click to select it, and delete it using delete key.
-    const clickEl = await getClickableBlockElementById(
+    const clickEl = await getClickableBlockElement(
       this.browser,
-      firstBlockId,
+      this.firstBlock,
     );
     await clickEl.click();
     await this.browser.keys([Key.Delete]);
@@ -170,7 +171,7 @@ suite('Delete blocks', function (done) {
   test('Delete block using context menu', async function () {
     const before = (await getAllBlocks(this.browser)).length;
     // Get first print block, click to select it, and delete it using context menu.
-    await contextMenuSelect(this.browser, firstBlockId, 'Delete 2 Blocks');
+    await contextMenuSelect(this.browser, this.firstBlock, 'Delete 2 Blocks');
     const after = (await getAllBlocks(this.browser)).length;
     chai.assert.equal(
       before - 2,
@@ -182,9 +183,9 @@ suite('Delete blocks', function (done) {
   test('Undo block deletion', async function () {
     const before = (await getAllBlocks(this.browser)).length;
     // Get first print block, click to select it, and delete it using backspace key.
-    const clickEl = await getClickableBlockElementById(
+    const clickEl = await getClickableBlockElement(
       this.browser,
-      firstBlockId,
+      this.firstBlock,
     );
     await clickEl.click();
     await this.browser.keys([Key.Backspace]);
@@ -202,9 +203,9 @@ suite('Delete blocks', function (done) {
   test('Redo block deletion', async function () {
     const before = (await getAllBlocks(this.browser)).length;
     // Get first print block, click to select it, and delete it using backspace key.
-    const clickEl = await getClickableBlockElementById(
+    const clickEl = await getClickableBlockElement(
       this.browser,
-      firstBlockId,
+      this.firstBlock,
     );
     await clickEl.click();
     await this.browser.keys([Key.Backspace]);

--- a/tests/browser/test/delete_blocks_test.js
+++ b/tests/browser/test/delete_blocks_test.js
@@ -10,7 +10,7 @@ const {
   testFileLocations,
   getAllBlocks,
   getBlockElementById,
-  getClickableBlockElement,
+  clickBlock,
   contextMenuSelect,
   PAUSE_TIME,
 } = require('./test_setup');
@@ -137,11 +137,7 @@ suite('Delete blocks', function (done) {
   test('Delete block using backspace key', async function () {
     const before = (await getAllBlocks(this.browser)).length;
     // Get first print block, click to select it, and delete it using backspace key.
-    const clickEl = await getClickableBlockElement(
-      this.browser,
-      this.firstBlock,
-    );
-    await clickEl.click();
+    await clickBlock(this.browser, this.firstBlock, {button: 1});
     await this.browser.keys([Key.Backspace]);
     const after = (await getAllBlocks(this.browser)).length;
     chai.assert.equal(
@@ -154,11 +150,7 @@ suite('Delete blocks', function (done) {
   test('Delete block using delete key', async function () {
     const before = (await getAllBlocks(this.browser)).length;
     // Get first print block, click to select it, and delete it using delete key.
-    const clickEl = await getClickableBlockElement(
-      this.browser,
-      this.firstBlock,
-    );
-    await clickEl.click();
+    await clickBlock(this.browser, this.firstBlock, {button: 1});
     await this.browser.keys([Key.Delete]);
     const after = (await getAllBlocks(this.browser)).length;
     chai.assert.equal(
@@ -183,11 +175,7 @@ suite('Delete blocks', function (done) {
   test('Undo block deletion', async function () {
     const before = (await getAllBlocks(this.browser)).length;
     // Get first print block, click to select it, and delete it using backspace key.
-    const clickEl = await getClickableBlockElement(
-      this.browser,
-      this.firstBlock,
-    );
-    await clickEl.click();
+    await clickBlock(this.browser, this.firstBlock, {button: 1});
     await this.browser.keys([Key.Backspace]);
     await this.browser.pause(PAUSE_TIME);
     // Undo
@@ -203,11 +191,7 @@ suite('Delete blocks', function (done) {
   test('Redo block deletion', async function () {
     const before = (await getAllBlocks(this.browser)).length;
     // Get first print block, click to select it, and delete it using backspace key.
-    const clickEl = await getClickableBlockElement(
-      this.browser,
-      this.firstBlock,
-    );
-    await clickEl.click();
+    await clickBlock(this.browser, this.firstBlock, {button: 1});
     await this.browser.keys([Key.Backspace]);
     await this.browser.pause(PAUSE_TIME);
     // Undo

--- a/tests/browser/test/test_setup.js
+++ b/tests/browser/test/test_setup.js
@@ -542,6 +542,7 @@ module.exports = {
   getSelectedBlockElement,
   getSelectedBlockId,
   getBlockElementById,
+  getClickableBlockElementById,
   getCategory,
   getNthBlockOfCategory,
   getBlockTypeFromCategory,

--- a/tests/browser/test/test_setup.js
+++ b/tests/browser/test/test_setup.js
@@ -162,11 +162,11 @@ async function getBlockElementById(browser, id) {
  * (e.g. statement inputs). Instead, this tries to get the first text field on the
  * block. It falls back on the block's SVG root.
  * @param browser The active WebdriverIO Browser object.
- * @param id The ID of the Blockly block to search for.
+ * @param block The block to click, as an interactable element.
  * @return A Promise that resolves to the text element of the first label
  *     field on the block, or the block's SVG root if no label field was found.
  */
-async function getClickableBlockElementById(browser, id) {
+async function getClickableBlockElement(browser, block) {
   // In the browser context, find the element that we want and give it a findable ID.
   await browser.execute((blockId) => {
     const block = Blockly.getMainWorkspace().getBlockById(blockId);
@@ -180,7 +180,7 @@ async function getClickableBlockElementById(browser, id) {
     }
     // No label field found. Fall back to the block's SVG root.
     block.getSvgRoot().id = 'clickTargetElement';
-  }, id);
+  }, block.id);
 
   // In the test context, get the Webdriverio Element that we've identified.
   const elem = await browser.$('#clickTargetElement');
@@ -460,13 +460,13 @@ async function dragBlockFromMutatorFlyout(browser, mutatorBlock, type, x, y) {
  * context menu item.
  *
  * @param browser The active WebdriverIO Browser object.
- * @param blockId The ID of the block to click. This block should
+ * @param block The block to click, as an interactable element. This block should
  *    have text on it, because we use the text element as the click target.
  * @param itemText The display text of the context menu item to click.
  * @return A Promise that resolves when the actions are completed.
  */
-async function contextMenuSelect(browser, blockId, itemText) {
-  const clickEl = await getClickableBlockElementById(browser, blockId);
+async function contextMenuSelect(browser, block, itemText) {
+  const clickEl = await getClickableBlockElement(browser, block);
   // Even though the element should definitely already exist,
   // one specific test breaks if you remove this...
   await clickEl.waitForExist();
@@ -542,7 +542,7 @@ module.exports = {
   getSelectedBlockElement,
   getSelectedBlockId,
   getBlockElementById,
-  getClickableBlockElementById,
+  getClickableBlockElement,
   getCategory,
   getNthBlockOfCategory,
   getBlockTypeFromCategory,

--- a/tests/browser/test/test_setup.js
+++ b/tests/browser/test/test_setup.js
@@ -460,13 +460,13 @@ async function dragBlockFromMutatorFlyout(browser, mutatorBlock, type, x, y) {
  * context menu item.
  *
  * @param browser The active WebdriverIO Browser object.
- * @param block The block to click, as an interactable element. This block must
+ * @param blockId The ID of the block to click. This block should
  *    have text on it, because we use the text element as the click target.
  * @param itemText The display text of the context menu item to click.
  * @return A Promise that resolves when the actions are completed.
  */
-async function contextMenuSelect(browser, block, itemText) {
-  const clickEl = await getClickableBlockElementById(browser, block.id);
+async function contextMenuSelect(browser, blockId, itemText) {
+  const clickEl = await getClickableBlockElementById(browser, blockId);
   // Even though the element should definitely already exist,
   // one specific test breaks if you remove this...
   await clickEl.waitForExist();


### PR DESCRIPTION
## The basics

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

Fixes https://github.com/google/blockly/issues/7484

### Proposed Changes

- Add a helper function that tags the first label field on a block, then uses that to get that element as a Webdriverio Element.
- Change context menu helper function to take in a block ID instead of a block element.
- Use the helper function in all context menu tests and in block deletion tests.

### Reason for Changes

Fix issues with clicking when the block's path is occluded or has a hole in it.

### Test Coverage

Ran browser tests and watched for unexpected behaviour.

### Documentation

I added JSDoc

### Additional Information

- You could run into issues if you used this function twice, on different blocks, within the same test context. In that case the solution is to add a helper that removes the ID from the SVG element. This seems not worth adding unless/until it becomes an issue.
- There are other tests that click on blocks and have not previously had any issues. I left them in their current state (clicking on the block's SVG root). I don't see a benefit to updating them to use the more complicated helper function unless they break.
  - I could be convinced otherwise just for consistency.