### PR TITLE
fix: insertion marker previewer finding wrong connection for different conn counts

### DIFF
--- a/core/connection_previewers/insertion_marker_previewer.ts
+++ b/core/connection_previewers/insertion_marker_previewer.ts
@@ -196,6 +196,7 @@ export class InsertionMarkerPreviewer implements IConnectionPreviewer {
   ) {
     const origConns = orig.getConnections_(true);
     const markerConns = marker.getConnections_(true);
+    if (origConns.length !== markerConns.length) return null;
     for (let i = 0; i < origConns.length; i++) {
       if (origConns[i] === origConn) {
         return markerConns[i];


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes N/A

### Proposed Changes + Reasons

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
If the insertion marker block had more connections that the original block (e.g. for [chameleon blocks](https://github.com/google/blockly-samples/pull/2193)) The insertion marker previewer could find the wrong connection and try to connect that.

How chameleon blocks work: If they were connected in a stack, when they start dragging, they add an output connection. Before this change, previews for the previous connection (previously the first connection) would grab the output connection of the insertion marker block (current first connection). This would cause the insertion marker to be positioned incorrectly, because the output couldn't connect where the previous connection is supposed to.

This makes is so that we fail early if the blocks don't match. And that makes the chameleon blocks work.

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->

Tested by linking with chameleon blocks. No more weird insertion marker positioning bugs.

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->
N/A

### Additional Information

<!-- Anything else we should know? -->
N/A