### PR TITLE
chore: fix shouldStartNewRow docs and param names

### DIFF
--- a/core/renderers/common/info.ts
+++ b/core/renderers/common/info.ts
@@ -345,34 +345,34 @@ export class RenderInfo {
   /**
    * Decide whether to start a new row between the two Blockly.Inputs.
    *
-   * @param input The first input to consider
-   * @param lastInput The input that follows.
-   * @returns True if the next input should be rendered on a new row.
+   * @param currInput The current input.
+   * @param prevInput The previous input.
+   * @returns True if the current input should be rendered on a new row.
    */
-  protected shouldStartNewRow_(input: Input, lastInput?: Input): boolean {
+  protected shouldStartNewRow_(currInput: Input, prevInput?: Input): boolean {
     // If this is the first input, just add to the existing row.
     // That row is either empty or has some icons in it.
-    if (!lastInput) {
+    if (!prevInput) {
       return false;
     }
     // If the previous input was an end-row input, then any following input
     // should always be rendered on the next row.
-    if (lastInput instanceof EndRowInput) {
+    if (prevInput instanceof EndRowInput) {
       return true;
     }
     // A statement input or an input following one always gets a new row.
     if (
-      input instanceof StatementInput ||
-      lastInput instanceof StatementInput
+      currInput instanceof StatementInput ||
+      prevInput instanceof StatementInput
     ) {
       return true;
     }
     // Value inputs, dummy inputs, and any input following an external value
     // input get a new row if inputs are not inlined.
     if (
-      input instanceof ValueInput ||
-      input instanceof DummyInput ||
-      lastInput instanceof ValueInput
+      currInput instanceof ValueInput ||
+      currInput instanceof DummyInput ||
+      prevInput instanceof ValueInput
     ) {
       return !this.isInline;
     }

--- a/core/renderers/zelos/info.ts
+++ b/core/renderers/zelos/info.ts
@@ -118,29 +118,29 @@ export class RenderInfo extends BaseRenderInfo {
     this.finalize_();
   }
 
-  override shouldStartNewRow_(input: Input, lastInput: Input): boolean {
+  override shouldStartNewRow_(currInput: Input, prevInput: Input): boolean {
     // If this is the first input, just add to the existing row.
     // That row is either empty or has some icons in it.
-    if (!lastInput) {
+    if (!prevInput) {
       return false;
     }
     // If the previous input was an end-row input, then any following input
     // should always be rendered on the next row.
-    if (lastInput instanceof EndRowInput) {
+    if (prevInput instanceof EndRowInput) {
       return true;
     }
     // A statement input or an input following one always gets a new row.
     if (
-      input instanceof StatementInput ||
-      lastInput instanceof StatementInput
+      currInput instanceof StatementInput ||
+      prevInput instanceof StatementInput
     ) {
       return true;
     }
     // Value, dummy, and end-row inputs get new row if inputs are not inlined.
     if (
-      input instanceof ValueInput ||
-      input instanceof DummyInput ||
-      input instanceof EndRowInput
+      currInput instanceof ValueInput ||
+      currInput instanceof DummyInput ||
+      currInput instanceof EndRowInput
     ) {
       return !this.isInline || this.isMultiRow;
     }


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes N/A

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
Fixes the docs for `shouldStartNewRow` since they were incorrect, and renames the params to be less confusing.

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
I have had trouble with this several times. When helping John, when writing the renderer guides (which are misleading because I didn't understand what the code was doing), and when helping App Inventor.

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->
N/A

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

- [ ] Custom renderer guides need updates. But that's not dependent on this PR.

### Additional Information

<!-- Anything else we should know? -->
Luckily params are one of the few things we can rename without breaking people :P

Please check my understanding of `createRows_` for yourself to make sure these doc changes are actually correct.
