### PR TITLE
feat: support keyboard navigation of flyout buttons

### DIFF
--- a/core/flyout_base.ts
+++ b/core/flyout_base.ts
@@ -162,6 +162,11 @@ export abstract class Flyout
   protected buttons_: FlyoutButton[] = [];
 
   /**
+   * List of visible buttons and blocks.
+   */
+  protected contents_: (FlyoutButton | BlockSvg | undefined)[] = [];
+
+  /**
    * List of event listeners.
    */
   private listeners: browserEvents.Data[] = [];
@@ -547,6 +552,32 @@ export abstract class Flyout
   }
 
   /**
+   * Get the list of buttons and blocks of the current flyout.
+   *
+   * @returns The array of flyout buttons and blocks.
+   */
+  getContents(): (FlyoutButton | BlockSvg | undefined)[] {
+    return this.contents_;
+  }
+
+  /**
+   * Store the list of buttons and blocks on the flyout.
+   *
+   * @param contents - The array of items for the flyout.
+   */
+  setContents(contents: FlyoutItem[]): void {
+    const blocksAndButtons = contents.map((item) => {
+      if (item.type === 'block' && item.block) {
+        return item.block;
+      }
+      if (item.type === 'button' && item.button) {
+        return item.button;
+      }
+    });
+
+    this.contents_ = blocksAndButtons;
+  }
+  /**
    * Update the display property of the flyout based whether it thinks it should
    * be visible and whether its containing workspace is visible.
    */
@@ -650,6 +681,8 @@ export abstract class Flyout
     const flyoutInfo = this.createFlyoutInfo(parsedContent);
 
     renderManagement.triggerQueuedRenders(this.workspace_);
+
+    this.setContents(flyoutInfo.contents);
 
     this.layout_(flyoutInfo.contents, flyoutInfo.gaps);
 

--- a/core/flyout_base.ts
+++ b/core/flyout_base.ts
@@ -13,7 +13,7 @@
 
 import type {Abstract as AbstractEvent} from './events/events_abstract.js';
 import type {Block} from './block.js';
-import type {BlockSvg} from './block_svg.js';
+import {BlockSvg} from './block_svg.js';
 import * as browserEvents from './browser_events.js';
 import * as common from './common.js';
 import {ComponentManager} from './component_manager.js';
@@ -164,7 +164,7 @@ export abstract class Flyout
   /**
    * List of visible buttons and blocks.
    */
-  protected contents_: (FlyoutButton | BlockSvg | undefined)[] = [];
+  protected contents: FlyoutItem[] = [];
 
   /**
    * List of event listeners.
@@ -556,8 +556,8 @@ export abstract class Flyout
    *
    * @returns The array of flyout buttons and blocks.
    */
-  getContents(): (FlyoutButton | BlockSvg | undefined)[] {
-    return this.contents_;
+  getContents(): FlyoutItem[] {
+    return this.contents;
   }
 
   /**
@@ -568,14 +568,14 @@ export abstract class Flyout
   setContents(contents: FlyoutItem[]): void {
     const blocksAndButtons = contents.map((item) => {
       if (item.type === 'block' && item.block) {
-        return item.block;
+        return item.block as BlockSvg;
       }
       if (item.type === 'button' && item.button) {
-        return item.button;
+        return item.button as FlyoutButton;
       }
     });
 
-    this.contents_ = blocksAndButtons;
+    this.contents = blocksAndButtons as FlyoutItem[];
   }
   /**
    * Update the display property of the flyout based whether it thinks it should

--- a/core/flyout_button.ts
+++ b/core/flyout_button.ts
@@ -262,6 +262,15 @@ export class FlyoutButton implements IASTNodeLocationSvg {
     return this.targetWorkspace;
   }
 
+  /**
+   * Get the button's workspace.
+   *
+   * @returns The workspace in which to place this button.
+   */
+  getWorkspace(): WorkspaceSvg {
+    return this.workspace;
+  }
+
   /** Dispose of this button. */
   dispose() {
     if (this.onMouseUpWrapper) {
@@ -293,8 +302,9 @@ export class FlyoutButton implements IASTNodeLocationSvg {
   }
 
   /**
-   * Required by IASTNodeLocationSvg, but not used. A marker cannot be set on a button.
-   * If the 'mark' shortcut is used on a button, its associated callback function is triggered.
+   * Required by IASTNodeLocationSvg, but not used. A marker cannot be set on a
+   * button. If the 'mark' shortcut is used on a button, its associated callback
+   * function is triggered.
    */
   setMarkerSvg() {
     throw new Error('Attempted to set a marker on a button.');

--- a/core/flyout_button.ts
+++ b/core/flyout_button.ts
@@ -20,11 +20,12 @@ import * as style from './utils/style.js';
 import {Svg} from './utils/svg.js';
 import type * as toolbox from './utils/toolbox.js';
 import type {WorkspaceSvg} from './workspace_svg.js';
+import type {IASTNodeLocationSvg} from './blockly.js';
 
 /**
  * Class for a button or label in the flyout.
  */
-export class FlyoutButton {
+export class FlyoutButton implements IASTNodeLocationSvg {
   /** The horizontal margin around the text in the button. */
   static TEXT_MARGIN_X = 5;
 
@@ -54,6 +55,12 @@ export class FlyoutButton {
 
   /** The SVG element with the text of the label or button. */
   private svgText: SVGTextElement | null = null;
+
+  /**
+   * Holds the cursors svg element when the cursor is attached to the button.
+   * This is null if there is no cursor on the button.
+   */
+  cursorSvg: SVGElement | null = null;
 
   /**
    * @param workspace The workspace in which to place this button.
@@ -266,6 +273,31 @@ export class FlyoutButton {
     if (this.svgText) {
       this.workspace.getThemeManager().unsubscribe(this.svgText);
     }
+  }
+
+  /**
+   * Add the cursor SVG to this buttons's SVG group.
+   *
+   * @param cursorSvg The SVG root of the cursor to be added to the button SVG
+   *     group.
+   */
+  setCursorSvg(cursorSvg: SVGElement) {
+    if (!cursorSvg) {
+      this.cursorSvg = null;
+      return;
+    }
+    if (this.svgGroup) {
+      this.svgGroup.appendChild(cursorSvg);
+      this.cursorSvg = cursorSvg;
+    }
+  }
+
+  /**
+   * Required by IASTNodeLocationSvg, but not used. A marker cannot be set on a button.
+   * If the 'mark' shortcut is used on a button, its associated callback function is triggered.
+   */
+  setMarkerSvg() {
+    throw new Error('Attempted to set a marker on a button.');
   }
 
   /**

--- a/core/keyboard_nav/ast_node.ts
+++ b/core/keyboard_nav/ast_node.ts
@@ -289,6 +289,9 @@ export class ASTNode {
     if (!curLocationAsBlock || curLocationAsBlock.isDeadOrDying()) {
       return null;
     }
+    if (curLocationAsBlock.workspace.isFlyout) {
+      return this.navigateFlyoutContents(forward);
+    }
     const curRoot = curLocationAsBlock.getRootBlock();
     const topBlocks = curRoot.workspace.getTopBlocks(true);
     for (let i = 0; i < topBlocks.length; i++) {
@@ -456,14 +459,9 @@ export class ASTNode {
    */
   next(): ASTNode | null {
     switch (this.type) {
-      case ASTNode.types.STACK: {
-        const block = this.location as Block;
-        if (block.workspace.isFlyout) {
-          return this.navigateFlyoutContents(true);
-        } else {
-          return this.navigateBetweenStacks(true);
-        }
-      }
+      case ASTNode.types.STACK:
+        return this.navigateBetweenStacks(true);
+
       case ASTNode.types.OUTPUT: {
         const connection = this.location as Connection;
         return ASTNode.createBlockNode(connection.getSourceBlock());
@@ -539,14 +537,8 @@ export class ASTNode {
    */
   prev(): ASTNode | null {
     switch (this.type) {
-      case ASTNode.types.STACK: {
-        const block = this.location as Block;
-        if (block.workspace.isFlyout) {
-          return this.navigateFlyoutContents(false);
-        } else {
-          return this.navigateBetweenStacks(false);
-        }
-      }
+      case ASTNode.types.STACK:
+        return this.navigateBetweenStacks(false);
 
       case ASTNode.types.OUTPUT:
         return null;

--- a/core/keyboard_nav/ast_node.ts
+++ b/core/keyboard_nav/ast_node.ts
@@ -21,6 +21,9 @@ import type {IASTNodeLocation} from '../interfaces/i_ast_node_location.js';
 import type {IASTNodeLocationWithBlock} from '../interfaces/i_ast_node_location_with_block.js';
 import {Coordinate} from '../utils/coordinate.js';
 import type {Workspace} from '../workspace.js';
+import {FlyoutButton} from '../flyout_button.js';
+import {WorkspaceSvg} from '../workspace_svg.js';
+import {Flyout} from '../flyout_base.js';
 
 /**
  * Class for an AST node.
@@ -305,6 +308,50 @@ export class ASTNode {
   }
 
   /**
+   * Navigate between buttons and stacks of blocks on the flyout workspace.
+   *
+   * @param forward True to go forward. False to go backwards.
+   * @returns The next button, or next stack's first block, or null
+   */
+  private navigateFlyoutContents(forward: boolean): ASTNode | null {
+    const nodeType = this.getType();
+    let location;
+    let targetWorkspace;
+
+    switch (nodeType) {
+      case ASTNode.types.STACK: {
+        location = this.getLocation() as Block;
+        const workspace = location.workspace as WorkspaceSvg;
+        targetWorkspace = workspace.targetWorkspace as WorkspaceSvg;
+        break;
+      }
+      case ASTNode.types.BUTTON: {
+        location = this.getLocation() as FlyoutButton;
+        targetWorkspace = location.getTargetWorkspace() as WorkspaceSvg;
+        break;
+      }
+      default:
+        return null;
+    }
+
+    const flyout = targetWorkspace.getFlyout() as Flyout;
+    const flyoutContents = flyout.getContents() as (Block | FlyoutButton)[];
+
+    const currentIndex = flyoutContents.indexOf(location);
+    const resultIndex = forward ? currentIndex + 1 : currentIndex - 1;
+    if (resultIndex === -1 || resultIndex === flyoutContents.length) {
+      return null;
+    }
+
+    const newLocation = flyoutContents[resultIndex];
+    if (newLocation instanceof FlyoutButton) {
+      return ASTNode.createButtonNode(newLocation);
+    } else {
+      return ASTNode.createStackNode(newLocation);
+    }
+  }
+
+  /**
    * Finds the top most AST node for a given block.
    * This is either the previous connection, output connection or block
    * depending on what kind of connections the block has.
@@ -385,7 +432,7 @@ export class ASTNode {
    * Finds the source block of the location of this node.
    *
    * @returns The source block of the location, or null if the node is of type
-   *     workspace.
+   *     workspace or button.
    */
   getSourceBlock(): Block | null {
     if (this.getType() === ASTNode.types.BLOCK) {
@@ -393,6 +440,8 @@ export class ASTNode {
     } else if (this.getType() === ASTNode.types.STACK) {
       return this.getLocation() as Block;
     } else if (this.getType() === ASTNode.types.WORKSPACE) {
+      return null;
+    } else if (this.getType() === ASTNode.types.BUTTON) {
       return null;
     } else {
       return (this.getLocation() as IASTNodeLocationWithBlock).getSourceBlock();
@@ -407,9 +456,14 @@ export class ASTNode {
    */
   next(): ASTNode | null {
     switch (this.type) {
-      case ASTNode.types.STACK:
-        return this.navigateBetweenStacks(true);
-
+      case ASTNode.types.STACK: {
+        const block = this.location as Block;
+        if (block.workspace.isFlyout) {
+          return this.navigateFlyoutContents(true);
+        } else {
+          return this.navigateBetweenStacks(true);
+        }
+      }
       case ASTNode.types.OUTPUT: {
         const connection = this.location as Connection;
         return ASTNode.createBlockNode(connection.getSourceBlock());
@@ -435,6 +489,8 @@ export class ASTNode {
         const targetConnection = connection.targetConnection;
         return ASTNode.createConnectionNode(targetConnection!);
       }
+      case ASTNode.types.BUTTON:
+        return this.navigateFlyoutContents(true);
     }
 
     return null;
@@ -483,8 +539,14 @@ export class ASTNode {
    */
   prev(): ASTNode | null {
     switch (this.type) {
-      case ASTNode.types.STACK:
-        return this.navigateBetweenStacks(false);
+      case ASTNode.types.STACK: {
+        const block = this.location as Block;
+        if (block.workspace.isFlyout) {
+          return this.navigateFlyoutContents(false);
+        } else {
+          return this.navigateBetweenStacks(false);
+        }
+      }
 
       case ASTNode.types.OUTPUT:
         return null;
@@ -513,6 +575,8 @@ export class ASTNode {
         const connection = this.location as Connection;
         return ASTNode.createBlockNode(connection.getSourceBlock());
       }
+      case ASTNode.types.BUTTON:
+        return this.navigateFlyoutContents(false);
     }
 
     return null;
@@ -689,6 +753,22 @@ export class ASTNode {
   }
 
   /**
+   * Create an AST node of type button. A button in this case refers
+   * specifically to a button in a flyout.
+   *
+   * @param button A top block has no parent and can be found in the list
+   *     returned by workspace.getTopBlocks().
+   * @returns An AST node of type stack that points to the top block on the
+   *     stack.
+   */
+  static createButtonNode(button: FlyoutButton): ASTNode | null {
+    if (!button) {
+      return null;
+    }
+    return new ASTNode(ASTNode.types.BUTTON, button);
+  }
+
+  /**
    * Creates an AST node pointing to a workspace.
    *
    * @param workspace The workspace that we are on.
@@ -740,6 +820,7 @@ export namespace ASTNode {
     PREVIOUS = 'previous',
     STACK = 'stack',
     WORKSPACE = 'workspace',
+    BUTTON = 'button',
   }
 }
 

--- a/core/renderers/common/marker_svg.ts
+++ b/core/renderers/common/marker_svg.ts
@@ -24,6 +24,7 @@ import * as svgPaths from '../../utils/svg_paths.js';
 import type {WorkspaceSvg} from '../../workspace_svg.js';
 
 import type {ConstantProvider, Notch, PuzzleTab} from './constants.js';
+import {FlyoutButton} from '../../flyout_button.js';
 
 /** The name of the CSS class for a cursor. */
 const CURSOR_CLASS = 'blocklyCursor';
@@ -205,6 +206,8 @@ export class MarkerSvg {
       this.showWithCoordinates_(curNode);
     } else if (curNode.getType() === ASTNode.types.STACK) {
       this.showWithStack_(curNode);
+    } else if (curNode.getType() === ASTNode.types.BUTTON) {
+      this.showWithButton_(curNode);
     }
   }
 
@@ -375,6 +378,38 @@ export class MarkerSvg {
     }
     this.positionRect_(x, y, width, height);
     this.setParent_(block);
+    this.showCurrent_();
+  }
+
+  /**
+   * Position and display the marker for a flyout button.
+   * This is a box with extra padding around the button.
+   *
+   * @param curNode The node to draw the marker for.
+   */
+  protected showWithButton_(curNode: ASTNode) {
+    const button = curNode.getLocation() as FlyoutButton;
+
+    // Gets the height and width of entire stack.
+    const heightWidth = {height: button.height, width: button.width};
+
+    // Add padding so that being on a button looks similar to being on a stack.
+    const width = heightWidth.width + this.constants_.CURSOR_STACK_PADDING;
+    const height = heightWidth.height + this.constants_.CURSOR_STACK_PADDING;
+
+    // Shift the rectangle slightly to upper left so padding is equal on all
+    // sides.
+    const xPadding = -this.constants_.CURSOR_STACK_PADDING / 2;
+    const yPadding = -this.constants_.CURSOR_STACK_PADDING / 2;
+
+    let x = xPadding;
+    const y = yPadding;
+
+    if (this.workspace.RTL) {
+      x = -(width + xPadding);
+    }
+    this.positionRect_(x, y, width, height);
+    this.setParent_(button);
     this.showCurrent_();
   }
 


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Makes it possible to support keyboard navigation of flyout buttons, which is listed as a limitation in the documentation:
https://developers.google.com/blockly/guides/configure/web/keyboard-nav

### Proposed Changes

![image](https://github.com/google/blockly/assets/43474485/cd7e9f86-aa6a-44ae-9332-76d46f288185)

- Create new AST Node type for flyout buttons. A marker for a flyout button resembles one used for a stack.
- Implement `IASTNodeLocationSvg` into the `FlyoutButton` class. This is necessary in order to be able to create a navigation cursor around a flyout button.
- Add methods `setContents()` and `getContents()` for flyouts. These are used to be able to return an ordered array of blocks and buttons, necessary for navigating the contents of a flyout.
- Add new `navigateFlyoutContents()` function which supports traversing next/previous flyout items.



### Reason for Changes

These changes will make it possible for users to navigate between stacks and buttons in a flyout. Code.org specifically needs this functionality for variables as well its modal editor for functions and behaviors.

There should not be any breaking changes here and you still do not have to use the plugin at all. However, if you use these changes in core with an old version of the plugin, there is a potential for crashing. Without updating the plugin, using the "mark" shortcut on a button will crash. Additionally, the first _block_ will always be selected when a flyout is focused, even if there is a button above it (e.g. Variables category). 

I have drafted a PR (https://github.com/google/blockly-samples/pull/2200) for @blockly/keyboard-navigation that includes those needed changes. Specifically, it will be necessary to:
- modify [`navigation.js`](https://github.com/google/blockly-samples/blob/7954a8fff50e41fa7c0f891e957bf9ed616361d6/plugins/keyboard-navigation/src/navigation.js#L503-L507) to find top button or block based on contents
- modify [`navigation_controller`](https://github.com/google/blockly-samples/blob/7954a8fff50e41fa7c0f891e957bf9ed616361d6/plugins/keyboard-navigation/src/navigation_controller.js#L512) to trigger button callbacks when pressing "mark" (enter key)

The changes described above are also working locally. The following screen recording demonstrates some simple flyout navigation including using various buttons. Note that the keyboard monitoring in the middle of the workspace is a separate application and just used here for illustration purposes.
https://github.com/google/blockly/assets/43474485/899bf8e3-5a76-4c5c-8e3a-3645e42de323

### Test Coverage

No additional tests have been added so far.

### Documentation

The following sections would need to be updated:
- [Inserting A Block From The Toolbox](https://developers.google.com/blockly/guides/configure/web/keyboard-nav#inserting_a_block_from_the_toolbox)
- [Limitations](https://developers.google.com/blockly/guides/configure/web/keyboard-nav#limitations)

### Additional Information

<!-- Anything else we should know? -->
