### PR TITLE
fix: trashcan flyout opening on drag

### DIFF
--- a/core/trashcan.ts
+++ b/core/trashcan.ts
@@ -545,7 +545,7 @@ export class Trashcan
 
   /** Inspect the contents of the trash. */
   click() {
-    if (!this.hasContents()) {
+    if (!this.hasContents() || this.workspace.isDragging()) {
       return;
     }
     this.openFlyout();


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes https://github.com/google/blockly/issues/7681

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
Has the trashcan check if there is a drag in progress before opening.

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
Unbork borkedness.

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->

Tested repro steps from https://github.com/google/blockly/issues/7681 and could not reproduce.

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->
N/A

### Additional Information

<!-- Anything else we should know? -->
N/A
