### PR TITLE
fix: bring block to front when icon clicked

### DIFF
--- a/core/gesture.ts
+++ b/core/gesture.ts
@@ -945,7 +945,7 @@ export class Gesture {
         'Cannot do an icon click because the start icon is undefined',
       );
     }
-
+    this.bringBlockToFront();
     this.startIcon.onClick();
   }
 


### PR DESCRIPTION
Closes #7588

<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #7588

### Proposed Changes

Added a call to bringBlockToFront() in doIconClick().
<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->

### Reason for Changes
N/A
<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage
N/A
<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->

### Documentation
N/A
<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information
N/A
<!-- Anything else we should know? -->
