### PR TITLE
fix: colour from colour picker not being updated

### DIFF
--- a/core/field_colour.ts
+++ b/core/field_colour.ts
@@ -246,6 +246,8 @@ export class FieldColour extends Field<string> {
 
     const block = this.getSourceBlock() as BlockSvg | null;
     if (!block) throw new UnattachedFieldError();
+    // Calling applyColour updates the UI (full-block vs non-full-block) for the
+    // colour field, and the colour of the field/block.
     block.applyColour();
   }
 

--- a/core/field_colour.ts
+++ b/core/field_colour.ts
@@ -246,12 +246,7 @@ export class FieldColour extends Field<string> {
 
     const block = this.getSourceBlock() as BlockSvg | null;
     if (!block) throw new UnattachedFieldError();
-    // In general, do *not* let fields control the color of blocks. Having the
-    // field control the color is unexpected, and could have performance
-    // impacts.
-    // Whenever we render, the field may no longer be a full-block-field so
-    // we need to update the colour.
-    if (this.getConstants()!.FIELD_COLOUR_FULL_BLOCK) block.applyColour();
+    block.applyColour();
   }
 
   /**


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes https://github.com/google/blockly/issues/7582

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
Makes it so picking a colour actually updates the colour field.

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
Bugs be bad.

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->
Manually tested selecting colors in geras and zelos. Manually tested adding and removing fields in zelos switches between full block and normal colour fields.

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->
N/A

### Additional Information

<!-- Anything else we should know? -->
N/A