### PR TITLE
fix!: have insertion markers use json deserialization

### DIFF
--- a/core/insertion_marker_manager.ts
+++ b/core/insertion_marker_manager.ts
@@ -17,7 +17,7 @@ import type {BlockSvg} from './block_svg.js';
 import * as common from './common.js';
 import {ComponentManager} from './component_manager.js';
 import {config} from './config.js';
-import * as constants from './constants.js';
+import * as blocks from './serialization/blocks.js';
 import * as eventUtils from './events/utils.js';
 import type {IDeleteArea} from './interfaces/i_delete_area.js';
 import type {IDragTarget} from './interfaces/i_drag_target.js';
@@ -41,16 +41,6 @@ interface CandidateConnection {
   local: RenderedConnection;
   radius: number;
 }
-
-/**
- * An error message to throw if the block created by createMarkerBlock_ is
- * missing any components.
- */
-const DUPLICATE_BLOCK_ERROR =
-  'The insertion marker ' +
-  'manager tried to create a marker but the result is missing %1. If ' +
-  'you are using a mutator, make sure your domToMutation method is ' +
-  'properly defined.';
 
 /**
  * Class that controls updates to connections during drags.  It is primarily
@@ -231,52 +221,29 @@ export class InsertionMarkerManager {
    * @returns The insertion marker that represents the given block.
    */
   private createMarkerBlock(sourceBlock: BlockSvg): BlockSvg {
-    const imType = sourceBlock.type;
-
     eventUtils.disable();
     let result: BlockSvg;
     try {
-      result = this.workspace.newBlock(imType);
-      result.setInsertionMarker(true);
-      if (sourceBlock.saveExtraState) {
-        const state = sourceBlock.saveExtraState(true);
-        if (state && result.loadExtraState) {
-          result.loadExtraState(state);
-        }
-      } else if (sourceBlock.mutationToDom) {
-        const oldMutationDom = sourceBlock.mutationToDom();
-        if (oldMutationDom && result.domToMutation) {
-          result.domToMutation(oldMutationDom);
-        }
-      }
-      // Copy field values from the other block.  These values may impact the
-      // rendered size of the insertion marker.  Note that we do not care about
-      // child blocks here.
-      for (let i = 0; i < sourceBlock.inputList.length; i++) {
-        const sourceInput = sourceBlock.inputList[i];
-        if (sourceInput.name === constants.COLLAPSED_INPUT_NAME) {
-          continue; // Ignore the collapsed input.
-        }
-        const resultInput = result.inputList[i];
-        if (!resultInput) {
-          throw new Error(DUPLICATE_BLOCK_ERROR.replace('%1', 'an input'));
-        }
-        for (let j = 0; j < sourceInput.fieldRow.length; j++) {
-          const sourceField = sourceInput.fieldRow[j];
-          const resultField = resultInput.fieldRow[j];
-          if (!resultField) {
-            throw new Error(DUPLICATE_BLOCK_ERROR.replace('%1', 'a field'));
-          }
-          resultField.setValue(sourceField.getValue());
-        }
+      const blockJson = blocks.save(sourceBlock, {
+        addCoordinates: false,
+        addInputBlocks: false,
+        addNextBlocks: false,
+        doFullSerialization: false,
+      });
+
+      if (!blockJson) {
+        throw new Error(
+          `Failed to serialize source block. ${sourceBlock.toDevString()}`,
+        );
       }
 
+      result = blocks.append(blockJson, this.workspace) as BlockSvg;
+
+      // Turn shadow blocks that are created programmatically during
+      // initalization to insertion markers too.
       for (const block of result.getDescendants(false)) {
         block.setInsertionMarker(true);
       }
-
-      result.setCollapsed(sourceBlock.isCollapsed());
-      result.setInputsInline(sourceBlock.getInputsInline());
 
       result.initSvg();
       result.getSvgRoot().setAttribute('visibility', 'hidden');


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #7316

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
Reverts https://github.com/google/blockly/pull/7430 https://github.com/google/blockly/pull/7429

Makes it so that insertion markers are created using JSON deserialization.

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

From https://github.com/google/blockly/pull/7364

> Insertion markers duplicate the block being dragged, and then tell the duplicate to be an insertion marker.

> Currently the duplication duplicates (ha) a lot of code from the serialization system. We think this is because in the past the XML system didn't have a good way to just serialize and deserialize a single block (without children). But the JSON system does have this!

> Sparked by this discussion: https://groups.google.com/g/blockly/c/gcvynl88QLY/m/shFyX4x0BwAJ

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->

All tests pass.

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
N/A

## Breaking changes / To fix

Insertion-marker-ness is now set after any mutation is deserialized.

If you have a block whose behavior depeonds on whether it is an insertion marker or not, they should check `doFullSerialization` instead. Insertion markers pass `doFullSerialization` as false.

You can see the [shareable procedure blocks](https://github.com/google/blockly-samples/blob/4e28e47679990f5deddfe312347c7942d7f434da/plugins/block-shareable-procedures/src/blocks.ts#L487) for an example of round-tripping whether full serialization was enabled from `saveExtraState` to `loadExtraState`. 