### PR TITLE
fix: Browser test helper: get workspace SVG root

### DIFF
--- a/tests/browser/test/field_edits_test.js
+++ b/tests/browser/test/field_edits_test.js
@@ -7,7 +7,7 @@
 /**
  * @fileoverview Node.js script to run Automated tests in Chrome, via webdriver.
  */
-
+import { myNewFunction } from './test_setup';
 const chai = require('chai');
 const {
   testSetup,
@@ -47,10 +47,11 @@ async function testFieldEdits(browser, direction) {
   await browser.keys([Key.Delete]);
   await browser.keys(['1093']);
 
-  // Click on the workspace to exit the field editor
-  const workspace = await browser.$('#blocklyDiv > div > svg.blocklySvg > g');
-  await workspace.click();
-  await browser.pause(PAUSE_TIME);
+  // // Click on the workspace to exit the field editor
+  // const workspace = await browser.$('#blocklyDiv > div > svg.blocklySvg > g');
+  // await workspace.click();
+  // await browser.pause(PAUSE_TIME);
+  myNewFunction();
 
   const fieldValue = await browser.execute((id) => {
     return Blockly.getMainWorkspace()

--- a/tests/browser/test/field_edits_test.js
+++ b/tests/browser/test/field_edits_test.js
@@ -7,7 +7,7 @@
 /**
  * @fileoverview Node.js script to run Automated tests in Chrome, via webdriver.
  */
-import { myNewFunction } from './test_setup';
+import {myNewFunction} from './test_setup';
 const chai = require('chai');
 const {
   testSetup,

--- a/tests/browser/test/test_setup.js
+++ b/tests/browser/test/test_setup.js
@@ -566,3 +566,13 @@ module.exports = {
   scrollFlyout,
   PAUSE_TIME,
 };
+
+
+async function myNewFunction() {
+  // Click on the workspace to exit the field editor
+const workspace = await browser.$('#blocklyDiv > div > svg.blocklySvg > g');
+await workspace.click();
+await browser.pause(PAUSE_TIME);
+}
+
+export { myNewFunction };

--- a/tests/browser/test/test_setup.js
+++ b/tests/browser/test/test_setup.js
@@ -567,12 +567,12 @@ module.exports = {
   PAUSE_TIME,
 };
 
-
-async function myNewFunction() {
+async function myNewFunction(browser) {
   // Click on the workspace to exit the field editor
-const workspace = await browser.$('#blocklyDiv > div > svg.blocklySvg > g');
-await workspace.click();
-await browser.pause(PAUSE_TIME);
+  // const browser;
+  const workspace = await browser.$('#blocklyDiv > div > svg.blocklySvg > g');
+  await workspace.click();
+  await browser.pause(PAUSE_TIME);
 }
 
-export { myNewFunction };
+export {myNewFunction};


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes https://github.com/google/blockly/issues/7332

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
Optionally added another helper to achieve similar functionality for a mutator workspace.

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
Providing similar access for a mutator workspace can ensure consistency and expand the range of interactions possible within different workspace types.

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->

This was finished by Mingjia Gong, Yuejia Yu and Qijun hu.
