### PR TITLE
fix: disposing of connection previewer

### DIFF
--- a/core/block_dragger.ts
+++ b/core/block_dragger.ts
@@ -382,6 +382,7 @@ export class BlockDragger implements IBlockDragger {
 
     blockAnimation.disconnectUiStop();
     this.connectionPreviewer.hidePreview();
+    this.connectionPreviewer.dispose();
 
     const preventMove =
       !!this.dragTarget_ &&


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes N/A

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
We were never actually calling dispose on the connection previewer. This worked fine because the default previewer's `dispose` method just calls `hidePreview`. But other previewers may need to do other work.

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->
Manually spot-tested, everything seems good.

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->
Discovered this when writing docs :P

### Additional Information

<!-- Anything else we should know? -->
N/A
