### PR TITLE
fix(generators): Fix generator typings

### DIFF
--- a/scripts/gulpfiles/package_tasks.js
+++ b/scripts/gulpfiles/package_tasks.js
@@ -348,7 +348,6 @@ function packageDTS() {
   return gulp.src(handwrittenSrcs, {base: 'typings'})
       .pipe(gulp.src(`${TYPINGS_BUILD_DIR}/**/*.d.ts`, {ignore: [
 	`${TYPINGS_BUILD_DIR}/blocks/**/*`,
-	`${TYPINGS_BUILD_DIR}/generators/**/*`,
       ]}))
       .pipe(gulp.replace('AnyDuringMigration', 'any'))
       .pipe(gulp.dest(RELEASE_DIR));

--- a/typings/dart.d.ts
+++ b/typings/dart.d.ts
@@ -4,25 +4,4 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-export enum Order {
-  ATOMIC = 0,         // 0 "" ...
-  UNARY_POSTFIX = 1,  // expr++ expr-- () [] . ?.
-  UNARY_PREFIX = 2,   // -expr !expr ~expr ++expr --expr
-  MULTIPLICATIVE = 3, // * / % ~/
-  ADDITIVE = 4,       // + -
-  SHIFT = 5,          // << >>
-  BITWISE_AND = 6,    // &
-  BITWISE_XOR = 7,    // ^
-  BITWISE_OR = 8,     // |
-  RELATIONAL = 9,     // >= > <= < as is is!
-  EQUALITY = 10,      // == !=
-  LOGICAL_AND = 11,   // &&
-  LOGICAL_OR = 12,    // ||
-  IF_NULL = 13,       // ??
-  CONDITIONAL = 14,   // expr ? expr : expr
-  CASCADE = 15,       // ..
-  ASSIGNMENT = 16,    // = *= /= ~/= %= += -= <<= >>= &= ^= |=
-  NONE = 99,          // (...)
-}
-
-export declare const dartGenerator: any;
+export * from 'generators/dart';

--- a/typings/javascript.d.ts
+++ b/typings/javascript.d.ts
@@ -4,42 +4,4 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-export enum Order {
-  ATOMIC = 0,            // 0 "" ...
-  NEW = 1.1,             // new
-  MEMBER = 1.2,          // . []
-  FUNCTION_CALL = 2,     // ()
-  INCREMENT = 3,         // ++
-  DECREMENT = 3,         // --
-  BITWISE_NOT = 4.1,     // ~
-  UNARY_PLUS = 4.2,      // +
-  UNARY_NEGATION = 4.3,  // -
-  LOGICAL_NOT = 4.4,     // !
-  TYPEOF = 4.5,          // typeof
-  VOID = 4.6,            // void
-  DELETE = 4.7,          // delete
-  AWAIT = 4.8,           // await
-  EXPONENTIATION = 5.0,  // **
-  MULTIPLICATION = 5.1,  // *
-  DIVISION = 5.2,        // /
-  MODULUS = 5.3,         // %
-  SUBTRACTION = 6.1,     // -
-  ADDITION = 6.2,        // +
-  BITWISE_SHIFT = 7,     // << >> >>>
-  RELATIONAL = 8,        // < <= > >=
-  IN = 8,                // in
-  INSTANCEOF = 8,        // instanceof
-  EQUALITY = 9,          // == != === !==
-  BITWISE_AND = 10,      // &
-  BITWISE_XOR = 11,      // ^
-  BITWISE_OR = 12,       // |
-  LOGICAL_AND = 13,      // &&
-  LOGICAL_OR = 14,       // ||
-  CONDITIONAL = 15,      // ?:
-  ASSIGNMENT = 16,       // = += -= **= *= /= %= <<= >>= ...
-  YIELD = 17,            // yield
-  COMMA = 18,            // ,
-  NONE = 99,             // (...)
-}
-
-export declare const javascriptGenerator: any;
+export * from 'generators/javascript';

--- a/typings/lua.d.ts
+++ b/typings/lua.d.ts
@@ -4,19 +4,4 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-export enum Order {
-  ATOMIC = 0,    // literals
-  // The next level was not explicit in documentation and inferred by Ellen.
-  HIGH = 1,            // Function calls, tables[]
-  EXPONENTIATION = 2,  // ^
-  UNARY = 3,           // not # - ~
-  MULTIPLICATIVE = 4,  // * / %
-  ADDITIVE = 5,        // + -
-  CONCATENATION = 6,   // ..
-  RELATIONAL = 7,      // < > <=  >= ~= ==
-  AND = 8,             // and
-  OR = 9,              // or
-  NONE = 99,
-}
-
-export declare const luaGenerator: any;
+export * from 'generators/lua';

--- a/typings/php.d.ts
+++ b/typings/php.d.ts
@@ -4,44 +4,4 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-export enum Order {
-  ATOMIC = 0,             // 0 "" ...
-  CLONE = 1,              // clone
-  NEW = 1,                // new
-  MEMBER = 2.1,           // []
-  FUNCTION_CALL = 2.2,    // ()
-  POWER = 3,              // **
-  INCREMENT = 4,          // ++
-  DECREMENT = 4,          // --
-  BITWISE_NOT = 4,        // ~
-  CAST = 4,               // (int) (float) (string) (array) ...
-  SUPPRESS_ERROR = 4,     // @
-  INSTANCEOF = 5,         // instanceof
-  LOGICAL_NOT = 6,        // !
-  UNARY_PLUS = 7.1,       // +
-  UNARY_NEGATION = 7.2,   // -
-  MULTIPLICATION = 8.1,   // *
-  DIVISION = 8.2,         // /
-  MODULUS = 8.3,          // %
-  ADDITION = 9.1,         // +
-  SUBTRACTION = 9.2,      // -
-  STRING_CONCAT = 9.3,    // .
-  BITWISE_SHIFT = 10,     // << >>
-  RELATIONAL = 11,        // < <= > >=
-  EQUALITY = 12,          // == != === !== <> <=>
-  REFERENCE = 13,         // &
-  BITWISE_AND = 13,       // &
-  BITWISE_XOR = 14,       // ^
-  BITWISE_OR = 15,        // |
-  LOGICAL_AND = 16,       // &&
-  LOGICAL_OR = 17,        // ||
-  IF_NULL = 18,           // ??
-  CONDITIONAL = 19,       // ?:
-  ASSIGNMENT = 20,        // = += -= *= /= %= <<= >>= ...
-  LOGICAL_AND_WEAK = 21,  // and
-  LOGICAL_XOR = 22,       // xor
-  LOGICAL_OR_WEAK = 23,   // or
-  NONE = 99,              // (...)
-}
-
-export declare const phpGenerator: any;
+export * from 'generators/php';

--- a/typings/python.d.ts
+++ b/typings/python.d.ts
@@ -4,28 +4,4 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-export enum Order {
-  ATOMIC = 0,             // 0 "" ...
-  COLLECTION = 1,         // tuples, lists, dictionaries
-  STRING_CONVERSION = 1,  // `expression...`
-  MEMBER = 2.1,           // . []
-  FUNCTION_CALL = 2.2,    // ()
-  EXPONENTIATION = 3,     // **
-  UNARY_SIGN = 4,         // + -
-  BITWISE_NOT = 4,        // ~
-  MULTIPLICATIVE = 5,     // * / // %
-  ADDITIVE = 6,           // + -
-  BITWISE_SHIFT = 7,      // << >>
-  BITWISE_AND = 8,        // &
-  BITWISE_XOR = 9,        // ^
-  BITWISE_OR = 10,        // |
-  RELATIONAL = 11,        // in, not in, is, is not, >, >=, <>, !=, ==
-  LOGICAL_NOT = 12,       // not
-  LOGICAL_AND = 13,       // and
-  LOGICAL_OR = 14,        // or
-  CONDITIONAL = 15,       // if else
-  LAMBDA = 16,            // lambda
-  NONE = 99,              // (...)
-}
-
-export declare const pythonGenerator: any;
+export * from 'generators/python';


### PR DESCRIPTION
## The basics

- [X] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

Fixes #7652.

### Proposed Changes

* Modify `package_tasks.js` to include `tsc`-generated `.d.ts` files for the generators in `dist` when building the `blockly` NPM package.
* Replace the hand-written `.d.ts` files for the generator chunks with ones that reexport the types from the corresponding `tsc`-generated `.d.ts` file.

### Reason for Changes

Publish accurate typings for the generators.

### Additional Information

BREAKING CHANGE: Previously the `dartGenerator`, `luaGenerator`, `javascriptGenerator`, `phpGenerator`, and `pythonGenerator` exports (from the `blockly/dart`, `blockly/lua`, `blockly/javascript`, `blockly/php` and `blockly/python` entrypoints respectively) were being typed `any`.  Now their types are correct.  There is no change to their runtime behaviour, but developers who have written code in TypeScript that manipulates generators (adding custom block generator functions, for example) may find they need to correct type error in their code in order for it to compile correctly with Blockly v11.

Notably, block  generator functions to be installed in the `javascriptGenerator.forBlock` dictionary should be typed
```
(block: Blockly.Block, generator: javascript.JavascriptGenerator) => [string, javascript.Order] | string | null
```
—and similarly for each of the other four languages we support.

