### PR TITLE
Throw an error for undefined messages in block definitions

### DIFF
--- a/core/block.ts
+++ b/core/block.ts
@@ -1641,6 +1641,18 @@ export class Block implements IASTNodeLocation, IDeletable {
       );
     }
 
+    // Validate that each arg has a corresponding message
+    let n = 0;
+    while (json['args' + n]) {
+      if (json['message' + n] === undefined) {
+        throw Error(
+          warningPrefix +
+            `args${n} must have a corresponding message (message${n}).`,
+        );
+      }
+      n++;
+    }
+
     // Set basic properties of block.
     // Makes styles backward compatible with old way of defining hat style.
     if (json['style'] && json['style'].hat) {


### PR DESCRIPTION
See #7589

<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #7589 

### Proposed Changes

Adding a check for `json["message0"] === undefined` at the start of `jsonInit` function.
<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->

### Reason for Changes

To fix current behavior which allows creation of blocks when messages is undefined.
<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
I wasn't actually able to reproduce the bug mentionned in #7589, so I added a check which should fix the issue if I understand correctly. How can I attempt to reproduce the issue, please ?

Also, I'd be happy to make any necessary changes. I know my current solution may not be what you had in mind.
