### PR TITLE
fix: text join block warning when using block-plus-minus plugin

### DIFF
--- a/blocks/text.ts
+++ b/blocks/text.ts
@@ -1018,6 +1018,8 @@ Extensions.register('text_indexOf_tooltip', INDEXOF_TOOLTIP_EXTENSION);
 
 Extensions.register('text_quotes', QUOTES_EXTENSION);
 
+Extensions.registerMixin('quote_image_mixin', QUOTE_IMAGE_MIXIN);
+
 Extensions.registerMutator(
   'text_join_mutator',
   JOIN_MUTATOR_MIXIN,


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
When combined with https://github.com/google/blockly-samples/pull/2025 this resolves https://github.com/google/blockly-samples/issues/1134.

### Proposed Changes
Register the quote_image_mixin.
<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->

### Reason for Changes
This allows the block-plus-minus plugin to access the mixin which stops the following warning (when combined with https://github.com/google/blockly-samples/pull/2025) from appearing when using the text_join block with the plugin:
`field named "TEXT" not found in "text_join" block`
<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Additional Information
The passing of this should be followed by the passing of https://github.com/google/blockly-samples/pull/2025.
<!-- Anything else we should know? -->
