### PR TITLE
fix: Releases the event listeners that has not been released

### DIFF
--- a/core/workspace_svg.ts
+++ b/core/workspace_svg.ts
@@ -317,6 +317,7 @@ export class WorkspaceSvg extends Workspace implements IASTNodeLocationSvg {
   svgBubbleCanvas_!: SVGElement;
   zoomControls_: ZoomControls | null = null;
 
+  private const wheelHandler = () => {}
   /**
    * @param options Dictionary of options.
    */
@@ -787,7 +788,7 @@ export class WorkspaceSvg extends Workspace implements IASTNodeLocationSvg {
       // This no-op works around https://bugs.webkit.org/show_bug.cgi?id=226683,
       // which otherwise prevents zoom/scroll events from being observed in
       // Safari. Once that bug is fixed it should be removed.
-      document.body.addEventListener('wheel', function () {});
+      document.body.addEventListener('wheel', this.wheelHandler);
       browserEvents.conditionalBind(
         this.svgGroup_,
         'wheel',
@@ -896,6 +897,8 @@ export class WorkspaceSvg extends Workspace implements IASTNodeLocationSvg {
       browserEvents.unbind(this.resizeHandlerWrapper);
       this.resizeHandlerWrapper = null;
     }
+
+    document.body.removeEventListener('wheel', this.wheelHandler)
   }
 
   /**


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Event listeners will not be disposed even workspace is cleared

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes 

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->

### Reason for Changes
Will cause the memory leak.

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
