### PR TITLE
fix: Can mutate blocks in readOnly workspace

### DIFF
--- a/core/icons/mutator_icon.ts
+++ b/core/icons/mutator_icon.ts
@@ -151,7 +151,9 @@ export class MutatorIcon extends Icon implements IHasBubble {
 
   override onClick(): void {
     super.onClick();
-    this.setBubbleVisible(!this.bubbleIsVisible());
+    if (this.sourceBlock.isEditable()) {
+      this.setBubbleVisible(!this.bubbleIsVisible());
+    }
   }
 
   bubbleIsVisible(): boolean {


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #7557  

### Proposed Changes

When the source block is not editable, the bubble won't be visible hence it won't allow mutation of the block.
<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->

### Reason for Changes

It was a bug causing the user to mutate a block in read-only workspace.
<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
