### PR TITLE
fix!: have Lua generators use 'nil' instead of 'None'

### DIFF
--- a/generators/lua/lists.ts
+++ b/generators/lua/lists.ts
@@ -33,7 +33,7 @@ export function lists_create_with(
   const elements = new Array(createWithBlock.itemCount_);
   for (let i = 0; i < createWithBlock.itemCount_; i++) {
     elements[i] =
-      generator.valueToCode(createWithBlock, 'ADD' + i, Order.NONE) || 'None';
+      generator.valueToCode(createWithBlock, 'ADD' + i, Order.NONE) || 'nil';
   }
   const code = '{' + elements.join(', ') + '}';
   return [code, Order.HIGH];
@@ -56,7 +56,7 @@ function ${generator.FUNCTION_NAME_PLACEHOLDER_}(item, count)
 end
   `,
   );
-  const element = generator.valueToCode(block, 'ITEM', Order.NONE) || 'None';
+  const element = generator.valueToCode(block, 'ITEM', Order.NONE) || 'nil';
   const repeatCount = generator.valueToCode(block, 'NUM', Order.NONE) || '0';
   const code = functionName + '(' + element + ', ' + repeatCount + ')';
   return [code, Order.HIGH];
@@ -258,7 +258,7 @@ export function lists_setIndex(block: Block, generator: LuaGenerator): string {
   const mode = block.getFieldValue('MODE') || 'SET';
   const where = block.getFieldValue('WHERE') || 'FROM_START';
   const at = generator.valueToCode(block, 'AT', Order.ADDITIVE) || '1';
-  const value = generator.valueToCode(block, 'TO', Order.NONE) || 'None';
+  const value = generator.valueToCode(block, 'TO', Order.NONE) || 'Nil';
 
   let code = '';
   // If `list` would be evaluated more than once (which is the case for LAST,


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #6720 

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
Makes it so that lua generators use 'nil' instead of 'None'. Reasoning is explained in the linked issue.

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->
N/A

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->
N/A

### Additional Information

<!-- Anything else we should know? -->
N/A

### Breaking changes

This may break some user's downstream block programs if they are assigning to a variable called 'None' and then initializing lists with empty inputs expecting them to contain the value assigned to `None`.

It is unlikely that this behavior was ever actually discovered, and as such the correction shouldn't affect end-users.
