### PR TITLE
fix: typo in Click event class docs

### DIFF
--- a/core/events/events_click.ts
+++ b/core/events/events_click.ts
@@ -20,7 +20,7 @@ import * as eventUtils from './utils.js';
 import {Workspace} from '../workspace.js';
 
 /**
- * Notifies listeners that ome blockly element was clicked.
+ * Notifies listeners that some blockly element was clicked.
  */
 export class Click extends UiBase {
   /** The ID of the block that was clicked, if a block was clicked. */


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details

This is a simple typo fix in Click event class docs (for my OCD sake 😸).
It ain't much, but it's honest work.
