### PR TITLE
fix: shadows in insertion markers being displayed as shadows

### DIFF
--- a/core/insertion_marker_manager.ts
+++ b/core/insertion_marker_manager.ts
@@ -271,6 +271,10 @@ export class InsertionMarkerManager {
         }
       }
 
+      for (const block of result.getDescendants(false)) {
+        block.setInsertionMarker(true);
+      }
+
       result.setCollapsed(sourceBlock.isCollapsed());
       result.setInputsInline(sourceBlock.getInputsInline());
 

--- a/tests/mocha/insertion_marker_manager_test.js
+++ b/tests/mocha/insertion_marker_manager_test.js
@@ -177,6 +177,79 @@ suite('Insertion marker manager', function () {
       const markers = manager.getInsertionMarkers();
       chai.assert.equal(markers.length, 2);
     });
+
+    suite.only('children being set as insertion markers', function () {
+      setup(function () {
+        Blockly.Blocks['shadows_in_init'] = {
+          init: function () {
+            this.appendValueInput('test').connection.setShadowState({
+              'type': 'math_number',
+            });
+            this.setPreviousStatement(true);
+          },
+        };
+
+        Blockly.Blocks['shadows_in_load'] = {
+          init: function () {
+            this.appendValueInput('test');
+            this.setPreviousStatement(true);
+          },
+
+          loadExtraState: function () {
+            this.getInput('test').connection.setShadowState({
+              'type': 'math_number',
+            });
+          },
+
+          saveExtraState: function () {
+            return true;
+          },
+        };
+      });
+
+      teardown(function () {
+        delete Blockly.Blocks['shadows_in_init'];
+        delete Blockly.Blocks['shadows_in_load'];
+      });
+
+      test('Shadows added in init are set as insertion markers', function () {
+        const state = {
+          'blocks': {
+            'blocks': [
+              {
+                'id': 'first',
+                'type': 'shadows_in_init',
+              },
+            ],
+          },
+        };
+        const manager = createBlocksAndManager(this.workspace, state);
+        const markers = manager.getInsertionMarkers();
+        chai.assert.isTrue(
+          markers[0].getChildren()[0].isInsertionMarker(),
+          'Expected the shadow block to be an insertion maker',
+        );
+      });
+
+      test('Shadows added in `loadExtraState` are set as insertion markers', function () {
+        const state = {
+          'blocks': {
+            'blocks': [
+              {
+                'id': 'first',
+                'type': 'shadows_in_load',
+              },
+            ],
+          },
+        };
+        const manager = createBlocksAndManager(this.workspace, state);
+        const markers = manager.getInsertionMarkers();
+        chai.assert.isTrue(
+          markers[0].getChildren()[0].isInsertionMarker(),
+          'Expected the shadow block to be an insertion maker',
+        );
+      });
+    });
   });
 
   suite('Would delete block', function () {

--- a/tests/mocha/insertion_marker_manager_test.js
+++ b/tests/mocha/insertion_marker_manager_test.js
@@ -178,7 +178,7 @@ suite('Insertion marker manager', function () {
       chai.assert.equal(markers.length, 2);
     });
 
-    suite.only('children being set as insertion markers', function () {
+    suite('children being set as insertion markers', function () {
       setup(function () {
         Blockly.Blocks['shadows_in_init'] = {
           init: function () {


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes https://github.com/google/blockly/issues/7466

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
Makes it so that children of insertion markers are also set as insertion markers

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
You can set shadow blocks programmatically, but they weren't previously being set as insertion markers.

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->

Tested with the following two block definitions. The first sets the shadow in the `init` method, the second sets the shadow in the `loadExtraState` method.

```js
      Blockly.Blocks['test'] = {
        init: function () {
          this.appendValueInput('test').connection.setShadowState({
            'type': 'math_number',
          });
          this.setPreviousStatement(true);
        },
      };

      Blockly.Blocks['test2'] = {
        init: function () {
          this.appendValueInput('test');
          this.setPreviousStatement(true);
        },

        loadExtraState: function () {
          this.getInput('test').connection.setShadowState({
            'type': 'math_number',
          });
        },

        saveExtraState: function () {
          return true;
        },
      };
```
[Screen recording 2023-10-23 3.06.57 PM.webm](https://github.com/google/blockly/assets/25440652/22dff7a1-f753-41d7-a730-ccbd715069ee)

Added unit tests.

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->
N/A

### Additional Information

<!-- Anything else we should know? -->
N/A
