### PR TITLE
chore: Bump Python from 3.7 to 3.12

### DIFF
--- a/appengine/app.yaml
+++ b/appengine/app.yaml
@@ -1,4 +1,4 @@
-runtime: python37
+runtime: python312
 
 handlers:
 # Redirect obsolete URLs.


### PR DESCRIPTION
3.7 is not supported from 31 January.  Failure to upgrade appears to result in the inability to push new versions.  3.12 is the latest available Python version for App Engine, and should last the longest.

Tested on DOM-Tutorials and Glockenspiel.  No issues there.
