### PR TITLE
fix: paste block in viewport/near cursor

### DIFF
--- a/core/interfaces/i_movable.ts
+++ b/core/interfaces/i_movable.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import {Coordinate} from '../utils';
+
 // Former goog.module ID: Blockly.IMovable
 
 /**
@@ -16,4 +18,5 @@ export interface IMovable {
    * @returns True if movable.
    */
   isMovable(): boolean;
+  getRelativeToSurfaceXY(): Coordinate;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -48,7 +48,7 @@
         "prettier": "3.0.3",
         "readline-sync": "^1.4.10",
         "rimraf": "^5.0.0",
-        "typescript": "^5.0.2",
+        "typescript": "^5.2.2",
         "webdriverio": "^8.16.7",
         "yargs": "^17.2.1"
       }
@@ -5837,6 +5837,35 @@
       "optional": true,
       "os": [
         "linux"
+      ]
+    },
+    "node_modules/google-closure-compiler-osx": {
+      "version": "20230802.0.0",
+      "resolved": "https://registry.npmjs.org/google-closure-compiler-osx/-/google-closure-compiler-osx-20230802.0.0.tgz",
+      "integrity": "sha512-ANAi/ux92Tt+Na7vFDLeK2hRzotjC5j+nxoPtE0OcuNcbjji5dREKoJxkq7r0YwRTCzAFZszK5ip/NPdTOdCEg==",
+      "cpu": [
+        "x32",
+        "x64",
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/google-closure-compiler-windows": {
+      "version": "20230802.0.0",
+      "resolved": "https://registry.npmjs.org/google-closure-compiler-windows/-/google-closure-compiler-windows-20230802.0.0.tgz",
+      "integrity": "sha512-ZQPujoNiiUyTGl8zEGR/0yAygWnbMtX/NQ/S/EHVgq5nmYkvDEVuiVbgpPAmO9lzBTq0hvUTRRATZbTU2ISxgA==",
+      "cpu": [
+        "x32",
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
       ]
     },
     "node_modules/got": {

--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "prettier": "3.0.3",
     "readline-sync": "^1.4.10",
     "rimraf": "^5.0.0",
-    "typescript": "^5.0.2",
+    "typescript": "^5.2.2",
     "webdriverio": "^8.16.7",
     "yargs": "^17.2.1"
   },


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x ] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

Fixes https://github.com/google/blockly/issues/6848

### Proposed Changes

Pastes copied block in the center of viewport or near the original block depending on whether or not original is inside the viewport. 

### Reason for Changes

Copied blocks should not be pasted near original if original is not in viewport. The copied block should be visible in viewport.

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
