### PR TITLE
chore: drop node16

### DIFF
--- a/.github/workflows/browser_test.yml
+++ b/.github/workflows/browser_test.yml
@@ -19,7 +19,7 @@ jobs:
         # TODO (#2114): re-enable osx build.
         # os: [ubuntu-latest, macos-latest]
         os: [macos-latest]
-        node-version: [16.x, 18.x, 20.x]
+        node-version: [18.x, 20.x]
         # See supported Node.js release schedule at
         # https://nodejs.org/en/about/releases/
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
         # TODO (#2114): re-enable osx build.
         # os: [ubuntu-latest, macos-latest]
         os: [ubuntu-latest]
-        node-version: [16.x, 18.x, 20.x]
+        node-version: [18.x, 20.x]
         # See supported Node.js release schedule at
         # https://nodejs.org/en/about/releases/
 


### PR DESCRIPTION
Dropping node 16 support to unblock https://github.com/google/blockly/pull/7615

Technically I don't think we /need/ to drop support from the browser tests, but I think it's better to run the tests on consistent node versions than to have them get out of sync.