### PR TITLE
fix: bad JSON state leaving events disabled

### DIFF
--- a/core/serialization/blocks.ts
+++ b/core/serialization/blocks.ts
@@ -399,9 +399,13 @@ export function appendInternal(
   }
   eventUtils.disable();
 
-  const block = appendPrivate(state, workspace, {parentConnection, isShadow});
+  let block;
+  try {
+    block = appendPrivate(state, workspace, {parentConnection, isShadow});
+  } finally {
+    eventUtils.enable();
+  }
 
-  eventUtils.enable();
   if (eventUtils.isEnabled()) {
     eventUtils.fire(new (eventUtils.get(eventUtils.BLOCK_CREATE))(block));
   }

--- a/tests/mocha/jso_deserialization_test.js
+++ b/tests/mocha/jso_deserialization_test.js
@@ -23,6 +23,25 @@ suite('JSO Deserialization', function () {
   });
 
   suite('Events', function () {
+    test('bad JSON does not leave events disabled', function () {
+      const state = {
+        'blocks': {
+          'blocks': [
+            {
+              'type': 'undefined_block',
+            },
+          ],
+        },
+      };
+      chai.assert.throws(() => {
+        Blockly.serialization.workspaces.load(state, this.workspace);
+      });
+      chai.assert.isTrue(
+        Blockly.Events.isEnabled(),
+        'Expected events to be enabled',
+      );
+    });
+
     suite('Finished loading', function () {
       test('Just var', function () {
         const state = {


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes https://github.com/google/blockly/issues/7486

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
Adds a `try... finally` block to make sure events are reenabled even if you load bad JSON.

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
Fix https://github.com/google/blockly/issues/7486

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->

Manual test steps do not reproduce.

Added a test that events are enabled even after bad JSON is loaded and deserialization throws.

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->
N/A

### Additional Information

<!-- Anything else we should know? -->
N/A