### PR TITLE
feat: make fields and icons optionally clickable in flyouts

### DIFF
--- a/core/field.ts
+++ b/core/field.ts
@@ -584,8 +584,7 @@ export abstract class Field<T = any>
    * @returns Whether the field should be clickable while the block is in a flyout.
    */
   isClickableInFlyout(autoClosingFlyout: boolean): boolean {
-    if (autoClosingFlyout) return false;
-    return true;
+    return !autoClosingFlyout;
   }
 
   /**

--- a/core/field.ts
+++ b/core/field.ts
@@ -574,6 +574,21 @@ export abstract class Field<T = any>
   }
 
   /**
+   * Check whether the field should be clickable while the block is in a flyout.
+   * The default is that fields are clickable in always-open flyouts such as the
+   * simple toolbox, but not in autoclosing flyouts such as the category toolbox.
+   * Subclasses may override this function to change this behavior. Note that
+   * `isClickable` must also return true for this to have any effect.
+   *
+   * @param autoClosingFlyout true if the containing flyout is an auto-closing one.
+   * @returns Whether the field should be clickable while the block is in a flyout.
+   */
+  isClickableInFlyout(autoClosingFlyout: boolean): boolean {
+    if (autoClosingFlyout) return false;
+    return true;
+  }
+
+  /**
    * Check whether this field is currently editable.  Some fields are never
    * EDITABLE (e.g. text labels). Other fields may be EDITABLE but may exist on
    * non-editable blocks or be currently disabled.

--- a/core/gesture.ts
+++ b/core/gesture.ts
@@ -1158,19 +1158,18 @@ export class Gesture {
   }
 
   /**
-   * Whether this gesture is a click on a field.  This should only be called
+   * Whether this gesture is a click on a field that should be handled.  This should only be called
    * when ending a gesture (pointerup).
    *
    * @returns Whether this gesture was a click on a field.
    */
   private isFieldClick(): boolean {
-    const fieldClickable = this.startField
-      ? this.startField.isClickable()
-      : false;
+    if (!this.startField) return false;
     return (
-      fieldClickable &&
+      this.startField.isClickable() &&
       !this.hasExceededDragRadius &&
-      (!this.flyout || !this.flyout.autoClose)
+      (!this.flyout ||
+        this.startField.isClickableInFlyout(this.flyout.autoClose))
     );
   }
 

--- a/core/gesture.ts
+++ b/core/gesture.ts
@@ -1173,9 +1173,14 @@ export class Gesture {
     );
   }
 
-  /** @returns Whether this gesture is a click on an icon. */
+  /** @returns Whether this gesture is a click on an icon that should be handled. */
   private isIconClick(): boolean {
-    return !!this.startIcon && !this.hasExceededDragRadius;
+    if (!this.startIcon) return false;
+    const handleInFlyout =
+      !this.flyout ||
+      !this.startIcon.isClickableInFlyout ||
+      this.startIcon.isClickableInFlyout(this.flyout.autoClose);
+    return !this.hasExceededDragRadius && handleInFlyout;
   }
 
   /**

--- a/core/icons/comment_icon.ts
+++ b/core/icons/comment_icon.ts
@@ -213,6 +213,10 @@ export class CommentIcon extends Icon implements IHasBubble, ISerializable {
     this.setBubbleVisible(!this.bubbleIsVisible());
   }
 
+  override isClickableInFlyout(): boolean {
+    return false;
+  }
+
   /**
    * Updates the text of this comment in response to changes in the text of
    * the input bubble.

--- a/core/icons/icon.ts
+++ b/core/icons/icon.ts
@@ -112,6 +112,19 @@ export abstract class Icon implements IIcon {
   onClick(): void {}
 
   /**
+   * Check whether the icon should be clickable while the block is in a flyout.
+   * The default is that icons are clickable in all flyouts (auto-closing or not).
+   * Subclasses may override this function to change this behavior.
+   *
+   * @param autoClosingFlyout true if the containing flyout is an auto-closing one.
+   * @returns Whether the icon should be clickable while the block is in a flyout.
+   */
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  isClickableInFlyout(autoClosingFlyout: boolean): boolean {
+    return true;
+  }
+
+  /**
    * Sets the visibility of the icon's bubble if one exists.
    *
    * @deprecated Use `setBubbleVisible` instead. To be removed in v11.

--- a/core/icons/mutator_icon.ts
+++ b/core/icons/mutator_icon.ts
@@ -146,6 +146,10 @@ export class MutatorIcon extends Icon implements IHasBubble {
     this.setBubbleVisible(!this.bubbleIsVisible());
   }
 
+  override isClickableInFlyout(): boolean {
+    return false;
+  }
+
   bubbleIsVisible(): boolean {
     return !!this.miniWorkspaceBubble;
   }

--- a/core/icons/warning_icon.ts
+++ b/core/icons/warning_icon.ts
@@ -160,6 +160,10 @@ export class WarningIcon extends Icon implements IHasBubble {
     this.setBubbleVisible(!this.bubbleIsVisible());
   }
 
+  override isClickableInFlyout(): boolean {
+    return false;
+  }
+
   bubbleIsVisible(): boolean {
     return !!this.textBubble;
   }

--- a/core/interfaces/i_icon.ts
+++ b/core/interfaces/i_icon.ts
@@ -83,6 +83,15 @@ export interface IIcon {
    * Notifies the icon that it has been clicked.
    */
   onClick(): void;
+
+  /**
+   * Check whether the icon should be clickable while the block is in a flyout.
+   * If this function is not defined, the icon will be clickable in all flyouts.
+   *
+   * @param autoClosingFlyout true if the containing flyout is an auto-closing one.
+   * @returns Whether the icon should be clickable while the block is in a flyout.
+   */
+  isClickableInFlyout?(autoClosingFlyout: boolean): boolean;
 }
 
 /** Type guard that checks whether the given object is an IIcon. */


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #7450 
Fixes #7451 

### Proposed Changes

- Adds overridable method for fields to enable clicking them in a flyout. Default is not clickable in autoclose flyouts but clickable in always open flyouts. This maintains the current behavior of fields.
- Adds optional method to the `IIcon` interface to control whether an icon is clickable in a flyout - it would be required except that would be a breaking change
- Adds an overridable method to the `Icon` abstract class to control whether it is clickable in a flyout. The default is clickable in all flyouts. This maintains the current behavior of icons.
- Overrides the above mentioned method for the built-in mutator, comment, and warning icons. **This is a change in behavior for them** however:
    - for mutators, they opened but were weird (see #7451). now they don't open and clicking it creates the block just like clicking on a field.
    - for comments, they didn't open when you clicked them, but if you clicked the icon and then dragged the block onto the workspace, the comment would be open then, which is pretty weird. now they don't open and clicking it creates the block just like clicking on a field.

### Reason for Changes

Some developers have fields that act like buttons, and they want those buttons to be clickable in flyouts.

### Test Coverage

Manual testing

### Documentation

I added (and updated adjacent) TsDoc. I don't think we need to add this anywhere else.

### Additional Information

<!-- Anything else we should know? -->
