### PR TITLE
feat: add tooltip support for icons

### DIFF
--- a/core/icons/icon.ts
+++ b/core/icons/icon.ts
@@ -15,6 +15,7 @@ import {Size} from '../utils/size.js';
 import {Svg} from '../utils/svg.js';
 import type {IconType} from './icon_types.js';
 import * as deprecation from '../utils/deprecation.js';
+import * as tooltip from '../tooltip.js';
 
 /**
  * The abstract icon class. Icons are visual elements that live in the top-start
@@ -35,7 +36,12 @@ export abstract class Icon implements IIcon {
   /** The root svg element visually representing this icon. */
   protected svgRoot: SVGGElement | null = null;
 
-  constructor(protected sourceBlock: Block) {}
+  /** The tooltip for this icon. */
+  protected tooltip: tooltip.TipInfo;
+
+  constructor(protected sourceBlock: Block) {
+    this.tooltip = sourceBlock;
+  }
 
   getType(): IconType<IIcon> {
     throw new Error('Icons must implement getType');
@@ -54,9 +60,12 @@ export abstract class Icon implements IIcon {
       this,
       pointerdownListener,
     );
+    (this.svgRoot as any).tooltip = this;
+    tooltip.bindMouseEvents(this.svgRoot);
   }
 
   dispose(): void {
+    tooltip.unbindMouseEvents(this.svgRoot);
     dom.removeNode(this.svgRoot);
   }
 
@@ -66,6 +75,19 @@ export abstract class Icon implements IIcon {
 
   getSize(): Size {
     return new Size(0, 0);
+  }
+
+  /**
+   * Sets the tooltip for this icon to the given value. Null to show the
+   * tooltip of the block.
+   */
+  setTooltip(tip: tooltip.TipInfo | null) {
+    this.tooltip = tip ?? this.sourceBlock;
+  }
+
+  /** Returns the tooltip for this icon. */
+  getTooltip(): tooltip.TipInfo {
+    return this.tooltip;
   }
 
   applyColour(): void {}


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #7047

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
Makes it so that built-in icons can have tooltips.

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
People want icons to have tooltips.

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->
Manually tested that by default icons show the tooltip of the parent.
Manually tested that setting the tooltip displays the new tooltip.
Manually tested that setting the new tooltip to `null` displays the tooltip of the parent.

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->
This should be added to the custom icons docs maybe? Need to check.

### Additional Information

<!-- Anything else we should know? -->
This adds tooltip support for any icons inheriting from `Blockly.icons.Icon`. Any icons made by external developers which are not inheriting can do what I've done here to support their own tooltips.
