### PR TITLE
Release dummy wheel listener on workspace dispose

### DIFF
--- a/core/workspace_svg.ts
+++ b/core/workspace_svg.ts
@@ -248,6 +248,12 @@ export class WorkspaceSvg extends Workspace implements IASTNodeLocationSvg {
     | null = null;
 
   /**
+   * A dummy wheel event listener used as a workaround for a Safari scrolling issue.
+   * Set in createDom and used for removal in dispose to ensure proper cleanup.
+   */
+  private dummyWheelListener: (() => void) | null = null;
+
+  /**
    * In a flyout, the target workspace where blocks should be placed after a
    * drag. Otherwise null.
    *
@@ -787,7 +793,8 @@ export class WorkspaceSvg extends Workspace implements IASTNodeLocationSvg {
       // This no-op works around https://bugs.webkit.org/show_bug.cgi?id=226683,
       // which otherwise prevents zoom/scroll events from being observed in
       // Safari. Once that bug is fixed it should be removed.
-      document.body.addEventListener('wheel', function () {});
+      this.dummyWheelListener = () => {};
+      document.body.addEventListener('wheel', this.dummyWheelListener);
       browserEvents.conditionalBind(
         this.svgGroup_,
         'wheel',
@@ -895,6 +902,12 @@ export class WorkspaceSvg extends Workspace implements IASTNodeLocationSvg {
     if (this.resizeHandlerWrapper) {
       browserEvents.unbind(this.resizeHandlerWrapper);
       this.resizeHandlerWrapper = null;
+    }
+
+    // Remove the dummy wheel listener
+    if (this.dummyWheelListener) {
+      document.body.removeEventListener('wheel', this.dummyWheelListener);
+      this.dummyWheelListener = null;
     }
   }
 


### PR DESCRIPTION
## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

Fixes #7674

### Proposed Changes
- Introduced a new class member dummyWheelListener in WorkspaceSvg to store the dummy wheel event listener.
- Modified the dispose method in WorkspaceSvg to remove the dummyWheelListener from the document body when the workspace is disposed.

### Reason for Changes
Previously, the dummy wheel event listener added to the document as a workaround for a Safari bug was not being properly disposed of. This could potentially lead to memory leaks and unintended behavior. By storing the listener in a class member, we can ensure it is correctly removed when the workspace is disposed, thus improving the robustness and cleanliness of the code.


### Test Coverage

- Manually tested to confirm that the dummyWheelListener is added and removed correctly.
- Ensured that the addition and removal of this listener have no side effects on the functionality of WorkspaceSvg.

### Documentation

- No major documentation updates required as these changes are internal and pertain to fixing a specific bug.

### Additional Information

N/A
