### PR TITLE
fix(build): Fix broken npm install of Closure Compiler

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5839,6 +5839,35 @@
         "linux"
       ]
     },
+    "node_modules/google-closure-compiler-osx": {
+      "version": "20230802.0.0",
+      "resolved": "https://registry.npmjs.org/google-closure-compiler-osx/-/google-closure-compiler-osx-20230802.0.0.tgz",
+      "integrity": "sha512-ANAi/ux92Tt+Na7vFDLeK2hRzotjC5j+nxoPtE0OcuNcbjji5dREKoJxkq7r0YwRTCzAFZszK5ip/NPdTOdCEg==",
+      "cpu": [
+        "x32",
+        "x64",
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/google-closure-compiler-windows": {
+      "version": "20230802.0.0",
+      "resolved": "https://registry.npmjs.org/google-closure-compiler-windows/-/google-closure-compiler-windows-20230802.0.0.tgz",
+      "integrity": "sha512-ZQPujoNiiUyTGl8zEGR/0yAygWnbMtX/NQ/S/EHVgq5nmYkvDEVuiVbgpPAmO9lzBTq0hvUTRRATZbTU2ISxgA==",
+      "cpu": [
+        "x32",
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
     "node_modules/got": {
       "version": "13.0.0",
       "resolved": "https://registry.npmjs.org/got/-/got-13.0.0.tgz",
@@ -11854,7 +11883,7 @@
     "node_modules/vinyl-sourcemaps-apply": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/vinyl-sourcemaps-apply/-/vinyl-sourcemaps-apply-0.2.1.tgz",
-      "integrity": "sha1-q2VJ1h0XLCsbh75cUI0jnI74dwU=",
+      "integrity": "sha512-+oDh3KYZBoZC8hfocrbrxbLUeaYtQK7J5WU5Br9VqWqmCll3tFJqKp97GC9GmMsVIL0qnx2DgEDVxdo5EZ5sSw==",
       "dev": true,
       "dependencies": {
         "source-map": "^0.5.1"


### PR DESCRIPTION
## The basics

- [ ] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

Fixes broken build due to missing `goog-closure-compiler` dependencies.

### Proposed Changes

Install `google-closure-compiler-osx` or …`-windows` as appropriate.

### Reason for Changes

Not having a broken build is good.

### Test Coverage

I ran `npm run build` and it succeeded.  What more do you want?!?
