### PR TITLE
fix: prevent block change event firing if editing is cancelled by using keypress

### DIFF
--- a/core/field_input.ts
+++ b/core/field_input.ts
@@ -542,7 +542,7 @@ export abstract class FieldInput<T extends InputTypes> extends Field<
     } else if (e.key === 'Escape') {
       this.setValue(
         this.htmlInput_!.getAttribute('data-untyped-default-value'),
-        false
+        false,
       );
       WidgetDiv.hide();
       dropDownDiv.hideWithoutAnimation();

--- a/core/field_input.ts
+++ b/core/field_input.ts
@@ -542,6 +542,7 @@ export abstract class FieldInput<T extends InputTypes> extends Field<
     } else if (e.key === 'Escape') {
       this.setValue(
         this.htmlInput_!.getAttribute('data-untyped-default-value'),
+        false
       );
       WidgetDiv.hide();
       dropDownDiv.hideWithoutAnimation();


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. --> 

Fixed the block change event firing. #7780 

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->

Passed false boolean  as a second argument to set_value() function located in the fields_input.ts file

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

Because the old_value field contains an incorrect value.

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->

I tested it out by doing the reproduction steps outlined in the issue #7780, and this time the old value was correct.
### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
