### PR TITLE
fix: prevent crash when clicking on a field to delete a block

### DIFF
--- a/core/block_svg.ts
+++ b/core/block_svg.ts
@@ -1185,7 +1185,7 @@ export class BlockSvg
     let block: this | null = this;
     do {
       const isDeadOrDying: boolean = block.isDeadOrDying();
-      if(isDeadOrDying){
+      if (isDeadOrDying) {
         break;
       }
       const root = block.getSvgRoot();

--- a/core/block_svg.ts
+++ b/core/block_svg.ts
@@ -1183,8 +1183,7 @@ export class BlockSvg
   bringToFront(blockOnly = false) {
     /* eslint-disable-next-line @typescript-eslint/no-this-alias */
     let block: this | null = this;
-    const isDeadOrDying: boolean = block.isDeadOrDying();
-    if (isDeadOrDying) {
+    if (block.isDeadOrDying()) {
       return;
     }
     do {

--- a/core/block_svg.ts
+++ b/core/block_svg.ts
@@ -1184,6 +1184,10 @@ export class BlockSvg
     /* eslint-disable-next-line @typescript-eslint/no-this-alias */
     let block: this | null = this;
     do {
+      const isDeadOrDying: boolean = block.isDeadOrDying();
+      if(isDeadOrDying){
+        break;
+      }
       const root = block.getSvgRoot();
       const parent = root.parentNode;
       const childNodes = parent!.childNodes;

--- a/core/block_svg.ts
+++ b/core/block_svg.ts
@@ -1183,11 +1183,11 @@ export class BlockSvg
   bringToFront(blockOnly = false) {
     /* eslint-disable-next-line @typescript-eslint/no-this-alias */
     let block: this | null = this;
+    const isDeadOrDying: boolean = block.isDeadOrDying();
+    if (isDeadOrDying) {
+      return;
+    }
     do {
-      const isDeadOrDying: boolean = block.isDeadOrDying();
-      if (isDeadOrDying) {
-        break;
-      }
       const root = block.getSvgRoot();
       const parent = root.parentNode;
       const childNodes = parent!.childNodes;


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes  #7587 

### Proposed Changes

The change is to check if the block is dead or is in dying state before accessing it in the ```bringToFront``` function.
<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->

### Reason for Changes


<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
