### PR TITLE
feat: connection highlight zelos

### DIFF
--- a/core/renderers/zelos/constants.ts
+++ b/core/renderers/zelos/constants.ts
@@ -392,19 +392,20 @@ export class ConstantProvider extends BaseConstantProvider {
         blockHeight > maxHeight ? blockHeight - maxHeight : 0;
       const height = blockHeight > maxHeight ? maxHeight : blockHeight;
       const radius = height / 2;
+      const sweep = right === up ? '0' : '1';
       return (
         svgPaths.arc(
           'a',
-          '0 0,1',
+          '0 0,' + sweep,
           radius,
-          svgPaths.point((up ? -1 : 1) * radius, (up ? -1 : 1) * radius),
+          svgPaths.point((right ? 1 : -1) * radius, (up ? -1 : 1) * radius),
         ) +
-        svgPaths.lineOnAxis('v', (right ? 1 : -1) * remainingHeight) +
+        svgPaths.lineOnAxis('v', (up ? -1 : 1) * remainingHeight) +
         svgPaths.arc(
           'a',
-          '0 0,1',
+          '0 0,' + sweep,
           radius,
-          svgPaths.point((up ? 1 : -1) * radius, (up ? -1 : 1) * radius),
+          svgPaths.point((right ? -1 : 1) * radius, (up ? -1 : 1) * radius),
         )
       );
     }
@@ -465,19 +466,20 @@ export class ConstantProvider extends BaseConstantProvider {
      */
     function makeMainPath(height: number, up: boolean, right: boolean): string {
       const innerHeight = height - radius * 2;
+      const sweep = right === up ? '0' : '1';
       return (
         svgPaths.arc(
           'a',
-          '0 0,1',
+          '0 0,' + sweep,
           radius,
-          svgPaths.point((up ? -1 : 1) * radius, (up ? -1 : 1) * radius),
+          svgPaths.point((right ? 1 : -1) * radius, (up ? -1 : 1) * radius),
         ) +
-        svgPaths.lineOnAxis('v', (right ? 1 : -1) * innerHeight) +
+        svgPaths.lineOnAxis('v', (up ? -1 : 1) * innerHeight) +
         svgPaths.arc(
           'a',
-          '0 0,1',
+          '0 0,' + sweep,
           radius,
-          svgPaths.point((up ? 1 : -1) * radius, (up ? -1 : 1) * radius),
+          svgPaths.point((right ? -1 : 1) * radius, (up ? -1 : 1) * radius),
         )
       );
     }

--- a/core/renderers/zelos/drawer.ts
+++ b/core/renderers/zelos/drawer.ts
@@ -10,14 +10,8 @@ import type {BlockSvg} from '../../block_svg.js';
 import {ConnectionType} from '../../connection_type.js';
 import {RenderedConnection} from '../../rendered_connection.js';
 import * as svgPaths from '../../utils/svg_paths.js';
-import type {
-  BaseShape,
-  DynamicShape,
-  Notch,
-  PuzzleTab,
-} from '../common/constants.js';
+import type {BaseShape, DynamicShape, Notch} from '../common/constants.js';
 import {Drawer as BaseDrawer} from '../common/drawer.js';
-import {Connection} from '../measurables/connection.js';
 import type {InlineInput} from '../measurables/inline_input.js';
 import {OutputConnection} from '../measurables/output_connection.js';
 import type {Row} from '../measurables/row.js';
@@ -267,7 +261,6 @@ export class Drawer extends BaseDrawer {
       const output = measurable as OutputConnection;
       const xPos = output.width;
       const yPos = -output.height / 2;
-      console.log((output.shape as DynamicShape).pathDown(output.height));
       path =
         svgPaths.moveTo(xPos, yPos) +
         (output.shape as DynamicShape).pathDown(output.height);

--- a/core/renderers/zelos/drawer.ts
+++ b/core/renderers/zelos/drawer.ts
@@ -7,9 +7,12 @@
 // Former goog.module ID: Blockly.zelos.Drawer
 
 import type {BlockSvg} from '../../block_svg.js';
+import {ConnectionType} from '../../connection_type.js';
+import {RenderedConnection} from '../../rendered_connection.js';
 import * as svgPaths from '../../utils/svg_paths.js';
 import type {BaseShape, DynamicShape, Notch} from '../common/constants.js';
 import {Drawer as BaseDrawer} from '../common/drawer.js';
+import {Connection} from '../measurables/connection.js';
 import type {InlineInput} from '../measurables/inline_input.js';
 import type {Row} from '../measurables/row.js';
 import type {SpacerRow} from '../measurables/spacer_row.js';
@@ -179,21 +182,27 @@ export class Drawer extends BaseDrawer {
       return;
     }
 
-    const width = input.width - input.connectionWidth * 2;
-    const height = input.height;
-    const yPos = input.centerline - height / 2;
-
+    const yPos = input.centerline - input.height / 2;
     const connectionRight = input.xPos + input.connectionWidth;
 
-    const outlinePath =
-      svgPaths.moveTo(connectionRight, yPos) +
-      svgPaths.lineOnAxis('h', width) +
-      (input.shape as DynamicShape).pathRightDown(input.height) +
-      svgPaths.lineOnAxis('h', -width) +
-      (input.shape as DynamicShape).pathUp(input.height) +
-      'z';
+    const path =
+      svgPaths.moveTo(connectionRight, yPos) + this.getInlineInputPath(input);
+
     const pathObject = this.block_.pathObject as PathObject;
-    pathObject.setOutlinePath(inputName, outlinePath);
+    pathObject.setOutlinePath(inputName, path);
+  }
+
+  private getInlineInputPath(input: InlineInput) {
+    const width = input.width - input.connectionWidth * 2;
+    const height = input.height;
+
+    return (
+      svgPaths.lineOnAxis('h', width) +
+      (input.shape as DynamicShape).pathRightDown(height) +
+      svgPaths.lineOnAxis('h', -width) +
+      (input.shape as DynamicShape).pathUp(height) +
+      'z'
+    );
   }
 
   override drawStatementInput_(row: Row) {
@@ -224,5 +233,42 @@ export class Drawer extends BaseDrawer {
       svgPaths.lineOnAxis('H', row.xPos + row.width);
 
     this.positionStatementInputConnection_(row);
+  }
+
+  /** Returns a path to highlight the given connection. */
+  drawConnectionHighlightPath(conn: RenderedConnection) {
+    if (
+      conn.type === ConnectionType.NEXT_STATEMENT ||
+      conn.type === ConnectionType.PREVIOUS_STATEMENT
+    ) {
+      super.drawConnectionHighlightPath(conn);
+      return;
+    }
+
+    const measurable = this.info_.getMeasureableForConnection(conn);
+    if (!measurable) {
+      throw new Error('Could not find measurable for connection');
+    }
+
+    let path = '';
+    if (conn.type === ConnectionType.INPUT_VALUE) {
+      const input = measurable as InlineInput;
+      const yPos = -input.height / 2;
+      const xPos = input.connectionWidth;
+      path = svgPaths.moveTo(xPos, yPos) + this.getInlineInputPath(input);
+    } else {
+      path = this.getOutputHighlightPath(measurable);
+    }
+    const block = conn.getSourceBlock();
+    block.pathObject.addConnectionHighlight?.(
+      conn,
+      path,
+      conn.getOffsetInBlock(),
+      block.RTL,
+    );
+  }
+
+  private getOutputHighlightPath(conn: Connection): string {
+    return '';
   }
 }


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Work on #7204 

### Proposed Changes + reasons

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
Makes it so that zelos has the ability to highlight connections, so the eventual connection previewer system can call the renderer to highlight connections consistently (instead of sometimes calling the renderer, and sometimes doing other things).

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->
Manually tested highlighting all three shapes of dynamic connections in zelos (hexagon, rounded, and square). Manually tested highlighting non-dynamic connections (puzzle tabs).

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->
N/A

### Additional Information

<!-- Anything else we should know? -->
N/A

### To Review

The drawer architecture is... a bit frustrating. All of the methods are stateful, so I had to pull out some logic for creating internal input paths into pure methods. This way the code could be reused.

Some of the "constants" for path shapes were also broken. Previously `pathDown()` was never being called, so no one noticed that it was busted. I fixed up the logic to actually work for all combinations of right or left side + drawing up or down.

[Edit: docs for context [https://developers.google.com/blockly/guides/create-custom-blocks/renderers/create-custom-renderers/connection-shapes#basic_shapes](https://developers.google.com/blockly/guides/create-custom-blocks/renderers/create-custom-renderers/connection-shapes#basic_shapes)]
