### PR TITLE
fix: missing loaders for appengine deployment

### DIFF
--- a/scripts/gulpfiles/appengine_tasks.js
+++ b/scripts/gulpfiles/appengine_tasks.js
@@ -51,7 +51,7 @@ function copyStaticSrc(done) {
  * Prerequisite: clean, build.
  */
 function copyBuilt(done) {
-  return gulp.src(['build/msg/*', 'dist/*_compressed.js*'], {base: '.'})
+  return gulp.src(['build/msg/*', 'dist/*_compressed.js*', 'build/*.loader.mjs'], {base: '.'})
       .pipe(gulp.dest(demoStaticTmpDir));
 }
 


### PR DESCRIPTION
This is the equivalent of #7559 for the demos on appengine. I tested it by making the change locally and running `npm run deployDemos`. Playgrounds now load correctly.

Note that we don't actually link to the playgrounds. We still serve them, so they should still work.