### PR TITLE
feat: update block dragger to use connection previewer

### DIFF
--- a/core/block_dragger.ts
+++ b/core/block_dragger.ts
@@ -21,7 +21,6 @@ import * as common from './common.js';
 import type {BlockMove} from './events/events_block_move.js';
 import * as eventUtils from './events/utils.js';
 import type {Icon} from './icons/icon.js';
-import {InsertionMarkerManager} from './insertion_marker_manager.js';
 import type {IBlockDragger} from './interfaces/i_block_dragger.js';
 import type {IDragTarget} from './interfaces/i_drag_target.js';
 import * as registry from './registry.js';
@@ -60,7 +59,6 @@ interface ConnectionCandidate {
 export class BlockDragger implements IBlockDragger {
   /** The top block in the stack that is being dragged. */
   protected draggingBlock_: BlockSvg;
-  protected draggedConnectionManager_: InsertionMarkerManager;
 
   protected connectionPreviewer: IConnectionPreviewer;
 
@@ -89,11 +87,6 @@ export class BlockDragger implements IBlockDragger {
   constructor(block: BlockSvg, workspace: WorkspaceSvg) {
     this.draggingBlock_ = block;
 
-    /** Object that keeps track of connections on dragged blocks. */
-    this.draggedConnectionManager_ = new InsertionMarkerManager(
-      this.draggingBlock_,
-    );
-
     // TODO: have this access the registry instead.
     this.connectionPreviewer = new InsertionMarkerPreviewer(block);
 
@@ -115,9 +108,6 @@ export class BlockDragger implements IBlockDragger {
    */
   dispose() {
     this.dragIconData_.length = 0;
-    if (this.draggedConnectionManager_) {
-      this.draggedConnectionManager_.dispose();
-    }
     this.connectionPreviewer.dispose();
   }
 
@@ -614,14 +604,9 @@ export class BlockDragger implements IBlockDragger {
    * @returns A possibly empty list of insertion marker blocks.
    */
   getInsertionMarkers(): BlockSvg[] {
-    // No insertion markers with the old style of dragged connection managers.
-    if (
-      this.draggedConnectionManager_ &&
-      this.draggedConnectionManager_.getInsertionMarkers
-    ) {
-      return this.draggedConnectionManager_.getInsertionMarkers();
-    }
-    return [];
+    return this.workspace_
+      .getAllBlocks()
+      .filter((block) => block.isInsertionMarker());
   }
 }
 

--- a/core/block_dragger.ts
+++ b/core/block_dragger.ts
@@ -191,14 +191,16 @@ export class BlockDragger implements IBlockDragger {
    * display accordingly.
    *
    * @param e The most recent move event.
-   * @param currentDragDeltaXY How far the pointer has moved from the position
+   * @param delta How far the pointer has moved from the position
    *     at the start of the drag, in pixel units.
    */
-  drag(e: PointerEvent, currentDragDeltaXY: Coordinate) {
-    this.moveBlock(this.draggingBlock_, currentDragDeltaXY);
-    this.updateDragTargets(e, this.draggingBlock_);
-    this.updateDeletePreview(e, this.draggingBlock_, currentDragDeltaXY);
-    this.updateConnectionPreview(this.draggingBlock_, currentDragDeltaXY);
+  drag(e: PointerEvent, delta: Coordinate) {
+    const block = this.draggingBlock_;
+    this.moveBlock(block, delta);
+    this.updateDragTargets(e, block);
+    this.wouldDeleteBlock_ = this.wouldDeleteBlock(e, block, delta);
+    this.updateCursorDuringBlockDrag_();
+    this.updateConnectionPreview(block, delta);
   }
 
   private moveBlock(draggingBlock: BlockSvg, dragDelta: Coordinate) {
@@ -215,16 +217,6 @@ export class BlockDragger implements IBlockDragger {
     }
     newDragTarget?.onDragOver(draggingBlock);
     this.dragTarget_ = newDragTarget;
-  }
-
-  private updateDeletePreview(
-    e: PointerEvent,
-    draggingBlock: BlockSvg,
-    delta: Coordinate,
-  ) {
-    draggingBlock.setDeleteStyle(
-      this.wouldDeleteBlock(e, this.draggingBlock_, delta),
-    );
   }
 
   /**
@@ -324,7 +316,9 @@ export class BlockDragger implements IBlockDragger {
       Coordinate.sum(localPos, delta),
       neighbourPos,
     );
-    return newCandidate.distance > distance - config.currentConnectionPreference;
+    return (
+      newCandidate.distance > distance - config.currentConnectionPreference
+    );
   }
 
   /**

--- a/core/block_dragger.ts
+++ b/core/block_dragger.ts
@@ -272,8 +272,7 @@ export class BlockDragger implements IBlockDragger {
     delta: Coordinate,
   ): ConnectionCandidate | null {
     const localConns = this.getLocalConnections(draggingBlock);
-    // TODO: Pass the actual candidate.
-    let radius = this.getStartRadius(null);
+    let radius = config.snapRadius;
     let candidate = null;
 
     for (const conn of localConns) {
@@ -289,19 +288,6 @@ export class BlockDragger implements IBlockDragger {
     }
 
     return candidate;
-  }
-
-  private getStartRadius(activeCandidate: ConnectionCandidate | null): number {
-    // TODO: Can we not just use the radius on the active candidate? Using
-    // two constants seems very fragile.
-
-    // If there is already a connection highlighted,
-    // increase the radius we check for making new connections.
-    // When a connection is highlighted, blocks move around when the
-    // insertion marker is created, which could cause the connection became out
-    // of range. By increasing radiusConnection when a connection already
-    // exists, we never "lose" the connection from the offset.
-    return activeCandidate ? config.connectingSnapRadius : config.snapRadius;
   }
 
   /**

--- a/core/config.ts
+++ b/core/config.ts
@@ -48,6 +48,7 @@ export const config: Config = {
    * Maximum misalignment between connections for them to snap together.
    * This should be the same as the snap radius.
    *
+   * @deprecated v11 - This is no longer used. Use snapRadius instead.
    */
   connectingSnapRadius: DEFAULT_SNAP_RADIUS,
   /**


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Work on #7204 

### Proposed Changes + Reasons

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
Switches the block dragger to use the connection previewer so we can actually swap the logic in and out.

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->
See https://github.com/google/blockly/pull/7792

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->
N/A

### Additional Information

<!-- Anything else we should know? -->
Dependent on https://github.com/google/blockly/pull/7792

## To review

Should be reviewed commit-wise. I did mess up one thing with deleting (blocks weren't actually getting deleted when dropped over delete areas), which is fixed in a further commit.

A lot of this code was adapted from the insertion marker manager, so it may be useful to look at that.

Let me know if anything needs more docs.