### PR TITLE
fix: shadow blocks with variable fields are allowed to be deserialized from XML

### DIFF
--- a/core/xml.ts
+++ b/core/xml.ts
@@ -995,10 +995,7 @@ function domToBlockHeadless(
         throw TypeError('Shadow block not allowed non-shadow child.');
       }
     }
-    // Ensure this block doesn't have any variable inputs.
-    if (block.getVarModels().length) {
-      throw TypeError('Shadow blocks cannot have variable references.');
-    }
+
     block.setShadow(true);
   }
   return block;


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Enabling the ability for shadow blocks to be de-serialized from XML.

Fixes #7779 

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
The PR deletes 
```
    // Ensure this block doesn't have any variable inputs.
    if (block.getVarModels().length) {
      throw TypeError('Shadow blocks cannot have variable references.');
    }
```
in the core/xml.ts file.

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
There is no reason to disallow serialization and also the JSON serialization system does not have this constraint.

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->
I tested the results by trying to reproduce the error.
The error was fixed as it did not appear in the console.

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
