### PR TITLE
fix: zelos full block fields rendering badly

### DIFF
--- a/core/block.ts
+++ b/core/block.ts
@@ -946,16 +946,10 @@ export class Block implements IASTNodeLocation, IDeletable {
   isSimpleReporter(): boolean {
     if (!this.outputConnection) return false;
 
-    let nFields = 0;
     for (const input of this.inputList) {
-      if (input.connection) return false;
-      // TODO: This comment is innacurate. Not sure what we want the spec to be.
-      // Count the number of fields excluding text fields.
-      for (const _ of input.fieldRow) {
-        nFields++;
-      }
+      if (input.connection || input.fieldRow.length > 1) return false;
     }
-    return nFields <= 1;
+    return true;
   }
 
   /**

--- a/core/block.ts
+++ b/core/block.ts
@@ -940,6 +940,25 @@ export class Block implements IASTNodeLocation, IDeletable {
   }
 
   /**
+   * @returns True if this block is a value block with a single editable field.
+   * @internal
+   */
+  isSimpleReporter(): boolean {
+    if (!this.outputConnection) return false;
+
+    let nFields = 0;
+    for (const input of this.inputList) {
+      if (input.connection) return false;
+      // TODO: This comment is innacurate. Not sure what we want the spec to be.
+      // Count the number of fields excluding text fields.
+      for (const _ of input.fieldRow) {
+        nFields++;
+      }
+    }
+    return nFields <= 1;
+  }
+
+  /**
    * Find the connection on this block that corresponds to the given connection
    * on the other block.
    * Used to match connections between a block and its insertion marker.

--- a/core/field.ts
+++ b/core/field.ts
@@ -331,6 +331,18 @@ export abstract class Field<T = any>
   initModel() {}
 
   /**
+   * Defines whether this field should take up the full block or not.
+   *
+   * Be cautious when overriding this function. It may not work as you expect /
+   * intend because the behavior was kind of hacked in. If you are thinking
+   * about overriding this function, post on the forum with your intended
+   * behavior to see if there's another approach.
+   */
+  protected isFullBlockField(): boolean {
+    return !this.borderRect_;
+  }
+
+  /**
    * Create a field border rect element. Not to be overridden by subclasses.
    * Instead modify the result of the function inside initView, or create a
    * separate function to call.
@@ -797,7 +809,7 @@ export abstract class Field<T = any>
     const xOffset =
       margin !== undefined
         ? margin
-        : this.borderRect_
+        : !this.isFullBlockField()
         ? this.getConstants()!.FIELD_BORDER_RECT_X_PADDING
         : 0;
     let totalWidth = xOffset * 2;
@@ -813,7 +825,7 @@ export abstract class Field<T = any>
       );
       totalWidth += contentWidth;
     }
-    if (this.borderRect_) {
+    if (!this.isFullBlockField()) {
       totalHeight = Math.max(totalHeight, constants!.FIELD_BORDER_RECT_HEIGHT);
     }
 
@@ -922,7 +934,7 @@ export abstract class Field<T = any>
       throw new UnattachedFieldError();
     }
 
-    if (!this.borderRect_) {
+    if (this.isFullBlockField()) {
       // Browsers are inconsistent in what they return for a bounding box.
       // - Webkit / Blink: fill-box / object bounding box
       // - Gecko: stroke-box
@@ -940,8 +952,8 @@ export abstract class Field<T = any>
         xy.y -= 0.5 * scale;
       }
     } else {
-      const bBox = this.borderRect_.getBoundingClientRect();
-      xy = style.getPageOffset(this.borderRect_);
+      const bBox = this.borderRect_!.getBoundingClientRect();
+      xy = style.getPageOffset(this.borderRect_!);
       scaledWidth = bBox.width;
       scaledHeight = bBox.height;
     }

--- a/core/field_colour.ts
+++ b/core/field_colour.ts
@@ -206,6 +206,7 @@ export class FieldColour extends Field<string> {
       // In general, do *not* let fields control the color of blocks. Having the
       // field control the color is unexpected, and could have performance
       // impacts.
+      console.log('updating colour');
       block.pathObject.svgPath.setAttribute('fill', this.getValue() as string);
       block.pathObject.svgPath.setAttribute('stroke', '#fff');
     }
@@ -222,6 +223,7 @@ export class FieldColour extends Field<string> {
     if (this.getConstants()?.FIELD_COLOUR_FULL_BLOCK) {
       // Full block fields have more control of the block than they should
       // (i.e. updating fill colour) so they always need to be rerendered.
+      console.log('rendering');
       this.render_();
       this.isDirty_ = false;
     }
@@ -289,26 +291,6 @@ export class FieldColour extends Field<string> {
       return null;
     }
     return colour.parse(newValue);
-  }
-
-  /**
-   * Update the value of this colour field, and update the displayed colour.
-   *
-   * @param newValue The value to be saved. The default validator guarantees
-   *     that this is a colour in '#rrggbb' format.
-   */
-  protected override doValueUpdate_(newValue: string) {
-    this.value_ = newValue;
-    if (this.borderRect_) {
-      this.borderRect_.style.fill = newValue;
-    } else if (
-      this.sourceBlock_ &&
-      this.sourceBlock_.rendered &&
-      this.sourceBlock_ instanceof BlockSvg
-    ) {
-      this.sourceBlock_.pathObject.svgPath.setAttribute('fill', newValue);
-      this.sourceBlock_.pathObject.svgPath.setAttribute('stroke', '#fff');
-    }
   }
 
   /**

--- a/core/field_colour.ts
+++ b/core/field_colour.ts
@@ -199,10 +199,10 @@ export class FieldColour extends Field<string> {
     if (!this.fieldGroup_) return;
 
     if (!this.isFullBlockField() && this.borderRect_) {
-      this.borderRect_!.style.visibility = 'visible';
+      this.borderRect_!.style.display = 'block';
       this.borderRect_.style.fill = this.getValue() as string;
     } else {
-      this.borderRect_!.style.visibility = 'hidden';
+      this.borderRect_!.style.display = 'none';
       // In general, do *not* let fields control the color of blocks. Having the
       // field control the color is unexpected, and could have performance
       // impacts.

--- a/core/field_colour.ts
+++ b/core/field_colour.ts
@@ -198,15 +198,19 @@ export class FieldColour extends Field<string> {
 
     if (!this.fieldGroup_) return;
 
-    if (!this.isFullBlockField() && this.borderRect_) {
-      this.borderRect_!.style.display = 'block';
-      this.borderRect_.style.fill = this.getValue() as string;
+    const borderRect = this.borderRect_;
+    if (!borderRect) {
+      throw new Error('The border rect has not been initialized');
+    }
+
+    if (!this.isFullBlockField()) {
+      borderRect.style.display = 'block';
+      borderRect.style.fill = this.getValue() as string;
     } else {
-      this.borderRect_!.style.display = 'none';
+      borderRect.style.display = 'none';
       // In general, do *not* let fields control the color of blocks. Having the
       // field control the color is unexpected, and could have performance
       // impacts.
-      console.log('updating colour');
       block.pathObject.svgPath.setAttribute('fill', this.getValue() as string);
       block.pathObject.svgPath.setAttribute('stroke', '#fff');
     }
@@ -221,9 +225,11 @@ export class FieldColour extends Field<string> {
    */
   override getSize(): Size {
     if (this.getConstants()?.FIELD_COLOUR_FULL_BLOCK) {
+      // In general, do *not* let fields control the color of blocks. Having the
+      // field control the color is unexpected, and could have performance
+      // impacts.
       // Full block fields have more control of the block than they should
       // (i.e. updating fill colour) so they always need to be rerendered.
-      console.log('rendering');
       this.render_();
       this.isDirty_ = false;
     }

--- a/core/field_colour.ts
+++ b/core/field_colour.ts
@@ -229,7 +229,8 @@ export class FieldColour extends Field<string> {
       // field control the color is unexpected, and could have performance
       // impacts.
       // Full block fields have more control of the block than they should
-      // (i.e. updating fill colour) so they always need to be rerendered.
+      // (i.e. updating fill colour). Whenever we get the size, the field may
+      // no longer be a full-block field, so we need to rerender.
       this.render_();
       this.isDirty_ = false;
     }

--- a/core/field_colour.ts
+++ b/core/field_colour.ts
@@ -218,7 +218,7 @@ export class FieldColour extends Field<string> {
    *
    * @returns Height and width.
    */
-  getSize(): Size {
+  override getSize(): Size {
     if (this.getConstants()?.FIELD_COLOUR_FULL_BLOCK) {
       // Full block fields have more control of the block than they should
       // (i.e. updating fill colour) so they always need to be rerendered.

--- a/core/field_input.ts
+++ b/core/field_input.ts
@@ -239,8 +239,12 @@ export abstract class FieldInput<T extends InputTypes> extends Field<
    */
   override getSize(): Size {
     if (this.getConstants()?.FULL_BLOCK_FIELDS) {
+      // In general, do *not* let fields control the color of blocks. Having the
+      // field control the color is unexpected, and could have performance
+      // impacts.
       // Full block fields have more control of the block than they should
-      // (i.e. updating fill colour) so they always need to be rerendered.
+      // (i.e. updating fill colour). Whenever we get the size, the field may
+      // no longer be a full-block field, so we need to rerender.
       this.render_();
       this.isDirty_ = false;
     }

--- a/core/field_input.ts
+++ b/core/field_input.ts
@@ -237,7 +237,7 @@ export abstract class FieldInput<T extends InputTypes> extends Field<
    *
    * @returns Height and width.
    */
-  getSize(): Size {
+  override getSize(): Size {
     if (this.getConstants()?.FULL_BLOCK_FIELDS) {
       // Full block fields have more control of the block than they should
       // (i.e. updating fill colour) so they always need to be rerendered.

--- a/core/field_input.ts
+++ b/core/field_input.ts
@@ -34,6 +34,7 @@ import * as userAgent from './utils/useragent.js';
 import * as WidgetDiv from './widgetdiv.js';
 import type {WorkspaceSvg} from './workspace_svg.js';
 import * as renderManagement from './render_management.js';
+import {Size} from './utils/size.js';
 
 /**
  * Supported types for FieldInput subclasses.
@@ -88,7 +89,7 @@ export abstract class FieldInput<T extends InputTypes> extends Field<
    * Whether the field should consider the whole parent block to be its click
    * target.
    */
-  fullBlockClickTarget_: boolean | null = false;
+  fullBlockClickTarget_: boolean = false;
 
   /** The workspace that this field belongs to. */
   protected workspace_: WorkspaceSvg | null = null;
@@ -142,37 +143,22 @@ export abstract class FieldInput<T extends InputTypes> extends Field<
 
   override initView() {
     const block = this.getSourceBlock();
-    if (!block) {
-      throw new UnattachedFieldError();
-    }
-    if (this.getConstants()!.FULL_BLOCK_FIELDS) {
-      // Step one: figure out if this is the only field on this block.
-      // Rendering is quite different in that case.
-      let nFields = 0;
-      let nConnections = 0;
-      // Count the number of fields, excluding text fields
-      for (let i = 0, input; (input = block.inputList[i]); i++) {
-        for (let j = 0; input.fieldRow[j]; j++) {
-          nFields++;
-        }
-        if (input.connection) {
-          nConnections++;
-        }
-      }
-      // The special case is when this is the only non-label field on the block
-      // and it has an output but no inputs.
-      this.fullBlockClickTarget_ =
-        nFields <= 1 && block.outputConnection && !nConnections;
-    } else {
-      this.fullBlockClickTarget_ = false;
-    }
+    if (!block) throw new UnattachedFieldError();
+    super.initView();
 
-    if (this.fullBlockClickTarget_) {
+    if (this.isFullBlockField()) {
       this.clickTarget_ = (this.sourceBlock_ as BlockSvg).getSvgRoot();
-    } else {
-      this.createBorderRect_();
     }
-    this.createTextElement_();
+  }
+
+  protected override isFullBlockField(): boolean {
+    const block = this.getSourceBlock();
+    if (!block) throw new UnattachedFieldError();
+
+    // Side effect for backwards compatibility.
+    this.fullBlockClickTarget_ =
+      !!this.getConstants()?.FULL_BLOCK_FIELDS && block.isSimpleReporter();
+    return this.fullBlockClickTarget_;
   }
 
   /**
@@ -223,14 +209,21 @@ export abstract class FieldInput<T extends InputTypes> extends Field<
    * Updates text field to match the colour/style of the block.
    */
   override applyColour() {
-    if (!this.sourceBlock_ || !this.getConstants()!.FULL_BLOCK_FIELDS) return;
+    const block = this.getSourceBlock() as BlockSvg | null;
+    if (!block) throw new UnattachedFieldError();
 
-    const source = this.sourceBlock_ as BlockSvg;
+    if (!this.getConstants()!.FULL_BLOCK_FIELDS) return;
+    if (!this.fieldGroup_) return;
 
-    if (this.borderRect_) {
-      this.borderRect_.setAttribute('stroke', source.style.colourTertiary);
+    if (!this.isFullBlockField() && this.borderRect_) {
+      this.borderRect_!.style.visibility = 'visible';
+      this.borderRect_.setAttribute('stroke', block.style.colourTertiary);
     } else {
-      source.pathObject.svgPath.setAttribute(
+      this.borderRect_!.style.visibility = 'hidden';
+      // In general, do *not* let fields control the color of blocks. Having the
+      // field control the color is unexpected, and could have performance
+      // impacts.
+      block.pathObject.svgPath.setAttribute(
         'fill',
         this.getConstants()!.FIELD_BORDER_RECT_COLOUR,
       );
@@ -238,8 +231,28 @@ export abstract class FieldInput<T extends InputTypes> extends Field<
   }
 
   /**
+   * Returns the height and width of the field.
+   *
+   * This should *in general* be the only place render_ gets called from.
+   *
+   * @returns Height and width.
+   */
+  getSize(): Size {
+    if (this.getConstants()?.FULL_BLOCK_FIELDS) {
+      // Full block fields have more control of the block than they should
+      // (i.e. updating fill colour) so they always need to be rerendered.
+      this.render_();
+      this.isDirty_ = false;
+    }
+    return super.getSize();
+  }
+
+  /**
    * Updates the colour of the htmlInput given the current validity of the
    * field's value.
+   *
+   * Also updates the colour of the block to reflect whether this is a full
+   * block field or not.
    */
   protected override render_() {
     super.render_();
@@ -256,6 +269,15 @@ export abstract class FieldInput<T extends InputTypes> extends Field<
         aria.setState(htmlInput, aria.State.INVALID, false);
       }
     }
+
+    const block = this.getSourceBlock() as BlockSvg | null;
+    if (!block) throw new UnattachedFieldError();
+    // In general, do *not* let fields control the color of blocks. Having the
+    // field control the color is unexpected, and could have performance
+    // impacts.
+    // Whenever we render, the field may no longer be a full-block-field so
+    // we need to update the colour.
+    if (this.getConstants()!.FULL_BLOCK_FIELDS) block.applyColour();
   }
 
   /**
@@ -374,7 +396,7 @@ export abstract class FieldInput<T extends InputTypes> extends Field<
     htmlInput.style.fontSize = fontSize;
     let borderRadius = FieldInput.BORDERRADIUS * scale + 'px';
 
-    if (this.fullBlockClickTarget_) {
+    if (this.isFullBlockField()) {
       const bBox = this.getScaledBBox();
 
       // Override border radius.
@@ -462,8 +484,6 @@ export abstract class FieldInput<T extends InputTypes> extends Field<
    * @param _value The new value of the field.
    */
   onFinishEditing_(_value: AnyDuringMigration) {}
-  // NOP by default.
-  // TODO(#2496): Support people passing a func into the field.
 
   /**
    * Bind handlers for user input on the text input field's editor.

--- a/core/field_input.ts
+++ b/core/field_input.ts
@@ -216,10 +216,10 @@ export abstract class FieldInput<T extends InputTypes> extends Field<
     if (!this.fieldGroup_) return;
 
     if (!this.isFullBlockField() && this.borderRect_) {
-      this.borderRect_!.style.visibility = 'visible';
+      this.borderRect_!.style.display = 'block';
       this.borderRect_.setAttribute('stroke', block.style.colourTertiary);
     } else {
-      this.borderRect_!.style.visibility = 'hidden';
+      this.borderRect_!.style.display = 'none';
       // In general, do *not* let fields control the color of blocks. Having the
       // field control the color is unexpected, and could have performance
       // impacts.

--- a/tests/playground.html
+++ b/tests/playground.html
@@ -58,7 +58,7 @@
           },
           toolbox: toolbox,
           toolboxPosition: 'start',
-          renderer: 'zelos',
+          renderer: 'geras',
           zoom: {
             controls: true,
             wheel: true,
@@ -475,45 +475,6 @@
           workspace.setVisible(false);
         });
       }
-
-      Blockly.Blocks['test'] = {
-        init: function () {
-          const field = new Blockly.FieldTextInput('test', () => {
-            this.getInput('test').appendField(
-              new Blockly.FieldDropdown([['test', 'test']]),
-            );
-          });
-          this.appendDummyInput('test').appendField(field);
-          this.setStyle('math_blocks');
-          this.setOutput(true);
-        },
-      };
-
-      Blockly.Blocks['test2'] = {
-        init: function () {
-          const field = new Blockly.FieldColour(
-            // 'media/arrow.png', 50, 50, '🐶',
-            '#ffcccc',
-            () => {
-              this.getInput('test').appendField(
-                new Blockly.FieldDropdown([['test', 'test']]),
-              );
-            },
-          );
-          this.appendDummyInput('test').appendField(field);
-          this.setStyle('math_blocks');
-          this.setOutput(true);
-        },
-      };
-
-      Blockly.Blocks['test3'] = {
-        init: function () {
-          const field = new Blockly.FieldTextInput('test');
-          this.appendDummyInput('test').appendField(field);
-          this.setStyle('math_blocks');
-          this.setOutput(true, 'Boolean');
-        },
-      };
 
       // Call start().  Because this <script> has type=module, it is
       // automatically deferred, so it will not be run until after the

--- a/tests/playground.html
+++ b/tests/playground.html
@@ -58,7 +58,7 @@
           },
           toolbox: toolbox,
           toolboxPosition: 'start',
-          renderer: 'geras',
+          renderer: 'zelos',
           zoom: {
             controls: true,
             wheel: true,
@@ -475,6 +475,45 @@
           workspace.setVisible(false);
         });
       }
+
+      Blockly.Blocks['test'] = {
+        init: function () {
+          const field = new Blockly.FieldTextInput('test', () => {
+            this.getInput('test').appendField(
+              new Blockly.FieldDropdown([['test', 'test']]),
+            );
+          });
+          this.appendDummyInput('test').appendField(field);
+          this.setStyle('math_blocks');
+          this.setOutput(true);
+        },
+      };
+
+      Blockly.Blocks['test2'] = {
+        init: function () {
+          const field = new Blockly.FieldColour(
+            // 'media/arrow.png', 50, 50, '🐶',
+            '#ffcccc',
+            () => {
+              this.getInput('test').appendField(
+                new Blockly.FieldDropdown([['test', 'test']]),
+              );
+            },
+          );
+          this.appendDummyInput('test').appendField(field);
+          this.setStyle('math_blocks');
+          this.setOutput(true);
+        },
+      };
+
+      Blockly.Blocks['test3'] = {
+        init: function () {
+          const field = new Blockly.FieldTextInput('test');
+          this.appendDummyInput('test').appendField(field);
+          this.setStyle('math_blocks');
+          this.setOutput(true, 'Boolean');
+        },
+      };
 
       // Call start().  Because this <script> has type=module, it is
       // automatically deferred, so it will not be run until after the


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #7442 

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
Makes it so that input fields (and subclasses) and colour fields properly switch back and forth between full block fields and normal fields when their blocks are modified.

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
Before they didn't have the ability to switch, so mutated blocks would break.

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->
Manually tested the following behaviors using the browser console for number inputs and colour fields:

1) Instantiate a full block field.
2) Add a label field to it via the console.
3) Observe how the original field is rerendered to not be a full block field.
4) Remove the added label field via the console.
5) Observe how the original field is rerendered to be a full block field again.

I think this would be a good candidate for screen shot testing. The code is so jank and I don't think unit testing is worthwhile.

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->
N/A

### Additional Information

<!-- Anything else we should know? -->
I disagree with most of how full block fields were implemented, so I've added inline docs discouraging people from using these parts of the API. But they should now approximately work under most circumstances.

Also need to update the colour field in samples, working on that now.