### PR TITLE
fix : Check for undefined in vertical flyout layout function#7523

### DIFF
--- a/core/flyout_vertical.ts
+++ b/core/flyout_vertical.ts
@@ -233,6 +233,9 @@ export class VerticalFlyout extends Flyout {
     for (let i = 0, item; (item = contents[i]); i++) {
       if (item.type === 'block') {
         const block = item.block;
+        if(block == undefined || block == null){
+          continue;
+        }
         const allBlocks = block!.getDescendants(false);
         for (let j = 0, child; (child = allBlocks[j]); j++) {
           // Mark blocks as being inside a flyout.  This is used to detect and
@@ -240,15 +243,15 @@ export class VerticalFlyout extends Flyout {
           // a block.
           child.isInFlyout = true;
         }
-        const root = block!.getSvgRoot();
-        const blockHW = block!.getHeightWidth();
-        const moveX = block!.outputConnection
+        const root = block.getSvgRoot();
+        const blockHW = block.getHeightWidth();
+        const moveX = block.outputConnection
           ? cursorX - this.tabWidth_
           : cursorX;
-        block!.moveBy(moveX, cursorY);
+        block.moveBy(moveX, cursorY);
 
         const rect = this.createRect_(
-          block!,
+          block,
           this.RTL ? moveX - blockHW.width : moveX,
           cursorY,
           blockHW,


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X ] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
In [layout_](https://github.com/google/blockly/blob/osd/core/flyout_vertical.ts#L227) in flyout_vertical.ts we access the block with const block = item.block. The result is nullable 

### Resolves
so all later uses of block have to have a [non-null assertion]

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes 
[Check for undefined in vertical flyout layout function#7523](https://github.com/google/blockly/issues/7523)
### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
Check whether block is undefined after setting const block = item.block.
continue if block doesn't exist.
Remove ! from after the remaining uses of block within the for loop.

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
