### PR TITLE
chore: Renable macos-latest build

### DIFF
--- a/.github/workflows/browser_test.yml
+++ b/.github/workflows/browser_test.yml
@@ -16,9 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        # TODO (#2114): re-enable osx build.
-        # os: [ubuntu-latest, macos-latest]
-        os: [macos-latest]
+        os: [ubuntu-latest, macos-latest]
         node-version: [18.x, 20.x]
         # See supported Node.js release schedule at
         # https://nodejs.org/en/about/releases/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,9 +15,7 @@ jobs:
 
     strategy:
       matrix:
-        # TODO (#2114): re-enable osx build.
-        # os: [ubuntu-latest, macos-latest]
-        os: [ubuntu-latest]
+        os: [ubuntu-latest, macos-latest]
         node-version: [18.x, 20.x]
         # See supported Node.js release schedule at
         # https://nodejs.org/en/about/releases/


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #2114 

### Proposed Changes

Re-enables build for macosx

build seems to work fine after several triggers: https://github.com/alicialics/blockly/actions/runs/6830695852

Re-enables browsers-test for ubuntu

browsers-test seem to fail but this is a manually triggered job that doesn't get run very often:
https://github.com/alicialics/blockly/actions/runs/6830698569

### Reason for Changes

#2114 

### Test Coverage

ran in CI

### Documentation

N/A

### Additional Information

cc @BeksOmega 