### PR TITLE
fix: style attribute for xml in ws factory

### DIFF
--- a/demos/blockfactory/workspacefactory/wfactory_generator.js
+++ b/demos/blockfactory/workspacefactory/wfactory_generator.js
@@ -45,7 +45,7 @@ WorkspaceFactoryGenerator.prototype.generateToolboxXml = function() {
   // Create DOM for XML.
   var xmlDom = Blockly.utils.xml.createElement('xml');
   xmlDom.id = 'toolbox';
-  xmlDom.style.display = 'none';
+  xmlDom.setAttribute('style', 'display: none');
 
   if (!this.model.hasElements()) {
     // Toolbox has no categories. Use XML directly from workspace.
@@ -111,7 +111,7 @@ WorkspaceFactoryGenerator.prototype.generateWorkspaceXml = function() {
   // Generate XML and set attributes.
   var xmlDom = Blockly.Xml.workspaceToDom(this.hiddenWorkspace);
   xmlDom.id = 'workspaceBlocks';
-  xmlDom.style.display = 'none';
+  xmlDom.setAttribute('style', 'display: none');
   return xmlDom;
 };
 


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes broken workspace factory

### Proposed Changes

Reverts changes in https://github.com/google/blockly/pull/7503 to the workspace factory that broke it

### Reason for Changes

The JavaScript class `Element` doesn't have a `style` property. Only `HTMLElement`s have a `style` property that can be set directly via JS.

`<xml>` elements in the DOM do have a `style` attribute, so we can set the attribute using the `setAttribute` API. This makes the CSP unhappy, but not really sure how to prevent that since there is no `style` property. Since this code is outside the library, we won't be breaking the CSP for anyone using blockly. Just on our own hosted demos site.

The dev-tools code will be removed soon.

### Test Coverage

tested manually

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
