### PR TITLE
fix: first block dragged from flyout will have same id

### DIFF
--- a/core/flyout_base.ts
+++ b/core/flyout_base.ts
@@ -1251,8 +1251,7 @@ export abstract class Flyout
     }
 
     // Clone the block.
-    // TODO(#7432): Add a saveIds parameter to `save`.
-    const json = blocks.save(oldBlock, {saveIds: false}) as blocks.State;
+    const json = blocks.save(oldBlock) as blocks.State;
     // Normallly this resizes leading to weird jumps. Save it for terminateDrag.
     targetWorkspace.setResizesEnabled(false);
     const block = blocks.append(json, targetWorkspace) as BlockSvg;


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes n/a

### Proposed Changes

Previously in https://github.com/google/blockly/issues/7432 we added a `saveIds` parameter to block serialization so that we could have blocks in the flyout *not* save their id, that way all new blocks created would have a unique id, instead of having the same id as the block in the flyout.

This PR keeps the option to disable saving block IDs during serialization, but it doesn't use the option when serializing flyout blocks. One of our partners was relying on the old behavior where the first block dragged from the toolbox had the same id as the original block in the toolbox.

### Reason for Changes

Unblocking partners.

### Test Coverage

We originally added this because our browser tests were searching for the `data-id` attribute on the page and assuming that only one block would match. We worked around that in the existing browser tests and never updated them after we added this feature so that block ids would never match, so none of the browser tests need to be changed. I tested this by running the browser tests before and after this PR, and actually fewer tests fail after... but that's just a result of flakiness, none of the failures are related to this issue.

### Documentation

n/a this behavior wasn't documented before and shouldn't be relied upon. if someone was relying on this undocumented behavior, then... this PR will also unblock them because however they were using it also probably broke in 10.3.

### Additional Information

This will be included in the next patch release.
