### PR TITLE
chore: move connection previewer out of subfolder

### DIFF
--- a/core/blockly.ts
+++ b/core/blockly.ts
@@ -128,7 +128,7 @@ import {Input} from './inputs/input.js';
 import {inputTypes} from './inputs/input_types.js';
 import * as inputs from './inputs.js';
 import {InsertionMarkerManager} from './insertion_marker_manager.js';
-import {InsertionMarkerPreviewer} from './connection_previewers/insertion_marker_previewer.js';
+import {InsertionMarkerPreviewer} from './insertion_marker_previewer.js';
 import {IASTNodeLocation} from './interfaces/i_ast_node_location.js';
 import {IASTNodeLocationSvg} from './interfaces/i_ast_node_location_svg.js';
 import {IASTNodeLocationWithBlock} from './interfaces/i_ast_node_location_with_block.js';

--- a/core/insertion_marker_previewer.ts
+++ b/core/insertion_marker_previewer.ts
@@ -4,14 +4,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {BlockSvg} from '../block_svg.js';
-import {IConnectionPreviewer} from '../interfaces/i_connection_previewer.js';
-import {RenderedConnection} from '../rendered_connection.js';
-import {WorkspaceSvg} from '../workspace_svg.js';
-import * as eventUtils from '../events/utils.js';
-import * as constants from '../constants.js';
-import * as renderManagement from '../render_management.js';
-import * as registry from '../registry.js';
+import {BlockSvg} from './block_svg.js';
+import {IConnectionPreviewer} from './interfaces/i_connection_previewer.js';
+import {RenderedConnection} from './rendered_connection.js';
+import {WorkspaceSvg} from './workspace_svg.js';
+import * as eventUtils from './events/utils.js';
+import * as constants from './constants.js';
+import * as renderManagement from './render_management.js';
+import * as registry from './registry.js';
 
 /**
  * An error message to throw if the block created by createMarkerBlock_ is


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes N/A

### Proposed Changes + Reasons

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
Moves the `InsertionMarkerPreviewer` out of the subdirectory since we're exporting it from the root level.

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->
N/A

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->
N/A

### Additional Information

<!-- Anything else we should know? -->
N/A
