### PR TITLE
feat: insertion marker previewer

### DIFF
--- a/core/connection_previewers/insertion_marker_previewer.ts
+++ b/core/connection_previewers/insertion_marker_previewer.ts
@@ -184,7 +184,7 @@ export class InsertionMarkerPreviewer implements IConnectionPreviewer {
    * connection on the original block.
    *
    * @param orig The original block.
-   * @param marker The marker block (where  we want to find the matching
+   * @param marker The marker block (where we want to find the matching
    *     connection).
    * @param origConn The original connection.
    */

--- a/core/connection_previewers/insertion_marker_previewer.ts
+++ b/core/connection_previewers/insertion_marker_previewer.ts
@@ -55,6 +55,10 @@ export class InsertionMarkerPreviewer implements IConnectionPreviewer {
     this.hidePreview();
     this.fadedBlock = replacedBlock;
     replacedBlock.fadeForReplacement(true);
+    if (this.workspace.getRenderer().shouldHighlightConnection(staticConn)) {
+      staticConn.highlight();
+      this.staticConn = staticConn;
+    }
   }
 
   /**
@@ -102,6 +106,10 @@ export class InsertionMarkerPreviewer implements IConnectionPreviewer {
       );
       marker?.getSvgRoot().setAttribute('visibility', 'visible');
     });
+
+    if (this.workspace.getRenderer().shouldHighlightConnection(staticConn)) {
+      staticConn.highlight();
+    }
 
     this.markerConn = markerConn;
     this.draggedConn = draggedConn;
@@ -180,6 +188,10 @@ export class InsertionMarkerPreviewer implements IConnectionPreviewer {
 
   /** Hide any previews that are currently displayed. */
   hidePreview() {
+    if (this.staticConn) {
+      this.staticConn.unhighlight();
+      this.staticConn = null;
+    }
     if (this.fadedBlock) {
       this.fadedBlock.fadeForReplacement(false);
       this.fadedBlock = null;
@@ -188,7 +200,6 @@ export class InsertionMarkerPreviewer implements IConnectionPreviewer {
       this.hideInsertionMarker(this.markerConn);
       this.markerConn = null;
       this.draggedConn = null;
-      this.staticConn = null;
     }
   }
 

--- a/core/connection_previewers/insertion_marker_previewer.ts
+++ b/core/connection_previewers/insertion_marker_previewer.ts
@@ -6,11 +6,13 @@
 
 import {BlockSvg} from '../block_svg.js';
 import {IConnectionPreviewer} from '../interfaces/i_connection_previewer.js';
-// import {RenderedConnection} from '../rendered_connection.js';
+import {RenderedConnection} from '../rendered_connection.js';
 import {WorkspaceSvg} from '../workspace_svg.js';
 
 export class InsertionMarkerPreviewer implements IConnectionPreviewer {
   private readonly workspace: WorkspaceSvg;
+
+  private fadedBlock: BlockSvg | null = null;
 
   constructor(draggedBlock: BlockSvg) {
     this.workspace = draggedBlock.workspace;
@@ -28,10 +30,14 @@ export class InsertionMarkerPreviewer implements IConnectionPreviewer {
    *     is being replaced.
    */
   previewReplacement(
-    // draggedConn: RenderedConnection,
-    // staticConn: RenderedConnection,
-    // replacedBlock: BlockSvg,
-  ) {}
+    draggedConn: RenderedConnection,
+    staticConn: RenderedConnection,
+    replacedBlock: BlockSvg,
+  ) {
+    this.hidePreview();
+    this.fadedBlock = replacedBlock;
+    replacedBlock.fadeForReplacement(true);
+  }
 
   /**
    * Display a connection preview where the draggedCon connects to the
@@ -47,8 +53,15 @@ export class InsertionMarkerPreviewer implements IConnectionPreviewer {
   ) {}
 
   /** Hide any previews that are currently displayed. */
-  hidePreview() {}
+  hidePreview() {
+    if (this.fadedBlock) {
+      this.fadedBlock.fadeForReplacement(false);
+      this.fadedBlock = null;
+    }
+  }
 
   /** Dispose of any references held by this connection previewer. */
-  dispose() {}
+  dispose() {
+    this.hidePreview();
+  }
 }

--- a/core/connection_previewers/insertion_marker_previewer.ts
+++ b/core/connection_previewers/insertion_marker_previewer.ts
@@ -179,6 +179,15 @@ export class InsertionMarkerPreviewer implements IConnectionPreviewer {
     return result;
   }
 
+  /**
+   * Gets the connection on the marker block that matches the original
+   * connection on the original block.
+   *
+   * @param orig The original block.
+   * @param marker The marker block (where  we want to find the matching
+   *     connection).
+   * @param origConn The original connection.
+   */
   private getMatchingConnection(
     orig: BlockSvg,
     marker: BlockSvg,

--- a/core/connection_previewers/insertion_marker_previewer.ts
+++ b/core/connection_previewers/insertion_marker_previewer.ts
@@ -1,0 +1,54 @@
+/**
+ * @license
+ * Copyright 2024 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {BlockSvg} from '../block_svg.js';
+import {IConnectionPreviewer} from '../interfaces/i_connection_previewer.js';
+// import {RenderedConnection} from '../rendered_connection.js';
+import {WorkspaceSvg} from '../workspace_svg.js';
+
+export class InsertionMarkerPreviewer implements IConnectionPreviewer {
+  private readonly workspace: WorkspaceSvg;
+
+  constructor(draggedBlock: BlockSvg) {
+    this.workspace = draggedBlock.workspace;
+  }
+
+  /**
+   * Display a connection preview where the draggedCon connects to the
+   * staticCon, replacing the replacedBlock (currently connected to the
+   * staticCon).
+   *
+   * @param draggedConn The connection on the block stack being dragged.
+   * @param staticConn The connection not being dragged that we are
+   *     connecting to.
+   * @param replacedBlock The block currently connected to the staticCon that
+   *     is being replaced.
+   */
+  previewReplacement(
+    // draggedConn: RenderedConnection,
+    // staticConn: RenderedConnection,
+    // replacedBlock: BlockSvg,
+  ) {}
+
+  /**
+   * Display a connection preview where the draggedCon connects to the
+   * staticCon, and no block is being relaced.
+   *
+   * @param draggedConn The connection on the block stack being dragged.
+   * @param staticConn The connection not being dragged that we are
+   *     connecting to.
+   */
+  previewConnection(
+    // draggedConn: RenderedConnection,
+    // staticConn: RenderedConnection,
+  ) {}
+
+  /** Hide any previews that are currently displayed. */
+  hidePreview() {}
+
+  /** Dispose of any references held by this connection previewer. */
+  dispose() {}
+}


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Work on #7204 

### Proposed Changes + Reasons

Adds the insertion marker previewer so we can stop relying on the insertion marker manager (in a future PR).

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->
Manually tested with the next PR that insertion markers and highlights properly appear:

- When inserting in stacks.
- When inserting around stacks.
- When inserting in rows.
- When inserting around rows.
- When replacing stacks.
- When replacing rows.

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->
N/A

### Additional Information

<!-- Anything else we should know? -->
N/A

## To Review

Recommend reveiewing comit-wise.

A lot of this code was adapted from the insertion marker manager, so it may be useful to look at that.

Please let me know if anything needs more docs.
