### PR TITLE
fix: include loaders in gh-pages commits

### DIFF
--- a/scripts/gulpfiles/git_tasks.js
+++ b/scripts/gulpfiles/git_tasks.js
@@ -25,6 +25,7 @@ const EXTRAS = [
   'build/msg',
   'dist/*_compressed.js*',
   'node_modules/@blockly',
+  'build/*.loader.mjs',
 ];
 
 let upstream = null;


### PR DESCRIPTION
## The basics

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves
Fixes an issue where playgrounds did not work on github pages because the `*.loader.mjs` files were not committed. They have to be committed explicitly with `-f` because they are gitignored in all non-gh-pages cases.

### Proposed Changes

Add `'build/*.loader.mjs'` to the list of `EXTRAS` IN `git_tasks.js`

Tested by manually doing the gh-pages steps with these additional files, then pushing to my gh-pages branch.
