### PR TITLE
fix: disabled render status after serialization

### DIFF
--- a/core/block_svg.ts
+++ b/core/block_svg.ts
@@ -1623,6 +1623,11 @@ export class BlockSvg
     if (this.isCollapsed()) {
       this.updateCollapsed_();
     }
+
+    if (!this.isEnabled()) {
+      this.updateDisabled();
+    }
+
     this.workspace.getRenderer().render(this);
     this.tightenChildrenEfficiently();
 

--- a/core/serialization/blocks.ts
+++ b/core/serialization/blocks.ts
@@ -733,7 +733,6 @@ function initBlock(block: Block, rendered: boolean) {
 
     blockSvg.initSvg();
     blockSvg.queueRender();
-    blockSvg.updateDisabled();
 
     // fixes #6076 JSO deserialization doesn't
     // set .iconXY_ property so here it will be set

--- a/core/xml.ts
+++ b/core/xml.ts
@@ -592,7 +592,6 @@ export function domToBlockInternal(
           topBlockSvg.setConnectionTracking(true);
         }
       }, 1);
-      topBlockSvg.updateDisabled();
       // Allow the scrollbars to resize and move based on the new contents.
       // TODO(@picklesrus): #387. Remove when domToBlock avoids resizing.
       (workspace as WorkspaceSvg).resizeContents();

--- a/tests/mocha/block_test.js
+++ b/tests/mocha/block_test.js
@@ -2244,15 +2244,15 @@ suite('Blocks', function () {
       test('Disabled blocks from JSON should have proper disabled status', function () {
         // Nested c-shaped blocks, inner block is disabled
         const blockJson = {
-          "type": "controls_if",
-          "inputs": {
-            "DO0": {
-              "block": {
-                "type": "controls_if",
-                "enabled": false
-              }
-            }
-          }
+          'type': 'controls_if',
+          'inputs': {
+            'DO0': {
+              'block': {
+                'type': 'controls_if',
+                'enabled': false,
+              },
+            },
+          },
         };
         Blockly.serialization.blocks.append(blockJson, this.workspace);
         // Inner block
@@ -2275,7 +2275,10 @@ suite('Blocks', function () {
           </statement>
         </block>
       </xml>`;
-        Blockly.Xml.domToWorkspace(Blockly.utils.xml.textToDom(blockXml), this.workspace);
+        Blockly.Xml.domToWorkspace(
+          Blockly.utils.xml.textToDom(blockXml),
+          this.workspace,
+        );
         // Inner block
         const block = this.workspace.getTopBlocks(false)[0].getChildren()[0];
         chai.assert.isTrue(
@@ -2287,73 +2290,99 @@ suite('Blocks', function () {
           'block should be marked disabled because enabled xml property was set to false',
         );
       });
-      suite('Disabling blocks with children and neighbors', function() {
-        setup( function() {
+      suite('Disabling blocks with children and neighbors', function () {
+        setup(function () {
           // c-shape block with a stack of 4 blocks in the input
           const blockJson = {
-            "type": "controls_if",
-            "id": "parent",
-            "inputs": {
-              "DO0": {
-                "block": {
-                  "type": "controls_repeat_ext",
-                  "id": "child1",
-                  "next": {
-                    "block": {
-                      "type": "controls_for",
-                      "id": "child2",
-                      "enabled": false,
-                      "next": {
-                        "block": {
-                          "type": "controls_whileUntil",
-                          "id": "child3",
-                          "next": {
-                            "block": {
-                              "type": "controls_forEach",
-                              "id": "child4",
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            }
+            'type': 'controls_if',
+            'id': 'parent',
+            'inputs': {
+              'DO0': {
+                'block': {
+                  'type': 'controls_repeat_ext',
+                  'id': 'child1',
+                  'next': {
+                    'block': {
+                      'type': 'controls_for',
+                      'id': 'child2',
+                      'enabled': false,
+                      'next': {
+                        'block': {
+                          'type': 'controls_whileUntil',
+                          'id': 'child3',
+                          'next': {
+                            'block': {
+                              'type': 'controls_forEach',
+                              'id': 'child4',
+                            },
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
           };
           Blockly.serialization.blocks.append(blockJson, this.workspace);
           this.parent = this.workspace.getBlockById('parent');
           this.child1 = this.workspace.getBlockById('child1');
           this.child2 = this.workspace.getBlockById('child2');
           this.child3 = this.workspace.getBlockById('child3');
-          this.child4 = this.workspace.getBlockById('child4');        
+          this.child4 = this.workspace.getBlockById('child4');
         });
-        test('Disabling parent block visually disables all descendants', async function() {
+        test('Disabling parent block visually disables all descendants', async function () {
           this.parent.setEnabled(false);
           await Blockly.renderManagement.finishQueuedRenders();
           for (const child of this.parent.getDescendants(false)) {
-            chai.assert.isTrue(child.visuallyDisabled, `block ${child.id} should be visually disabled`);
+            chai.assert.isTrue(
+              child.visuallyDisabled,
+              `block ${child.id} should be visually disabled`,
+            );
           }
         });
-        test('Child blocks regain original status after parent is re-enabled', async function() {
+        test('Child blocks regain original status after parent is re-enabled', async function () {
           this.parent.setEnabled(false);
           await Blockly.renderManagement.finishQueuedRenders();
           this.parent.setEnabled(true);
           await Blockly.renderManagement.finishQueuedRenders();
 
           // child2 is disabled, rest should be enabled
-          chai.assert.isTrue(this.child1.isEnabled(), 'child1 should be enabled');
-          chai.assert.isFalse(this.child1.visuallyDisabled, 'child1 should not be visually disabled');
+          chai.assert.isTrue(
+            this.child1.isEnabled(),
+            'child1 should be enabled',
+          );
+          chai.assert.isFalse(
+            this.child1.visuallyDisabled,
+            'child1 should not be visually disabled',
+          );
 
-          chai.assert.isFalse(this.child2.isEnabled(), 'child2 should be disabled');
-          chai.assert.isTrue(this.child2.visuallyDisabled, 'child2 should be visually disabled');
+          chai.assert.isFalse(
+            this.child2.isEnabled(),
+            'child2 should be disabled',
+          );
+          chai.assert.isTrue(
+            this.child2.visuallyDisabled,
+            'child2 should be visually disabled',
+          );
 
-          chai.assert.isTrue(this.child3.isEnabled(), 'child3 should be enabled');
-          chai.assert.isFalse(this.child3.visuallyDisabled, 'child3 should not be visually disabled');
+          chai.assert.isTrue(
+            this.child3.isEnabled(),
+            'child3 should be enabled',
+          );
+          chai.assert.isFalse(
+            this.child3.visuallyDisabled,
+            'child3 should not be visually disabled',
+          );
 
-          chai.assert.isTrue(this.child4.isEnabled(), 'child34 should be enabled');
-          chai.assert.isFalse(this.child4.visuallyDisabled, 'child4 should not be visually disabled');
-
+          chai.assert.isTrue(
+            this.child4.isEnabled(),
+            'child34 should be enabled',
+          );
+          chai.assert.isFalse(
+            this.child4.visuallyDisabled,
+            'child4 should not be visually disabled',
+          );
         });
       });
     });

--- a/tests/mocha/block_test.js
+++ b/tests/mocha/block_test.js
@@ -2255,7 +2255,9 @@ suite('Blocks', function () {
           },
         };
         Blockly.serialization.blocks.append(blockJson, this.workspace);
-        const innerBlock = this.workspace.getTopBlocks(false)[0].getChildren()[0];
+        const innerBlock = this.workspace
+          .getTopBlocks(false)[0]
+          .getChildren()[0];
         chai.assert.isTrue(
           innerBlock.visuallyDisabled,
           'block should have visuallyDisabled set because it is disabled',
@@ -2278,7 +2280,9 @@ suite('Blocks', function () {
           Blockly.utils.xml.textToDom(blockXml),
           this.workspace,
         );
-        const innerBlock = this.workspace.getTopBlocks(false)[0].getChildren()[0];
+        const innerBlock = this.workspace
+          .getTopBlocks(false)[0]
+          .getChildren()[0];
         chai.assert.isTrue(
           innerBlock.visuallyDisabled,
           'block should have visuallyDisabled set because it is disabled',

--- a/tests/mocha/block_test.js
+++ b/tests/mocha/block_test.js
@@ -2255,14 +2255,13 @@ suite('Blocks', function () {
           },
         };
         Blockly.serialization.blocks.append(blockJson, this.workspace);
-        // Inner block
-        const block = this.workspace.getTopBlocks(false)[0].getChildren()[0];
+        const innerBlock = this.workspace.getTopBlocks(false)[0].getChildren()[0];
         chai.assert.isTrue(
-          block.visuallyDisabled,
+          innerBlock.visuallyDisabled,
           'block should have visuallyDisabled set because it is disabled',
         );
         chai.assert.isFalse(
-          block.isEnabled(),
+          innerBlock.isEnabled(),
           'block should be marked disabled because enabled json property was set to false',
         );
       });
@@ -2279,14 +2278,13 @@ suite('Blocks', function () {
           Blockly.utils.xml.textToDom(blockXml),
           this.workspace,
         );
-        // Inner block
-        const block = this.workspace.getTopBlocks(false)[0].getChildren()[0];
+        const innerBlock = this.workspace.getTopBlocks(false)[0].getChildren()[0];
         chai.assert.isTrue(
-          block.visuallyDisabled,
+          innerBlock.visuallyDisabled,
           'block should have visuallyDisabled set because it is disabled',
         );
         chai.assert.isFalse(
-          block.isEnabled(),
+          innerBlock.isEnabled(),
           'block should be marked disabled because enabled xml property was set to false',
         );
       });

--- a/tests/mocha/block_test.js
+++ b/tests/mocha/block_test.js
@@ -2242,12 +2242,21 @@ suite('Blocks', function () {
         chai.assert.isTrue(blockB.disabled);
       });
       test('Disabled blocks from JSON should have proper disabled status', function () {
+        // Nested c-shaped blocks, inner block is disabled
         const blockJson = {
-          'type': 'controls_if',
-          'enabled': false,
+          "type": "controls_if",
+          "inputs": {
+            "DO0": {
+              "block": {
+                "type": "controls_if",
+                "enabled": false
+              }
+            }
+          }
         };
         Blockly.serialization.blocks.append(blockJson, this.workspace);
-        const block = this.workspace.getTopBlocks(false)[0];
+        // Inner block
+        const block = this.workspace.getTopBlocks(false)[0].getChildren()[0];
         chai.assert.isTrue(
           block.visuallyDisabled,
           'block should have visuallyDisabled set because it is disabled',
@@ -2256,6 +2265,96 @@ suite('Blocks', function () {
           block.isEnabled(),
           'block should be marked disabled because enabled json property was set to false',
         );
+      });
+      test('Disabled blocks from XML should have proper disabled status', function () {
+        // Nested c-shaped blocks, inner block is disabled
+        const blockXml = `<xml xmlns="https://developers.google.com/blockly/xml">
+        <block type="controls_if" x="63" y="87">
+          <statement name="DO0">
+            <block type="controls_if" disabled="true"></block>
+          </statement>
+        </block>
+      </xml>`;
+        Blockly.Xml.domToWorkspace(Blockly.utils.xml.textToDom(blockXml), this.workspace);
+        // Inner block
+        const block = this.workspace.getTopBlocks(false)[0].getChildren()[0];
+        chai.assert.isTrue(
+          block.visuallyDisabled,
+          'block should have visuallyDisabled set because it is disabled',
+        );
+        chai.assert.isFalse(
+          block.isEnabled(),
+          'block should be marked disabled because enabled xml property was set to false',
+        );
+      });
+      suite('Disabling blocks with children and neighbors', function() {
+        setup( function() {
+          // c-shape block with a stack of 4 blocks in the input
+          const blockJson = {
+            "type": "controls_if",
+            "id": "parent",
+            "inputs": {
+              "DO0": {
+                "block": {
+                  "type": "controls_repeat_ext",
+                  "id": "child1",
+                  "next": {
+                    "block": {
+                      "type": "controls_for",
+                      "id": "child2",
+                      "enabled": false,
+                      "next": {
+                        "block": {
+                          "type": "controls_whileUntil",
+                          "id": "child3",
+                          "next": {
+                            "block": {
+                              "type": "controls_forEach",
+                              "id": "child4",
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          };
+          Blockly.serialization.blocks.append(blockJson, this.workspace);
+          this.parent = this.workspace.getBlockById('parent');
+          this.child1 = this.workspace.getBlockById('child1');
+          this.child2 = this.workspace.getBlockById('child2');
+          this.child3 = this.workspace.getBlockById('child3');
+          this.child4 = this.workspace.getBlockById('child4');        
+        });
+        test('Disabling parent block visually disables all descendants', async function() {
+          this.parent.setEnabled(false);
+          await Blockly.renderManagement.finishQueuedRenders();
+          for (const child of this.parent.getDescendants(false)) {
+            chai.assert.isTrue(child.visuallyDisabled, `block ${child.id} should be visually disabled`);
+          }
+        });
+        test('Child blocks regain original status after parent is re-enabled', async function() {
+          this.parent.setEnabled(false);
+          await Blockly.renderManagement.finishQueuedRenders();
+          this.parent.setEnabled(true);
+          await Blockly.renderManagement.finishQueuedRenders();
+
+          // child2 is disabled, rest should be enabled
+          chai.assert.isTrue(this.child1.isEnabled(), 'child1 should be enabled');
+          chai.assert.isFalse(this.child1.visuallyDisabled, 'child1 should not be visually disabled');
+
+          chai.assert.isFalse(this.child2.isEnabled(), 'child2 should be disabled');
+          chai.assert.isTrue(this.child2.visuallyDisabled, 'child2 should be visually disabled');
+
+          chai.assert.isTrue(this.child3.isEnabled(), 'child3 should be enabled');
+          chai.assert.isFalse(this.child3.visuallyDisabled, 'child3 should not be visually disabled');
+
+          chai.assert.isTrue(this.child4.isEnabled(), 'child34 should be enabled');
+          chai.assert.isFalse(this.child4.visuallyDisabled, 'child4 should not be visually disabled');
+
+        });
       });
     });
   });


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #7113 

### Proposed Changes

- Update the disabled status of a block when it is rendered
- Removed call to `updateDisabled` from both XML and JSON serialization, since we do it in render instead
- Added tests for XML and disabling child / neighbor blocks

### Reason for Changes

- fixing bugs

### Test Coverage

- Added XML test that mirrors JSON test. Confirmed that this test would have caught this bug.
- Added tests that would have caught #6988 
- Manual testing in playground

### Documentation

no

### Additional Information

There were a couple different options listed in #7113, but this seemed the most straightforward. I'd like @BeksOmega 's input as I'm not sure if this line was removed intentionally in #7308 or if it was an oversight. If it was removed intentionally then maybe an alternative solution is better.
