### PR TITLE
fix: connection previewer disposing too early

### DIFF
--- a/core/block_dragger.ts
+++ b/core/block_dragger.ts
@@ -382,7 +382,6 @@ export class BlockDragger implements IBlockDragger {
 
     blockAnimation.disconnectUiStop();
     this.connectionPreviewer.hidePreview();
-    this.connectionPreviewer.dispose();
 
     const preventMove =
       !!this.dragTarget_ &&
@@ -417,6 +416,9 @@ export class BlockDragger implements IBlockDragger {
         );
       }
     }
+    // Must dispose after `updateBlockAfterMove_` is called to not break the
+    // dynamic connections plugin.
+    this.connectionPreviewer.dispose();
     this.workspace_.setResizesEnabled(true);
 
     eventUtils.setGroup(false);


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes N/A

### Proposed Changes + Reasons

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->

Makes it so the conneciton previewer is disposed after the blocks are connected, because the dynamic connections plugin tears down and rebuilds the block when `disposed` is called. If we dispose before they're connected, the block dragger's connection references are invalid, so the blocks can't actually connect.

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->
Manually tested.

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->
N/A

### Additional Information

<!-- Anything else we should know? -->
N/A
