### PR TITLE
fix: minor issues in browser tests

### DIFF
--- a/tests/browser/test/delete_blocks_test.js
+++ b/tests/browser/test/delete_blocks_test.js
@@ -179,7 +179,8 @@ suite('Delete blocks', function (done) {
     await this.browser.keys([Key.Backspace]);
     await this.browser.pause(PAUSE_TIME);
     // Undo
-    await this.browser.keys([Key.Ctrl, 'Z']);
+    await this.browser.keys([Key.Ctrl, 'z']);
+    await this.browser.pause(PAUSE_TIME);
     const after = (await getAllBlocks(this.browser)).length;
     chai.assert.equal(
       before,
@@ -195,10 +196,10 @@ suite('Delete blocks', function (done) {
     await this.browser.keys([Key.Backspace]);
     await this.browser.pause(PAUSE_TIME);
     // Undo
-    await this.browser.keys([Key.Ctrl, 'Z']);
+    await this.browser.keys([Key.Ctrl, 'z']);
     await this.browser.pause(PAUSE_TIME);
     // Redo
-    await this.browser.keys([Key.Ctrl, Key.Shift, 'Z']);
+    await this.browser.keys([Key.Ctrl, Key.Shift, 'z']);
     await this.browser.pause(PAUSE_TIME);
     const after = (await getAllBlocks(this.browser)).length;
     chai.assert.equal(

--- a/tests/browser/test/field_edits_test.js
+++ b/tests/browser/test/field_edits_test.js
@@ -45,8 +45,8 @@ async function testFieldEdits(browser, direction) {
   // Click on the field to change the value
   await numberBlock.click();
   await browser.keys([Key.Delete]);
-  await numberBlock.click();
   await browser.keys(['1093']);
+
   // Click on the workspace to exit the field editor
   const workspace = await browser.$('#blocklyDiv > div > svg.blocklySvg > g');
   await workspace.click();

--- a/tests/browser/test/procedure_test.js
+++ b/tests/browser/test/procedure_test.js
@@ -104,5 +104,6 @@ suite('Testing Connecting Blocks', function (done) {
     await this.browser.pause(PAUSE_TIME);
     const alertText = await this.browser.getAlertText(); // get the alert text
     chai.assert.equal(alertText, '123');
+    await this.browser.acceptAlert();
   });
 });

--- a/tests/browser/test/toolbox_drag_test.js
+++ b/tests/browser/test/toolbox_drag_test.js
@@ -148,8 +148,8 @@ async function openCategories(browser, categoryList, directionMultiplier) {
         const flyoutBlock = await browser.$(
           `.blocklyFlyout .blocklyBlockCanvas > g:nth-child(${3 + i * 2})`,
         );
-        if (!(await elementInBounds(browser, flyoutBlock))) {
-          await scrollFlyout(browser, 0, 500);
+        while (!(await elementInBounds(browser, flyoutBlock))) {
+          await scrollFlyout(browser, 0, 50);
         }
 
         await flyoutBlock.dragAndDrop({x: directionMultiplier * 50, y: 0});


### PR DESCRIPTION
## The basics

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

Fixes some issues that I found while working on https://github.com/google/blockly/issues/7488.
Webdriverio v8.16 is slightly stricter about some things.

### Proposed Changes

- In undo/redo tests: use a lower case z instead of upper case, and add a standard pause after the undo.
- In the procedure test: accept the alert to close it at the end of the test.
- In field edit test: don't click between edits--the field editor is already open.
- In the toolbox drag test: scroll a small amount at a time to avoid dragging the mouse outside of the browser window.

### Reason for Changes

Newer webdriverio is stricter about keeping drags within the screen and not clicking on occluded elements. Keys are case sensitive, and not closing the alert works but throws a warning.

### Test Coverage
These are tests!