### PR TITLE
fix: pasting with nothing selected

### DIFF
--- a/core/shortcut_items.ts
+++ b/core/shortcut_items.ts
@@ -12,7 +12,7 @@ import * as common from './common.js';
 import {Gesture} from './gesture.js';
 import {ICopyData, isCopyable} from './interfaces/i_copyable.js';
 import {KeyboardShortcut, ShortcutRegistry} from './shortcut_registry.js';
-import { Rect } from './utils.js';
+import {Rect} from './utils/rect.js';
 import {Coordinate} from './utils/coordinate.js';
 import {KeyCodes} from './utils/keycodes.js';
 import type {WorkspaceSvg} from './workspace_svg.js';

--- a/core/shortcut_items.ts
+++ b/core/shortcut_items.ts
@@ -191,9 +191,10 @@ export function registerPaste() {
     },
     callback() {
       if (!copyData || !copyCoords || !copyWorkspace) return false;
-      const {left, top, width, height} =
-          copyWorkspace.getMetricsManager().getViewMetrics(true);
-      const viewportRect = new Rect(top, top + height, left, left + width)
+      const {left, top, width, height} = copyWorkspace
+        .getMetricsManager()
+        .getViewMetrics(true);
+      const viewportRect = new Rect(top, top + height, left, left + width);
 
       if (viewportRect.contains(copyCoords.x, copyCoords.y)) {
         // Pass the default copy coordinates when they are inside the viewport.


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes https://github.com/google/blockly/issues/6848

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
Removes references to `getSelected` so you can paste while nothing is selected. Also reorganizes code to use Rect.contains

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
Bug fixing.

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->
Tested pasting when the original coords are inside and outside the viewport. Works correctly in both cases.

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->
N/A

### Additional Information

<!-- Anything else we should know? -->
N/A
