### PR TITLE
fix: destroy connection highlight when the connection is disposed

### DIFF
--- a/core/rendered_connection.ts
+++ b/core/rendered_connection.ts
@@ -79,6 +79,7 @@ export class RenderedConnection extends Connection {
     if (this.trackedState === RenderedConnection.TrackedState.TRACKED) {
       this.db.removeConnection(this, this.y);
     }
+    this.sourceBlock_.pathObject.removeConnectionHighlight?.(this);
   }
 
   /**


### PR DESCRIPTION
Accidentally dropped #7817 when rebasing, so this needs to be merged again (but into develop this time).