### PR TITLE
fix: mutator coordinates not respecting flyout

### DIFF
--- a/core/flyout_horizontal.ts
+++ b/core/flyout_horizontal.ts
@@ -386,15 +386,14 @@ export class HorizontalFlyout extends Flyout {
       // Workspace with no scrollbars where this is permanently open on the top.
       // If scrollbars exist they properly update the metrics.
       if (
-        this.targetWorkspace!.toolboxPosition === this.toolboxPosition_ &&
-        this.toolboxPosition_ === toolbox.Position.TOP &&
-        !this.targetWorkspace!.getToolbox() &&
+        !this.targetWorkspace.scrollbar &&
         !this.autoClose &&
-        !this.targetWorkspace.scrollbar
+        this.targetWorkspace.getFlyout() === this &&
+        this.toolboxPosition_ === toolbox.Position.TOP
       ) {
-        this.targetWorkspace!.translate(
-          this.targetWorkspace!.scrollX,
-          this.targetWorkspace!.scrollY + flyoutHeight,
+        this.targetWorkspace.translate(
+          this.targetWorkspace.scrollX,
+          this.targetWorkspace.scrollY + flyoutHeight,
         );
       }
 

--- a/core/flyout_horizontal.ts
+++ b/core/flyout_horizontal.ts
@@ -382,6 +382,22 @@ export class HorizontalFlyout extends Flyout {
         }
       }
 
+      // TODO(#7689): Remove this.
+      // Workspace with no scrollbars where this is permanently open on the top.
+      // If scrollbars exist they properly update the metrics.
+      if (
+        this.targetWorkspace!.toolboxPosition === this.toolboxPosition_ &&
+        this.toolboxPosition_ === toolbox.Position.TOP &&
+        !this.targetWorkspace!.getToolbox() &&
+        !this.autoClose &&
+        !this.targetWorkspace.scrollbar
+      ) {
+        this.targetWorkspace!.translate(
+          this.targetWorkspace!.scrollX,
+          this.targetWorkspace!.scrollY + flyoutHeight,
+        );
+      }
+
       this.height_ = flyoutHeight;
       this.position();
       this.targetWorkspace.resizeContents();

--- a/core/flyout_vertical.ts
+++ b/core/flyout_vertical.ts
@@ -375,6 +375,22 @@ export class VerticalFlyout extends Flyout {
         }
       }
 
+      // TODO(#7689): Remove this.
+      // Workspace with no scrollbars where this is permanently
+      // open on the left.
+      // If scrollbars exist they properly update the metrics.
+      if (
+        !this.targetWorkspace.scrollbar &&
+        !this.autoClose &&
+        this.targetWorkspace!.toolboxPosition === this.toolboxPosition_ &&
+        this.toolboxPosition_ === toolbox.Position.LEFT
+      ) {
+        this.targetWorkspace!.translate(
+          this.targetWorkspace!.scrollX + flyoutWidth,
+          this.targetWorkspace!.scrollY,
+        );
+      }
+
       this.width_ = flyoutWidth;
       this.position();
       this.targetWorkspace.resizeContents();

--- a/core/flyout_vertical.ts
+++ b/core/flyout_vertical.ts
@@ -382,12 +382,12 @@ export class VerticalFlyout extends Flyout {
       if (
         !this.targetWorkspace.scrollbar &&
         !this.autoClose &&
-        this.targetWorkspace!.toolboxPosition === this.toolboxPosition_ &&
+        this.targetWorkspace.getFlyout() === this &&
         this.toolboxPosition_ === toolbox.Position.LEFT
       ) {
-        this.targetWorkspace!.translate(
-          this.targetWorkspace!.scrollX + flyoutWidth,
-          this.targetWorkspace!.scrollY,
+        this.targetWorkspace.translate(
+          this.targetWorkspace.scrollX + flyoutWidth,
+          this.targetWorkspace.scrollY,
         );
       }
 


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes https://github.com/google/blockly/issues/7677

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
Re-adds logic for setting absolute metrics in the flyout code removed in https://github.com/google/blockly/pull/7634/files#r1385439054

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
Unbork borkedness.

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->
* Manually tested mutators.
* Tested that setting the autoclose-ness of flyouts on workspaces with scrollbars still properly updates the absolute metrics.

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->
N/A

### Additional Information

<!-- Anything else we should know? -->
Filed https://github.com/google/blockly/issues/7689 to track actually fixing this.
