### PR TITLE
chore: fix docs for shouldHighlightConnection to say it might not be respected

### DIFF
--- a/core/renderers/common/renderer.ts
+++ b/core/renderers/common/renderer.ts
@@ -188,7 +188,10 @@ export class Renderer implements IRegistrable {
   }
 
   /**
-   * Determine whether or not to highlight a connection.
+   * Determine whether or not to highlight a connection when previewing a
+   * connection.
+   *
+   * This may not be respected by all connection previewers.
    *
    * @param _conn The connection to determine whether or not to highlight.
    * @returns True if we should highlight the connection.


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes N/A

### Proposed Changes + Reasons

Updates docs to reflect that `shouldHighlightConnection` might not be respected by all connection previewers.

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->
N/A

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->
N/A

### Additional Information

<!-- Anything else we should know? -->
N/A
