### PR TITLE
fix(generators): Modify type signature of `forBlock`

### DIFF
--- a/core/generator.ts
+++ b/core/generator.ts
@@ -19,8 +19,10 @@ import type {Workspace} from './workspace.js';
 import {warn} from './utils/deprecation.js';
 
 /**
- * Type declaration for per-block-type generator functions.
+ * Deprecated, no-longer used type declaration for per-block-type generator
+ * functions.
  *
+ * @deprecated
  * @see {@link https://developers.google.com/blockly/guides/create-custom-blocks/generating-code}
  * @param block The Block instance to generate code for.
  * @param genearator The CodeGenerator calling the function.
@@ -39,8 +41,25 @@ export type BlockGenerator = (
 export class CodeGenerator {
   name_: string;
 
-  /** A dictionary of block generator functions keyed by block type. */
-  forBlock: {[type: string]: BlockGenerator} = Object.create(null);
+  /**
+   * A dictionary of block generator functions, keyed by block type.
+   * Each block generator function takes two parameters:
+   *
+   * - the Block to generate code for, and
+   * - the calling CodeGenerator (or subclass) instance, so the
+   *   function can call methods defined below (e.g. blockToCode) or
+   *   on the relevant subclass (e.g. JavascripGenerator),
+   *
+   * and returns:
+   *
+   * - a [code, precedence] tuple (for value/expression blocks), or
+   * - a string containing the generated code (for statement blocks), or
+   * - null if no code should be emitted for block.
+   */
+  forBlock: Record<
+    string,
+    (block: Block, generator: this) => [string, number] | string | null
+  > = Object.create(null);
 
   /**
    * This is used as a placeholder in functions defined using


### PR DESCRIPTION
## The basics

- [X] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

Part of #6828; solves a problem with the typing of the second (`generator`) argument to block generator functions.

### Proposed Changes

Make two changes to the `forBlock` dictionary on CodeGenerator objects:

- Change the type of the second argument to the special [polymorphic `this` type](https://www.typescriptlang.org/docs/handbook/2/classes.html#this-types) (was CodeGenerator)

- Change the way `forBlock` is declared from using an index signature to using the `Record<>` template type.  The two should be equivalent but [the former provokes type errors when used with the 'this' type](https://stackoverflow.com/q/77197616/4969945).

Additionally, mark the now-unused (but exported) `BlockGenerator` type alias as `@deprecated` pending removal in the next major version.

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->

### Reason for Changes

Having the `forBlock` dictionary typed `(block: Block, generator: CodeGenerator) => /*...*/` creates some difficulties when trying to write block generator functions for `CodeGenerator` subclasses like `Javascript Generator):

* If the generator function is typed to match, with a second argument of type `CodeGenerator`, then the body would need to cast to call methods defined only on the subclass—e.g.: `(generator as JavascriptGenerator).getAdjusted(/*...*/)`.
* If the generator is typed with second argument of the specific subclass (e.g. `JavascriptGenerator`) then the function itself must be cast `as (/*...*/, generator: CodeGenerator) => /*...*/` when installing it in the `.forBlock` dictionary.

### Test Coverage

`npm test` succeeds.

### Documentation

We should check any existing generator documentation for examples written in TypeScript, which will can be updated accordingly.

### Additional Information

Technically the change of signature is a breaking change, but it is unlikely to affect any developers in practice, since any block generator function `(block: Block, generator: CodeGenerator) => /*...*/` can be substituted for `(block: Block, generator: C extends CodeGenerator) => /*...*/`, so any existing generator functions can still be added to any `CodeGenerator` _or subclass_ instance's `.forBlock`.  The only situation in which this would be breaking is if a developer was obtaining block generator functions _from_ a subclass instance's `forBlock` dictionary and assuming they were `(block: Block generator: CodeGenerator) => /*...*/`.
