### PR TITLE
fix: fix reference docs toc generation

### DIFF
--- a/scripts/gulpfiles/docs_tasks.js
+++ b/scripts/gulpfiles/docs_tasks.js
@@ -95,7 +95,11 @@ const createToc = function(done) {
   const files = fs.readdirSync(DOCS_DIR);
   const map = buildAlternatePathsMap(files);
   const referencePath = '/blockly/reference/js';
-  fs.writeSync(toc, 'toc:\n');
+
+  const tocHeader = `toc:
+- title: Overview
+  path: /blockly/reference/js/blockly.md\n`;
+  fs.writeSync(toc, tocHeader);
 
   // Generate a section of TOC for each section/heading in the overview file.
   const sections = fileContent.split('##');


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes issue with the reference docs table of contents on devsite

### Proposed Changes

- Adds the `blockly.md` landing page to the generated TOC file

### Reason for Changes

- With the devsite redesign, when you click the "Reference" tab it automatically goes to the first article in the TOC
- Since `blockly.md` was not in the TOC at all, when you clicked the `blockly` breadcrumb in any reference page, it took you to the landing page but with no toc showing

### Test Coverage

I verified this markdown by testing and staging it on devsite and have prepared a change updating it there to match the new generated text

### Documentation

n/a

### Additional Information

<!-- Anything else we should know? -->
