### PR TITLE
fix: bump neighbours performance regression

### DIFF
--- a/core/block.ts
+++ b/core/block.ts
@@ -558,9 +558,10 @@ export class Block implements IASTNodeLocation, IDeletable {
   /**
    * Bump unconnected blocks out of alignment.  Two blocks which aren't actually
    * connected should not coincidentally line up on screen.
+   * 
+   * @deprecated v11 - You should not need to call bump neighbours directly.
    */
   bumpNeighbours() {}
-  // noop.
 
   /**
    * Return the parent block or null if this block is at the top level. The

--- a/core/block.ts
+++ b/core/block.ts
@@ -558,7 +558,7 @@ export class Block implements IASTNodeLocation, IDeletable {
   /**
    * Bump unconnected blocks out of alignment.  Two blocks which aren't actually
    * connected should not coincidentally line up on screen.
-   * 
+   *
    * @deprecated v11 - You should not need to call bump neighbours directly.
    */
   bumpNeighbours() {}

--- a/core/block.ts
+++ b/core/block.ts
@@ -558,8 +558,6 @@ export class Block implements IASTNodeLocation, IDeletable {
   /**
    * Bump unconnected blocks out of alignment.  Two blocks which aren't actually
    * connected should not coincidentally line up on screen.
-   *
-   * @deprecated v11 - You should not need to call bump neighbours directly.
    */
   bumpNeighbours() {}
 

--- a/core/block_dragger.ts
+++ b/core/block_dragger.ts
@@ -287,13 +287,13 @@ export class BlockDragger implements IBlockDragger {
    */
   protected updateBlockAfterMove_() {
     this.fireMoveEvent_();
-    this.draggingBlock_.snapToGrid();
     if (this.draggedConnectionManager_.wouldConnectBlock()) {
       // Applying connections also rerenders the relevant blocks.
       this.draggedConnectionManager_.applyConnections();
     } else {
       this.draggingBlock_.queueRender();
     }
+    this.draggingBlock_.snapToGrid();
   }
 
   /** Fire a UI event at the end of a block drag. */

--- a/core/block_dragger.ts
+++ b/core/block_dragger.ts
@@ -287,13 +287,13 @@ export class BlockDragger implements IBlockDragger {
    */
   protected updateBlockAfterMove_() {
     this.fireMoveEvent_();
+    this.draggingBlock_.snapToGrid();
     if (this.draggedConnectionManager_.wouldConnectBlock()) {
       // Applying connections also rerenders the relevant blocks.
       this.draggedConnectionManager_.applyConnections();
     } else {
       this.draggingBlock_.queueRender();
     }
-    this.draggingBlock_.scheduleSnapAndBump();
   }
 
   /** Fire a UI event at the end of a block drag. */

--- a/core/block_svg.ts
+++ b/core/block_svg.ts
@@ -1397,24 +1397,21 @@ export class BlockSvg
    *
    * Two blocks which aren't actually connected should not coincidentally line
    * up on screen, because that creates confusion for end-users.
+   * 
+   * @deprecated v11 - You should not need to call bump neighbours directly.
    */
   override bumpNeighbours() {
-    if (this.bumpNeighboursPid) return;
-    const group = eventUtils.getGroup();
-
-    this.bumpNeighboursPid = setTimeout(() => {
-      const oldGroup = eventUtils.getGroup();
-      eventUtils.setGroup(group);
-      this.getRootBlock().bumpNeighboursInternal();
-      eventUtils.setGroup(oldGroup);
-      this.bumpNeighboursPid = 0;
-    }, config.bumpDelay);
+    deprecation.warn('bumpNeighbours', 'v11', 'v12');
+    // After rendering neighbours will get bumped.
+    this.queueRender();
   }
 
   /**
    * Bumps unconnected blocks out of alignment.
+   * 
+   * @internal
    */
-  private bumpNeighboursInternal() {
+  public bumpNeighboursInternal() {
     const root = this.getRootBlock();
     if (
       this.isDeadOrDying() ||
@@ -1435,12 +1432,9 @@ export class BlockSvg
       }
 
       for (const neighbour of conn.neighbours(config.snapRadius)) {
-        // Don't bump away from things that are in our stack.
         if (neighbourIsInStack(neighbour)) continue;
-        // If both connections are connected, that's fine.
         if (conn.isConnected() && neighbour.isConnected()) continue;
 
-        // Always bump the inferior connection.
         if (conn.isSuperior()) {
           neighbour.bumpAwayFrom(conn);
         } else {
@@ -1458,7 +1452,7 @@ export class BlockSvg
    */
   scheduleSnapAndBump() {
     this.snapToGrid();
-    this.bumpNeighbours();
+    this.bumpNeighboursInternal();
   }
 
   /**

--- a/core/block_svg.ts
+++ b/core/block_svg.ts
@@ -1417,6 +1417,15 @@ export class BlockSvg
   }
 
   /**
+   * Schedule snapping to grid and bumping neighbours to occur after a brief
+   * delay.
+   */
+  scheduleSnapAndBump() {
+    this.snapToGrid();
+    this.bumpNeighbours();
+  }
+
+  /**
    * Position a block so that it doesn't move the target block when connected.
    * The block to position is usually either the first block in a dragged stack
    * or an insertion marker.

--- a/core/block_svg.ts
+++ b/core/block_svg.ts
@@ -142,12 +142,6 @@ export class BlockSvg
 
   private translation = '';
 
-  /**
-   * The ID of the setTimeout callback for bumping neighbours, or 0 if no bump
-   * is currently scheduled.
-   */
-  private bumpNeighboursPid = 0;
-
   /** Whether this block is currently being dragged. */
   private dragging = false;
 
@@ -990,7 +984,6 @@ export class BlockSvg
     icon.applyColour();
     icon.updateEditable();
     this.queueRender();
-    this.bumpNeighbours();
 
     return icon;
   }
@@ -1015,7 +1008,6 @@ export class BlockSvg
     if (type.equals(MutatorIcon.TYPE)) this.mutator = null;
 
     this.queueRender();
-    this.bumpNeighbours();
 
     return removed;
   }
@@ -1173,7 +1165,6 @@ export class BlockSvg
   ) {
     super.setPreviousStatement(newBoolean, opt_check);
     this.queueRender();
-    this.bumpNeighbours();
   }
 
   /**
@@ -1189,7 +1180,6 @@ export class BlockSvg
   ) {
     super.setNextStatement(newBoolean, opt_check);
     this.queueRender();
-    this.bumpNeighbours();
   }
 
   /**
@@ -1205,7 +1195,6 @@ export class BlockSvg
   ) {
     super.setOutput(newBoolean, opt_check);
     this.queueRender();
-    this.bumpNeighbours();
   }
 
   /**
@@ -1216,7 +1205,6 @@ export class BlockSvg
   override setInputsInline(newBoolean: boolean) {
     super.setInputsInline(newBoolean);
     this.queueRender();
-    this.bumpNeighbours();
   }
 
   /**
@@ -1231,7 +1219,6 @@ export class BlockSvg
   override removeInput(name: string, opt_quiet?: boolean): boolean {
     const removed = super.removeInput(name, opt_quiet);
     this.queueRender();
-    this.bumpNeighbours();
     return removed;
   }
 
@@ -1244,14 +1231,12 @@ export class BlockSvg
   override moveNumberedInputBefore(inputIndex: number, refIndex: number) {
     super.moveNumberedInputBefore(inputIndex, refIndex);
     this.queueRender();
-    this.bumpNeighbours();
   }
 
   /** @override */
   override appendInput(input: Input): Input {
     super.appendInput(input);
     this.queueRender();
-    this.bumpNeighbours();
     return input;
   }
 

--- a/core/block_svg.ts
+++ b/core/block_svg.ts
@@ -1382,7 +1382,7 @@ export class BlockSvg
    *
    * Two blocks which aren't actually connected should not coincidentally line
    * up on screen, because that creates confusion for end-users.
-   * 
+   *
    * @deprecated v11 - You should not need to call bump neighbours directly.
    */
   override bumpNeighbours() {
@@ -1393,7 +1393,7 @@ export class BlockSvg
 
   /**
    * Bumps unconnected blocks out of alignment.
-   * 
+   *
    * @internal
    */
   bumpNeighboursInternal() {

--- a/core/block_svg.ts
+++ b/core/block_svg.ts
@@ -60,6 +60,7 @@ import type {WorkspaceSvg} from './workspace_svg.js';
 import * as renderManagement from './render_management.js';
 import {IconType} from './icons/icon_types.js';
 import {BlockCopyData, BlockPaster} from './clipboard/block_paster.js';
+import * as deprecation from './utils/deprecation.js';
 
 /**
  * Class for a block's SVG representation.

--- a/core/block_svg.ts
+++ b/core/block_svg.ts
@@ -1417,8 +1417,8 @@ export class BlockSvg
   }
 
   /**
-   * Schedule snapping to grid and bumping neighbours to occur after a brief
-   * delay.
+   * Snap to grid, and then bump neighbouring blocks away at the ned of the next
+   * render.
    */
   scheduleSnapAndBump() {
     this.snapToGrid();

--- a/core/block_svg.ts
+++ b/core/block_svg.ts
@@ -1417,7 +1417,7 @@ export class BlockSvg
   }
 
   /**
-   * Snap to grid, and then bump neighbouring blocks away at the ned of the next
+   * Snap to grid, and then bump neighbouring blocks away at the end of the next
    * render.
    */
   scheduleSnapAndBump() {

--- a/core/block_svg.ts
+++ b/core/block_svg.ts
@@ -1411,7 +1411,7 @@ export class BlockSvg
    * 
    * @internal
    */
-  public bumpNeighboursInternal() {
+  bumpNeighboursInternal() {
     const root = this.getRootBlock();
     if (
       this.isDeadOrDying() ||
@@ -1442,17 +1442,6 @@ export class BlockSvg
         }
       }
     }
-  }
-
-  /**
-   * Schedule snapping to grid and bumping neighbours to occur after a brief
-   * delay.
-   *
-   * @internal
-   */
-  scheduleSnapAndBump() {
-    this.snapToGrid();
-    this.bumpNeighboursInternal();
   }
 
   /**

--- a/core/block_svg.ts
+++ b/core/block_svg.ts
@@ -1384,16 +1384,6 @@ export class BlockSvg
    * up on screen, because that creates confusion for end-users.
    */
   override bumpNeighbours() {
-    // After rendering neighbours will get bumped.
-    this.queueRender();
-  }
-
-  /**
-   * Bumps unconnected blocks out of alignment.
-   *
-   * @internal
-   */
-  bumpNeighboursInternal() {
     const root = this.getRootBlock();
     if (
       this.isDeadOrDying() ||
@@ -1410,7 +1400,7 @@ export class BlockSvg
     for (const conn of this.getConnections_(false)) {
       if (conn.isSuperior()) {
         // Recurse down the block stack.
-        conn.targetBlock()?.bumpNeighboursInternal();
+        conn.targetBlock()?.bumpNeighbours();
       }
 
       for (const neighbour of conn.neighbours(config.snapRadius)) {

--- a/core/block_svg.ts
+++ b/core/block_svg.ts
@@ -60,7 +60,6 @@ import type {WorkspaceSvg} from './workspace_svg.js';
 import * as renderManagement from './render_management.js';
 import {IconType} from './icons/icon_types.js';
 import {BlockCopyData, BlockPaster} from './clipboard/block_paster.js';
-import * as deprecation from './utils/deprecation.js';
 
 /**
  * Class for a block's SVG representation.
@@ -1383,11 +1382,8 @@ export class BlockSvg
    *
    * Two blocks which aren't actually connected should not coincidentally line
    * up on screen, because that creates confusion for end-users.
-   *
-   * @deprecated v11 - You should not need to call bump neighbours directly.
    */
   override bumpNeighbours() {
-    deprecation.warn('bumpNeighbours', 'v11', 'v12');
     // After rendering neighbours will get bumped.
     this.queueRender();
   }

--- a/core/field.ts
+++ b/core/field.ts
@@ -1062,7 +1062,6 @@ export abstract class Field<T = any>
     this.isDirty_ = true;
     if (this.sourceBlock_ && this.sourceBlock_.rendered) {
       (this.sourceBlock_ as BlockSvg).queueRender();
-      (this.sourceBlock_ as BlockSvg).bumpNeighbours();
     }
   }
 

--- a/core/gesture.ts
+++ b/core/gesture.ts
@@ -963,7 +963,8 @@ export class Gesture {
           eventUtils.setGroup(true);
         }
         const newBlock = this.flyout.createBlock(this.targetBlock);
-        newBlock.scheduleSnapAndBump();
+        newBlock.snapToGrid();
+        newBlock.bumpNeighboursInternal();
       }
     } else {
       if (!this.startWorkspace_) {

--- a/core/gesture.ts
+++ b/core/gesture.ts
@@ -125,6 +125,9 @@ export class Gesture {
    */
   private workspaceDragger: WorkspaceDragger | null = null;
 
+  /** Whether the gesture is dragging or not. */
+  private dragging: boolean = false;
+
   /** The flyout a gesture started in, if any. */
   private flyout: IFlyout | null = null;
 
@@ -369,6 +372,7 @@ export class Gesture {
       : this.startWorkspace_ && this.startWorkspace_.isDraggable();
     if (!wsMovable) return;
 
+    this.dragging = true;
     this.workspaceDragger = new WorkspaceDragger(this.startWorkspace_);
 
     this.workspaceDragger.startDrag();
@@ -408,6 +412,7 @@ export class Gesture {
       true,
     );
 
+    this.dragging = true;
     this.blockDragger = new BlockDraggerClass!(
       this.targetBlock,
       this.startWorkspace_,
@@ -431,6 +436,7 @@ export class Gesture {
       );
     }
 
+    this.dragging = true;
     this.bubbleDragger = new BubbleDragger(
       this.startBubble,
       this.startWorkspace_,
@@ -1206,9 +1212,7 @@ export class Gesture {
    * @internal
    */
   isDragging(): boolean {
-    return (
-      !!this.workspaceDragger || !!this.blockDragger || !!this.bubbleDragger
-    );
+    return this.dragging;
   }
 
   /**

--- a/core/gesture.ts
+++ b/core/gesture.ts
@@ -964,7 +964,7 @@ export class Gesture {
         }
         const newBlock = this.flyout.createBlock(this.targetBlock);
         newBlock.snapToGrid();
-        newBlock.bumpNeighboursInternal();
+        newBlock.bumpNeighbours();
       }
     } else {
       if (!this.startWorkspace_) {

--- a/core/inputs/input.ts
+++ b/core/inputs/input.ts
@@ -124,7 +124,6 @@ export class Input {
 
     if (this.sourceBlock.rendered) {
       (this.sourceBlock as BlockSvg).queueRender();
-      this.sourceBlock.bumpNeighbours();
     }
     return index;
   }
@@ -145,7 +144,6 @@ export class Input {
         this.fieldRow.splice(i, 1);
         if (this.sourceBlock.rendered) {
           (this.sourceBlock as BlockSvg).queueRender();
-          this.sourceBlock.bumpNeighbours();
         }
         return true;
       }

--- a/core/render_management.ts
+++ b/core/render_management.ts
@@ -124,6 +124,9 @@ function doRenders() {
     const blockOrigin = block.getRelativeToSurfaceXY();
     block.updateComponentLocations(blockOrigin);
   }
+  for (const block of blocks) {
+    block.bumpNeighboursInternal();
+  }
 
   rootBlocks.clear();
   dirtyBlocks = new Set();

--- a/core/render_management.ts
+++ b/core/render_management.ts
@@ -134,7 +134,7 @@ function doRenders() {
     const newGroup = eventGroups.get(block);
     if (newGroup) eventUtils.setGroup(newGroup);
 
-    block.bumpNeighboursInternal();
+    block.bumpNeighbours();
 
     eventUtils.setGroup(oldGroup);
   }

--- a/core/rendered_connection.ts
+++ b/core/rendered_connection.ts
@@ -579,8 +579,6 @@ export class RenderedConnection extends Connection {
     ) {
       const child = this.isSuperior() ? this.targetBlock() : this.sourceBlock_;
       child!.unplug();
-      // Bump away.
-      this.sourceBlock_.bumpNeighbours();
     }
   }
 

--- a/core/rendered_connection.ts
+++ b/core/rendered_connection.ts
@@ -499,6 +499,9 @@ export class RenderedConnection extends Connection {
     const {parentConnection, childConnection} =
       this.getParentAndChildConnections();
     if (!parentConnection || !childConnection) return;
+    const existingGroup = eventUtils.getGroup();
+    if (!existingGroup) eventUtils.setGroup(true);
+
     const parent = parentConnection.getSourceBlock() as BlockSvg;
     const child = childConnection.getSourceBlock() as BlockSvg;
     super.disconnectInternal(setParent);
@@ -508,6 +511,8 @@ export class RenderedConnection extends Connection {
     child.queueRender();
     // Reset visibility, since the child is now a top block.
     child.getSvgRoot().style.display = 'block';
+
+    eventUtils.setGroup(existingGroup);
   }
 
   /**

--- a/tests/mocha/input_test.js
+++ b/tests/mocha/input_test.js
@@ -27,14 +27,12 @@ suite('Inputs', function () {
     );
 
     this.renderStub = sinon.stub(this.block, 'queueRender');
-    this.bumpNeighboursStub = sinon.stub(this.block, 'bumpNeighbours');
 
     this.dummy = this.block.appendDummyInput('DUMMY');
     this.value = this.block.appendValueInput('VALUE');
     this.statement = this.block.appendStatementInput('STATEMENT');
 
     this.renderStub.resetHistory();
-    this.bumpNeighboursStub.resetHistory();
   });
   teardown(function () {
     sharedTestTeardown.call(this);
@@ -158,7 +156,6 @@ suite('Inputs', function () {
         chai.assert.equal(setBlockSpy.getCall(0).args[0], this.block);
         sinon.assert.calledOnce(initSpy);
         sinon.assert.calledOnce(this.renderStub);
-        sinon.assert.calledOnce(this.bumpNeighboursStub);
 
         setBlockSpy.restore();
         initSpy.restore();
@@ -177,7 +174,6 @@ suite('Inputs', function () {
         chai.assert.equal(setBlockSpy.getCall(0).args[0], this.block);
         sinon.assert.calledOnce(initModelSpy);
         sinon.assert.notCalled(this.renderStub);
-        sinon.assert.notCalled(this.bumpNeighboursStub);
 
         setBlockSpy.restore();
         initModelSpy.restore();
@@ -196,12 +192,10 @@ suite('Inputs', function () {
       this.dummy.appendField(field, 'FIELD');
 
       this.renderStub.resetHistory();
-      this.bumpNeighboursStub.resetHistory();
 
       this.dummy.removeField('FIELD');
       sinon.assert.calledOnce(disposeSpy);
       sinon.assert.calledOnce(this.renderStub);
-      sinon.assert.calledOnce(this.bumpNeighboursStub);
     });
     test('Headless', function () {
       const field = new Blockly.FieldLabel('field');
@@ -209,14 +203,12 @@ suite('Inputs', function () {
       this.dummy.appendField(field, 'FIELD');
 
       this.renderStub.resetHistory();
-      this.bumpNeighboursStub.resetHistory();
 
       this.block.rendered = false;
 
       this.dummy.removeField('FIELD');
       sinon.assert.calledOnce(disposeSpy);
       sinon.assert.notCalled(this.renderStub);
-      sinon.assert.notCalled(this.bumpNeighboursStub);
     });
   });
   suite('Field Ordering/Manipulation', function () {

--- a/tests/mocha/render_management_test.js
+++ b/tests/mocha/render_management_test.js
@@ -32,6 +32,7 @@ suite('Render Management', function () {
         isDisposed: () => false,
         getRelativeToSurfaceXY: () => ({x: 0, y: 0}),
         updateComponentLocations: () => {},
+        bumpNeighboursInternal: () => {},
         workspace: {
           resizeContents: () => {},
         },

--- a/tests/mocha/render_management_test.js
+++ b/tests/mocha/render_management_test.js
@@ -32,7 +32,7 @@ suite('Render Management', function () {
         isDisposed: () => false,
         getRelativeToSurfaceXY: () => ({x: 0, y: 0}),
         updateComponentLocations: () => {},
-        bumpNeighboursInternal: () => {},
+        bumpNeighbours: () => {},
         workspace: {
           resizeContents: () => {},
         },


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
N/A

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
Makes it so that `bumpNeighbours` is called as part of the rendering cycle.

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
1) You no longer have to remember to call `bumpNeighbours` because it just happens whenever the block changes shape.
2) Alleviates a performance regression caused by https://github.com/google/blockly/pull/7747 . The regression was that `bumpNeighbours` was being called on every single block initialization action during deserialization, which meant a ton of `setTimeout` calls, which were slowing everything down. Making `bumpNeighbours` part of serialization gets rid of these `setTimeout` calls.

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->

Manually tested.
Manually profiled performance.
Also covered by some existing unit tests (caught the issue with event grouping!)

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->
N/A

### Additional Information

<!-- Anything else we should know? -->
Dependent on https://github.com/google/blockly/pull/7747
