### PR TITLE
fix: flyout id is different than first placed block

### DIFF
--- a/core/flyout_base.ts
+++ b/core/flyout_base.ts
@@ -1207,13 +1207,14 @@ export abstract class Flyout extends DeleteArea implements IFlyout {
   private placeNewBlock(oldBlock: BlockSvg): BlockSvg {
     const targetWorkspace = this.targetWorkspace;
     const svgRootOld = oldBlock.getSvgRoot();
+
     if (!svgRootOld) {
       throw Error('oldBlock is not rendered');
     }
 
     // Clone the block.
     // TODO(#7432): Add a saveIds parameter to `save`.
-    const json = blocks.save(oldBlock) as blocks.State;
+    const json = blocks.save(oldBlock, {saveIds: false}) as blocks.State;
     // Normallly this resizes leading to weird jumps. Save it for terminateDrag.
     targetWorkspace.setResizesEnabled(false);
     const block = blocks.append(json, targetWorkspace) as BlockSvg;

--- a/core/flyout_base.ts
+++ b/core/flyout_base.ts
@@ -1207,7 +1207,6 @@ export abstract class Flyout extends DeleteArea implements IFlyout {
   private placeNewBlock(oldBlock: BlockSvg): BlockSvg {
     const targetWorkspace = this.targetWorkspace;
     const svgRootOld = oldBlock.getSvgRoot();
-
     if (!svgRootOld) {
       throw Error('oldBlock is not rendered');
     }

--- a/core/serialization/blocks.ts
+++ b/core/serialization/blocks.ts
@@ -123,12 +123,12 @@ export function save(
   if (addInputBlocks) {
     // AnyDuringMigration because:  Argument of type '{ type: string; id:
     // string; }' is not assignable to parameter of type 'State'.
-    saveInputBlocks(block, state as AnyDuringMigration, doFullSerialization);
+    saveInputBlocks(block, state as AnyDuringMigration, doFullSerialization, saveIds);
   }
   if (addNextBlocks) {
     // AnyDuringMigration because:  Argument of type '{ type: string; id:
     // string; }' is not assignable to parameter of type 'State'.
-    saveNextBlocks(block, state as AnyDuringMigration, doFullSerialization);
+    saveNextBlocks(block, state as AnyDuringMigration, doFullSerialization, saveIds);
   }
 
   // AnyDuringMigration because:  Type '{ type: string; id: string; }' is not
@@ -271,6 +271,7 @@ function saveInputBlocks(
   block: Block,
   state: State,
   doFullSerialization: boolean,
+  addIds: boolean,
 ) {
   const inputs = Object.create(null);
   for (let i = 0; i < block.inputList.length; i++) {
@@ -279,6 +280,7 @@ function saveInputBlocks(
     const connectionState = saveConnection(
       input.connection as Connection,
       doFullSerialization,
+      addIds
     );
     if (connectionState) {
       inputs[input.name] = connectionState;
@@ -302,6 +304,7 @@ function saveNextBlocks(
   block: Block,
   state: State,
   doFullSerialization: boolean,
+  saveIds: boolean
 ) {
   if (!block.nextConnection) {
     return;
@@ -309,6 +312,7 @@ function saveNextBlocks(
   const connectionState = saveConnection(
     block.nextConnection,
     doFullSerialization,
+    saveIds
   );
   if (connectionState) {
     state['next'] = connectionState;
@@ -327,6 +331,7 @@ function saveNextBlocks(
 function saveConnection(
   connection: Connection,
   doFullSerialization: boolean,
+  saveIds: boolean
 ): ConnectionState | null {
   const shadow = connection.getShadowState(true);
   const child = connection.targetBlock();
@@ -338,7 +343,7 @@ function saveConnection(
     state['shadow'] = shadow;
   }
   if (child && !child.isShadow()) {
-    state['block'] = save(child, {doFullSerialization});
+    state['block'] = save(child, {doFullSerialization, saveIds});
   }
   return state;
 }

--- a/core/serialization/blocks.ts
+++ b/core/serialization/blocks.ts
@@ -281,7 +281,7 @@ function saveInputBlocks(
   block: Block,
   state: State,
   doFullSerialization: boolean,
-  addIds: boolean,
+  saveIds: boolean,
 ) {
   const inputs = Object.create(null);
   for (let i = 0; i < block.inputList.length; i++) {
@@ -290,7 +290,7 @@ function saveInputBlocks(
     const connectionState = saveConnection(
       input.connection as Connection,
       doFullSerialization,
-      addIds,
+      saveIds,
     );
     if (connectionState) {
       inputs[input.name] = connectionState;

--- a/core/serialization/blocks.ts
+++ b/core/serialization/blocks.ts
@@ -86,20 +86,21 @@ export function save(
     addInputBlocks = true,
     addNextBlocks = true,
     doFullSerialization = true,
+    saveIds = true,
   }: {
     addCoordinates?: boolean;
     addInputBlocks?: boolean;
     addNextBlocks?: boolean;
     doFullSerialization?: boolean;
+    saveIds?: boolean;
   } = {},
 ): State | null {
   if (block.isInsertionMarker()) {
     return null;
   }
-
   const state = {
     'type': block.type,
-    'id': block.id,
+    'id': saveIds ? block.id : null,
   };
 
   if (addCoordinates) {

--- a/core/serialization/blocks.ts
+++ b/core/serialization/blocks.ts
@@ -100,7 +100,7 @@ export function save(
   }
   const state = {
     'type': block.type,
-    'id': saveIds ? block.id : null,
+    'id': saveIds ? block.id : undefined,
   };
 
   if (addCoordinates) {

--- a/core/serialization/blocks.ts
+++ b/core/serialization/blocks.ts
@@ -123,12 +123,22 @@ export function save(
   if (addInputBlocks) {
     // AnyDuringMigration because:  Argument of type '{ type: string; id:
     // string; }' is not assignable to parameter of type 'State'.
-    saveInputBlocks(block, state as AnyDuringMigration, doFullSerialization, saveIds);
+    saveInputBlocks(
+      block,
+      state as AnyDuringMigration,
+      doFullSerialization,
+      saveIds,
+    );
   }
   if (addNextBlocks) {
     // AnyDuringMigration because:  Argument of type '{ type: string; id:
     // string; }' is not assignable to parameter of type 'State'.
-    saveNextBlocks(block, state as AnyDuringMigration, doFullSerialization, saveIds);
+    saveNextBlocks(
+      block,
+      state as AnyDuringMigration,
+      doFullSerialization,
+      saveIds,
+    );
   }
 
   // AnyDuringMigration because:  Type '{ type: string; id: string; }' is not
@@ -280,7 +290,7 @@ function saveInputBlocks(
     const connectionState = saveConnection(
       input.connection as Connection,
       doFullSerialization,
-      addIds
+      addIds,
     );
     if (connectionState) {
       inputs[input.name] = connectionState;
@@ -304,7 +314,7 @@ function saveNextBlocks(
   block: Block,
   state: State,
   doFullSerialization: boolean,
-  saveIds: boolean
+  saveIds: boolean,
 ) {
   if (!block.nextConnection) {
     return;
@@ -312,7 +322,7 @@ function saveNextBlocks(
   const connectionState = saveConnection(
     block.nextConnection,
     doFullSerialization,
-    saveIds
+    saveIds,
   );
   if (connectionState) {
     state['next'] = connectionState;
@@ -331,7 +341,7 @@ function saveNextBlocks(
 function saveConnection(
   connection: Connection,
   doFullSerialization: boolean,
-  saveIds: boolean
+  saveIds: boolean,
 ): ConnectionState | null {
   const shadow = connection.getShadowState(true);
   const child = connection.targetBlock();

--- a/tests/mocha/jso_serialization_test.js
+++ b/tests/mocha/jso_serialization_test.js
@@ -64,7 +64,7 @@ suite('JSO Serialization', function () {
     test('saveId false', function () {
       const block = this.workspace.newBlock('row_block');
       const jso = Blockly.serialization.blocks.save(block, {saveIds: false});
-      assertProperty(jso, 'id', null);
+      assertProperty(jso, 'id', undefined);
     });
 
     suite('Attributes', function () {

--- a/tests/mocha/jso_serialization_test.js
+++ b/tests/mocha/jso_serialization_test.js
@@ -61,6 +61,12 @@ suite('JSO Serialization', function () {
       assertProperty(jso, 'id', 'id0');
     });
 
+    test('saveId false', function () {
+      const block = this.workspace.newBlock('row_block');
+      const jso = Blockly.serialization.blocks.save(block, {saveIds: false});
+      assertProperty(jso, 'id', null);
+    });
+
     suite('Attributes', function () {
       suite('Collapsed', function () {
         test('True', function () {


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [ x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes  #7432 

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
Adds a parameter,  `saveIds: boolean`, to the [`save`](https://github.com/google/blockly/blob/4ab8d000995a93eafbc29444abb76e535aedf134/core/serialization/blocks.ts#L82) function. I also made sure that the parameter is passed through the recursive calls.

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
This ensures that when a block is dragged out, the ID of the newly placed block is different than the one in the flyout. 

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->

1. Open up the flyout, inspect the if block and note the data-id attribute 
2. Drag the block out, note the data-id attribute
3. The data-ids are not the same

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
