### PR TITLE
feat: Paste block in viewport / near cursor

### DIFF
--- a/core/block.ts
+++ b/core/block.ts
@@ -1672,8 +1672,11 @@ export class Block implements IASTNodeLocation, IDeletable {
     }
 
     if (json['inputsInline'] !== undefined) {
+      eventUtils.disable();
       this.setInputsInline(json['inputsInline']);
+      eventUtils.enable();
     }
+
     // Set output and previous/next connections.
     if (json['output'] !== undefined) {
       this.setOutput(true, json['output']);

--- a/core/interfaces/i_movable.ts
+++ b/core/interfaces/i_movable.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Coordinate } from "../utils";
+import {Coordinate} from '../utils';
 
 // Former goog.module ID: Blockly.IMovable
 
@@ -25,5 +25,5 @@ export interface IMovable {
    *
    * @returns Object with .x and .y properties.
    */
-  getRelativeToSurfaceXY(): Coordinate
+  getRelativeToSurfaceXY(): Coordinate;
 }

--- a/core/interfaces/i_movable.ts
+++ b/core/interfaces/i_movable.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {Coordinate} from '../utils';
+import {Coordinate} from '../utils/coordinate.js';
 
 // Former goog.module ID: Blockly.IMovable
 

--- a/core/interfaces/i_movable.ts
+++ b/core/interfaces/i_movable.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { Coordinate } from "../utils";
+
 // Former goog.module ID: Blockly.IMovable
 
 /**
@@ -16,4 +18,12 @@ export interface IMovable {
    * @returns True if movable.
    */
   isMovable(): boolean;
+
+  /**
+   * Return the coordinates of the top-left corner of this movable object
+   *  relative to the drawing surface's origin (0,0), in workspace units.
+   *
+   * @returns Object with .x and .y properties.
+   */
+  getRelativeToSurfaceXY(): Coordinate
 }

--- a/core/shortcut_items.ts
+++ b/core/shortcut_items.ts
@@ -12,7 +12,7 @@ import * as common from './common.js';
 import {Gesture} from './gesture.js';
 import {ICopyData, isCopyable} from './interfaces/i_copyable.js';
 import {KeyboardShortcut, ShortcutRegistry} from './shortcut_registry.js';
-import { Coordinate } from './utils.js';
+import {Coordinate} from './utils.js';
 import {KeyCodes} from './utils/keycodes.js';
 import type {WorkspaceSvg} from './workspace_svg.js';
 
@@ -193,19 +193,24 @@ export function registerPaste() {
     },
     callback() {
       if (!copyData || !copyCoords || !copyWorkspace) return false;
-      const {left:vpLeft, top:vpTop, width:vpWidth, height:vpHeight } =  
-              copyWorkspace.getMetricsManager().getViewMetrics(true);
-      if(
-        copyCoords.x >= vpLeft
-        && copyCoords.x <= (vpLeft + vpWidth)
-        && copyCoords.y >= vpTop
-        && copyCoords.y <= (vpTop + vpHeight)
-        ){
+      const {
+        left: vpLeft,
+        top: vpTop,
+        width: vpWidth,
+        height: vpHeight,
+      } = copyWorkspace.getMetricsManager().getViewMetrics(true);
+      if (
+        copyCoords.x >= vpLeft &&
+        copyCoords.x <= vpLeft + vpWidth &&
+        copyCoords.y >= vpTop &&
+        copyCoords.y <= vpTop + vpHeight
+      ) {
         return !!clipboard.paste(copyData, copyWorkspace, copyCoords);
-      }
-      else{
-        const centerCoords = new Coordinate(vpLeft + Math.trunc(vpWidth / 2),
-                                            vpTop + Math.trunc(vpHeight / 2));
+      } else {
+        const centerCoords = new Coordinate(
+          vpLeft + Math.trunc(vpWidth / 2),
+          vpTop + Math.trunc(vpHeight / 2),
+        );
         return !!clipboard.paste(copyData, copyWorkspace, centerCoords);
       }
     },

--- a/core/shortcut_items.ts
+++ b/core/shortcut_items.ts
@@ -194,22 +194,28 @@ export function registerPaste() {
     callback() {
       if (!copyData || !copyCoords || !copyWorkspace) return false;
       const {
-        left: vpLeft,
-        top: vpTop,
-        width: vpWidth,
-        height: vpHeight,
+        left: viewportLeft,
+        top: viewportTop,
+        width: viewportWidth,
+        height: viewportHeight,
       } = copyWorkspace.getMetricsManager().getViewMetrics(true);
+      const selected = common.getSelected() as BlockSvg;
+
+      // Pass the default copy coordinates when
+      // default location is inside viewport.
       if (
-        copyCoords.x >= vpLeft &&
-        copyCoords.x <= vpLeft + vpWidth &&
-        copyCoords.y >= vpTop &&
-        copyCoords.y <= vpTop + vpHeight
+        copyCoords.x >= viewportLeft &&
+        copyCoords.x + selected.width <= viewportLeft + viewportWidth &&
+        copyCoords.y >= viewportTop &&
+        copyCoords.y + selected.height <= viewportTop + viewportHeight
       ) {
         return !!clipboard.paste(copyData, copyWorkspace, copyCoords);
       } else {
+        // Pass the center of the new viewport
+        // to paste the copied block
         const centerCoords = new Coordinate(
-          vpLeft + Math.trunc(vpWidth / 2),
-          vpTop + Math.trunc(vpHeight / 2),
+          viewportLeft + Math.trunc(viewportWidth / 2 - selected.width / 2),
+          viewportTop + Math.trunc(viewportHeight / 2 - selected.height / 2),
         );
         return !!clipboard.paste(copyData, copyWorkspace, centerCoords);
       }

--- a/core/shortcut_items.ts
+++ b/core/shortcut_items.ts
@@ -12,7 +12,7 @@ import * as common from './common.js';
 import {Gesture} from './gesture.js';
 import {ICopyData, isCopyable} from './interfaces/i_copyable.js';
 import {KeyboardShortcut, ShortcutRegistry} from './shortcut_registry.js';
-import {Coordinate} from './utils.js';
+import {Coordinate} from './utils/coordinate.js';
 import {KeyCodes} from './utils/keycodes.js';
 import type {WorkspaceSvg} from './workspace_svg.js';
 


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes https://github.com/google/blockly/issues/6848

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
When copying a block, blocky pastes the block near the original block. With this change, it will paste the new block either in the middle of the view or near where the cursor is.

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->
The method getRelativeToSurfaceXY(): Coordinate is added to the IMovable interface

### Additional Information

<!-- Anything else we should know? -->
