### PR TITLE
fix: updated mocha tests to display error messages

### DIFF
--- a/tests/mocha/webdriver.js
+++ b/tests/mocha/webdriver.js
@@ -64,7 +64,7 @@ async function runMochaTestsInBrowser() {
     }
     for (const el of failureMessagesEls) {
       const messageHtml = await el.getHTML();
-      console.log(messageHtml.replace("<p>", "").replace("</p>", ""));
+      console.log(messageHtml.replace('<p>', '').replace('</p>', ''));
     }
   }
 

--- a/tests/mocha/webdriver.js
+++ b/tests/mocha/webdriver.js
@@ -63,7 +63,8 @@ async function runMochaTestsInBrowser() {
       console.log('There is at least one test failure, but no messages reported. Mocha may be failing because no tests are being run.');
     }
     for (const el of failureMessagesEls) {
-      console.log(await el.getText());
+      const messageHtml = await el.getHTML();
+      console.log(messageHtml.replace("<p>", "").replace("</p>", ""));
     }
   }
 


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

Fixes https://github.com/google/blockly/issues/7649

### Proposed Changes

Instead of using `getText()`, which requires a visible element, I use `getHTML()` and strip out the `p` tag.
    - See https://webdriver.io/docs/api/element/getText and **note:** only visible elements will return display.
    - The root element with id `failureCount` has `display: none`, so the text content here never displays.

Previous output:
```
Loading URL: file:///usr/local/google/home/blaketw/git/blockly/blockly/tests/mocha/index.html
============Blockly Mocha Test Failures================

============Blockly Mocha Test Summary=================
1 tests failed
============Blockly Mocha Test Summary=================
Mocha tests failed
```

Updated  output:
```
Loading URL: file:///usr/local/google/home/blaketw/git/blockly/blockly/tests/mocha/index.html
============Blockly Mocha Test Failures================
"Comments Set/Get Bubble Size Set Size While Invisible" failed: expected 100 to equal 101
============Blockly Mocha Test Summary=================
1 tests failed
============Blockly Mocha Test Summary=================
Mocha tests failed
```

### Reason for Changes

To resolve https://github.com/google/blockly/issues/7649

### Test Coverage

N/A

### Documentation

N/A

### Additional Information

<!-- Anything else we should know? -->

- Not sure if `#failureCount` was previously visible, though another way to mitigate this would be to set it visible
