### PR TITLE
fix: disableOrphans should not enable procedure callers if their associated definitions are disabled

### DIFF
--- a/core/events/utils.ts
+++ b/core/events/utils.ts
@@ -20,6 +20,7 @@ import type {BlockMove} from './events_block_move.js';
 import type {CommentCreate} from './events_comment_create.js';
 import type {CommentMove} from './events_comment_move.js';
 import type {ViewportChange} from './events_viewport.js';
+import { isProcedureBlock } from '../procedures.js';
 
 /** Group ID for new events.  Grouped events are indivisible. */
 let group = '';
@@ -542,6 +543,10 @@ export function disableOrphans(event: Abstract) {
         if (parent && parent.isEnabled()) {
           const children = block.getDescendants(false);
           for (let i = 0, child; (child = children[i]); i++) {
+            // Check if the block is a procedure block and if its procedure model is enabled
+            if(isProcedureBlock(child) && !child.getProcedureModel().getEnabled()){
+              continue;
+            }
             child.setEnabled(true);
           }
         } else if (

--- a/core/events/utils.ts
+++ b/core/events/utils.ts
@@ -20,7 +20,7 @@ import type {BlockMove} from './events_block_move.js';
 import type {CommentCreate} from './events_comment_create.js';
 import type {CommentMove} from './events_comment_move.js';
 import type {ViewportChange} from './events_viewport.js';
-import { isProcedureBlock } from '../procedures.js';
+import { isProcedureBlock } from '../interfaces/i_procedure_block.js'
 
 /** Group ID for new events.  Grouped events are indivisible. */
 let group = '';

--- a/core/events/utils.ts
+++ b/core/events/utils.ts
@@ -20,7 +20,7 @@ import type {BlockMove} from './events_block_move.js';
 import type {CommentCreate} from './events_comment_create.js';
 import type {CommentMove} from './events_comment_move.js';
 import type {ViewportChange} from './events_viewport.js';
-import { isProcedureBlock } from '../interfaces/i_procedure_block.js'
+import {isProcedureBlock} from '../interfaces/i_procedure_block.js';
 
 /** Group ID for new events.  Grouped events are indivisible. */
 let group = '';
@@ -544,7 +544,10 @@ export function disableOrphans(event: Abstract) {
           const children = block.getDescendants(false);
           for (let i = 0, child; (child = children[i]); i++) {
             // Check if the block is a procedure block and if its procedure model is enabled
-            if(isProcedureBlock(child) && !child.getProcedureModel().getEnabled()){
+            if (
+              isProcedureBlock(child) &&
+              !child.getProcedureModel().getEnabled()
+            ) {
               continue;
             }
             child.setEnabled(true);

--- a/tests/playgrounds/advanced_playground.html
+++ b/tests/playgrounds/advanced_playground.html
@@ -22,7 +22,6 @@
       function start() {
         setBackgroundColour();
         initPlayground();
-        workspace.addChangeListener(Blockly.Events.disableOrphans);
       }
 
       function createWorkspace(blocklyDiv, options) {

--- a/tests/playgrounds/advanced_playground.html
+++ b/tests/playgrounds/advanced_playground.html
@@ -22,6 +22,7 @@
       function start() {
         setBackgroundColour();
         initPlayground();
+        workspace.addChangeListener(Blockly.Events.disableOrphans);
       }
 
       function createWorkspace(blocklyDiv, options) {


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

disable-top-blocks should not enable procedure callers if their associated definitions are disabled
fixes #7154

### Proposed Changes

Using the Type Guard in Loop: Inside the loop that iterates over each child block, the code uses the isProcedureBlock function to determine if child is a procedure block.

```
if(isProcedureBlock(child) && !child.getProcedureModel().getEnabled()){
  continue;
}
```
`isProcedureBlock(child)`: Checks if the current child block is a procedure block.
`!child.getProcedureModel().getEnabled()`: Checks if the procedure model corresponding to this block is not enabled.
If both conditions are true, it skips enabling the current child block by using continue; to move to the next iteration of the loop.

### Reason for Changes

This condition does two things:

First, it checks if the child block is a procedure block using the isProcedureBlock function.
Second, if it's a procedure block, it checks if the procedure model for that block is enabled using `child.getProcedureModel().getEnabled()`. If the model isn't enabled, the loop continues to the next child block without enabling this particular child.
This ensures that if a block is a procedure block, it will only be enabled if its corresponding procedure model is enabled.



### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
