### PR TITLE
fix: prevent flyout block highlighting during workspace drag

### DIFF
--- a/core/flyout_base.ts
+++ b/core/flyout_base.ts
@@ -988,16 +988,32 @@ export abstract class Flyout
       ),
     );
     this.listeners.push(
-      browserEvents.bind(root, 'pointerenter', block, block.addSelect),
+      browserEvents.bind(root, 'pointerenter', block, () => {
+        if (!this.targetWorkspace.isDragging()) {
+          block.addSelect();
+        }
+      }),
     );
     this.listeners.push(
-      browserEvents.bind(root, 'pointerleave', block, block.removeSelect),
+      browserEvents.bind(root, 'pointerleave', block, () => {
+        if (!this.targetWorkspace.isDragging()) {
+          block.removeSelect();
+        }
+      }),
     );
     this.listeners.push(
-      browserEvents.bind(rect, 'pointerenter', block, block.addSelect),
+      browserEvents.bind(rect, 'pointerenter', block, () => {
+        if (!this.targetWorkspace.isDragging()) {
+          block.addSelect();
+        }
+      }),
     );
     this.listeners.push(
-      browserEvents.bind(rect, 'pointerleave', block, block.removeSelect),
+      browserEvents.bind(rect, 'pointerleave', block, () => {
+        if (!this.targetWorkspace.isDragging()) {
+          block.removeSelect();
+        }
+      }),
     );
   }
 


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #1801

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
Fixes issue where flyout blocks were incorrectly highlighted during workspace drag,
by adding a check for the workspace's drag state before triggering block highlighting events.
### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
Flyout blocks should not highlight if the workspace is being dragged.
### Test Coverage
N/A
<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->

### Documentation
N/A
<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information
N/A
<!-- Anything else we should know? -->
