### PR TITLE
fix: move delete keyboard shortcut in-progress gesture check to precondition #6274

### DIFF
--- a/core/shortcut_items.ts
+++ b/core/shortcut_items.ts
@@ -59,7 +59,8 @@ export function registerDelete() {
       return (
         !workspace.options.readOnly &&
         selected != null &&
-        selected.isDeletable()
+        selected.isDeletable() &&
+        !Gesture.inProgress()
       );
     },
     callback(workspace, e) {
@@ -68,10 +69,6 @@ export function registerDelete() {
       // Do this first to prevent an error in the delete code from resulting in
       // data loss.
       e.preventDefault();
-      // Don't delete while dragging.  Jeez.
-      if (Gesture.inProgress()) {
-        return false;
-      }
       (common.getSelected() as BlockSvg).checkAndDelete();
       return true;
     },


### PR DESCRIPTION
## The basics

- [ ] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves
- Fixes #6274: Move delete keyboard shortcut in-progress gesture check to precondition

### Proposed Changes
- Add a check to the precondition function  to make sure a gesture is not in progress.
- Remove the gesture check

### Reason for Changes
-The delete keyboard shortcut was  checking if there is a gesture in progress from within its callback function, and returns early if so which should not have been the case

### Test Coverage

### Documentation

### Additional Information
- issue https://github.com/google/blockly/issues/6274
