### PR TITLE
fix: manually add typings for generator classes

### DIFF
--- a/scripts/gulpfiles/package_tasks.js
+++ b/scripts/gulpfiles/package_tasks.js
@@ -348,7 +348,6 @@ function packageDTS() {
   return gulp.src(handwrittenSrcs, {base: 'typings'})
       .pipe(gulp.src(`${TYPINGS_BUILD_DIR}/**/*.d.ts`, {ignore: [
 	`${TYPINGS_BUILD_DIR}/blocks/**/*`,
-	`${TYPINGS_BUILD_DIR}/generators/**/*`,
       ]}))
       .pipe(gulp.replace('AnyDuringMigration', 'any'))
       .pipe(gulp.dest(RELEASE_DIR));

--- a/tests/typescript/src/generators.ts
+++ b/tests/typescript/src/generators.ts
@@ -1,0 +1,31 @@
+/**
+ * @license
+ * Copyright 2024 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as Blockly from 'blockly-test/core';
+import {JavascriptGenerator} from 'blockly-test/javascript';
+import {PhpGenerator, phpGenerator, Order} from 'blockly-test/php';
+import {LuaGenerator} from 'blockly-test/lua';
+import {PythonGenerator} from 'blockly-test/python';
+import {DartGenerator} from 'blockly-test/dart';
+
+JavascriptGenerator;
+PhpGenerator;
+LuaGenerator;
+PythonGenerator;
+DartGenerator;
+
+class TestGenerator extends PhpGenerator {}
+
+const testGenerator = new TestGenerator();
+
+testGenerator.forBlock['test_block'] = function (
+  _block: Blockly.Block,
+  _generator: TestGenerator,
+) {
+  return ['a fake code string', Order.ADDITION];
+};
+
+phpGenerator.quote_();

--- a/typings/dart.d.ts
+++ b/typings/dart.d.ts
@@ -26,3 +26,5 @@ export enum Order {
 }
 
 export declare const dartGenerator: any;
+
+export declare const DartGenerator: any;

--- a/typings/dart.d.ts
+++ b/typings/dart.d.ts
@@ -27,4 +27,4 @@ export enum Order {
 
 export declare const dartGenerator: any;
 
-export declare const DartGenerator: any;
+export {DartGenerator} from './generators/dart';

--- a/typings/javascript.d.ts
+++ b/typings/javascript.d.ts
@@ -44,4 +44,4 @@ export enum Order {
 
 export declare const javascriptGenerator: any;
 
-export declare const JavascriptGenerator: any;
+export {JavascriptGenerator} from './generators/javascript';

--- a/typings/javascript.d.ts
+++ b/typings/javascript.d.ts
@@ -43,3 +43,5 @@ export enum Order {
 }
 
 export declare const javascriptGenerator: any;
+
+export declare const JavascriptGenerator: any;

--- a/typings/lua.d.ts
+++ b/typings/lua.d.ts
@@ -20,3 +20,5 @@ export enum Order {
 }
 
 export declare const luaGenerator: any;
+
+export declare const LuaGenerator: any;

--- a/typings/lua.d.ts
+++ b/typings/lua.d.ts
@@ -21,4 +21,4 @@ export enum Order {
 
 export declare const luaGenerator: any;
 
-export declare const LuaGenerator: any;
+export {LuaGenerator} from './generators/lua';

--- a/typings/php.d.ts
+++ b/typings/php.d.ts
@@ -46,4 +46,4 @@ export enum Order {
 
 export declare const phpGenerator: any;
 
-export declare const PhpGenerator: any;
+export {PhpGenerator} from './generators/php';

--- a/typings/php.d.ts
+++ b/typings/php.d.ts
@@ -45,3 +45,5 @@ export enum Order {
 }
 
 export declare const phpGenerator: any;
+
+export declare const PhpGenerator: any;

--- a/typings/python.d.ts
+++ b/typings/python.d.ts
@@ -29,3 +29,5 @@ export enum Order {
 }
 
 export declare const pythonGenerator: any;
+
+export declare const PythonGenerator: any;

--- a/typings/python.d.ts
+++ b/typings/python.d.ts
@@ -30,4 +30,4 @@ export enum Order {
 
 export declare const pythonGenerator: any;
 
-export declare const PythonGenerator: any;
+export {PythonGenerator} from './generators/python';


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

Fixes missing generator types.

### Proposed Changes

Exports type for the `JavascriptGenerator` class and other similar classes in the other generator languages.

### Reason for Changes

Blockly exports both a `JavascriptGenerator` class, and a `javascriptGenerator` instance of that class. In most cases, folks use the instance. However, in some scenarios, a developer needs to access the class itself, whether to subclass or to use as a type in TypeScript. The class is exported and thus available in JavaScript, but it was not present in the `.d.ts` files and therefore invisible to TypeScript tooling.

The `.d.ts` files are currently manually maintained in Blockly v10. This is because for a while, generator classes were in JavaScript and no types were available. After converting them to TypeScript, more precise types are available, but it would be disruptive to TS developers to introduce them when previously the instance was typed as `any`, so we maintained the manual typing. In Blockly v11, we'll switch to generated type definitions that will include full information for both the class and instance of the class.

This PR only adds accurate typing for the class itself, not the instance. Because the class was not previously in TypeScript definitions at all, this isn't disruptive in the same way as it would be for the instance. If you wish to preview accurate typings for the instance as well as the class, please try the Blockly v11 beta by installing `blockly@beta` from npm.

### Test Coverage

Added a TypeScript test file.

### Documentation

None, other than release notes.

### Additional Information

We'll plan to put this in a patch release for Blockly v10.

Note, if you arrive here due to a merge conflict between develop and the rc/v11 branch, you probably just want to accept the changes from rc/v11. This PR is a partial (non-breaking) implementation of the changes in #7727 and #7750 
