### PR TITLE
fix: color field sizing being incorrect

### DIFF
--- a/core/field_colour.ts
+++ b/core/field_colour.ts
@@ -262,28 +262,20 @@ export class FieldColour extends Field<string> {
    */
   protected updateSize_(margin?: number) {
     const constants = this.getConstants();
-    const xOffset =
-      margin !== undefined
-        ? margin
-        : !this.isFullBlockField()
-        ? constants!.FIELD_BORDER_RECT_X_PADDING
-        : 0;
-    let totalWidth = xOffset * 2;
-    let contentWidth = 0;
-    if (!this.isFullBlockField()) {
-      contentWidth = constants!.FIELD_COLOUR_DEFAULT_WIDTH;
-      totalWidth += contentWidth;
-    }
-
-    let totalHeight = constants!.FIELD_TEXT_HEIGHT;
-    if (!this.isFullBlockField()) {
-      totalHeight = Math.max(totalHeight, constants!.FIELD_BORDER_RECT_HEIGHT);
+    let totalWidth;
+    let totalHeight;
+    if (this.isFullBlockField()) {
+      const xOffset = margin ?? 0;
+      totalWidth = xOffset * 2;
+      totalHeight = constants!.FIELD_TEXT_HEIGHT;
+    } else {
+      totalWidth = constants!.FIELD_COLOUR_DEFAULT_WIDTH;
+      totalHeight = constants!.FIELD_COLOUR_DEFAULT_HEIGHT;
     }
 
     this.size_.height = totalHeight;
     this.size_.width = totalWidth;
 
-    this.positionTextElement_(xOffset, contentWidth);
     this.positionBorderRect_();
   }
 

--- a/core/renderers/zelos/constants.ts
+++ b/core/renderers/zelos/constants.ts
@@ -217,9 +217,9 @@ export class ConstantProvider extends BaseConstantProvider {
 
     this.FIELD_DROPDOWN_SVG_ARROW_PADDING = this.FIELD_BORDER_RECT_X_PADDING;
 
-    this.FIELD_COLOUR_DEFAULT_WIDTH = 2 * this.GRID_UNIT;
+    this.FIELD_COLOUR_DEFAULT_WIDTH = 6 * this.GRID_UNIT;
 
-    this.FIELD_COLOUR_DEFAULT_HEIGHT = 4 * this.GRID_UNIT;
+    this.FIELD_COLOUR_DEFAULT_HEIGHT = 8 * this.GRID_UNIT;
 
     this.FIELD_CHECKBOX_X_OFFSET = 1 * this.GRID_UNIT;
 


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes https://github.com/google/blockly/issues/7562

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
Makes it so the color field size is correct in geras.

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
Color field got wider with release v10.2.0

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->
Tested that geras sizing matches v10.1.2, and zelos sizing matches v10.2.0 Tested zelos sizing with full block fields and non-full-block fields.

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->
N/A

### Additional Information

<!-- Anything else we should know? -->
This should be patched.

The zelos non-full-block field is now a pixel taller, but I think it's better to conform to the grid than make it 31 pixels tall.