### PR TITLE
minor: update 'field_input.ts' file

### DIFF
--- a/core/field_input.ts
+++ b/core/field_input.ts
@@ -375,7 +375,7 @@ export abstract class FieldInput<T extends InputTypes> extends Field<
    *
    * @returns The newly created text input editor.
    */
-  protected widgetCreate_(): HTMLElement {
+  protected widgetCreate_(): HTMLInputElement {
     const block = this.getSourceBlock();
     if (!block) {
       throw new UnattachedFieldError();

--- a/core/field_input.ts
+++ b/core/field_input.ts
@@ -358,7 +358,7 @@ export abstract class FieldInput<T extends InputTypes> extends Field<
       throw new UnattachedFieldError();
     }
     WidgetDiv.show(this, block.RTL, this.widgetDispose_.bind(this));
-    this.htmlInput_ = this.widgetCreate_() as HTMLInputElement;
+    this.htmlInput_ = this.widgetCreate_();
     this.isBeingEdited_ = true;
     this.valueWhenEditorWasOpened_ = this.value_;
 

--- a/core/field_input.ts
+++ b/core/field_input.ts
@@ -358,7 +358,7 @@ export abstract class FieldInput<T extends InputTypes> extends Field<
       throw new UnattachedFieldError();
     }
     WidgetDiv.show(this, block.RTL, this.widgetDispose_.bind(this));
-    this.htmlInput_ = this.widgetCreate_();
+    this.htmlInput_ = this.widgetCreate_() as HTMLInputElement;
     this.isBeingEdited_ = true;
     this.valueWhenEditorWasOpened_ = this.value_;
 
@@ -375,7 +375,7 @@ export abstract class FieldInput<T extends InputTypes> extends Field<
    *
    * @returns The newly created text input editor.
    */
-  protected widgetCreate_(): HTMLInputElement {
+  protected widgetCreate_(): HTMLInputElement | HTMLTextAreaElement {
     const block = this.getSourceBlock();
     if (!block) {
       throw new UnattachedFieldError();


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [ ] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #7253 

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
Update the `field_input.ts` file with the following changes:
- Update the return type info from `HTMLElement` to `HTMLInputElement` for [widgetCreate_](https://github.com/google/blockly/blob/344861698e65c3fc5f05db000c01cff2155f56ff/core/field_input.ts#L351)
- Remove the `as HTMLInputElement` cast in [showInlineEditor](https://github.com/google/blockly/blob/344861698e65c3fc5f05db000c01cff2155f56ff/core/field_input.ts#L334C10-L334C20).

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
Returning proper type info for input-specific manipulations of the element.

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
