### PR TITLE
fix!: remove `couldConnect` parameter from `wouldDelete`

### DIFF
--- a/core/block_dragger.ts
+++ b/core/block_dragger.ts
@@ -188,7 +188,7 @@ export class BlockDragger implements IBlockDragger {
     const block = this.draggingBlock_;
     this.moveBlock(block, delta);
     this.updateDragTargets(e, block);
-    this.wouldDeleteBlock_ = this.wouldDeleteBlock(e, block, delta);
+    this.wouldDeleteBlock_ = this.wouldDeleteBlock(e, block);
     this.updateCursorDuringBlockDrag_();
     this.updateConnectionPreview(block, delta);
   }
@@ -213,11 +213,7 @@ export class BlockDragger implements IBlockDragger {
    * Returns true if we would delete the block if it was dropped at this time,
    * false otherwise.
    */
-  private wouldDeleteBlock(
-    e: PointerEvent,
-    draggingBlock: BlockSvg,
-    delta: Coordinate,
-  ): boolean {
+  private wouldDeleteBlock(e: PointerEvent, draggingBlock: BlockSvg): boolean {
     const dragTarget = this.workspace_.getDragTarget(e);
     if (!dragTarget) return false;
 
@@ -228,10 +224,7 @@ export class BlockDragger implements IBlockDragger {
     );
     if (!isDeleteArea) return false;
 
-    return (dragTarget as IDeleteArea).wouldDelete(
-      draggingBlock,
-      !!this.getConnectionCandidate(draggingBlock, delta),
-    );
+    return (dragTarget as IDeleteArea).wouldDelete(draggingBlock);
   }
 
   private updateConnectionPreview(draggingBlock: BlockSvg, delta: Coordinate) {

--- a/core/bubble_dragger.ts
+++ b/core/bubble_dragger.ts
@@ -116,7 +116,7 @@ export class BubbleDragger {
         ComponentManager.Capability.DELETE_AREA,
       );
       if (isDeleteArea) {
-        return (dragTarget as IDeleteArea).wouldDelete(this.bubble, false);
+        return (dragTarget as IDeleteArea).wouldDelete(this.bubble);
       }
     }
     return false;

--- a/core/delete_area.ts
+++ b/core/delete_area.ts
@@ -51,15 +51,14 @@ export class DeleteArea extends DragTarget implements IDeleteArea {
    * before onDragEnter/onDragOver/onDragExit.
    *
    * @param element The block or bubble currently being dragged.
-   * @param couldConnect Whether the element could could connect to another.
    * @returns Whether the element provided would be deleted if dropped on this
    *     area.
    */
-  wouldDelete(element: IDraggable, couldConnect: boolean): boolean {
+  wouldDelete(element: IDraggable): boolean {
     if (element instanceof BlockSvg) {
       const block = element;
       const couldDeleteBlock = !block.getParent() && block.isDeletable();
-      this.updateWouldDelete_(couldDeleteBlock && !couldConnect);
+      this.updateWouldDelete_(couldDeleteBlock);
     } else {
       this.updateWouldDelete_(element.isDeletable());
     }

--- a/core/dragging/dragger.ts
+++ b/core/dragging/dragger.ts
@@ -1,0 +1,139 @@
+/**
+ * @license
+ * Copyright 2024 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {IDragTarget} from '../interfaces/i_drag_target.js';
+import {IDeletable, isDeletable} from '../interfaces/i_deletable.js';
+import {IDragger} from '../interfaces/i_dragger.js';
+import {IDraggable} from '../interfaces/new_i_draggable.js';
+import {Coordinate} from '../utils/coordinate.js';
+import {WorkspaceSvg} from '../workspace_svg.js';
+import {ComponentManager} from '../component_manager.js';
+import {IDeleteArea} from '../interfaces/i_delete_area.js';
+
+export class Dragger implements IDragger {
+  private startLoc: Coordinate;
+
+  private dragTarget: IDragTarget | null = null;
+
+  constructor(
+    private draggable: IDraggable,
+    private workspace: WorkspaceSvg,
+  ) {
+    this.startLoc = draggable.getLocation();
+  }
+
+  /** Handles any drag startup. */
+  onDragStart(e: PointerEvent) {
+    this.draggable.startDrag(e);
+  }
+
+  /**
+   * Handles calculating where the element should actually be moved to.
+   *
+   * @param totalDelta The total amount in pixel coordinates the mouse has moved
+   *     since the start of the drag.
+   */
+  onDrag(e: PointerEvent, totalDelta: Coordinate) {
+    this.moveDraggable(e, totalDelta);
+
+    // Must check `wouldDelete` before calling other hoooks on drag targets
+    // since we have documented that we would do so.
+    if (isDeletable(this.draggable)) {
+      (this.draggable as AnyDuringMigration).setDeleteStyle(
+        this.wouldDeleteDraggable(e, this.draggable),
+      );
+    }
+    this.updateDragTarget(e);
+  }
+
+  /** Updates the drag target under the pointer (if there is one). */
+  protected updateDragTarget(e: PointerEvent) {
+    const newDragTarget = this.workspace.getDragTarget(e);
+    if (this.dragTarget !== newDragTarget) {
+      this.dragTarget?.onDragExit(this.draggable as AnyDuringMigration);
+      newDragTarget?.onDragEnter(this.draggable as AnyDuringMigration);
+    }
+    newDragTarget?.onDragOver(this.draggable as AnyDuringMigration);
+    this.dragTarget = newDragTarget;
+  }
+
+  /**
+   * Calculates the correct workspace coordinate for the movable and tells
+   * the draggable to go to that location.
+   */
+  private moveDraggable(e: PointerEvent, totalDelta: Coordinate) {
+    const delta = this.pixelsToWorkspaceUnits(totalDelta);
+    const newLoc = Coordinate.sum(this.startLoc, delta);
+    const dragTarget = this.workspace.getDragTarget(e);
+    this.draggable.drag(newLoc, dragTarget ?? undefined, e);
+  }
+
+  /**
+   * Returns true if we would delete the draggable if it was dropped
+   * at the current location.
+   */
+  protected wouldDeleteDraggable(
+    e: PointerEvent,
+    draggable: IDraggable & IDeletable,
+  ) {
+    const dragTarget = this.workspace.getDragTarget(e);
+    if (!dragTarget) return false;
+
+    const componentManager = this.workspace.getComponentManager();
+    const isDeleteArea = componentManager.hasCapability(
+      dragTarget.id,
+      ComponentManager.Capability.DELETE_AREA,
+    );
+    if (!isDeleteArea) return false;
+
+    return (dragTarget as IDeleteArea).wouldDelete(
+      draggable,
+      false,
+      // !!this.getConnectionCandidate(draggable, delta),
+    );
+  }
+
+  /** Handles any drag cleanup. */
+  onDragEnd(e: PointerEvent) {
+    if (this.shouldReturnToStart(e, this.draggable)) {
+      this.draggable.drag(this.startLoc);
+    }
+
+    this.draggable.endDrag(e);
+
+    if (
+      isDeletable(this.draggable) &&
+      this.wouldDeleteDraggable(e, this.draggable)
+    ) {
+      (this.draggable as AnyDuringMigration).dispose();
+    }
+  }
+
+  /**
+   * Returns true if we should return the draggable to its original location
+   * at the end of the drag.
+   */
+  protected shouldReturnToStart(e: PointerEvent, draggable: IDraggable) {
+    const dragTarget = this.workspace.getDragTarget(e);
+    if (!dragTarget) return false;
+    return dragTarget.shouldPreventMove(draggable as AnyDuringMigration);
+  }
+
+  protected pixelsToWorkspaceUnits(pixelCoord: Coordinate): Coordinate {
+    const result = new Coordinate(
+      pixelCoord.x / this.workspace.scale,
+      pixelCoord.y / this.workspace.scale,
+    );
+    if (this.workspace.isMutator) {
+      // If we're in a mutator, its scale is always 1, purely because of some
+      // oddities in our rendering optimizations.  The actual scale is the same
+      // as the scale on the parent workspace. Fix that for dragging.
+      const mainScale = this.workspace.options.parentWorkspace!.scale;
+      result.scale(1 / mainScale);
+    }
+    return result;
+  }
+}

--- a/core/dragging/dragger.ts
+++ b/core/dragging/dragger.ts
@@ -89,11 +89,7 @@ export class Dragger implements IDragger {
     );
     if (!isDeleteArea) return false;
 
-    return (dragTarget as IDeleteArea).wouldDelete(
-      draggable,
-      false,
-      // !!this.getConnectionCandidate(draggable, delta),
-    );
+    return (dragTarget as IDeleteArea).wouldDelete(draggable);
   }
 
   /** Handles any drag cleanup. */

--- a/core/insertion_marker_manager.ts
+++ b/core/insertion_marker_manager.ts
@@ -384,10 +384,7 @@ export class InsertionMarkerManager {
         ComponentManager.Capability.DELETE_AREA,
       );
       if (isDeleteArea) {
-        return (dragTarget as IDeleteArea).wouldDelete(
-          this.topBlock,
-          newCandidate,
-        );
+        return (dragTarget as IDeleteArea).wouldDelete(this.topBlock);
       }
     }
     return false;

--- a/core/interfaces/i_deletable.ts
+++ b/core/interfaces/i_deletable.ts
@@ -17,3 +17,8 @@ export interface IDeletable {
    */
   isDeletable(): boolean;
 }
+
+/** Returns whether the given object is an IDeletable. */
+export function isDeletable(obj: any): obj is IDeletable {
+  return obj['isDeletable'] !== undefined;
+}

--- a/core/interfaces/i_delete_area.ts
+++ b/core/interfaces/i_delete_area.ts
@@ -21,9 +21,8 @@ export interface IDeleteArea extends IDragTarget {
    * before onDragEnter/onDragOver/onDragExit.
    *
    * @param element The block or bubble currently being dragged.
-   * @param couldConnect Whether the element could could connect to another.
    * @returns Whether the element provided would be deleted if dropped on this
    *     area.
    */
-  wouldDelete(element: IDraggable, couldConnect: boolean): boolean;
+  wouldDelete(element: IDraggable): boolean;
 }

--- a/core/interfaces/i_dragger.ts
+++ b/core/interfaces/i_dragger.ts
@@ -1,0 +1,18 @@
+/**
+ * @license
+ * Copyright 2024 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {Coordinate} from '../utils/coordinate';
+
+export interface IDragger {
+  /** Handles any drag startup. */
+  onDragStart(e: PointerEvent): void;
+
+  /** Handles calculating where the element should actually be moved to. */
+  onDrag(e: PointerEvent, totalDelta: Coordinate): void;
+
+  /** Handles any drag cleanup. */
+  onDragEnd(e: PointerEvent): void;
+}

--- a/core/interfaces/new_i_draggable.ts
+++ b/core/interfaces/new_i_draggable.ts
@@ -1,0 +1,36 @@
+/**
+ * @license
+ * Copyright 2021 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// Former goog.module ID: Blockly.IDraggable
+
+import {Coordinate} from '../utils/coordinate';
+import {IDragTarget} from './i_drag_target';
+
+/**
+ * Represents an object that can be dragged.
+ */
+export interface IDraggable {
+  /** Returns true if the element is currently movable. False otherwise. */
+  isMovable(e: PointerEvent): boolean;
+
+  /** Returns the current location of the draggable in workspace coordinates. */
+  getLocation(): Coordinate;
+
+  /**
+   * Handles any drag startup (e.g moving elements to the front
+   * of the workspace).
+   */
+  startDrag(e?: PointerEvent): void;
+
+  /**
+   * Handles moving elements to the new location, and updating any visuals
+   * based on that (e.g connection previews for blocks).
+   */
+  drag(newLoc: Coordinate, target: IDragTarget, e?: PointerEvent): void;
+
+  /** Handles any drag cleanup. */
+  endDrag(e?: PointerEvent): void;
+}

--- a/core/interfaces/new_i_draggable.ts
+++ b/core/interfaces/new_i_draggable.ts
@@ -29,7 +29,7 @@ export interface IDraggable {
    * Handles moving elements to the new location, and updating any visuals
    * based on that (e.g connection previews for blocks).
    */
-  drag(newLoc: Coordinate, target: IDragTarget, e?: PointerEvent): void;
+  drag(newLoc: Coordinate, target?: IDragTarget, e?: PointerEvent): void;
 
   /** Handles any drag cleanup. */
   endDrag(e?: PointerEvent): void;

--- a/core/interfaces/new_i_draggable.ts
+++ b/core/interfaces/new_i_draggable.ts
@@ -14,7 +14,7 @@ import {IDragTarget} from './i_drag_target';
  */
 export interface IDraggable {
   /** Returns true if the element is currently movable. False otherwise. */
-  isMovable(e: PointerEvent): boolean;
+  isMovable(e?: PointerEvent): boolean;
 
   /** Returns the current location of the draggable in workspace coordinates. */
   getLocation(): Coordinate;

--- a/core/toolbox/toolbox.ts
+++ b/core/toolbox/toolbox.ts
@@ -532,14 +532,12 @@ export class Toolbox
    * before onDragEnter/onDragOver/onDragExit.
    *
    * @param element The block or bubble currently being dragged.
-   * @param _couldConnect Whether the element could could connect to another.
    * @returns Whether the element provided would be deleted if dropped on this
    *     area.
    */
-  override wouldDelete(element: IDraggable, _couldConnect: boolean): boolean {
+  override wouldDelete(element: IDraggable): boolean {
     if (element instanceof BlockSvg) {
       const block = element;
-      // Prefer dragging to the toolbox over connecting to other blocks.
       this.updateWouldDelete_(!block.getParent() && block.isDeletable());
     } else {
       this.updateWouldDelete_(element.isDeletable());


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes N/A

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
Removes the `couldConnect` parameter from `wouldDelete` since that doesn't really make sense in the context of generic `IDraggable` implementations.

In practice, the only thing this changes is that if you're dragging over the trashcan and the block could connect to something, the block will now be deleted instead of connecting.

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->
N/A

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->
N/A

### Additional Information

<!-- Anything else we should know? -->
