### PR TITLE
refactor(generators): Migrate Lua generators to TypeScript

### DIFF
--- a/generators/lua.ts
+++ b/generators/lua.ts
@@ -7,7 +7,6 @@
 /**
  * @file Complete helper functions for generating Lua for
  *     blocks.  This is the entrypoint for lua_compressed.js.
- * @suppress {extraRequire}
  */
 
 // Former goog.module ID: Blockly.Lua.all
@@ -32,8 +31,15 @@ export const luaGenerator = new LuaGenerator();
 
 // Install per-block-type generator functions:
 const generators: typeof luaGenerator.forBlock = {
-  ...colour, ...lists, ...logic, ...loops, ...math,
-  ...procedures, ...text, ...variables, ...variablesDynamic
+  ...colour,
+  ...lists,
+  ...logic,
+  ...loops,
+  ...math,
+  ...procedures,
+  ...text,
+  ...variables,
+  ...variablesDynamic,
 };
 for (const name in generators) {
   luaGenerator.forBlock[name] = generators[name];

--- a/generators/lua.ts
+++ b/generators/lua.ts
@@ -5,7 +5,7 @@
  */
 
 /**
- * @fileoverview Complete helper functions for generating Lua for
+ * @file Complete helper functions for generating Lua for
  *     blocks.  This is the entrypoint for lua_compressed.js.
  * @suppress {extraRequire}
  */
@@ -27,13 +27,14 @@ export * from './lua/lua_generator.js';
 
 /**
  * Lua code generator instance.
- * @type {!LuaGenerator}
  */
 export const luaGenerator = new LuaGenerator();
 
 // Install per-block-type generator functions:
-Object.assign(
-  luaGenerator.forBlock,
-  colour, lists, logic, loops, math, procedures,
-  text, variables, variablesDynamic
-);
+const generators: typeof luaGenerator.forBlock = {
+  ...colour, ...lists, ...logic, ...loops, ...math,
+  ...procedures, ...text, ...variables, ...variablesDynamic
+};
+for (const name in generators) {
+  luaGenerator.forBlock[name] = generators[name];
+}

--- a/generators/lua/colour.ts
+++ b/generators/lua/colour.ts
@@ -14,39 +14,55 @@ import type {Block} from '../../core/block.js';
 import type {LuaGenerator} from './lua_generator.js';
 import {Order} from './lua_generator.js';
 
-
-export function colour_picker(block: Block, generator: LuaGenerator): [string, Order] {
+export function colour_picker(
+  block: Block,
+  generator: LuaGenerator,
+): [string, Order] {
   // Colour picker.
   const code = generator.quote_(block.getFieldValue('COLOUR'));
   return [code, Order.ATOMIC];
-};
+}
 
-export function colour_random(block: Block, generator: LuaGenerator): [string, Order] {
+export function colour_random(
+  block: Block,
+  generator: LuaGenerator,
+): [string, Order] {
   // Generate a random colour.
   const code = 'string.format("#%06x", math.random(0, 2^24 - 1))';
   return [code, Order.HIGH];
-};
+}
 
-export function colour_rgb(block: Block, generator: LuaGenerator): [string, Order] {
+export function colour_rgb(
+  block: Block,
+  generator: LuaGenerator,
+): [string, Order] {
   // Compose a colour from RGB components expressed as percentages.
-  const functionName = generator.provideFunction_('colour_rgb', `
+  const functionName = generator.provideFunction_(
+    'colour_rgb',
+    `
 function ${generator.FUNCTION_NAME_PLACEHOLDER_}(r, g, b)
   r = math.floor(math.min(100, math.max(0, r)) * 2.55 + .5)
   g = math.floor(math.min(100, math.max(0, g)) * 2.55 + .5)
   b = math.floor(math.min(100, math.max(0, b)) * 2.55 + .5)
   return string.format("#%02x%02x%02x", r, g, b)
 end
-`);
+`,
+  );
   const r = generator.valueToCode(block, 'RED', Order.NONE) || 0;
   const g = generator.valueToCode(block, 'GREEN', Order.NONE) || 0;
   const b = generator.valueToCode(block, 'BLUE', Order.NONE) || 0;
   const code = functionName + '(' + r + ', ' + g + ', ' + b + ')';
   return [code, Order.HIGH];
-};
+}
 
-export function colour_blend(block: Block, generator: LuaGenerator): [string, Order] {
+export function colour_blend(
+  block: Block,
+  generator: LuaGenerator,
+): [string, Order] {
   // Blend two colours together.
-  const functionName = generator.provideFunction_('colour_blend', `
+  const functionName = generator.provideFunction_(
+    'colour_blend',
+    `
 function ${generator.FUNCTION_NAME_PLACEHOLDER_}(colour1, colour2, ratio)
   local r1 = tonumber(string.sub(colour1, 2, 3), 16)
   local r2 = tonumber(string.sub(colour2, 2, 3), 16)
@@ -60,13 +76,14 @@ function ${generator.FUNCTION_NAME_PLACEHOLDER_}(colour1, colour2, ratio)
   local b = math.floor(b1 * (1 - ratio) + b2 * ratio + .5)
   return string.format("#%02x%02x%02x", r, g, b)
 end
-`);
+`,
+  );
   const colour1 =
-      generator.valueToCode(block, 'COLOUR1', Order.NONE) || "'#000000'";
+    generator.valueToCode(block, 'COLOUR1', Order.NONE) || "'#000000'";
   const colour2 =
-      generator.valueToCode(block, 'COLOUR2', Order.NONE) || "'#000000'";
+    generator.valueToCode(block, 'COLOUR2', Order.NONE) || "'#000000'";
   const ratio = generator.valueToCode(block, 'RATIO', Order.NONE) || 0;
   const code =
-      functionName + '(' + colour1 + ', ' + colour2 + ', ' + ratio + ')';
+    functionName + '(' + colour1 + ', ' + colour2 + ', ' + ratio + ')';
   return [code, Order.HIGH];
-};
+}

--- a/generators/lua/colour.ts
+++ b/generators/lua/colour.ts
@@ -5,27 +5,29 @@
  */
 
 /**
- * @fileoverview Generating Lua for colour blocks.
+ * @file Generating Lua for colour blocks.
  */
 
 // Former goog.module ID: Blockly.Lua.colour
 
+import type {Block} from '../../core/block.js';
+import type {LuaGenerator} from './lua_generator.js';
 import {Order} from './lua_generator.js';
 
 
-export function colour_picker(block, generator) {
+export function colour_picker(block: Block, generator: LuaGenerator): [string, Order] {
   // Colour picker.
   const code = generator.quote_(block.getFieldValue('COLOUR'));
   return [code, Order.ATOMIC];
 };
 
-export function colour_random(block, generator) {
+export function colour_random(block: Block, generator: LuaGenerator): [string, Order] {
   // Generate a random colour.
   const code = 'string.format("#%06x", math.random(0, 2^24 - 1))';
   return [code, Order.HIGH];
 };
 
-export function colour_rgb(block, generator) {
+export function colour_rgb(block: Block, generator: LuaGenerator): [string, Order] {
   // Compose a colour from RGB components expressed as percentages.
   const functionName = generator.provideFunction_('colour_rgb', `
 function ${generator.FUNCTION_NAME_PLACEHOLDER_}(r, g, b)
@@ -42,7 +44,7 @@ end
   return [code, Order.HIGH];
 };
 
-export function colour_blend(block, generator) {
+export function colour_blend(block: Block, generator: LuaGenerator): [string, Order] {
   // Blend two colours together.
   const functionName = generator.provideFunction_('colour_blend', `
 function ${generator.FUNCTION_NAME_PLACEHOLDER_}(colour1, colour2, ratio)

--- a/generators/lua/lists.ts
+++ b/generators/lua/lists.ts
@@ -5,21 +5,23 @@
  */
 
 /**
- * @fileoverview Generating Lua for list blocks.
+ * @file Generating Lua for list blocks.
  */
 
 // Former goog.module ID: Blockly.Lua.lists
 
+import type {Block} from '../../core/block.js';
+import type {LuaGenerator} from './lua_generator.js';
 import {NameType} from '../../core/names.js';
 import {Order} from './lua_generator.js';
 
 
-export function lists_create_empty(block, generator) {
+export function lists_create_empty(block: Block, generator: LuaGenerator): [string, Order] {
   // Create an empty list.
   return ['{}', Order.HIGH];
 };
 
-export function lists_create_with(block, generator) {
+export function lists_create_with(block: Block, generator: LuaGenerator): [string, Order] {
   // Create a list with any number of elements of any type.
   const elements = new Array(block.itemCount_);
   for (let i = 0; i < block.itemCount_; i++) {
@@ -30,7 +32,7 @@ export function lists_create_with(block, generator) {
   return [code, Order.HIGH];
 };
 
-export function lists_repeat(block, generator) {
+export function lists_repeat(block: Block, generator: LuaGenerator): [string, Order] {
   // Create a list with one element repeated.
   const functionName = generator.provideFunction_('create_list_repeated', `
 function ${generator.FUNCTION_NAME_PLACEHOLDER_}(item, count)
@@ -47,20 +49,20 @@ end
   return [code, Order.HIGH];
 };
 
-export function lists_length(block, generator) {
+export function lists_length(block: Block, generator: LuaGenerator): [string, Order] {
   // String or array length.
   const list = generator.valueToCode(block, 'VALUE', Order.UNARY) || '{}';
   return ['#' + list, Order.UNARY];
 };
 
-export function lists_isEmpty(block, generator) {
+export function lists_isEmpty(block: Block, generator: LuaGenerator): [string, Order] {
   // Is the string null or array empty?
   const list = generator.valueToCode(block, 'VALUE', Order.UNARY) || '{}';
   const code = '#' + list + ' == 0';
   return [code, Order.RELATIONAL];
 };
 
-export function lists_indexOf(block, generator) {
+export function lists_indexOf(block: Block, generator: LuaGenerator): [string, Order] {
   // Find an item in the list.
   const item = generator.valueToCode(block, 'FIND', Order.NONE) || "''";
   const list = generator.valueToCode(block, 'VALUE', Order.NONE) || '{}';
@@ -94,12 +96,13 @@ end
 
 /**
  * Returns an expression calculating the index into a list.
- * @param {string} listName Name of the list, used to calculate length.
- * @param {string} where The method of indexing, selected by dropdown in Blockly
- * @param {string=} opt_at The optional offset when indexing from start/end.
- * @return {string|undefined} Index expression.
+ *
+ * @param listName Name of the list, used to calculate length.
+ * @param where The method of indexing, selected by dropdown in Blockly
+ * @param opt_at The optional offset when indexing from start/end.
+ * @returns Index expression.
  */
-const getListIndex = function(listName, where, opt_at) {
+const getListIndex = function(listName: string, where: string, opt_at: string): string {
   if (where === 'FIRST') {
     return '1';
   } else if (where === 'FROM_END') {
@@ -113,7 +116,7 @@ const getListIndex = function(listName, where, opt_at) {
   }
 };
 
-export function lists_getIndex(block, generator) {
+export function lists_getIndex(block: Block, generator: LuaGenerator): [string, Order] | string {
   // Get element at index.
   // Note: Until January 2013 this block did not have MODE or WHERE inputs.
   const mode = block.getFieldValue('MODE') || 'GET';
@@ -131,7 +134,7 @@ export function lists_getIndex(block, generator) {
           (where === 'FROM_END') ? Order.ADDITIVE : Order.NONE;
       let at = generator.valueToCode(block, 'AT', atOrder) || '1';
       const listVar =
-          generator.nameDB_.getDistinctName('tmp_list', NameType.VARIABLE);
+          generator.nameDB_!.getDistinctName('tmp_list', NameType.VARIABLE);
       at = getListIndex(listVar, where, at);
       const code = listVar + ' = ' + list + '\n' +
           'table.remove(' + listVar + ', ' + at + ')\n';
@@ -193,7 +196,7 @@ export function lists_getIndex(block, generator) {
   }
 };
 
-export function lists_setIndex(block, generator) {
+export function lists_setIndex(block: Block, generator: LuaGenerator): string {
   // Set element at index.
   // Note: Until February 2013 this block did not have MODE or WHERE inputs.
   let list = generator.valueToCode(block, 'LIST', Order.HIGH) || '{}';
@@ -210,7 +213,7 @@ export function lists_setIndex(block, generator) {
     // `list` is an expression, so we may not evaluate it more than once.
     // We can use multiple statements.
     const listVar =
-        generator.nameDB_.getDistinctName('tmp_list', NameType.VARIABLE);
+        generator.nameDB_!.getDistinctName('tmp_list', NameType.VARIABLE);
     code = listVar + ' = ' + list + '\n';
     list = listVar;
   }
@@ -226,7 +229,7 @@ export function lists_setIndex(block, generator) {
   return code + '\n';
 };
 
-export function lists_getSublist(block, generator) {
+export function lists_getSublist(block: Block, generator: LuaGenerator): [string, Order] {
   // Get sublist.
   const list = generator.valueToCode(block, 'LIST', Order.NONE) || '{}';
   const where1 = block.getFieldValue('WHERE1');
@@ -261,7 +264,7 @@ end
   return [code, Order.HIGH];
 };
 
-export function lists_sort(block, generator) {
+export function lists_sort(block: Block, generator: LuaGenerator): [string, Order] {
   // Block for sorting a list.
   const list = generator.valueToCode(block, 'LIST', Order.NONE) || '{}';
   const direction = block.getFieldValue('DIRECTION') === '1' ? 1 : -1;
@@ -295,7 +298,7 @@ end
   return [code, Order.HIGH];
 };
 
-export function lists_split(block, generator) {
+export function lists_split(block: Block, generator: LuaGenerator): [string, Order] {
   // Block for splitting text into a list, or joining a list into text.
   let input = generator.valueToCode(block, 'INPUT', Order.NONE);
   const delimiter =
@@ -335,7 +338,7 @@ end
   return [code, Order.HIGH];
 };
 
-export function lists_reverse(block, generator) {
+export function lists_reverse(block: Block, generator: LuaGenerator): [string, Order] {
   // Block for reversing a list.
   const list = generator.valueToCode(block, 'LIST', Order.NONE) || '{}';
   const functionName = generator.provideFunction_('list_reverse', `

--- a/generators/lua/lists.ts
+++ b/generators/lua/lists.ts
@@ -16,27 +16,37 @@ import type {LuaGenerator} from './lua_generator.js';
 import {NameType} from '../../core/names.js';
 import {Order} from './lua_generator.js';
 
-
-export function lists_create_empty(block: Block, generator: LuaGenerator): [string, Order] {
+export function lists_create_empty(
+  block: Block,
+  generator: LuaGenerator,
+): [string, Order] {
   // Create an empty list.
   return ['{}', Order.HIGH];
-};
+}
 
-export function lists_create_with(block: Block, generator: LuaGenerator): [string, Order] {
+export function lists_create_with(
+  block: Block,
+  generator: LuaGenerator,
+): [string, Order] {
   const createWithBlock = block as CreateWithBlock;
   // Create a list with any number of elements of any type.
   const elements = new Array(createWithBlock.itemCount_);
   for (let i = 0; i < createWithBlock.itemCount_; i++) {
     elements[i] =
-        generator.valueToCode(createWithBlock, 'ADD' + i, Order.NONE) || 'None';
+      generator.valueToCode(createWithBlock, 'ADD' + i, Order.NONE) || 'None';
   }
   const code = '{' + elements.join(', ') + '}';
   return [code, Order.HIGH];
-};
+}
 
-export function lists_repeat(block: Block, generator: LuaGenerator): [string, Order] {
+export function lists_repeat(
+  block: Block,
+  generator: LuaGenerator,
+): [string, Order] {
   // Create a list with one element repeated.
-  const functionName = generator.provideFunction_('create_list_repeated', `
+  const functionName = generator.provideFunction_(
+    'create_list_repeated',
+    `
 function ${generator.FUNCTION_NAME_PLACEHOLDER_}(item, count)
   local t = {}
   for i = 1, count do
@@ -44,33 +54,45 @@ function ${generator.FUNCTION_NAME_PLACEHOLDER_}(item, count)
   end
   return t
 end
-  `);
+  `,
+  );
   const element = generator.valueToCode(block, 'ITEM', Order.NONE) || 'None';
   const repeatCount = generator.valueToCode(block, 'NUM', Order.NONE) || '0';
   const code = functionName + '(' + element + ', ' + repeatCount + ')';
   return [code, Order.HIGH];
-};
+}
 
-export function lists_length(block: Block, generator: LuaGenerator): [string, Order] {
+export function lists_length(
+  block: Block,
+  generator: LuaGenerator,
+): [string, Order] {
   // String or array length.
   const list = generator.valueToCode(block, 'VALUE', Order.UNARY) || '{}';
   return ['#' + list, Order.UNARY];
-};
+}
 
-export function lists_isEmpty(block: Block, generator: LuaGenerator): [string, Order] {
+export function lists_isEmpty(
+  block: Block,
+  generator: LuaGenerator,
+): [string, Order] {
   // Is the string null or array empty?
   const list = generator.valueToCode(block, 'VALUE', Order.UNARY) || '{}';
   const code = '#' + list + ' == 0';
   return [code, Order.RELATIONAL];
-};
+}
 
-export function lists_indexOf(block: Block, generator: LuaGenerator): [string, Order] {
+export function lists_indexOf(
+  block: Block,
+  generator: LuaGenerator,
+): [string, Order] {
   // Find an item in the list.
   const item = generator.valueToCode(block, 'FIND', Order.NONE) || "''";
   const list = generator.valueToCode(block, 'VALUE', Order.NONE) || '{}';
   let functionName;
   if (block.getFieldValue('END') === 'FIRST') {
-    functionName = generator.provideFunction_('first_index', `
+    functionName = generator.provideFunction_(
+      'first_index',
+      `
 function ${generator.FUNCTION_NAME_PLACEHOLDER_}(t, elem)
   for k, v in ipairs(t) do
     if v == elem then
@@ -79,9 +101,12 @@ function ${generator.FUNCTION_NAME_PLACEHOLDER_}(t, elem)
   end
   return 0
 end
-`);
+`,
+    );
   } else {
-    functionName = generator.provideFunction_('last_index', `
+    functionName = generator.provideFunction_(
+      'last_index',
+      `
 function ${generator.FUNCTION_NAME_PLACEHOLDER_}(t, elem)
   for i = #t, 1, -1 do
     if t[i] == elem then
@@ -90,11 +115,12 @@ function ${generator.FUNCTION_NAME_PLACEHOLDER_}(t, elem)
   end
   return 0
 end
-`);
+`,
+    );
   }
   const code = functionName + '(' + list + ', ' + item + ')';
   return [code, Order.HIGH];
-};
+}
 
 /**
  * Returns an expression calculating the index into a list.
@@ -104,7 +130,11 @@ end
  * @param opt_at The optional offset when indexing from start/end.
  * @returns Index expression.
  */
-const getListIndex = function(listName: string, where: string, opt_at: string): string {
+const getListIndex = function (
+  listName: string,
+  where: string,
+  opt_at: string,
+): string {
   if (where === 'FIRST') {
     return '1';
   } else if (where === 'FROM_END') {
@@ -118,7 +148,10 @@ const getListIndex = function(listName: string, where: string, opt_at: string): 
   }
 };
 
-export function lists_getIndex(block: Block, generator: LuaGenerator): [string, Order] | string {
+export function lists_getIndex(
+  block: Block,
+  generator: LuaGenerator,
+): [string, Order] | string {
   // Get element at index.
   // Note: Until January 2013 this block did not have MODE or WHERE inputs.
   const mode = block.getFieldValue('MODE') || 'GET';
@@ -127,19 +160,30 @@ export function lists_getIndex(block: Block, generator: LuaGenerator): [string, 
 
   // If `list` would be evaluated more than once (which is the case for LAST,
   // FROM_END, and RANDOM) and is non-trivial, make sure to access it only once.
-  if ((where === 'LAST' || where === 'FROM_END' || where === 'RANDOM') &&
-      !list.match(/^\w+$/)) {
+  if (
+    (where === 'LAST' || where === 'FROM_END' || where === 'RANDOM') &&
+    !list.match(/^\w+$/)
+  ) {
     // `list` is an expression, so we may not evaluate it more than once.
     if (mode === 'REMOVE') {
       // We can use multiple statements.
-      const atOrder =
-          (where === 'FROM_END') ? Order.ADDITIVE : Order.NONE;
+      const atOrder = where === 'FROM_END' ? Order.ADDITIVE : Order.NONE;
       let at = generator.valueToCode(block, 'AT', atOrder) || '1';
-      const listVar =
-          generator.nameDB_!.getDistinctName('tmp_list', NameType.VARIABLE);
+      const listVar = generator.nameDB_!.getDistinctName(
+        'tmp_list',
+        NameType.VARIABLE,
+      );
       at = getListIndex(listVar, where, at);
-      const code = listVar + ' = ' + list + '\n' +
-          'table.remove(' + listVar + ', ' + at + ')\n';
+      const code =
+        listVar +
+        ' = ' +
+        list +
+        '\n' +
+        'table.remove(' +
+        listVar +
+        ', ' +
+        at +
+        ')\n';
       return code;
     } else {
       // We need to create a procedure to avoid reevaluating values.
@@ -147,41 +191,49 @@ export function lists_getIndex(block: Block, generator: LuaGenerator): [string, 
       let functionName;
       if (mode === 'GET') {
         functionName = generator.provideFunction_(
-          'list_get_' + where.toLowerCase(), [
-          'function ' + generator.FUNCTION_NAME_PLACEHOLDER_ + '(t' +
+          'list_get_' + where.toLowerCase(),
+          [
+            'function ' +
+              generator.FUNCTION_NAME_PLACEHOLDER_ +
+              '(t' +
               // The value for 'FROM_END' and'FROM_START' depends on `at` so
               // we add it as a parameter.
-              ((where === 'FROM_END' || where === 'FROM_START') ? ', at)' :
-                                                                  ')'),
-          '  return t[' + getListIndex('t', where, 'at') + ']', 'end'
-        ]);
-      } else {  // `mode` === 'GET_REMOVE'
-        functionName =
-            generator.provideFunction_(
-              'list_remove_' + where.toLowerCase(), [
-              'function ' + generator.FUNCTION_NAME_PLACEHOLDER_ + '(t' +
-                  // The value for 'FROM_END' and'FROM_START' depends on `at` so
-                  // we add it as a parameter.
-                  ((where === 'FROM_END' || where === 'FROM_START') ? ', at)' :
-                                                                      ')'),
-              '  return table.remove(t, ' + getListIndex('t', where, 'at') +
-                  ')',
-              'end'
-            ]);
+              (where === 'FROM_END' || where === 'FROM_START' ? ', at)' : ')'),
+            '  return t[' + getListIndex('t', where, 'at') + ']',
+            'end',
+          ],
+        );
+      } else {
+        // `mode` === 'GET_REMOVE'
+        functionName = generator.provideFunction_(
+          'list_remove_' + where.toLowerCase(),
+          [
+            'function ' +
+              generator.FUNCTION_NAME_PLACEHOLDER_ +
+              '(t' +
+              // The value for 'FROM_END' and'FROM_START' depends on `at` so
+              // we add it as a parameter.
+              (where === 'FROM_END' || where === 'FROM_START' ? ', at)' : ')'),
+            '  return table.remove(t, ' + getListIndex('t', where, 'at') + ')',
+            'end',
+          ],
+        );
       }
-      const code = functionName + '(' + list +
-          // The value for 'FROM_END' and 'FROM_START' depends on `at` so we
-          // pass it.
-          ((where === 'FROM_END' || where === 'FROM_START') ? ', ' + at : '') +
-          ')';
+      const code =
+        functionName +
+        '(' +
+        list +
+        // The value for 'FROM_END' and 'FROM_START' depends on `at` so we
+        // pass it.
+        (where === 'FROM_END' || where === 'FROM_START' ? ', ' + at : '') +
+        ')';
       return [code, Order.HIGH];
     }
   } else {
     // Either `list` is a simple variable, or we only need to refer to `list`
     // once.
-    const atOrder = (mode === 'GET' && where === 'FROM_END') ?
-        Order.ADDITIVE :
-        Order.NONE;
+    const atOrder =
+      mode === 'GET' && where === 'FROM_END' ? Order.ADDITIVE : Order.NONE;
     let at = generator.valueToCode(block, 'AT', atOrder) || '1';
     at = getListIndex(list, where, at);
     if (mode === 'GET') {
@@ -191,12 +243,13 @@ export function lists_getIndex(block: Block, generator: LuaGenerator): [string, 
       const code = 'table.remove(' + list + ', ' + at + ')';
       if (mode === 'GET_REMOVE') {
         return [code, Order.HIGH];
-      } else {  // `mode` === 'REMOVE'
+      } else {
+        // `mode` === 'REMOVE'
         return code + '\n';
       }
     }
   }
-};
+}
 
 export function lists_setIndex(block: Block, generator: LuaGenerator): string {
   // Set element at index.
@@ -210,28 +263,41 @@ export function lists_setIndex(block: Block, generator: LuaGenerator): string {
   let code = '';
   // If `list` would be evaluated more than once (which is the case for LAST,
   // FROM_END, and RANDOM) and is non-trivial, make sure to access it only once.
-  if ((where === 'LAST' || where === 'FROM_END' || where === 'RANDOM') &&
-      !list.match(/^\w+$/)) {
+  if (
+    (where === 'LAST' || where === 'FROM_END' || where === 'RANDOM') &&
+    !list.match(/^\w+$/)
+  ) {
     // `list` is an expression, so we may not evaluate it more than once.
     // We can use multiple statements.
-    const listVar =
-        generator.nameDB_!.getDistinctName('tmp_list', NameType.VARIABLE);
+    const listVar = generator.nameDB_!.getDistinctName(
+      'tmp_list',
+      NameType.VARIABLE,
+    );
     code = listVar + ' = ' + list + '\n';
     list = listVar;
   }
   if (mode === 'SET') {
     code += list + '[' + getListIndex(list, where, at) + '] = ' + value;
-  } else {  // `mode` === 'INSERT'
+  } else {
+    // `mode` === 'INSERT'
     // LAST is a special case, because we want to insert
     // *after* not *before*, the existing last element.
-    code += 'table.insert(' + list + ', ' +
-        (getListIndex(list, where, at) + (where === 'LAST' ? ' + 1' : '')) +
-        ', ' + value + ')';
+    code +=
+      'table.insert(' +
+      list +
+      ', ' +
+      (getListIndex(list, where, at) + (where === 'LAST' ? ' + 1' : '')) +
+      ', ' +
+      value +
+      ')';
   }
   return code + '\n';
-};
+}
 
-export function lists_getSublist(block: Block, generator: LuaGenerator): [string, Order] {
+export function lists_getSublist(
+  block: Block,
+  generator: LuaGenerator,
+): [string, Order] {
   // Get sublist.
   const list = generator.valueToCode(block, 'LIST', Order.NONE) || '{}';
   const where1 = block.getFieldValue('WHERE1');
@@ -242,11 +308,12 @@ export function lists_getSublist(block: Block, generator: LuaGenerator): [string
   // The value for 'FROM_END' and'FROM_START' depends on `at` so
   // we add it as a parameter.
   const at1Param =
-      (where1 === 'FROM_END' || where1 === 'FROM_START') ? ', at1' : '';
+    where1 === 'FROM_END' || where1 === 'FROM_START' ? ', at1' : '';
   const at2Param =
-      (where2 === 'FROM_END' || where2 === 'FROM_START') ? ', at2' : '';
+    where2 === 'FROM_END' || where2 === 'FROM_START' ? ', at2' : '';
   const functionName = generator.provideFunction_(
-      'list_sublist_' + where1.toLowerCase() + '_' + where2.toLowerCase(), `
+    'list_sublist_' + where1.toLowerCase() + '_' + where2.toLowerCase(),
+    `
 function ${generator.FUNCTION_NAME_PLACEHOLDER_}(source${at1Param}${at2Param})
   local t = {}
   local start = ${getListIndex('source', where1, 'at1')}
@@ -256,23 +323,32 @@ function ${generator.FUNCTION_NAME_PLACEHOLDER_}(source${at1Param}${at2Param})
   end
   return t
 end
-`);
-  const code = functionName + '(' + list +
-      // The value for 'FROM_END' and 'FROM_START' depends on `at` so we
-      // pass it.
-      ((where1 === 'FROM_END' || where1 === 'FROM_START') ? ', ' + at1 : '') +
-      ((where2 === 'FROM_END' || where2 === 'FROM_START') ? ', ' + at2 : '') +
-      ')';
+`,
+  );
+  const code =
+    functionName +
+    '(' +
+    list +
+    // The value for 'FROM_END' and 'FROM_START' depends on `at` so we
+    // pass it.
+    (where1 === 'FROM_END' || where1 === 'FROM_START' ? ', ' + at1 : '') +
+    (where2 === 'FROM_END' || where2 === 'FROM_START' ? ', ' + at2 : '') +
+    ')';
   return [code, Order.HIGH];
-};
+}
 
-export function lists_sort(block: Block, generator: LuaGenerator): [string, Order] {
+export function lists_sort(
+  block: Block,
+  generator: LuaGenerator,
+): [string, Order] {
   // Block for sorting a list.
   const list = generator.valueToCode(block, 'LIST', Order.NONE) || '{}';
   const direction = block.getFieldValue('DIRECTION') === '1' ? 1 : -1;
   const type = block.getFieldValue('TYPE');
 
-  const functionName = generator.provideFunction_('list_sort', `
+  const functionName = generator.provideFunction_(
+    'list_sort',
+    `
 function ${generator.FUNCTION_NAME_PLACEHOLDER_}(list, typev, direction)
   local t = {}
   for n,v in pairs(list) do table.insert(t, v) end
@@ -293,25 +369,30 @@ function ${generator.FUNCTION_NAME_PLACEHOLDER_}(list, typev, direction)
   table.sort(t, compare)
   return t
 end
-`);
+`,
+  );
 
   const code =
-      functionName + '(' + list + ',"' + type + '", ' + direction + ')';
+    functionName + '(' + list + ',"' + type + '", ' + direction + ')';
   return [code, Order.HIGH];
-};
+}
 
-export function lists_split(block: Block, generator: LuaGenerator): [string, Order] {
+export function lists_split(
+  block: Block,
+  generator: LuaGenerator,
+): [string, Order] {
   // Block for splitting text into a list, or joining a list into text.
   let input = generator.valueToCode(block, 'INPUT', Order.NONE);
-  const delimiter =
-      generator.valueToCode(block, 'DELIM', Order.NONE) || "''";
+  const delimiter = generator.valueToCode(block, 'DELIM', Order.NONE) || "''";
   const mode = block.getFieldValue('MODE');
   let functionName;
   if (mode === 'SPLIT') {
     if (!input) {
       input = "''";
     }
-    functionName = generator.provideFunction_('list_string_split', `
+    functionName = generator.provideFunction_(
+      'list_string_split',
+      `
 function ${generator.FUNCTION_NAME_PLACEHOLDER_}(input, delim)
   local t = {}
   local pos = 1
@@ -327,7 +408,8 @@ function ${generator.FUNCTION_NAME_PLACEHOLDER_}(input, delim)
   end
   return t
 end
-`);
+`,
+    );
   } else if (mode === 'JOIN') {
     if (!input) {
       input = '{}';
@@ -338,12 +420,17 @@ end
   }
   const code = functionName + '(' + input + ', ' + delimiter + ')';
   return [code, Order.HIGH];
-};
+}
 
-export function lists_reverse(block: Block, generator: LuaGenerator): [string, Order] {
+export function lists_reverse(
+  block: Block,
+  generator: LuaGenerator,
+): [string, Order] {
   // Block for reversing a list.
   const list = generator.valueToCode(block, 'LIST', Order.NONE) || '{}';
-  const functionName = generator.provideFunction_('list_reverse', `
+  const functionName = generator.provideFunction_(
+    'list_reverse',
+    `
 function ${generator.FUNCTION_NAME_PLACEHOLDER_}(input)
   local reversed = {}
   for i = #input, 1, -1 do
@@ -351,7 +438,8 @@ function ${generator.FUNCTION_NAME_PLACEHOLDER_}(input)
   end
   return reversed
 end
-`);
+`,
+  );
   const code = functionName + '(' + list + ')';
   return [code, Order.HIGH];
-};
+}

--- a/generators/lua/lists.ts
+++ b/generators/lua/lists.ts
@@ -11,6 +11,7 @@
 // Former goog.module ID: Blockly.Lua.lists
 
 import type {Block} from '../../core/block.js';
+import type {CreateWithBlock} from '../../blocks/lists.js';
 import type {LuaGenerator} from './lua_generator.js';
 import {NameType} from '../../core/names.js';
 import {Order} from './lua_generator.js';
@@ -22,11 +23,12 @@ export function lists_create_empty(block: Block, generator: LuaGenerator): [stri
 };
 
 export function lists_create_with(block: Block, generator: LuaGenerator): [string, Order] {
+  const createWithBlock = block as CreateWithBlock;
   // Create a list with any number of elements of any type.
-  const elements = new Array(block.itemCount_);
-  for (let i = 0; i < block.itemCount_; i++) {
+  const elements = new Array(createWithBlock.itemCount_);
+  for (let i = 0; i < createWithBlock.itemCount_; i++) {
     elements[i] =
-        generator.valueToCode(block, 'ADD' + i, Order.NONE) || 'None';
+        generator.valueToCode(createWithBlock, 'ADD' + i, Order.NONE) || 'None';
   }
   const code = '{' + elements.join(', ') + '}';
   return [code, Order.HIGH];

--- a/generators/lua/logic.ts
+++ b/generators/lua/logic.ts
@@ -14,7 +14,6 @@ import type {Block} from '../../core/block.js';
 import type {LuaGenerator} from './lua_generator.js';
 import {Order} from './lua_generator.js';
 
-
 export function controls_if(block: Block, generator: LuaGenerator): string {
   // If/elseif/else condition.
   let n = 0;
@@ -25,15 +24,17 @@ export function controls_if(block: Block, generator: LuaGenerator): string {
   }
   do {
     const conditionCode =
-        generator.valueToCode(block, 'IF' + n, Order.NONE) || 'false';
+      generator.valueToCode(block, 'IF' + n, Order.NONE) || 'false';
     let branchCode = generator.statementToCode(block, 'DO' + n);
     if (generator.STATEMENT_SUFFIX) {
-      branchCode = generator.prefixLines(
+      branchCode =
+        generator.prefixLines(
           generator.injectId(generator.STATEMENT_SUFFIX, block),
-          generator.INDENT) + branchCode;
+          generator.INDENT,
+        ) + branchCode;
     }
     code +=
-        (n > 0 ? 'else' : '') + 'if ' + conditionCode + ' then\n' + branchCode;
+      (n > 0 ? 'else' : '') + 'if ' + conditionCode + ' then\n' + branchCode;
     n++;
   } while (block.getInput('IF' + n));
 
@@ -41,37 +42,46 @@ export function controls_if(block: Block, generator: LuaGenerator): string {
     let branchCode = generator.statementToCode(block, 'ELSE');
     if (generator.STATEMENT_SUFFIX) {
       branchCode =
-          generator.prefixLines(
-            generator.injectId(
-              generator.STATEMENT_SUFFIX, block),
-            generator.INDENT) +
-          branchCode;
+        generator.prefixLines(
+          generator.injectId(generator.STATEMENT_SUFFIX, block),
+          generator.INDENT,
+        ) + branchCode;
     }
     code += 'else\n' + branchCode;
   }
   return code + 'end\n';
-};
+}
 
 export const controls_ifelse = controls_if;
 
-export function logic_compare(block: Block, generator: LuaGenerator): [string, Order] {
+export function logic_compare(
+  block: Block,
+  generator: LuaGenerator,
+): [string, Order] {
   // Comparison operator.
-  const OPERATORS =
-      {'EQ': '==', 'NEQ': '~=', 'LT': '<', 'LTE': '<=', 'GT': '>', 'GTE': '>='};
+  const OPERATORS = {
+    'EQ': '==',
+    'NEQ': '~=',
+    'LT': '<',
+    'LTE': '<=',
+    'GT': '>',
+    'GTE': '>=',
+  };
   type OperatorOption = keyof typeof OPERATORS;
   const operator = OPERATORS[block.getFieldValue('OP') as OperatorOption];
-  const argument0 =
-        generator.valueToCode(block, 'A', Order.RELATIONAL) || '0';
-  const argument1 =
-        generator.valueToCode(block, 'B', Order.RELATIONAL) || '0';
+  const argument0 = generator.valueToCode(block, 'A', Order.RELATIONAL) || '0';
+  const argument1 = generator.valueToCode(block, 'B', Order.RELATIONAL) || '0';
   const code = argument0 + ' ' + operator + ' ' + argument1;
   return [code, Order.RELATIONAL];
-};
+}
 
-export function logic_operation(block: Block, generator: LuaGenerator): [string, Order] {
+export function logic_operation(
+  block: Block,
+  generator: LuaGenerator,
+): [string, Order] {
   // Operations 'and', 'or'.
-  const operator = (block.getFieldValue('OP') === 'AND') ? 'and' : 'or';
-  const order = (operator === 'and') ? Order.AND : Order.OR;
+  const operator = block.getFieldValue('OP') === 'AND' ? 'and' : 'or';
+  const order = operator === 'and' ? Order.AND : Order.OR;
   let argument0 = generator.valueToCode(block, 'A', order);
   let argument1 = generator.valueToCode(block, 'B', order);
   if (!argument0 && !argument1) {
@@ -80,7 +90,7 @@ export function logic_operation(block: Block, generator: LuaGenerator): [string,
     argument1 = 'false';
   } else {
     // Single missing arguments have no effect on the return value.
-    const defaultArgument = (operator === 'and') ? 'true' : 'false';
+    const defaultArgument = operator === 'and' ? 'true' : 'false';
     if (!argument0) {
       argument0 = defaultArgument;
     }
@@ -90,33 +100,43 @@ export function logic_operation(block: Block, generator: LuaGenerator): [string,
   }
   const code = argument0 + ' ' + operator + ' ' + argument1;
   return [code, order];
-};
+}
 
-export function logic_negate(block: Block, generator: LuaGenerator): [string, Order] {
+export function logic_negate(
+  block: Block,
+  generator: LuaGenerator,
+): [string, Order] {
   // Negation.
-  const argument0 =
-        generator.valueToCode(block, 'BOOL', Order.UNARY) || 'true';
+  const argument0 = generator.valueToCode(block, 'BOOL', Order.UNARY) || 'true';
   const code = 'not ' + argument0;
   return [code, Order.UNARY];
-};
+}
 
-export function logic_boolean(block: Block, generator: LuaGenerator): [string, Order] {
+export function logic_boolean(
+  block: Block,
+  generator: LuaGenerator,
+): [string, Order] {
   // Boolean values true and false.
-  const code = (block.getFieldValue('BOOL') === 'TRUE') ? 'true' : 'false';
+  const code = block.getFieldValue('BOOL') === 'TRUE' ? 'true' : 'false';
   return [code, Order.ATOMIC];
-};
+}
 
-export function logic_null(block: Block, generator: LuaGenerator): [string, Order] {
+export function logic_null(
+  block: Block,
+  generator: LuaGenerator,
+): [string, Order] {
   // Null data type.
   return ['nil', Order.ATOMIC];
-};
+}
 
-export function logic_ternary(block: Block, generator: LuaGenerator): [string, Order] {
+export function logic_ternary(
+  block: Block,
+  generator: LuaGenerator,
+): [string, Order] {
   // Ternary operator.
   const value_if = generator.valueToCode(block, 'IF', Order.AND) || 'false';
-  const value_then =
-        generator.valueToCode(block, 'THEN', Order.AND) || 'nil';
+  const value_then = generator.valueToCode(block, 'THEN', Order.AND) || 'nil';
   const value_else = generator.valueToCode(block, 'ELSE', Order.OR) || 'nil';
   const code = value_if + ' and ' + value_then + ' or ' + value_else;
   return [code, Order.OR];
-};
+}

--- a/generators/lua/logic.ts
+++ b/generators/lua/logic.ts
@@ -58,7 +58,8 @@ export function logic_compare(block: Block, generator: LuaGenerator): [string, O
   // Comparison operator.
   const OPERATORS =
       {'EQ': '==', 'NEQ': '~=', 'LT': '<', 'LTE': '<=', 'GT': '>', 'GTE': '>='};
-  const operator = OPERATORS[block.getFieldValue('OP')];
+  type OperatorOption = keyof typeof OPERATORS;
+  const operator = OPERATORS[block.getFieldValue('OP') as OperatorOption];
   const argument0 =
         generator.valueToCode(block, 'A', Order.RELATIONAL) || '0';
   const argument1 =

--- a/generators/lua/logic.ts
+++ b/generators/lua/logic.ts
@@ -5,15 +5,17 @@
  */
 
 /**
- * @fileoverview Generating Lua for logic blocks.
+ * @file Generating Lua for logic blocks.
  */
 
 // Former goog.module ID: Blockly.Lua.logic
 
+import type {Block} from '../../core/block.js';
+import type {LuaGenerator} from './lua_generator.js';
 import {Order} from './lua_generator.js';
 
 
-export function controls_if(block, generator) {
+export function controls_if(block: Block, generator: LuaGenerator): string {
   // If/elseif/else condition.
   let n = 0;
   let code = '';
@@ -52,7 +54,7 @@ export function controls_if(block, generator) {
 
 export const controls_ifelse = controls_if;
 
-export function logic_compare(block, generator) {
+export function logic_compare(block: Block, generator: LuaGenerator): [string, Order] {
   // Comparison operator.
   const OPERATORS =
       {'EQ': '==', 'NEQ': '~=', 'LT': '<', 'LTE': '<=', 'GT': '>', 'GTE': '>='};
@@ -65,7 +67,7 @@ export function logic_compare(block, generator) {
   return [code, Order.RELATIONAL];
 };
 
-export function logic_operation(block, generator) {
+export function logic_operation(block: Block, generator: LuaGenerator): [string, Order] {
   // Operations 'and', 'or'.
   const operator = (block.getFieldValue('OP') === 'AND') ? 'and' : 'or';
   const order = (operator === 'and') ? Order.AND : Order.OR;
@@ -89,7 +91,7 @@ export function logic_operation(block, generator) {
   return [code, order];
 };
 
-export function logic_negate(block, generator) {
+export function logic_negate(block: Block, generator: LuaGenerator): [string, Order] {
   // Negation.
   const argument0 =
         generator.valueToCode(block, 'BOOL', Order.UNARY) || 'true';
@@ -97,18 +99,18 @@ export function logic_negate(block, generator) {
   return [code, Order.UNARY];
 };
 
-export function logic_boolean(block, generator) {
+export function logic_boolean(block: Block, generator: LuaGenerator): [string, Order] {
   // Boolean values true and false.
   const code = (block.getFieldValue('BOOL') === 'TRUE') ? 'true' : 'false';
   return [code, Order.ATOMIC];
 };
 
-export function logic_null(block, generator) {
+export function logic_null(block: Block, generator: LuaGenerator): [string, Order] {
   // Null data type.
   return ['nil', Order.ATOMIC];
 };
 
-export function logic_ternary(block, generator) {
+export function logic_ternary(block: Block, generator: LuaGenerator): [string, Order] {
   // Ternary operator.
   const value_if = generator.valueToCode(block, 'IF', Order.AND) || 'false';
   const value_then =

--- a/generators/lua/loops.ts
+++ b/generators/lua/loops.ts
@@ -12,6 +12,7 @@
 
 import * as stringUtils from '../../core/utils/string.js';
 import type {Block} from '../../core/block.js';
+import type {ControlFlowInLoopBlock} from '../../blocks/loops.js';
 import type {LuaGenerator} from './lua_generator.js';
 import {NameType} from '../../core/names.js';
 import {Order} from './lua_generator.js';
@@ -152,7 +153,7 @@ export function controls_flow_statements(block: Block, generator: LuaGenerator):
     xfix += generator.injectId(generator.STATEMENT_SUFFIX, block);
   }
   if (generator.STATEMENT_PREFIX) {
-    const loop = block.getSurroundLoop();
+    const loop = (block as ControlFlowInLoopBlock).getSurroundLoop();
     if (loop && !loop.suppressPrefixSuffix) {
       // Inject loop's statement prefix here since the regular one at the end
       // of the loop will not get executed if 'continue' is triggered.

--- a/generators/lua/loops.ts
+++ b/generators/lua/loops.ts
@@ -5,12 +5,14 @@
  */
 
 /**
- * @fileoverview Generating Lua for loop blocks.
+ * @file Generating Lua for loop blocks.
  */
 
 // Former goog.module ID: Blockly.Lua.loops
 
 import * as stringUtils from '../../core/utils/string.js';
+import type {Block} from '../../core/block.js';
+import type {LuaGenerator} from './lua_generator.js';
 import {NameType} from '../../core/names.js';
 import {Order} from './lua_generator.js';
 
@@ -19,7 +21,6 @@ import {Order} from './lua_generator.js';
  * This is the text used to implement a <pre>continue</pre>.
  * It is also used to recognise <pre>continue</pre>s in generated code so that
  * the appropriate label can be put at the end of the loop body.
- * @const {string}
  */
 const CONTINUE_STATEMENT = 'goto continue\n';
 
@@ -29,11 +30,11 @@ const CONTINUE_STATEMENT = 'goto continue\n';
  * in all outer loops, but this is safer than duplicating the logic of
  * blockToCode.
  *
- * @param {string} branch Generated code of the loop body
- * @param {string} indent Whitespace by which to indent a continue statement.
- * @return {string} Generated label or '' if unnecessary
+ * @param branch Generated code of the loop body
+ * @param indent Whitespace by which to indent a continue statement.
+ * @returns Generated label or '' if unnecessary
  */
-function addContinueLabel(branch, indent) {
+function addContinueLabel(branch: string, indent: string): string {
   if (branch.indexOf(CONTINUE_STATEMENT) !== -1) {
     // False positives are possible (e.g. a string literal), but are harmless.
     return branch + indent + '::continue::\n';
@@ -42,7 +43,7 @@ function addContinueLabel(branch, indent) {
   }
 };
 
-export function controls_repeat_ext(block, generator) {
+export function controls_repeat_ext(block: Block, generator: LuaGenerator): string {
   // Repeat n times.
   let repeats;
   if (block.getField('TIMES')) {
@@ -60,7 +61,7 @@ export function controls_repeat_ext(block, generator) {
   let branch = generator.statementToCode(block, 'DO');
   branch = generator.addLoopTrap(branch, block);
   branch = addContinueLabel(branch, generator.INDENT);
-  const loopVar = generator.nameDB_.getDistinctName('count', NameType.VARIABLE);
+  const loopVar = generator.nameDB_!.getDistinctName('count', NameType.VARIABLE);
   const code =
       'for ' + loopVar + ' = 1, ' + repeats + ' do\n' + branch + 'end\n';
   return code;
@@ -68,7 +69,7 @@ export function controls_repeat_ext(block, generator) {
 
 export const controls_repeat = controls_repeat_ext;
 
-export function controls_whileUntil(block, generator) {
+export function controls_whileUntil(block: Block, generator: LuaGenerator): string {
   // Do while/until loop.
   const until = block.getFieldValue('MODE') === 'UNTIL';
   let argument0 =
@@ -84,7 +85,7 @@ export function controls_whileUntil(block, generator) {
   return 'while ' + argument0 + ' do\n' + branch + 'end\n';
 };
 
-export function controls_for(block, generator) {
+export function controls_for(block: Block, generator: LuaGenerator): string {
   // For loop.
   const variable0 =
       generator.getVariableName(block.getFieldValue('VAR'));
@@ -107,11 +108,11 @@ export function controls_for(block, generator) {
     // Determine loop direction at start, in case one of the bounds
     // changes during loop execution.
     incValue =
-        generator.nameDB_.getDistinctName(
+        generator.nameDB_!.getDistinctName(
           variable0 + '_inc', NameType.VARIABLE);
     code += incValue + ' = ';
     if (stringUtils.isNumber(increment)) {
-      code += Math.abs(increment) + '\n';
+      code += Math.abs(increment as unknown as number) + '\n';
     } else {
       code += 'math.abs(' + increment + ')\n';
     }
@@ -125,7 +126,7 @@ export function controls_for(block, generator) {
   return code;
 };
 
-export function controls_forEach(block, generator) {
+export function controls_forEach(block: Block, generator: LuaGenerator): string {
   // For each loop.
   const variable0 =
       generator.getVariableName(block.getFieldValue('VAR'));
@@ -138,7 +139,7 @@ export function controls_forEach(block, generator) {
   return code;
 };
 
-export function controls_flow_statements(block, generator) {
+export function controls_flow_statements(block: Block, generator: LuaGenerator): string {
   // Flow statements: continue, break.
   let xfix = '';
   if (generator.STATEMENT_PREFIX) {

--- a/generators/lua/loops.ts
+++ b/generators/lua/loops.ts
@@ -17,7 +17,6 @@ import type {LuaGenerator} from './lua_generator.js';
 import {NameType} from '../../core/names.js';
 import {Order} from './lua_generator.js';
 
-
 /**
  * This is the text used to implement a <pre>continue</pre>.
  * It is also used to recognise <pre>continue</pre>s in generated code so that
@@ -42,9 +41,12 @@ function addContinueLabel(branch: string, indent: string): string {
   } else {
     return branch;
   }
-};
+}
 
-export function controls_repeat_ext(block: Block, generator: LuaGenerator): string {
+export function controls_repeat_ext(
+  block: Block,
+  generator: LuaGenerator,
+): string {
   // Repeat n times.
   let repeats;
   if (block.getField('TIMES')) {
@@ -62,21 +64,26 @@ export function controls_repeat_ext(block: Block, generator: LuaGenerator): stri
   let branch = generator.statementToCode(block, 'DO');
   branch = generator.addLoopTrap(branch, block);
   branch = addContinueLabel(branch, generator.INDENT);
-  const loopVar = generator.nameDB_!.getDistinctName('count', NameType.VARIABLE);
+  const loopVar = generator.nameDB_!.getDistinctName(
+    'count',
+    NameType.VARIABLE,
+  );
   const code =
-      'for ' + loopVar + ' = 1, ' + repeats + ' do\n' + branch + 'end\n';
+    'for ' + loopVar + ' = 1, ' + repeats + ' do\n' + branch + 'end\n';
   return code;
-};
+}
 
 export const controls_repeat = controls_repeat_ext;
 
-export function controls_whileUntil(block: Block, generator: LuaGenerator): string {
+export function controls_whileUntil(
+  block: Block,
+  generator: LuaGenerator,
+): string {
   // Do while/until loop.
   const until = block.getFieldValue('MODE') === 'UNTIL';
   let argument0 =
-      generator.valueToCode(
-          block, 'BOOL', until ? Order.UNARY : Order.NONE) ||
-      'false';
+    generator.valueToCode(block, 'BOOL', until ? Order.UNARY : Order.NONE) ||
+    'false';
   let branch = generator.statementToCode(block, 'DO');
   branch = generator.addLoopTrap(branch, block);
   branch = addContinueLabel(branch, generator.INDENT);
@@ -84,12 +91,11 @@ export function controls_whileUntil(block: Block, generator: LuaGenerator): stri
     argument0 = 'not ' + argument0;
   }
   return 'while ' + argument0 + ' do\n' + branch + 'end\n';
-};
+}
 
 export function controls_for(block: Block, generator: LuaGenerator): string {
   // For loop.
-  const variable0 =
-      generator.getVariableName(block.getFieldValue('VAR'));
+  const variable0 = generator.getVariableName(block.getFieldValue('VAR'));
   const startVar = generator.valueToCode(block, 'FROM', Order.NONE) || '0';
   const endVar = generator.valueToCode(block, 'TO', Order.NONE) || '0';
   const increment = generator.valueToCode(block, 'BY', Order.NONE) || '1';
@@ -98,8 +104,11 @@ export function controls_for(block: Block, generator: LuaGenerator): string {
   branch = addContinueLabel(branch, generator.INDENT);
   let code = '';
   let incValue;
-  if (stringUtils.isNumber(startVar) && stringUtils.isNumber(endVar) &&
-      stringUtils.isNumber(increment)) {
+  if (
+    stringUtils.isNumber(startVar) &&
+    stringUtils.isNumber(endVar) &&
+    stringUtils.isNumber(increment)
+  ) {
     // All arguments are simple numbers.
     const up = Number(startVar) <= Number(endVar);
     const step = Math.abs(Number(increment));
@@ -108,9 +117,10 @@ export function controls_for(block: Block, generator: LuaGenerator): string {
     code = '';
     // Determine loop direction at start, in case one of the bounds
     // changes during loop execution.
-    incValue =
-        generator.nameDB_!.getDistinctName(
-          variable0 + '_inc', NameType.VARIABLE);
+    incValue = generator.nameDB_!.getDistinctName(
+      variable0 + '_inc',
+      NameType.VARIABLE,
+    );
     code += incValue + ' = ';
     if (stringUtils.isNumber(increment)) {
       code += Math.abs(increment as unknown as number) + '\n';
@@ -122,25 +132,36 @@ export function controls_for(block: Block, generator: LuaGenerator): string {
     code += 'end\n';
   }
   code +=
-      'for ' + variable0 + ' = ' + startVar + ', ' + endVar + ', ' + incValue;
+    'for ' + variable0 + ' = ' + startVar + ', ' + endVar + ', ' + incValue;
   code += ' do\n' + branch + 'end\n';
   return code;
-};
+}
 
-export function controls_forEach(block: Block, generator: LuaGenerator): string {
+export function controls_forEach(
+  block: Block,
+  generator: LuaGenerator,
+): string {
   // For each loop.
-  const variable0 =
-      generator.getVariableName(block.getFieldValue('VAR'));
+  const variable0 = generator.getVariableName(block.getFieldValue('VAR'));
   const argument0 = generator.valueToCode(block, 'LIST', Order.NONE) || '{}';
   let branch = generator.statementToCode(block, 'DO');
   branch = generator.addLoopTrap(branch, block);
   branch = addContinueLabel(branch, generator.INDENT);
-  const code = 'for _, ' + variable0 + ' in ipairs(' + argument0 + ') do \n' +
-      branch + 'end\n';
+  const code =
+    'for _, ' +
+    variable0 +
+    ' in ipairs(' +
+    argument0 +
+    ') do \n' +
+    branch +
+    'end\n';
   return code;
-};
+}
 
-export function controls_flow_statements(block: Block, generator: LuaGenerator): string {
+export function controls_flow_statements(
+  block: Block,
+  generator: LuaGenerator,
+): string {
   // Flow statements: continue, break.
   let xfix = '';
   if (generator.STATEMENT_PREFIX) {
@@ -168,4 +189,4 @@ export function controls_flow_statements(block: Block, generator: LuaGenerator):
       return xfix + CONTINUE_STATEMENT;
   }
   throw Error('Unknown flow statement.');
-};
+}

--- a/generators/lua/lua_generator.ts
+++ b/generators/lua/lua_generator.ts
@@ -18,24 +18,23 @@ import {Names} from '../../core/names.js';
 import type {Workspace} from '../../core/workspace.js';
 import {inputTypes} from '../../core/inputs/input_types.js';
 
-
 /**
  * Order of operation ENUMs.
  * http://www.lua.org/manual/5.3/manual.html#3.4.8
  * @enum {number}
  */
 export enum Order {
-  ATOMIC = 0,    // literals
+  ATOMIC = 0, // literals
   // The next level was not explicit in documentation and inferred by Ellen.
-  HIGH = 1,            // Function calls, tables[]
-  EXPONENTIATION = 2,  // ^
-  UNARY = 3,           // not # - ~
-  MULTIPLICATIVE = 4,  // * / %
-  ADDITIVE = 5,        // + -
-  CONCATENATION = 6,   // ..
-  RELATIONAL = 7,      // < > <=  >= ~= ==
-  AND = 8,             // and
-  OR = 9,              // or
+  HIGH = 1, // Function calls, tables[]
+  EXPONENTIATION = 2, // ^
+  UNARY = 3, // not # - ~
+  MULTIPLICATIVE = 4, // * / %
+  ADDITIVE = 5, // + -
+  CONCATENATION = 6, // ..
+  RELATIONAL = 7, // < > <=  >= ~= ==
+  AND = 8, // and
+  OR = 9, // or
   NONE = 99,
 }
 
@@ -78,28 +77,28 @@ export class LuaGenerator extends CodeGenerator {
     this.addReservedWords(
       // Special character
       '_,' +
-      // From theoriginalbit's script:
-      // https://github.com/espertus/blockly-lua/issues/6
-      '__inext,assert,bit,colors,colours,coroutine,disk,dofile,error,fs,' +
-      'fetfenv,getmetatable,gps,help,io,ipairs,keys,loadfile,loadstring,math,' +
-      'native,next,os,paintutils,pairs,parallel,pcall,peripheral,print,' +
-      'printError,rawequal,rawget,rawset,read,rednet,redstone,rs,select,' +
-      'setfenv,setmetatable,sleep,string,table,term,textutils,tonumber,' +
-      'tostring,turtle,type,unpack,vector,write,xpcall,_VERSION,__indext,' +
-      // Not included in the script, probably because it wasn't enabled:
-      'HTTP,' +
-      // Keywords (http://www.lua.org/pil/1.3.html).
-      'and,break,do,else,elseif,end,false,for,function,if,in,local,nil,not,' +
-      'or,repeat,return,then,true,until,while,' +
-      // Metamethods (http://www.lua.org/manual/5.2/manual.html).
-      'add,sub,mul,div,mod,pow,unm,concat,len,eq,lt,le,index,newindex,call,' +
-      // Basic functions (http://www.lua.org/manual/5.2/manual.html,
-      // section 6.1).
-      'assert,collectgarbage,dofile,error,_G,getmetatable,inpairs,load,' +
-      'loadfile,next,pairs,pcall,print,rawequal,rawget,rawlen,rawset,select,' +
-      'setmetatable,tonumber,tostring,type,_VERSION,xpcall,' +
-      // Modules (http://www.lua.org/manual/5.2/manual.html, section 6.3).
-      'require,package,string,table,math,bit32,io,file,os,debug'
+        // From theoriginalbit's script:
+        // https://github.com/espertus/blockly-lua/issues/6
+        '__inext,assert,bit,colors,colours,coroutine,disk,dofile,error,fs,' +
+        'fetfenv,getmetatable,gps,help,io,ipairs,keys,loadfile,loadstring,math,' +
+        'native,next,os,paintutils,pairs,parallel,pcall,peripheral,print,' +
+        'printError,rawequal,rawget,rawset,read,rednet,redstone,rs,select,' +
+        'setfenv,setmetatable,sleep,string,table,term,textutils,tonumber,' +
+        'tostring,turtle,type,unpack,vector,write,xpcall,_VERSION,__indext,' +
+        // Not included in the script, probably because it wasn't enabled:
+        'HTTP,' +
+        // Keywords (http://www.lua.org/pil/1.3.html).
+        'and,break,do,else,elseif,end,false,for,function,if,in,local,nil,not,' +
+        'or,repeat,return,then,true,until,while,' +
+        // Metamethods (http://www.lua.org/manual/5.2/manual.html).
+        'add,sub,mul,div,mod,pow,unm,concat,len,eq,lt,le,index,newindex,call,' +
+        // Basic functions (http://www.lua.org/manual/5.2/manual.html,
+        // section 6.1).
+        'assert,collectgarbage,dofile,error,_G,getmetatable,inpairs,load,' +
+        'loadfile,next,pairs,pcall,print,rawequal,rawget,rawlen,rawset,select,' +
+        'setmetatable,tonumber,tostring,type,_VERSION,xpcall,' +
+        // Modules (http://www.lua.org/manual/5.2/manual.html, section 6.3).
+        'require,package,string,table,math,bit32,io,file,os,debug',
     );
   }
 
@@ -162,11 +161,12 @@ export class LuaGenerator extends CodeGenerator {
    * @returns Lua string.
    */
   quote_(string: string): string {
-    string = string.replace(/\\/g, '\\\\')
-        .replace(/\n/g, '\\\n')
-        .replace(/'/g, '\\\'');
-    return '\'' + string + '\'';
-  };
+    string = string
+      .replace(/\\/g, '\\\\')
+      .replace(/\n/g, '\\\n')
+      .replace(/'/g, "\\'");
+    return "'" + string + "'";
+  }
 
   /**
    * Encode a string as a properly escaped multiline Lua string, complete with
@@ -179,7 +179,7 @@ export class LuaGenerator extends CodeGenerator {
     const lines = string.split(/\n/g).map(this.quote_);
     // Join with the following, plus a newline:
     // .. '\n' ..
-    return lines.join(' .. \'\\n\' ..\n');
+    return lines.join(" .. '\\n' ..\n");
   }
 
   /**
@@ -215,7 +215,8 @@ export class LuaGenerator extends CodeGenerator {
         }
       }
     }
-    const nextBlock = block.nextConnection && block.nextConnection.targetBlock();
+    const nextBlock =
+      block.nextConnection && block.nextConnection.targetBlock();
     const nextCode = thisOnly ? '' : this.blockToCode(nextBlock);
     return commentCode + code + nextCode;
   }

--- a/generators/lua/lua_generator.ts
+++ b/generators/lua/lua_generator.ts
@@ -5,7 +5,9 @@
  */
 
 /**
- * @file Helper functions for generating Lua for blocks.
+ * @file Lua code generator class, including helper methods for
+ * generating Lua for blocks.
+ *
  * Based on Ellen Spertus's blocky-lua project.
  */
 
@@ -21,20 +23,20 @@ import {inputTypes} from '../../core/inputs/input_types.js';
 /**
  * Order of operation ENUMs.
  * http://www.lua.org/manual/5.3/manual.html#3.4.8
- * @enum {number}
  */
+// prettier-ignore
 export enum Order {
-  ATOMIC = 0, // literals
+  ATOMIC = 0,    // literals
   // The next level was not explicit in documentation and inferred by Ellen.
-  HIGH = 1, // Function calls, tables[]
-  EXPONENTIATION = 2, // ^
-  UNARY = 3, // not # - ~
-  MULTIPLICATIVE = 4, // * / %
-  ADDITIVE = 5, // + -
-  CONCATENATION = 6, // ..
-  RELATIONAL = 7, // < > <=  >= ~= ==
-  AND = 8, // and
-  OR = 9, // or
+  HIGH = 1,            // Function calls, tables[]
+  EXPONENTIATION = 2,  // ^
+  UNARY = 3,           // not # - ~
+  MULTIPLICATIVE = 4,  // * / %
+  ADDITIVE = 5,        // + -
+  CONCATENATION = 6,   // ..
+  RELATIONAL = 7,      // < > <=  >= ~= ==
+  AND = 8,             // and
+  OR = 9,              // or
   NONE = 99,
 }
 

--- a/generators/lua/math.ts
+++ b/generators/lua/math.ts
@@ -5,22 +5,24 @@
  */
 
 /**
- * @fileoverview Generating Lua for math blocks.
+ * @file Generating Lua for math blocks.
  */
 
 // Former goog.module ID: Blockly.Lua.math
 
+import type {Block} from '../../core/block.js';
+import type {LuaGenerator} from './lua_generator.js';
 import {Order} from './lua_generator.js';
 
 
-export function math_number(block, generator) {
+export function math_number(block: Block, generator: LuaGenerator): [string, Order] {
   // Numeric value.
   const code = Number(block.getFieldValue('NUM'));
   const order = code < 0 ? Order.UNARY : Order.ATOMIC;
   return [code, order];
 };
 
-export function math_arithmetic(block, generator) {
+export function math_arithmetic(block: Block, generator: LuaGenerator): [string, Order] {
   // Basic arithmetic operators, and power.
   const OPERATORS = {
     'ADD': [' + ', Order.ADDITIVE],
@@ -38,7 +40,7 @@ export function math_arithmetic(block, generator) {
   return [code, order];
 };
 
-export function math_single(block, generator) {
+export function math_single(block: Block, generator: LuaGenerator): [string, Order] {
   // Math operators with single operand.
   const operator = block.getFieldValue('OP');
   let arg;
@@ -108,9 +110,9 @@ export function math_single(block, generator) {
   return [code, Order.HIGH];
 };
 
-export function math_constant(block, generator) {
+export function math_constant(block: Block, generator: LuaGenerator): [string, Order] {
   // Constants: PI, E, the Golden Ratio, sqrt(2), 1/sqrt(2), INFINITY.
-  const CONSTANTS = {
+  const CONSTANTS: {[key: string]: [string, Order]} = {
     'PI': ['math.pi', Order.HIGH],
     'E': ['math.exp(1)', Order.HIGH],
     'GOLDEN_RATIO': ['(1 + math.sqrt(5)) / 2', Order.MULTIPLICATIVE],
@@ -121,10 +123,10 @@ export function math_constant(block, generator) {
   return CONSTANTS[block.getFieldValue('CONSTANT')];
 };
 
-export function math_number_property(block, generator) {
+export function math_number_property(block: Block, generator: LuaGenerator): [string, Order] {
   // Check if a number is even, odd, prime, whole, positive, or negative
   // or if it is divisible by certain number. Returns true or false.
-  const PROPERTIES = {
+  const PROPERTIES: {[key: string]: [string|null, Order, Order]} = {
     'EVEN': [' % 2 == 0', Order.MULTIPLICATIVE, Order.RELATIONAL],
     'ODD': [' % 2 == 1', Order.MULTIPLICATIVE, Order.RELATIONAL],
     'WHOLE': [' % 1 == 0', Order.MULTIPLICATIVE, Order.RELATIONAL],
@@ -179,7 +181,7 @@ end
   return [code, outputOrder];
 };
 
-export function math_change(block, generator) {
+export function math_change(block: Block, generator: LuaGenerator): string {
   // Add to a variable in place.
   const argument0 =
       generator.valueToCode(block, 'DELTA', Order.ADDITIVE) || '0';
@@ -193,7 +195,7 @@ export const math_round = math_single;
 // Trigonometry functions have a single operand.
 export const math_trig = math_single;
 
-export function math_on_list(block, generator) {
+export function math_on_list(block: Block, generator: LuaGenerator): [string, Order] {
   // Math functions for lists.
   const func = block.getFieldValue('OP');
   const list = generator.valueToCode(block, 'LIST', Order.NONE) || '{}';
@@ -360,7 +362,7 @@ end
   return [functionName + '(' + list + ')', Order.HIGH];
 };
 
-export function math_modulo(block, generator) {
+export function math_modulo(block: Block, generator: LuaGenerator): [string, Order] {
   // Remainder computation.
   const argument0 =
       generator.valueToCode(block, 'DIVIDEND', Order.MULTIPLICATIVE) || '0';
@@ -370,7 +372,7 @@ export function math_modulo(block, generator) {
   return [code, Order.MULTIPLICATIVE];
 };
 
-export function math_constrain(block, generator) {
+export function math_constrain(block: Block, generator: LuaGenerator): [string, Order] {
   // Constrain a number between two limits.
   const argument0 = generator.valueToCode(block, 'VALUE', Order.NONE) || '0';
   const argument1 =
@@ -382,7 +384,7 @@ export function math_constrain(block, generator) {
   return [code, Order.HIGH];
 };
 
-export function math_random_int(block, generator) {
+export function math_random_int(block: Block, generator: LuaGenerator): [string, Order] {
   // Random integer between [X] and [Y].
   const argument0 = generator.valueToCode(block, 'FROM', Order.NONE) || '0';
   const argument1 = generator.valueToCode(block, 'TO', Order.NONE) || '0';
@@ -390,12 +392,12 @@ export function math_random_int(block, generator) {
   return [code, Order.HIGH];
 };
 
-export function math_random_float(block, generator) {
+export function math_random_float(block: Block, generator: LuaGenerator): [string, Order] {
   // Random fraction between 0 and 1.
   return ['math.random()', Order.HIGH];
 };
 
-export function math_atan2(block, generator) {
+export function math_atan2(block: Block, generator: LuaGenerator): [string, Order] {
   // Arctangent of point (X, Y) in degrees from -180 to 180.
   const argument0 = generator.valueToCode(block, 'X', Order.NONE) || '0';
   const argument1 = generator.valueToCode(block, 'Y', Order.NONE) || '0';

--- a/generators/lua/math.ts
+++ b/generators/lua/math.ts
@@ -14,15 +14,20 @@ import type {Block} from '../../core/block.js';
 import type {LuaGenerator} from './lua_generator.js';
 import {Order} from './lua_generator.js';
 
-
-export function math_number(block: Block, generator: LuaGenerator): [string, Order] {
+export function math_number(
+  block: Block,
+  generator: LuaGenerator,
+): [string, Order] {
   // Numeric value.
   const code = Number(block.getFieldValue('NUM'));
   const order = code < 0 ? Order.UNARY : Order.ATOMIC;
   return [String(code), order];
-};
+}
 
-export function math_arithmetic(block: Block, generator: LuaGenerator): [string, Order] {
+export function math_arithmetic(
+  block: Block,
+  generator: LuaGenerator,
+): [string, Order] {
   // Basic arithmetic operators, and power.
   const OPERATORS: Record<string, [string, Order]> = {
     'ADD': [' + ', Order.ADDITIVE],
@@ -39,9 +44,12 @@ export function math_arithmetic(block: Block, generator: LuaGenerator): [string,
   const argument1 = generator.valueToCode(block, 'B', order) || '0';
   const code = argument0 + operator + argument1;
   return [code, order];
-};
+}
 
-export function math_single(block: Block, generator: LuaGenerator): [string, Order] {
+export function math_single(
+  block: Block,
+  generator: LuaGenerator,
+): [string, Order] {
   // Math operators with single operand.
   const operator = block.getFieldValue('OP');
   let arg;
@@ -109,9 +117,12 @@ export function math_single(block: Block, generator: LuaGenerator): [string, Ord
       throw Error('Unknown math operator: ' + operator);
   }
   return [code, Order.HIGH];
-};
+}
 
-export function math_constant(block: Block, generator: LuaGenerator): [string, Order] {
+export function math_constant(
+  block: Block,
+  generator: LuaGenerator,
+): [string, Order] {
   // Constants: PI, E, the Golden Ratio, sqrt(2), 1/sqrt(2), INFINITY.
   const CONSTANTS: Record<string, [string, Order]> = {
     'PI': ['math.pi', Order.HIGH],
@@ -122,9 +133,12 @@ export function math_constant(block: Block, generator: LuaGenerator): [string, O
     'INFINITY': ['math.huge', Order.HIGH],
   };
   return CONSTANTS[block.getFieldValue('CONSTANT')];
-};
+}
 
-export function math_number_property(block: Block, generator: LuaGenerator): [string, Order] {
+export function math_number_property(
+  block: Block,
+  generator: LuaGenerator,
+): [string, Order] {
   // Check if a number is even, odd, prime, whole, positive, or negative
   // or if it is divisible by certain number. Returns true or false.
   const PROPERTIES: Record<string, [string | null, Order, Order]> = {
@@ -138,12 +152,14 @@ export function math_number_property(block: Block, generator: LuaGenerator): [st
   };
   const dropdownProperty = block.getFieldValue('PROPERTY');
   const [suffix, inputOrder, outputOrder] = PROPERTIES[dropdownProperty];
-  const numberToCheck = generator.valueToCode(block, 'NUMBER_TO_CHECK',
-      inputOrder) || '0';
+  const numberToCheck =
+    generator.valueToCode(block, 'NUMBER_TO_CHECK', inputOrder) || '0';
   let code;
   if (dropdownProperty === 'PRIME') {
     // Prime is a special case as it is not a one-liner test.
-    const functionName = generator.provideFunction_('math_isPrime', `
+    const functionName = generator.provideFunction_(
+      'math_isPrime',
+      `
 function ${generator.FUNCTION_NAME_PLACEHOLDER_}(n)
   -- https://en.wikipedia.org/wiki/Primality_test#Naive_methods
   if n == 2 or n == 3 then
@@ -162,11 +178,12 @@ function ${generator.FUNCTION_NAME_PLACEHOLDER_}(n)
   end
   return true
 end
-`);
+`,
+    );
     code = functionName + '(' + numberToCheck + ')';
   } else if (dropdownProperty === 'DIVISIBLE_BY') {
-    const divisor = generator.valueToCode(block, 'DIVISOR',
-        Order.MULTIPLICATIVE) || '0';
+    const divisor =
+      generator.valueToCode(block, 'DIVISOR', Order.MULTIPLICATIVE) || '0';
     // If 'divisor' is some code that evals to 0, generator will produce a nan.
     // Let's produce nil if we can determine this at compile-time.
     if (divisor === '0') {
@@ -180,23 +197,25 @@ end
     code = numberToCheck + suffix;
   }
   return [code, outputOrder];
-};
+}
 
 export function math_change(block: Block, generator: LuaGenerator): string {
   // Add to a variable in place.
   const argument0 =
-      generator.valueToCode(block, 'DELTA', Order.ADDITIVE) || '0';
-  const varName =
-      generator.getVariableName(block.getFieldValue('VAR'));
+    generator.valueToCode(block, 'DELTA', Order.ADDITIVE) || '0';
+  const varName = generator.getVariableName(block.getFieldValue('VAR'));
   return varName + ' = ' + varName + ' + ' + argument0 + '\n';
-};
+}
 
 // Rounding functions have a single operand.
 export const math_round = math_single;
 // Trigonometry functions have a single operand.
 export const math_trig = math_single;
 
-export function math_on_list(block: Block, generator: LuaGenerator): [string, Order] {
+export function math_on_list(
+  block: Block,
+  generator: LuaGenerator,
+): [string, Order] {
   // Math functions for lists.
   const func = block.getFieldValue('OP');
   const list = generator.valueToCode(block, 'LIST', Order.NONE) || '{}';
@@ -204,7 +223,9 @@ export function math_on_list(block: Block, generator: LuaGenerator): [string, Or
 
   // Functions needed in more than one case.
   function provideSum() {
-    return generator.provideFunction_('math_sum', `
+    return generator.provideFunction_(
+      'math_sum',
+      `
 function ${generator.FUNCTION_NAME_PLACEHOLDER_}(t)
   local result = 0
   for _, v in ipairs(t) do
@@ -212,7 +233,8 @@ function ${generator.FUNCTION_NAME_PLACEHOLDER_}(t)
   end
   return result
 end
-`);
+`,
+    );
   }
 
   switch (func) {
@@ -222,7 +244,9 @@ end
 
     case 'MIN':
       // Returns 0 for the empty list.
-      functionName = generator.provideFunction_('math_min', `
+      functionName = generator.provideFunction_(
+        'math_min',
+        `
 function ${generator.FUNCTION_NAME_PLACEHOLDER_}(t)
   if #t == 0 then
     return 0
@@ -235,24 +259,30 @@ function ${generator.FUNCTION_NAME_PLACEHOLDER_}(t)
   end
   return result
 end
-`);
+`,
+      );
       break;
 
     case 'AVERAGE':
       // Returns 0 for the empty list.
-      functionName = generator.provideFunction_('math_average', `
+      functionName = generator.provideFunction_(
+        'math_average',
+        `
 function ${generator.FUNCTION_NAME_PLACEHOLDER_}(t)
   if #t == 0 then
     return 0
   end
   return ${provideSum()}(t) / #t
 end
-`);
+`,
+      );
       break;
 
     case 'MAX':
       // Returns 0 for the empty list.
-      functionName = generator.provideFunction_('math_max', `
+      functionName = generator.provideFunction_(
+        'math_max',
+        `
 function ${generator.FUNCTION_NAME_PLACEHOLDER_}(t)
   if #t == 0 then
     return 0
@@ -265,12 +295,15 @@ function ${generator.FUNCTION_NAME_PLACEHOLDER_}(t)
   end
   return result
 end
-`);
+`,
+      );
       break;
 
     case 'MEDIAN':
       // This operation excludes non-numbers.
-      functionName = generator.provideFunction_('math_median', `
+      functionName = generator.provideFunction_(
+        'math_median',
+        `
 function ${generator.FUNCTION_NAME_PLACEHOLDER_}(t)
   -- Source: http://lua-users.org/wiki/SimpleStats
   if #t == 0 then
@@ -289,14 +322,17 @@ function ${generator.FUNCTION_NAME_PLACEHOLDER_}(t)
     return temp[math.ceil(#temp / 2)]
   end
 end
-`);
+`,
+      );
       break;
 
     case 'MODE':
       // As a list of numbers can contain more than one mode,
       // the returned result is provided as an array.
       // The generator version includes non-numbers.
-      functionName = generator.provideFunction_('math_modes', `
+      functionName = generator.provideFunction_(
+        'math_modes',
+        `
 function ${generator.FUNCTION_NAME_PLACEHOLDER_}(t)
   -- Source: http://lua-users.org/wiki/SimpleStats
   local counts = {}
@@ -321,11 +357,14 @@ function ${generator.FUNCTION_NAME_PLACEHOLDER_}(t)
   end
   return temp
 end
-`);
+`,
+      );
       break;
 
     case 'STD_DEV':
-      functionName = generator.provideFunction_('math_standard_deviation', `
+      functionName = generator.provideFunction_(
+        'math_standard_deviation',
+        `
 function ${generator.FUNCTION_NAME_PLACEHOLDER_}(t)
   local m
   local vm
@@ -343,66 +382,92 @@ function ${generator.FUNCTION_NAME_PLACEHOLDER_}(t)
   result = math.sqrt(total / (count-1))
   return result
 end
-`);
+`,
+      );
       break;
 
     case 'RANDOM':
-      functionName = generator.provideFunction_('math_random_list', `
+      functionName = generator.provideFunction_(
+        'math_random_list',
+        `
 function ${generator.FUNCTION_NAME_PLACEHOLDER_}(t)
   if #t == 0 then
     return nil
   end
   return t[math.random(#t)]
 end
-`);
+`,
+      );
       break;
 
     default:
       throw Error('Unknown operator: ' + func);
   }
   return [functionName + '(' + list + ')', Order.HIGH];
-};
+}
 
-export function math_modulo(block: Block, generator: LuaGenerator): [string, Order] {
+export function math_modulo(
+  block: Block,
+  generator: LuaGenerator,
+): [string, Order] {
   // Remainder computation.
   const argument0 =
-      generator.valueToCode(block, 'DIVIDEND', Order.MULTIPLICATIVE) || '0';
+    generator.valueToCode(block, 'DIVIDEND', Order.MULTIPLICATIVE) || '0';
   const argument1 =
-      generator.valueToCode(block, 'DIVISOR', Order.MULTIPLICATIVE) || '0';
+    generator.valueToCode(block, 'DIVISOR', Order.MULTIPLICATIVE) || '0';
   const code = argument0 + ' % ' + argument1;
   return [code, Order.MULTIPLICATIVE];
-};
+}
 
-export function math_constrain(block: Block, generator: LuaGenerator): [string, Order] {
+export function math_constrain(
+  block: Block,
+  generator: LuaGenerator,
+): [string, Order] {
   // Constrain a number between two limits.
   const argument0 = generator.valueToCode(block, 'VALUE', Order.NONE) || '0';
   const argument1 =
-      generator.valueToCode(block, 'LOW', Order.NONE) || '-math.huge';
+    generator.valueToCode(block, 'LOW', Order.NONE) || '-math.huge';
   const argument2 =
-      generator.valueToCode(block, 'HIGH', Order.NONE) || 'math.huge';
-  const code = 'math.min(math.max(' + argument0 + ', ' + argument1 + '), ' +
-      argument2 + ')';
+    generator.valueToCode(block, 'HIGH', Order.NONE) || 'math.huge';
+  const code =
+    'math.min(math.max(' +
+    argument0 +
+    ', ' +
+    argument1 +
+    '), ' +
+    argument2 +
+    ')';
   return [code, Order.HIGH];
-};
+}
 
-export function math_random_int(block: Block, generator: LuaGenerator): [string, Order] {
+export function math_random_int(
+  block: Block,
+  generator: LuaGenerator,
+): [string, Order] {
   // Random integer between [X] and [Y].
   const argument0 = generator.valueToCode(block, 'FROM', Order.NONE) || '0';
   const argument1 = generator.valueToCode(block, 'TO', Order.NONE) || '0';
   const code = 'math.random(' + argument0 + ', ' + argument1 + ')';
   return [code, Order.HIGH];
-};
+}
 
-export function math_random_float(block: Block, generator: LuaGenerator): [string, Order] {
+export function math_random_float(
+  block: Block,
+  generator: LuaGenerator,
+): [string, Order] {
   // Random fraction between 0 and 1.
   return ['math.random()', Order.HIGH];
-};
+}
 
-export function math_atan2(block: Block, generator: LuaGenerator): [string, Order] {
+export function math_atan2(
+  block: Block,
+  generator: LuaGenerator,
+): [string, Order] {
   // Arctangent of point (X, Y) in degrees from -180 to 180.
   const argument0 = generator.valueToCode(block, 'X', Order.NONE) || '0';
   const argument1 = generator.valueToCode(block, 'Y', Order.NONE) || '0';
   return [
-    'math.deg(math.atan2(' + argument1 + ', ' + argument0 + '))', Order.HIGH
+    'math.deg(math.atan2(' + argument1 + ', ' + argument0 + '))',
+    Order.HIGH,
   ];
-};
+}

--- a/generators/lua/math.ts
+++ b/generators/lua/math.ts
@@ -19,19 +19,20 @@ export function math_number(block: Block, generator: LuaGenerator): [string, Ord
   // Numeric value.
   const code = Number(block.getFieldValue('NUM'));
   const order = code < 0 ? Order.UNARY : Order.ATOMIC;
-  return [code, order];
+  return [String(code), order];
 };
 
 export function math_arithmetic(block: Block, generator: LuaGenerator): [string, Order] {
   // Basic arithmetic operators, and power.
-  const OPERATORS = {
+  const OPERATORS: Record<string, [string, Order]> = {
     'ADD': [' + ', Order.ADDITIVE],
     'MINUS': [' - ', Order.ADDITIVE],
     'MULTIPLY': [' * ', Order.MULTIPLICATIVE],
     'DIVIDE': [' / ', Order.MULTIPLICATIVE],
     'POWER': [' ^ ', Order.EXPONENTIATION],
   };
-  const tuple = OPERATORS[block.getFieldValue('OP')];
+  type OperatorOption = keyof typeof OPERATORS;
+  const tuple = OPERATORS[block.getFieldValue('OP') as OperatorOption];
   const operator = tuple[0];
   const order = tuple[1];
   const argument0 = generator.valueToCode(block, 'A', order) || '0';
@@ -112,7 +113,7 @@ export function math_single(block: Block, generator: LuaGenerator): [string, Ord
 
 export function math_constant(block: Block, generator: LuaGenerator): [string, Order] {
   // Constants: PI, E, the Golden Ratio, sqrt(2), 1/sqrt(2), INFINITY.
-  const CONSTANTS: {[key: string]: [string, Order]} = {
+  const CONSTANTS: Record<string, [string, Order]> = {
     'PI': ['math.pi', Order.HIGH],
     'E': ['math.exp(1)', Order.HIGH],
     'GOLDEN_RATIO': ['(1 + math.sqrt(5)) / 2', Order.MULTIPLICATIVE],
@@ -126,7 +127,7 @@ export function math_constant(block: Block, generator: LuaGenerator): [string, O
 export function math_number_property(block: Block, generator: LuaGenerator): [string, Order] {
   // Check if a number is even, odd, prime, whole, positive, or negative
   // or if it is divisible by certain number. Returns true or false.
-  const PROPERTIES: {[key: string]: [string|null, Order, Order]} = {
+  const PROPERTIES: Record<string, [string | null, Order, Order]> = {
     'EVEN': [' % 2 == 0', Order.MULTIPLICATIVE, Order.RELATIONAL],
     'ODD': [' % 2 == 1', Order.MULTIPLICATIVE, Order.RELATIONAL],
     'WHOLE': [' % 1 == 0', Order.MULTIPLICATIVE, Order.RELATIONAL],

--- a/generators/lua/procedures.ts
+++ b/generators/lua/procedures.ts
@@ -11,11 +11,12 @@
 // Former goog.module ID: Blockly.Lua.procedures
 
 import type {Block} from '../../core/block.js';
+import type {IfReturnBlock} from '../../blocks/procedures.js';
 import type {LuaGenerator} from './lua_generator.js';
 import {Order} from './lua_generator.js';
 
 
-export function procedures_defreturn(block: Block, generator: LuaGenerator): [string, Order] {
+export function procedures_defreturn(block: Block, generator: LuaGenerator): null {
   // Define a procedure with a return value.
   const funcName =
       generator.getProcedureName(block.getFieldValue('NAME'));
@@ -56,7 +57,9 @@ export function procedures_defreturn(block: Block, generator: LuaGenerator): [st
       loopTrap + branch + xfix2 + returnValue + 'end\n';
   code = generator.scrub_(block, code);
   // Add % so as not to collide with helper functions in definitions list.
-  generator.definitions_['%' + funcName] = code;
+  // TODO(#7600): find better approach than casting to any to override
+  // CodeGenerator declaring .definitions protected.
+  (generator as AnyDuringMigration).definitions_['%' + funcName] = code;
   return null;
 };
 
@@ -98,7 +101,7 @@ export function procedures_ifreturn(block: Block, generator: LuaGenerator): stri
           generator.injectId(generator.STATEMENT_SUFFIX, block),
           generator.INDENT);
   }
-  if (block.hasReturnValue_) {
+  if ((block as IfReturnBlock).hasReturnValue_) {
     const value = generator.valueToCode(block, 'VALUE', Order.NONE) || 'nil';
     code += generator.INDENT + 'return ' + value + '\n';
   } else {

--- a/generators/lua/procedures.ts
+++ b/generators/lua/procedures.ts
@@ -15,11 +15,12 @@ import type {IfReturnBlock} from '../../blocks/procedures.js';
 import type {LuaGenerator} from './lua_generator.js';
 import {Order} from './lua_generator.js';
 
-
-export function procedures_defreturn(block: Block, generator: LuaGenerator): null {
+export function procedures_defreturn(
+  block: Block,
+  generator: LuaGenerator,
+): null {
   // Define a procedure with a return value.
-  const funcName =
-      generator.getProcedureName(block.getFieldValue('NAME'));
+  const funcName = generator.getProcedureName(block.getFieldValue('NAME'));
   let xfix1 = '';
   if (generator.STATEMENT_PREFIX) {
     xfix1 += generator.injectId(generator.STATEMENT_PREFIX, block);
@@ -33,8 +34,9 @@ export function procedures_defreturn(block: Block, generator: LuaGenerator): nul
   let loopTrap = '';
   if (generator.INFINITE_LOOP_TRAP) {
     loopTrap = generator.prefixLines(
-        generator.injectId(
-          generator.INFINITE_LOOP_TRAP, block), generator.INDENT);
+      generator.injectId(generator.INFINITE_LOOP_TRAP, block),
+      generator.INDENT,
+    );
   }
   let branch = generator.statementToCode(block, 'STACK');
   let returnValue = generator.valueToCode(block, 'RETURN', Order.NONE) || '';
@@ -53,24 +55,36 @@ export function procedures_defreturn(block: Block, generator: LuaGenerator): nul
   for (let i = 0; i < variables.length; i++) {
     args[i] = generator.getVariableName(variables[i]);
   }
-  let code = 'function ' + funcName + '(' + args.join(', ') + ')\n' + xfix1 +
-      loopTrap + branch + xfix2 + returnValue + 'end\n';
+  let code =
+    'function ' +
+    funcName +
+    '(' +
+    args.join(', ') +
+    ')\n' +
+    xfix1 +
+    loopTrap +
+    branch +
+    xfix2 +
+    returnValue +
+    'end\n';
   code = generator.scrub_(block, code);
   // Add % so as not to collide with helper functions in definitions list.
   // TODO(#7600): find better approach than casting to any to override
   // CodeGenerator declaring .definitions protected.
   (generator as AnyDuringMigration).definitions_['%' + funcName] = code;
   return null;
-};
+}
 
 // Defining a procedure without a return value uses the same generator as
 // a procedure with a return value.
 export const procedures_defnoreturn = procedures_defreturn;
 
-export function procedures_callreturn(block: Block, generator: LuaGenerator): [string, Order] {
+export function procedures_callreturn(
+  block: Block,
+  generator: LuaGenerator,
+): [string, Order] {
   // Call a procedure with a return value.
-  const funcName =
-      generator.getProcedureName(block.getFieldValue('NAME'));
+  const funcName = generator.getProcedureName(block.getFieldValue('NAME'));
   const args = [];
   const variables = block.getVars();
   for (let i = 0; i < variables.length; i++) {
@@ -78,28 +92,37 @@ export function procedures_callreturn(block: Block, generator: LuaGenerator): [s
   }
   const code = funcName + '(' + args.join(', ') + ')';
   return [code, Order.HIGH];
-};
+}
 
-export function procedures_callnoreturn(block: Block, generator: LuaGenerator): string {
+export function procedures_callnoreturn(
+  block: Block,
+  generator: LuaGenerator,
+): string {
   // Call a procedure with no return value.
   // Generated code is for a function call as a statement is the same as a
   // function call as a value, with the addition of line ending.
-  const tuple = generator.forBlock['procedures_callreturn'](block, generator) as [string, number];
+  const tuple = generator.forBlock['procedures_callreturn'](
+    block,
+    generator,
+  ) as [string, number];
   return tuple[0] + '\n';
-};
+}
 
-export function procedures_ifreturn(block: Block, generator: LuaGenerator): string {
+export function procedures_ifreturn(
+  block: Block,
+  generator: LuaGenerator,
+): string {
   // Conditionally return value from a procedure.
   const condition =
-      generator.valueToCode(block, 'CONDITION', Order.NONE) || 'false';
+    generator.valueToCode(block, 'CONDITION', Order.NONE) || 'false';
   let code = 'if ' + condition + ' then\n';
   if (generator.STATEMENT_SUFFIX) {
     // Inject any statement suffix here since the regular one at the end
     // will not get executed if the return is triggered.
-    code +=
-        generator.prefixLines(
-          generator.injectId(generator.STATEMENT_SUFFIX, block),
-          generator.INDENT);
+    code += generator.prefixLines(
+      generator.injectId(generator.STATEMENT_SUFFIX, block),
+      generator.INDENT,
+    );
   }
   if ((block as IfReturnBlock).hasReturnValue_) {
     const value = generator.valueToCode(block, 'VALUE', Order.NONE) || 'nil';
@@ -109,4 +132,4 @@ export function procedures_ifreturn(block: Block, generator: LuaGenerator): stri
   }
   code += 'end\n';
   return code;
-};
+}

--- a/generators/lua/procedures.ts
+++ b/generators/lua/procedures.ts
@@ -5,15 +5,17 @@
  */
 
 /**
- * @fileoverview Generating Lua for procedure blocks.
+ * @file Generating Lua for procedure blocks.
  */
 
 // Former goog.module ID: Blockly.Lua.procedures
 
+import type {Block} from '../../core/block.js';
+import type {LuaGenerator} from './lua_generator.js';
 import {Order} from './lua_generator.js';
 
 
-export function procedures_defreturn(block, generator) {
+export function procedures_defreturn(block: Block, generator: LuaGenerator): [string, Order] {
   // Define a procedure with a return value.
   const funcName =
       generator.getProcedureName(block.getFieldValue('NAME'));
@@ -62,7 +64,7 @@ export function procedures_defreturn(block, generator) {
 // a procedure with a return value.
 export const procedures_defnoreturn = procedures_defreturn;
 
-export function procedures_callreturn(block, generator) {
+export function procedures_callreturn(block: Block, generator: LuaGenerator): [string, Order] {
   // Call a procedure with a return value.
   const funcName =
       generator.getProcedureName(block.getFieldValue('NAME'));
@@ -75,15 +77,15 @@ export function procedures_callreturn(block, generator) {
   return [code, Order.HIGH];
 };
 
-export function procedures_callnoreturn(block, generator) {
+export function procedures_callnoreturn(block: Block, generator: LuaGenerator): string {
   // Call a procedure with no return value.
   // Generated code is for a function call as a statement is the same as a
   // function call as a value, with the addition of line ending.
-  const tuple = generator.forBlock['procedures_callreturn'](block, generator);
+  const tuple = generator.forBlock['procedures_callreturn'](block, generator) as [string, number];
   return tuple[0] + '\n';
 };
 
-export function procedures_ifreturn(block, generator) {
+export function procedures_ifreturn(block: Block, generator: LuaGenerator): string {
   // Conditionally return value from a procedure.
   const condition =
       generator.valueToCode(block, 'CONDITION', Order.NONE) || 'false';

--- a/generators/lua/text.ts
+++ b/generators/lua/text.ts
@@ -5,21 +5,23 @@
  */
 
 /**
- * @fileoverview Generating Lua for text blocks.
+ * @file Generating Lua for text blocks.
  */
 
 // Former goog.module ID: Blockly.Lua.texts
 
+import type {Block} from '../../core/block.js';
+import type {LuaGenerator} from './lua_generator.js';
 import {Order} from './lua_generator.js';
 
 
-export function text(block, generator) {
+export function text(block: Block, generator: LuaGenerator): [string, Order] {
   // Text value.
   const code = generator.quote_(block.getFieldValue('TEXT'));
   return [code, Order.ATOMIC];
 };
 
-export function text_multiline(block, generator) {
+export function text_multiline(block: Block, generator: LuaGenerator): [string, Order] {
   // Text value.
   const code = generator.multiline_quote_(block.getFieldValue('TEXT'));
   const order =
@@ -27,7 +29,7 @@ export function text_multiline(block, generator) {
   return [code, order];
 };
 
-export function text_join(block, generator) {
+export function text_join(block: Block, generator: LuaGenerator): [string, Order] {
   // Create a string made up of any number of elements of any type.
   if (block.itemCount_ === 0) {
     return ["''", Order.ATOMIC];
@@ -53,7 +55,7 @@ export function text_join(block, generator) {
   }
 };
 
-export function text_append(block, generator) {
+export function text_append(block: Block, generator: LuaGenerator): string {
   // Append to a variable in place.
   const varName =
       generator.getVariableName(block.getFieldValue('VAR'));
@@ -62,19 +64,19 @@ export function text_append(block, generator) {
   return varName + ' = ' + varName + ' .. ' + value + '\n';
 };
 
-export function text_length(block, generator) {
+export function text_length(block: Block, generator: LuaGenerator): [string, Order] {
   // String or array length.
   const text = generator.valueToCode(block, 'VALUE', Order.UNARY) || "''";
   return ['#' + text, Order.UNARY];
 };
 
-export function text_isEmpty(block, generator) {
+export function text_isEmpty(block: Block, generator: LuaGenerator): [string, Order] {
   // Is the string null or array empty?
   const text = generator.valueToCode(block, 'VALUE', Order.UNARY) || "''";
   return ['#' + text + ' == 0', Order.RELATIONAL];
 };
 
-export function text_indexOf(block, generator) {
+export function text_indexOf(block: Block, generator: LuaGenerator): [string, Order] {
   // Search the text for a substring.
   const substring = generator.valueToCode(block, 'FIND', Order.NONE) || "''";
   const text = generator.valueToCode(block, 'VALUE', Order.NONE) || "''";
@@ -104,7 +106,7 @@ end
   return [code, Order.HIGH];
 };
 
-export function text_charAt(block, generator) {
+export function text_charAt(block: Block, generator: LuaGenerator): [string, Order] {
   // Get letter at index.
   // Note: Until January 2013 this block did not have the WHERE input.
   const where = block.getFieldValue('WHERE') || 'FROM_START';
@@ -150,7 +152,7 @@ end
   return [code, Order.HIGH];
 };
 
-export function text_getSubstring(block, generator) {
+export function text_getSubstring(block: Block, generator: LuaGenerator): [string, Order] {
   // Get substring.
   const text = generator.valueToCode(block, 'STRING', Order.NONE) || "''";
 
@@ -187,7 +189,7 @@ export function text_getSubstring(block, generator) {
   return [code, Order.HIGH];
 };
 
-export function text_changeCase(block, generator) {
+export function text_changeCase(block: Block, generator: LuaGenerator): [string, Order] {
   // Change capitalization.
   const operator = block.getFieldValue('CASE');
   const text = generator.valueToCode(block, 'TEXT', Order.NONE) || "''";
@@ -224,7 +226,7 @@ end
   return [code, Order.HIGH];
 };
 
-export function text_trim(block, generator) {
+export function text_trim(block: Block, generator: LuaGenerator): [string, Order] {
   // Trim spaces.
   const OPERATORS = {LEFT: '^%s*(,-)', RIGHT: '(.-)%s*$', BOTH: '^%s*(.-)%s*$'};
   const operator = OPERATORS[block.getFieldValue('MODE')];
@@ -233,13 +235,13 @@ export function text_trim(block, generator) {
   return [code, Order.HIGH];
 };
 
-export function text_print(block, generator) {
+export function text_print(block: Block, generator: LuaGenerator): string {
   // Print statement.
   const msg = generator.valueToCode(block, 'TEXT', Order.NONE) || "''";
   return 'print(' + msg + ')\n';
 };
 
-export function text_prompt_ext(block, generator) {
+export function text_prompt_ext(block: Block, generator: LuaGenerator): [string, Order] {
   // Prompt function.
   let msg;
   if (block.getField('TEXT')) {
@@ -268,7 +270,7 @@ end
 
 export const text_prompt = text_prompt_ext;
 
-export function text_count(block, generator) {
+export function text_count(block: Block, generator: LuaGenerator): [string, Order] {
   const text = generator.valueToCode(block, 'TEXT', Order.NONE) || "''";
   const sub = generator.valueToCode(block, 'SUB', Order.NONE) || "''";
   const functionName = generator.provideFunction_('text_count', `
@@ -293,7 +295,7 @@ end
   return [code, Order.HIGH];
 };
 
-export function text_replace(block, generator) {
+export function text_replace(block: Block, generator: LuaGenerator): [string, Order] {
   const text = generator.valueToCode(block, 'TEXT', Order.NONE) || "''";
   const from = generator.valueToCode(block, 'FROM', Order.NONE) || "''";
   const to = generator.valueToCode(block, 'TO', Order.NONE) || "''";
@@ -319,7 +321,7 @@ end
   return [code, Order.HIGH];
 };
 
-export function text_reverse(block, generator) {
+export function text_reverse(block: Block, generator: LuaGenerator): [string, Order] {
   const text = generator.valueToCode(block, 'TEXT', Order.NONE) || "''";
   const code = 'string.reverse(' + text + ')';
   return [code, Order.HIGH];

--- a/generators/lua/text.ts
+++ b/generators/lua/text.ts
@@ -15,22 +15,26 @@ import type {JoinMutatorBlock} from '../../blocks/text.js';
 import type {LuaGenerator} from './lua_generator.js';
 import {Order} from './lua_generator.js';
 
-
 export function text(block: Block, generator: LuaGenerator): [string, Order] {
   // Text value.
   const code = generator.quote_(block.getFieldValue('TEXT'));
   return [code, Order.ATOMIC];
-};
+}
 
-export function text_multiline(block: Block, generator: LuaGenerator): [string, Order] {
+export function text_multiline(
+  block: Block,
+  generator: LuaGenerator,
+): [string, Order] {
   // Text value.
   const code = generator.multiline_quote_(block.getFieldValue('TEXT'));
-  const order =
-      code.indexOf('..') !== -1 ? Order.CONCATENATION : Order.ATOMIC;
+  const order = code.indexOf('..') !== -1 ? Order.CONCATENATION : Order.ATOMIC;
   return [code, order];
-};
+}
 
-export function text_join(block: Block, generator: LuaGenerator): [string, Order] {
+export function text_join(
+  block: Block,
+  generator: LuaGenerator,
+): [string, Order] {
   const joinBlock = block as JoinMutatorBlock;
   // Create a string made up of any number of elements of any type.
   if (joinBlock.itemCount_ === 0) {
@@ -41,50 +45,59 @@ export function text_join(block: Block, generator: LuaGenerator): [string, Order
     return [code, Order.HIGH];
   } else if (joinBlock.itemCount_ === 2) {
     const element0 =
-        generator.valueToCode(block, 'ADD0', Order.CONCATENATION) || "''";
+      generator.valueToCode(block, 'ADD0', Order.CONCATENATION) || "''";
     const element1 =
-        generator.valueToCode(block, 'ADD1', Order.CONCATENATION) || "''";
+      generator.valueToCode(block, 'ADD1', Order.CONCATENATION) || "''";
     const code = element0 + ' .. ' + element1;
     return [code, Order.CONCATENATION];
   } else {
     const elements = [];
     for (let i = 0; i < joinBlock.itemCount_; i++) {
-      elements[i] =
-          generator.valueToCode(block, 'ADD' + i, Order.NONE) || "''";
+      elements[i] = generator.valueToCode(block, 'ADD' + i, Order.NONE) || "''";
     }
     const code = 'table.concat({' + elements.join(', ') + '})';
     return [code, Order.HIGH];
   }
-};
+}
 
 export function text_append(block: Block, generator: LuaGenerator): string {
   // Append to a variable in place.
-  const varName =
-      generator.getVariableName(block.getFieldValue('VAR'));
+  const varName = generator.getVariableName(block.getFieldValue('VAR'));
   const value =
-      generator.valueToCode(block, 'TEXT', Order.CONCATENATION) || "''";
+    generator.valueToCode(block, 'TEXT', Order.CONCATENATION) || "''";
   return varName + ' = ' + varName + ' .. ' + value + '\n';
-};
+}
 
-export function text_length(block: Block, generator: LuaGenerator): [string, Order] {
+export function text_length(
+  block: Block,
+  generator: LuaGenerator,
+): [string, Order] {
   // String or array length.
   const text = generator.valueToCode(block, 'VALUE', Order.UNARY) || "''";
   return ['#' + text, Order.UNARY];
-};
+}
 
-export function text_isEmpty(block: Block, generator: LuaGenerator): [string, Order] {
+export function text_isEmpty(
+  block: Block,
+  generator: LuaGenerator,
+): [string, Order] {
   // Is the string null or array empty?
   const text = generator.valueToCode(block, 'VALUE', Order.UNARY) || "''";
   return ['#' + text + ' == 0', Order.RELATIONAL];
-};
+}
 
-export function text_indexOf(block: Block, generator: LuaGenerator): [string, Order] {
+export function text_indexOf(
+  block: Block,
+  generator: LuaGenerator,
+): [string, Order] {
   // Search the text for a substring.
   const substring = generator.valueToCode(block, 'FIND', Order.NONE) || "''";
   const text = generator.valueToCode(block, 'VALUE', Order.NONE) || "''";
   let functionName;
   if (block.getFieldValue('END') === 'FIRST') {
-    functionName = generator.provideFunction_('firstIndexOf', `
+    functionName = generator.provideFunction_(
+      'firstIndexOf',
+      `
 function ${generator.FUNCTION_NAME_PLACEHOLDER_}(str, substr)
   local i = string.find(str, substr, 1, true)
   if i == nil then
@@ -92,9 +105,12 @@ function ${generator.FUNCTION_NAME_PLACEHOLDER_}(str, substr)
   end
   return i
 end
-`);
+`,
+    );
   } else {
-    functionName = generator.provideFunction_('lastIndexOf', `
+    functionName = generator.provideFunction_(
+      'lastIndexOf',
+      `
 function ${generator.FUNCTION_NAME_PLACEHOLDER_}(str, substr)
   local i = string.find(string.reverse(str), string.reverse(substr), 1, true)
   if i then
@@ -102,27 +118,34 @@ function ${generator.FUNCTION_NAME_PLACEHOLDER_}(str, substr)
   end
   return 0
 end
-`);
+`,
+    );
   }
   const code = functionName + '(' + text + ', ' + substring + ')';
   return [code, Order.HIGH];
-};
+}
 
-export function text_charAt(block: Block, generator: LuaGenerator): [string, Order] {
+export function text_charAt(
+  block: Block,
+  generator: LuaGenerator,
+): [string, Order] {
   // Get letter at index.
   // Note: Until January 2013 this block did not have the WHERE input.
   const where = block.getFieldValue('WHERE') || 'FROM_START';
-  const atOrder = (where === 'FROM_END') ? Order.UNARY : Order.NONE;
+  const atOrder = where === 'FROM_END' ? Order.UNARY : Order.NONE;
   const at = generator.valueToCode(block, 'AT', atOrder) || '1';
   const text = generator.valueToCode(block, 'VALUE', Order.NONE) || "''";
   let code;
   if (where === 'RANDOM') {
-    const functionName = generator.provideFunction_('text_random_letter', `
+    const functionName = generator.provideFunction_(
+      'text_random_letter',
+      `
 function ${generator.FUNCTION_NAME_PLACEHOLDER_}(str)
   local index = math.random(string.len(str))
   return string.sub(str, index, index)
 end
-`);
+`,
+    );
     code = functionName + '(' + text + ')';
   } else {
     let start;
@@ -143,24 +166,30 @@ end
       code = 'string.sub(' + text + ', ' + start + ', ' + start + ')';
     } else {
       // use function to avoid reevaluation
-      const functionName = generator.provideFunction_('text_char_at', `
+      const functionName = generator.provideFunction_(
+        'text_char_at',
+        `
 function ${generator.FUNCTION_NAME_PLACEHOLDER_}(str, index)
   return string.sub(str, index, index)
 end
-`);
+`,
+      );
       code = functionName + '(' + text + ', ' + start + ')';
     }
   }
   return [code, Order.HIGH];
-};
+}
 
-export function text_getSubstring(block: Block, generator: LuaGenerator): [string, Order] {
+export function text_getSubstring(
+  block: Block,
+  generator: LuaGenerator,
+): [string, Order] {
   // Get substring.
   const text = generator.valueToCode(block, 'STRING', Order.NONE) || "''";
 
   // Get start index.
   const where1 = block.getFieldValue('WHERE1');
-  const at1Order = (where1 === 'FROM_END') ? Order.UNARY : Order.NONE;
+  const at1Order = where1 === 'FROM_END' ? Order.UNARY : Order.NONE;
   const at1 = generator.valueToCode(block, 'AT1', at1Order) || '1';
   let start;
   if (where1 === 'FIRST') {
@@ -175,7 +204,7 @@ export function text_getSubstring(block: Block, generator: LuaGenerator): [strin
 
   // Get end index.
   const where2 = block.getFieldValue('WHERE2');
-  const at2Order = (where2 === 'FROM_END') ? Order.UNARY : Order.NONE;
+  const at2Order = where2 === 'FROM_END' ? Order.UNARY : Order.NONE;
   const at2 = generator.valueToCode(block, 'AT2', at2Order) || '1';
   let end;
   if (where2 === 'LAST') {
@@ -189,9 +218,12 @@ export function text_getSubstring(block: Block, generator: LuaGenerator): [strin
   }
   const code = 'string.sub(' + text + ', ' + start + ', ' + end + ')';
   return [code, Order.HIGH];
-};
+}
 
-export function text_changeCase(block: Block, generator: LuaGenerator): [string, Order] {
+export function text_changeCase(
+  block: Block,
+  generator: LuaGenerator,
+): [string, Order] {
   // Change capitalization.
   const operator = block.getFieldValue('CASE');
   const text = generator.valueToCode(block, 'TEXT', Order.NONE) || "''";
@@ -204,7 +236,9 @@ export function text_changeCase(block: Block, generator: LuaGenerator): [string,
     // There are shorter versions at
     // http://lua-users.org/wiki/SciteTitleCase
     // that do not preserve whitespace.
-    functionName = generator.provideFunction_('text_titlecase', `
+    functionName = generator.provideFunction_(
+      'text_titlecase',
+      `
 function ${generator.FUNCTION_NAME_PLACEHOLDER_}(str)
   local buf = {}
   local inWord = false
@@ -222,13 +256,17 @@ function ${generator.FUNCTION_NAME_PLACEHOLDER_}(str)
   end
   return table.concat(buf)
 end
-`);
+`,
+    );
   }
   const code = functionName + '(' + text + ')';
   return [code, Order.HIGH];
-};
+}
 
-export function text_trim(block: Block, generator: LuaGenerator): [string, Order] {
+export function text_trim(
+  block: Block,
+  generator: LuaGenerator,
+): [string, Order] {
   // Trim spaces.
   const OPERATORS = {LEFT: '^%s*(,-)', RIGHT: '(.-)%s*$', BOTH: '^%s*(.-)%s*$'};
   type OperatorOption = keyof typeof OPERATORS;
@@ -236,15 +274,18 @@ export function text_trim(block: Block, generator: LuaGenerator): [string, Order
   const text = generator.valueToCode(block, 'TEXT', Order.NONE) || "''";
   const code = 'string.gsub(' + text + ', "' + operator + '", "%1")';
   return [code, Order.HIGH];
-};
+}
 
 export function text_print(block: Block, generator: LuaGenerator): string {
   // Print statement.
   const msg = generator.valueToCode(block, 'TEXT', Order.NONE) || "''";
   return 'print(' + msg + ')\n';
-};
+}
 
-export function text_prompt_ext(block: Block, generator: LuaGenerator): [string, Order] {
+export function text_prompt_ext(
+  block: Block,
+  generator: LuaGenerator,
+): [string, Order] {
   // Prompt function.
   let msg;
   if (block.getField('TEXT')) {
@@ -255,13 +296,16 @@ export function text_prompt_ext(block: Block, generator: LuaGenerator): [string,
     msg = generator.valueToCode(block, 'TEXT', Order.NONE) || "''";
   }
 
-  const functionName = generator.provideFunction_('text_prompt', `
+  const functionName = generator.provideFunction_(
+    'text_prompt',
+    `
 function ${generator.FUNCTION_NAME_PLACEHOLDER_}(msg)
   io.write(msg)
   io.flush()
   return io.read()
 end
-`);
+`,
+  );
   let code = functionName + '(' + msg + ')';
 
   const toNumber = block.getFieldValue('TYPE') === 'NUMBER';
@@ -269,14 +313,19 @@ end
     code = 'tonumber(' + code + ', 10)';
   }
   return [code, Order.HIGH];
-};
+}
 
 export const text_prompt = text_prompt_ext;
 
-export function text_count(block: Block, generator: LuaGenerator): [string, Order] {
+export function text_count(
+  block: Block,
+  generator: LuaGenerator,
+): [string, Order] {
   const text = generator.valueToCode(block, 'TEXT', Order.NONE) || "''";
   const sub = generator.valueToCode(block, 'SUB', Order.NONE) || "''";
-  const functionName = generator.provideFunction_('text_count', `
+  const functionName = generator.provideFunction_(
+    'text_count',
+    `
 function ${generator.FUNCTION_NAME_PLACEHOLDER_}(haystack, needle)
   if #needle == 0 then
     return #haystack + 1
@@ -293,16 +342,22 @@ function ${generator.FUNCTION_NAME_PLACEHOLDER_}(haystack, needle)
   end
   return count
 end
-`);
+`,
+  );
   const code = functionName + '(' + text + ', ' + sub + ')';
   return [code, Order.HIGH];
-};
+}
 
-export function text_replace(block: Block, generator: LuaGenerator): [string, Order] {
+export function text_replace(
+  block: Block,
+  generator: LuaGenerator,
+): [string, Order] {
   const text = generator.valueToCode(block, 'TEXT', Order.NONE) || "''";
   const from = generator.valueToCode(block, 'FROM', Order.NONE) || "''";
   const to = generator.valueToCode(block, 'TO', Order.NONE) || "''";
-  const functionName = generator.provideFunction_('text_replace', `
+  const functionName = generator.provideFunction_(
+    'text_replace',
+    `
 function ${generator.FUNCTION_NAME_PLACEHOLDER_}(haystack, needle, replacement)
   local buf = {}
   local i = 1
@@ -319,13 +374,17 @@ function ${generator.FUNCTION_NAME_PLACEHOLDER_}(haystack, needle, replacement)
   end
   return table.concat(buf)
 end
-`);
+`,
+  );
   const code = functionName + '(' + text + ', ' + from + ', ' + to + ')';
   return [code, Order.HIGH];
-};
+}
 
-export function text_reverse(block: Block, generator: LuaGenerator): [string, Order] {
+export function text_reverse(
+  block: Block,
+  generator: LuaGenerator,
+): [string, Order] {
   const text = generator.valueToCode(block, 'TEXT', Order.NONE) || "''";
   const code = 'string.reverse(' + text + ')';
   return [code, Order.HIGH];
-};
+}

--- a/generators/lua/text.ts
+++ b/generators/lua/text.ts
@@ -11,6 +11,7 @@
 // Former goog.module ID: Blockly.Lua.texts
 
 import type {Block} from '../../core/block.js';
+import type {JoinMutatorBlock} from '../../blocks/text.js';
 import type {LuaGenerator} from './lua_generator.js';
 import {Order} from './lua_generator.js';
 
@@ -30,14 +31,15 @@ export function text_multiline(block: Block, generator: LuaGenerator): [string, 
 };
 
 export function text_join(block: Block, generator: LuaGenerator): [string, Order] {
+  const joinBlock = block as JoinMutatorBlock;
   // Create a string made up of any number of elements of any type.
-  if (block.itemCount_ === 0) {
+  if (joinBlock.itemCount_ === 0) {
     return ["''", Order.ATOMIC];
-  } else if (block.itemCount_ === 1) {
+  } else if (joinBlock.itemCount_ === 1) {
     const element = generator.valueToCode(block, 'ADD0', Order.NONE) || "''";
     const code = 'tostring(' + element + ')';
     return [code, Order.HIGH];
-  } else if (block.itemCount_ === 2) {
+  } else if (joinBlock.itemCount_ === 2) {
     const element0 =
         generator.valueToCode(block, 'ADD0', Order.CONCATENATION) || "''";
     const element1 =
@@ -46,7 +48,7 @@ export function text_join(block: Block, generator: LuaGenerator): [string, Order
     return [code, Order.CONCATENATION];
   } else {
     const elements = [];
-    for (let i = 0; i < block.itemCount_; i++) {
+    for (let i = 0; i < joinBlock.itemCount_; i++) {
       elements[i] =
           generator.valueToCode(block, 'ADD' + i, Order.NONE) || "''";
     }
@@ -229,7 +231,8 @@ end
 export function text_trim(block: Block, generator: LuaGenerator): [string, Order] {
   // Trim spaces.
   const OPERATORS = {LEFT: '^%s*(,-)', RIGHT: '(.-)%s*$', BOTH: '^%s*(.-)%s*$'};
-  const operator = OPERATORS[block.getFieldValue('MODE')];
+  type OperatorOption = keyof typeof OPERATORS;
+  const operator = OPERATORS[block.getFieldValue('MODE') as OperatorOption];
   const text = generator.valueToCode(block, 'TEXT', Order.NONE) || "''";
   const code = 'string.gsub(' + text + ', "' + operator + '", "%1")';
   return [code, Order.HIGH];

--- a/generators/lua/variables.ts
+++ b/generators/lua/variables.ts
@@ -14,18 +14,18 @@ import type {Block} from '../../core/block.js';
 import type {LuaGenerator} from './lua_generator.js';
 import {Order} from './lua_generator.js';
 
-
-export function variables_get(block: Block, generator: LuaGenerator): [string, Order] {
+export function variables_get(
+  block: Block,
+  generator: LuaGenerator,
+): [string, Order] {
   // Variable getter.
-  const code =
-      generator.getVariableName(block.getFieldValue('VAR'));
+  const code = generator.getVariableName(block.getFieldValue('VAR'));
   return [code, Order.ATOMIC];
-};
+}
 
 export function variables_set(block: Block, generator: LuaGenerator): string {
   // Variable setter.
   const argument0 = generator.valueToCode(block, 'VALUE', Order.NONE) || '0';
-  const varName =
-      generator.getVariableName(block.getFieldValue('VAR'));
+  const varName = generator.getVariableName(block.getFieldValue('VAR'));
   return varName + ' = ' + argument0 + '\n';
-};
+}

--- a/generators/lua/variables.ts
+++ b/generators/lua/variables.ts
@@ -5,22 +5,24 @@
  */
 
 /**
- * @fileoverview Generating Lua for variable blocks.
+ * @file Generating Lua for variable blocks.
  */
 
 // Former goog.module ID: Blockly.Lua.variables
 
+import type {Block} from '../../core/block.js';
+import type {LuaGenerator} from './lua_generator.js';
 import {Order} from './lua_generator.js';
 
 
-export function variables_get(block, generator) {
+export function variables_get(block: Block, generator: LuaGenerator): [string, Order] {
   // Variable getter.
   const code =
       generator.getVariableName(block.getFieldValue('VAR'));
   return [code, Order.ATOMIC];
 };
 
-export function variables_set(block, generator) {
+export function variables_set(block: Block, generator: LuaGenerator): string {
   // Variable setter.
   const argument0 = generator.valueToCode(block, 'VALUE', Order.NONE) || '0';
   const varName =

--- a/generators/lua/variables_dynamic.ts
+++ b/generators/lua/variables_dynamic.ts
@@ -5,7 +5,7 @@
  */
 
 /**
- * @fileoverview Generating Lua for dynamic variable blocks.
+ * @file Generating Lua for dynamic variable blocks.
  */
 
 // Former goog.module ID: Blockly.Lua.variablesDynamic

--- a/generators/lua/variables_dynamic.ts
+++ b/generators/lua/variables_dynamic.ts
@@ -10,7 +10,6 @@
 
 // Former goog.module ID: Blockly.Lua.variablesDynamic
 
-
 // Lua is dynamically typed.
 export {
   variables_get as variables_get_dynamic,


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

Part of https://github.com/google/blockly/issues/6828.

### Proposed Changes

Migrate `generators/lua/*.js` and `generators/lua.js` to TypeScript.

### Reason for Changes

Finish TS migration.

### Test Coverage

`npm test` passes. No changes to manual test procedures required.

### Documentation

No changes to documentation yet, as there should be minimal changes to the generated code and no changes to the published typings (because during build we overwrite the generated `.d.ts` files with the ones from `typings/`).

### Additional Information

It may be easier to review this commit-by-commit, as the final format commit make a lot of noisy changes.
