### PR TITLE
fix: recreate dropdown div

### DIFF
--- a/core/dropdowndiv.ts
+++ b/core/dropdowndiv.ts
@@ -113,7 +113,7 @@ export interface PositionMetrics {
  * @internal
  */
 export function createDom() {
-  if (div) {
+  if (document.querySelector('.blocklyDropDownDiv')) {
     return; // Already created.
   }
   div = document.createElement('div');

--- a/core/dropdowndiv.ts
+++ b/core/dropdowndiv.ts
@@ -55,14 +55,14 @@ let animateOutTimer: ReturnType<typeof setTimeout> | null = null;
 /** Callback for when the drop-down is hidden. */
 let onHide: Function | null = null;
 
+/** A class name representing the current owner's workspace container. */
+const containerClassName = 'blocklyDropDownDiv';
+
 /** A class name representing the current owner's workspace renderer. */
 let renderedClassName = '';
 
 /** A class name representing the current owner's workspace theme. */
 let themeClassName = '';
-
-/** The content element. */
-let div: HTMLDivElement;
 
 /** The content element. */
 let content: HTMLDivElement;
@@ -108,16 +108,25 @@ export interface PositionMetrics {
 }
 
 /**
+ * Returns the HTML container for dropdown div.
+ *
+ * @returns The editor widget container.
+ */
+export function getDiv(): HTMLDivElement | null {
+  return document.querySelector('.' + containerClassName);
+}
+
+/**
  * Create and insert the DOM element for this div.
  *
  * @internal
  */
 export function createDom() {
-  if (document.querySelector('.blocklyDropDownDiv')) {
+  if (getDiv()) {
     return; // Already created.
   }
-  div = document.createElement('div');
-  div.className = 'blocklyDropDownDiv';
+  const div = document.createElement('div');
+  div.className = containerClassName;
   const parentDiv = common.getParentContainer() || document.body;
   parentDiv.appendChild(div);
 
@@ -183,6 +192,7 @@ export function clearContent() {
  * @param borderColour Any CSS colour for the border.
  */
 export function setColour(backgroundColour: string, borderColour: string) {
+  const div = getDiv()!;
   div.style.backgroundColor = backgroundColour;
   div.style.borderColor = borderColour;
 }
@@ -338,6 +348,11 @@ export function show<T>(
 ): boolean {
   owner = newOwner as Field;
   onHide = opt_onHide || null;
+  const div = getDiv();
+  if (!div) {
+    return false;
+  }
+
   // Set direction.
   div.style.direction = rtl ? 'rtl' : 'ltr';
 
@@ -401,7 +416,7 @@ const internal = {
     secondaryY: number,
   ): PositionMetrics {
     const boundsInfo = internal.getBoundsInfo();
-    const divSize = style.getSize(div as Element);
+    const divSize = style.getSize(getDiv()! as Element);
 
     // Can we fit in-bounds below the target?
     if (primaryY + divSize.height < boundsInfo.bottom) {
@@ -628,6 +643,11 @@ export function hideIfOwner<T>(
 
 /** Hide the menu, triggering animation. */
 export function hide() {
+  const div = getDiv();
+  if (!div) {
+    return;
+  }
+
   // Start the animation by setting the translation and fading out.
   // Reset to (initialX, initialY) - i.e., no translation.
   div.style.transform = 'translate(0, 0)';
@@ -649,6 +669,10 @@ export function hideWithoutAnimation() {
   }
   if (animateOutTimer) {
     clearTimeout(animateOutTimer);
+  }
+  const div = getDiv();
+  if (!div) {
+    return;
   }
 
   // Reset style properties in case this gets called directly
@@ -694,6 +718,11 @@ function positionInternal(
   secondaryX: number,
   secondaryY: number,
 ): boolean {
+  const div = getDiv();
+  if (!div) {
+    return false;
+  }
+
   const metrics = internal.getPositionMetrics(
     primaryX,
     primaryY,

--- a/core/dropdowndiv.ts
+++ b/core/dropdowndiv.ts
@@ -55,14 +55,14 @@ let animateOutTimer: ReturnType<typeof setTimeout> | null = null;
 /** Callback for when the drop-down is hidden. */
 let onHide: Function | null = null;
 
-/** A class name representing the current owner's workspace container. */
-const containerClassName = 'blocklyDropDownDiv';
-
 /** A class name representing the current owner's workspace renderer. */
 let renderedClassName = '';
 
 /** A class name representing the current owner's workspace theme. */
 let themeClassName = '';
+
+/** The content element. */
+let div: HTMLDivElement;
 
 /** The content element. */
 let content: HTMLDivElement;
@@ -108,25 +108,16 @@ export interface PositionMetrics {
 }
 
 /**
- * Returns the HTML container for dropdown div.
- *
- * @returns The editor widget container.
- */
-export function getDiv(): HTMLDivElement | null {
-  return document.querySelector('.' + containerClassName);
-}
-
-/**
  * Create and insert the DOM element for this div.
  *
  * @internal
  */
 export function createDom() {
-  if (getDiv()) {
+  if (document.querySelector('.blocklyDropDownDiv')) {
     return; // Already created.
   }
-  const div = document.createElement('div');
-  div.className = containerClassName;
+  div = document.createElement('div');
+  div.className = 'blocklyDropDownDiv';
   const parentDiv = common.getParentContainer() || document.body;
   parentDiv.appendChild(div);
 
@@ -192,7 +183,6 @@ export function clearContent() {
  * @param borderColour Any CSS colour for the border.
  */
 export function setColour(backgroundColour: string, borderColour: string) {
-  const div = getDiv()!;
   div.style.backgroundColor = backgroundColour;
   div.style.borderColor = borderColour;
 }
@@ -348,11 +338,6 @@ export function show<T>(
 ): boolean {
   owner = newOwner as Field;
   onHide = opt_onHide || null;
-  const div = getDiv();
-  if (!div) {
-    return false;
-  }
-
   // Set direction.
   div.style.direction = rtl ? 'rtl' : 'ltr';
 
@@ -416,7 +401,7 @@ const internal = {
     secondaryY: number,
   ): PositionMetrics {
     const boundsInfo = internal.getBoundsInfo();
-    const divSize = style.getSize(getDiv()! as Element);
+    const divSize = style.getSize(div as Element);
 
     // Can we fit in-bounds below the target?
     if (primaryY + divSize.height < boundsInfo.bottom) {
@@ -643,11 +628,6 @@ export function hideIfOwner<T>(
 
 /** Hide the menu, triggering animation. */
 export function hide() {
-  const div = getDiv();
-  if (!div) {
-    return;
-  }
-
   // Start the animation by setting the translation and fading out.
   // Reset to (initialX, initialY) - i.e., no translation.
   div.style.transform = 'translate(0, 0)';
@@ -669,10 +649,6 @@ export function hideWithoutAnimation() {
   }
   if (animateOutTimer) {
     clearTimeout(animateOutTimer);
-  }
-  const div = getDiv();
-  if (!div) {
-    return;
   }
 
   // Reset style properties in case this gets called directly
@@ -718,11 +694,6 @@ function positionInternal(
   secondaryX: number,
   secondaryY: number,
 ): boolean {
-  const div = getDiv();
-  if (!div) {
-    return false;
-  }
-
   const metrics = internal.getPositionMetrics(
     primaryX,
     primaryY,

--- a/core/tooltip.ts
+++ b/core/tooltip.ts
@@ -184,7 +184,7 @@ function getTargetObject(
  * Create the tooltip div and inject it onto the page.
  */
 export function createDom() {
-  if (containerDiv) {
+  if (document.querySelector('.blocklyTooltipDiv')) {
     return; // Already created.
   }
   // Create an HTML container for popup overlays (e.g. editor widgets).

--- a/core/tooltip.ts
+++ b/core/tooltip.ts
@@ -125,8 +125,8 @@ export const HOVER_MS = 750;
  */
 export const MARGINS = 5;
 
-/** A class name representing the HTML tooltip container. */
-const containerClassName = 'blocklyTooltipDiv';
+/** The HTML container.  Set once by createDom. */
+let containerDiv: HTMLDivElement | null = null;
 
 /**
  * Returns the HTML tooltip container.
@@ -134,7 +134,7 @@ const containerClassName = 'blocklyTooltipDiv';
  * @returns The HTML tooltip container.
  */
 export function getDiv(): HTMLDivElement | null {
-  return document.querySelector('.' + containerClassName);
+  return containerDiv;
 }
 
 /**
@@ -184,12 +184,12 @@ function getTargetObject(
  * Create the tooltip div and inject it onto the page.
  */
 export function createDom() {
-  if (getDiv()) {
+  if (document.querySelector('.blocklyTooltipDiv')) {
     return; // Already created.
   }
   // Create an HTML container for popup overlays (e.g. editor widgets).
-  const containerDiv = document.createElement('div');
-  containerDiv.className = containerClassName;
+  containerDiv = document.createElement('div');
+  containerDiv.className = 'blocklyTooltipDiv';
   const container = common.getParentContainer() || document.body;
   container.appendChild(containerDiv);
 }
@@ -339,7 +339,6 @@ export function dispose() {
 export function hide() {
   if (visible) {
     visible = false;
-    const containerDiv = getDiv();
     if (containerDiv) {
       containerDiv.style.display = 'none';
     }
@@ -373,7 +372,6 @@ export function unblock() {
 
 /** Renders the tooltip content into the tooltip div. */
 function renderContent() {
-  const containerDiv = getDiv();
   if (!containerDiv || !element) {
     // This shouldn't happen, but if it does, we can't render.
     return;
@@ -394,7 +392,7 @@ function renderDefaultContent() {
   for (let i = 0; i < lines.length; i++) {
     const div = document.createElement('div');
     div.appendChild(document.createTextNode(lines[i]));
-    getDiv()!.appendChild(div);
+    containerDiv!.appendChild(div);
   }
 }
 
@@ -406,22 +404,21 @@ function renderDefaultContent() {
  * @returns Coordinates at which the tooltip div should be placed.
  */
 function getPosition(rtl: boolean): {x: number; y: number} {
-  const containerDiv = getDiv()!;
   // Position the tooltip just below the cursor.
   const windowWidth = document.documentElement.clientWidth;
   const windowHeight = document.documentElement.clientHeight;
 
   let anchorX = lastX;
   if (rtl) {
-    anchorX -= OFFSET_X + containerDiv.offsetWidth;
+    anchorX -= OFFSET_X + containerDiv!.offsetWidth;
   } else {
     anchorX += OFFSET_X;
   }
 
   let anchorY = lastY + OFFSET_Y;
-  if (anchorY + containerDiv.offsetHeight > windowHeight + window.scrollY) {
+  if (anchorY + containerDiv!.offsetHeight > windowHeight + window.scrollY) {
     // Falling off the bottom of the screen; shift the tooltip up.
-    anchorY -= containerDiv.offsetHeight + 2 * OFFSET_Y;
+    anchorY -= containerDiv!.offsetHeight + 2 * OFFSET_Y;
   }
 
   if (rtl) {
@@ -429,12 +426,12 @@ function getPosition(rtl: boolean): {x: number; y: number} {
     anchorX = Math.max(MARGINS - window.scrollX, anchorX);
   } else {
     if (
-      anchorX + containerDiv.offsetWidth >
+      anchorX + containerDiv!.offsetWidth >
       windowWidth + window.scrollX - 2 * MARGINS
     ) {
       // Falling off the right edge of the screen;
       // clamp the tooltip on the edge.
-      anchorX = windowWidth - containerDiv.offsetWidth - 2 * MARGINS;
+      anchorX = windowWidth - containerDiv!.offsetWidth - 2 * MARGINS;
     }
   }
 
@@ -448,7 +445,6 @@ function show() {
     return;
   }
   poisonedElement = element;
-  const containerDiv = getDiv();
   if (!containerDiv) {
     return;
   }

--- a/core/tooltip.ts
+++ b/core/tooltip.ts
@@ -125,8 +125,8 @@ export const HOVER_MS = 750;
  */
 export const MARGINS = 5;
 
-/** The HTML container.  Set once by createDom. */
-let containerDiv: HTMLDivElement | null = null;
+/** A class name representing the HTML tooltip container. */
+const containerClassName = 'blocklyTooltipDiv';
 
 /**
  * Returns the HTML tooltip container.
@@ -134,7 +134,7 @@ let containerDiv: HTMLDivElement | null = null;
  * @returns The HTML tooltip container.
  */
 export function getDiv(): HTMLDivElement | null {
-  return containerDiv;
+  return document.querySelector('.' + containerClassName);
 }
 
 /**
@@ -184,12 +184,12 @@ function getTargetObject(
  * Create the tooltip div and inject it onto the page.
  */
 export function createDom() {
-  if (document.querySelector('.blocklyTooltipDiv')) {
+  if (getDiv()) {
     return; // Already created.
   }
   // Create an HTML container for popup overlays (e.g. editor widgets).
-  containerDiv = document.createElement('div');
-  containerDiv.className = 'blocklyTooltipDiv';
+  const containerDiv = document.createElement('div');
+  containerDiv.className = containerClassName;
   const container = common.getParentContainer() || document.body;
   container.appendChild(containerDiv);
 }
@@ -339,6 +339,7 @@ export function dispose() {
 export function hide() {
   if (visible) {
     visible = false;
+    const containerDiv = getDiv();
     if (containerDiv) {
       containerDiv.style.display = 'none';
     }
@@ -372,6 +373,7 @@ export function unblock() {
 
 /** Renders the tooltip content into the tooltip div. */
 function renderContent() {
+  const containerDiv = getDiv();
   if (!containerDiv || !element) {
     // This shouldn't happen, but if it does, we can't render.
     return;
@@ -392,7 +394,7 @@ function renderDefaultContent() {
   for (let i = 0; i < lines.length; i++) {
     const div = document.createElement('div');
     div.appendChild(document.createTextNode(lines[i]));
-    containerDiv!.appendChild(div);
+    getDiv()!.appendChild(div);
   }
 }
 
@@ -404,21 +406,22 @@ function renderDefaultContent() {
  * @returns Coordinates at which the tooltip div should be placed.
  */
 function getPosition(rtl: boolean): {x: number; y: number} {
+  const containerDiv = getDiv()!;
   // Position the tooltip just below the cursor.
   const windowWidth = document.documentElement.clientWidth;
   const windowHeight = document.documentElement.clientHeight;
 
   let anchorX = lastX;
   if (rtl) {
-    anchorX -= OFFSET_X + containerDiv!.offsetWidth;
+    anchorX -= OFFSET_X + containerDiv.offsetWidth;
   } else {
     anchorX += OFFSET_X;
   }
 
   let anchorY = lastY + OFFSET_Y;
-  if (anchorY + containerDiv!.offsetHeight > windowHeight + window.scrollY) {
+  if (anchorY + containerDiv.offsetHeight > windowHeight + window.scrollY) {
     // Falling off the bottom of the screen; shift the tooltip up.
-    anchorY -= containerDiv!.offsetHeight + 2 * OFFSET_Y;
+    anchorY -= containerDiv.offsetHeight + 2 * OFFSET_Y;
   }
 
   if (rtl) {
@@ -426,12 +429,12 @@ function getPosition(rtl: boolean): {x: number; y: number} {
     anchorX = Math.max(MARGINS - window.scrollX, anchorX);
   } else {
     if (
-      anchorX + containerDiv!.offsetWidth >
+      anchorX + containerDiv.offsetWidth >
       windowWidth + window.scrollX - 2 * MARGINS
     ) {
       // Falling off the right edge of the screen;
       // clamp the tooltip on the edge.
-      anchorX = windowWidth - containerDiv!.offsetWidth - 2 * MARGINS;
+      anchorX = windowWidth - containerDiv.offsetWidth - 2 * MARGINS;
     }
   }
 
@@ -445,6 +448,7 @@ function show() {
     return;
   }
   poisonedElement = element;
+  const containerDiv = getDiv();
   if (!containerDiv) {
     return;
   }

--- a/core/widgetdiv.ts
+++ b/core/widgetdiv.ts
@@ -19,6 +19,9 @@ let owner: unknown = null;
 /** Optional cleanup function set by whichever object uses the widget. */
 let dispose: (() => void) | null = null;
 
+/** A class name representing the current owner's workspace container. */
+const containerClassName = 'blocklyWidgetDiv';
+
 /** A class name representing the current owner's workspace renderer. */
 let rendererClassName = '';
 
@@ -45,18 +48,21 @@ export function getDiv(): HTMLDivElement | null {
  */
 export function testOnly_setDiv(newDiv: HTMLDivElement | null) {
   containerDiv = newDiv;
+  if (newDiv === null) {
+    document.querySelector('.' + containerClassName)?.remove();
+  }
 }
 
 /**
  * Create the widget div and inject it onto the page.
  */
 export function createDom() {
-  if (document.querySelector('.blocklyWidgetDiv')) {
+  if (document.querySelector('.' + containerClassName)) {
     return; // Already created.
   }
 
   containerDiv = document.createElement('div') as HTMLDivElement;
-  containerDiv.className = 'blocklyWidgetDiv';
+  containerDiv.className = containerClassName;
   const container = common.getParentContainer() || document.body;
   container.appendChild(containerDiv);
 }

--- a/core/widgetdiv.ts
+++ b/core/widgetdiv.ts
@@ -19,14 +19,14 @@ let owner: unknown = null;
 /** Optional cleanup function set by whichever object uses the widget. */
 let dispose: (() => void) | null = null;
 
-/** A class name representing the current owner's workspace container. */
-const containerClassName = 'blocklyWidgetDiv';
-
 /** A class name representing the current owner's workspace renderer. */
 let rendererClassName = '';
 
 /** A class name representing the current owner's workspace theme. */
 let themeClassName = '';
+
+/** The HTML container for popup overlays (e.g. editor widgets). */
+let containerDiv: HTMLDivElement | null;
 
 /**
  * Returns the HTML container for editor widgets.
@@ -34,7 +34,7 @@ let themeClassName = '';
  * @returns The editor widget container.
  */
 export function getDiv(): HTMLDivElement | null {
-  return document.querySelector('.' + containerClassName);
+  return containerDiv;
 }
 
 /**
@@ -44,28 +44,19 @@ export function getDiv(): HTMLDivElement | null {
  * @internal
  */
 export function testOnly_setDiv(newDiv: HTMLDivElement | null) {
-  const div = getDiv();
-  if (!div) {
-    return;
-  }
-
-  if (newDiv === null) {
-    div.remove();
-  } else {
-    div.replaceWith(newDiv);
-  }
+  containerDiv = newDiv;
 }
 
 /**
  * Create the widget div and inject it onto the page.
  */
 export function createDom() {
-  if (getDiv()) {
+  if (document.querySelector('.blocklyWidgetDiv')) {
     return; // Already created.
   }
 
-  const containerDiv = document.createElement('div') as HTMLDivElement;
-  containerDiv.className = containerClassName;
+  containerDiv = document.createElement('div') as HTMLDivElement;
+  containerDiv.className = 'blocklyWidgetDiv';
   const container = common.getParentContainer() || document.body;
   container.appendChild(containerDiv);
 }
@@ -82,10 +73,8 @@ export function show(newOwner: unknown, rtl: boolean, newDispose: () => void) {
   hide();
   owner = newOwner;
   dispose = newDispose;
-  const div = getDiv();
-  if (!div) {
-    return;
-  }
+  const div = containerDiv;
+  if (!div) return;
   div.style.direction = rtl ? 'rtl' : 'ltr';
   div.style.display = 'block';
   const mainWorkspace = common.getMainWorkspace() as WorkspaceSvg;
@@ -108,7 +97,7 @@ export function hide() {
   }
   owner = null;
 
-  const div = getDiv();
+  const div = containerDiv;
   if (!div) return;
   div.style.display = 'none';
   div.style.left = '';
@@ -157,10 +146,9 @@ export function hideIfOwner(oldOwner: unknown) {
  * @param height The height of the widget div (pixels).
  */
 function positionInternal(x: number, y: number, height: number) {
-  const div = getDiv()!;
-  div.style.left = x + 'px';
-  div.style.top = y + 'px';
-  div.style.height = height + 'px';
+  containerDiv!.style.left = x + 'px';
+  containerDiv!.style.top = y + 'px';
+  containerDiv!.style.height = height + 'px';
 }
 
 /**

--- a/core/widgetdiv.ts
+++ b/core/widgetdiv.ts
@@ -51,7 +51,7 @@ export function testOnly_setDiv(newDiv: HTMLDivElement | null) {
  * Create the widget div and inject it onto the page.
  */
 export function createDom() {
-  if (containerDiv) {
+  if (document.querySelector('.blocklyWidgetDiv')) {
     return; // Already created.
   }
 

--- a/core/widgetdiv.ts
+++ b/core/widgetdiv.ts
@@ -19,14 +19,14 @@ let owner: unknown = null;
 /** Optional cleanup function set by whichever object uses the widget. */
 let dispose: (() => void) | null = null;
 
+/** A class name representing the current owner's workspace container. */
+const containerClassName = 'blocklyWidgetDiv';
+
 /** A class name representing the current owner's workspace renderer. */
 let rendererClassName = '';
 
 /** A class name representing the current owner's workspace theme. */
 let themeClassName = '';
-
-/** The HTML container for popup overlays (e.g. editor widgets). */
-let containerDiv: HTMLDivElement | null;
 
 /**
  * Returns the HTML container for editor widgets.
@@ -34,7 +34,7 @@ let containerDiv: HTMLDivElement | null;
  * @returns The editor widget container.
  */
 export function getDiv(): HTMLDivElement | null {
-  return containerDiv;
+  return document.querySelector('.' + containerClassName);
 }
 
 /**
@@ -44,19 +44,28 @@ export function getDiv(): HTMLDivElement | null {
  * @internal
  */
 export function testOnly_setDiv(newDiv: HTMLDivElement | null) {
-  containerDiv = newDiv;
+  const div = getDiv();
+  if (!div) {
+    return;
+  }
+
+  if (newDiv === null) {
+    div.remove();
+  } else {
+    div.replaceWith(newDiv);
+  }
 }
 
 /**
  * Create the widget div and inject it onto the page.
  */
 export function createDom() {
-  if (document.querySelector('.blocklyWidgetDiv')) {
+  if (getDiv()) {
     return; // Already created.
   }
 
-  containerDiv = document.createElement('div') as HTMLDivElement;
-  containerDiv.className = 'blocklyWidgetDiv';
+  const containerDiv = document.createElement('div') as HTMLDivElement;
+  containerDiv.className = containerClassName;
   const container = common.getParentContainer() || document.body;
   container.appendChild(containerDiv);
 }
@@ -73,8 +82,10 @@ export function show(newOwner: unknown, rtl: boolean, newDispose: () => void) {
   hide();
   owner = newOwner;
   dispose = newDispose;
-  const div = containerDiv;
-  if (!div) return;
+  const div = getDiv();
+  if (!div) {
+    return;
+  }
   div.style.direction = rtl ? 'rtl' : 'ltr';
   div.style.display = 'block';
   const mainWorkspace = common.getMainWorkspace() as WorkspaceSvg;
@@ -97,7 +108,7 @@ export function hide() {
   }
   owner = null;
 
-  const div = containerDiv;
+  const div = getDiv();
   if (!div) return;
   div.style.display = 'none';
   div.style.left = '';
@@ -146,9 +157,10 @@ export function hideIfOwner(oldOwner: unknown) {
  * @param height The height of the widget div (pixels).
  */
 function positionInternal(x: number, y: number, height: number) {
-  containerDiv!.style.left = x + 'px';
-  containerDiv!.style.top = y + 'px';
-  containerDiv!.style.height = height + 'px';
+  const div = getDiv()!;
+  div.style.left = x + 'px';
+  div.style.top = y + 'px';
+  div.style.height = height + 'px';
 }
 
 /**


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #7571 

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
Check if the element(.blocklyDropDownDiv) exists.

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
Closing blockly does not reset the 'div' variable.
Therefore, the createDom method of dropDownDiv is not re-executed.

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->
I have verified that the drop-down elements are displayed on the second view.

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
