### PR TITLE
correcting typo from 'codefor' to 'code for'

### DIFF
--- a/core/generator.ts
+++ b/core/generator.ts
@@ -248,7 +248,7 @@ export class CodeGenerator {
     }
     if (typeof func !== 'function') {
       throw Error(
-        `${this.name_} generator does not know how to generate code` +
+        `${this.name_} generator does not know how to generate code ` +
           `for block type "${block.type}".`,
       );
     }


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves 
Fixes https://github.com/google/blockly/issues/7367

### Proposed Changes

Adding " " between two strings

### Reason for Changes

Correcting typo

### Test Coverage

N/A

### Documentation

N/A

### Additional Information

N/A
