### PR TITLE
chore: run build before and during interactive mocha

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "test": "gulp test",
     "test:browser": "cd tests/browser && npx mocha",
     "test:generators": "gulp testGenerators",
-    "test:mocha:interactive": "http-server ./ -o /tests/mocha/index.html -c-1",
+    "test:mocha:interactive": "npm run build && concurrently -n tsc,server \"tsc --watch --preserveWatchOutput --outDir \"build/src\" --declarationDir \"build/declarations\"\" \"http-server ./ -o /tests/mocha/index.html -c-1\"",
     "test:compile:advanced": "gulp buildAdvancedCompilationTest --debug",
     "updateGithubPages": "npm ci && gulp gitUpdateGithubPages"
   },


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes annoyance where if you modify blockly while trying to debug tests, you

1) run `npm run test:mocha:interative` to run the tests
2) make a change in blockly itself
3) kill the mocha server (or switch to a new terminal tab)
4) rebuild blockly
5) restart mocha server

I always forget that I have to rebuild blockly so I end up thinking my tests pass when they don't or vice versa

### Proposed Changes

- Runs npm run build before launching tests, and uses concurrently and tsc watch to also rebuild on changes to core, just like we do for the playground.
- Now you just need to wait for blockly to rebuild and then refresh the mocha page

### Reason for Changes

i was annoyed while writing tests

### Test Coverage

no

### Documentation

no

### Additional Information

<!-- Anything else we should know? -->
