### PR TITLE
fix: snap immediately

### DIFF
--- a/core/block_svg.ts
+++ b/core/block_svg.ts
@@ -455,23 +455,12 @@ export class BlockSvg
 
   /** Snap this block to the nearest grid point. */
   snapToGrid() {
-    if (this.isDeadOrDying()) {
-      return; // Deleted block.
-    }
-    if (this.workspace.isDragging()) {
-      return; // Don't bump blocks during a drag.
-    }
-
-    if (this.getParent()) {
-      return; // Only snap top-level blocks.
-    }
-    if (this.isInFlyout) {
-      return; // Don't move blocks around in a flyout.
-    }
+    if (this.isDeadOrDying()) return;
+    if (this.getParent()) return;
+    if (this.isInFlyout) return;
     const grid = this.workspace.getGrid();
-    if (!grid || !grid.shouldSnap()) {
-      return; // Config says no snapping.
-    }
+    if (!grid || !grid.shouldSnap()) return;
+
     const spacing = grid.getSpacing();
     const half = spacing / 2;
     const xy = this.getRelativeToSurfaceXY();
@@ -1530,15 +1519,7 @@ export class BlockSvg
    * @internal
    */
   scheduleSnapAndBump() {
-    // Ensure that any snap and bump are part of this move's event group.
-    const group = eventUtils.getGroup();
-
-    setTimeout(() => {
-      eventUtils.setGroup(group);
-      this.snapToGrid();
-      eventUtils.setGroup(false);
-    }, config.bumpDelay / 2);
-
+    this.snapToGrid();
     this.bumpNeighbours();
   }
 


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Work on #5146  #4288 

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
Makes it so that snapping to the grid happens immediately instead of after a delay.

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
I am working on refactoring how block initialization works. As part of it, I need to have `bumpNeighbors` be triggered by the render management system, instead of being triggered by each individual change that might change the shape of the block.

But before `bumpNeighbors` gets called, I need to make sure the snap has happened. So I'm getting rid of the delay.

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->

Manually tested that snapping works properly, and looks correct when dropping after dragging.

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->
N/A

### Additional Information

<!-- Anything else we should know? -->
Dependent on #7743 
