### PR TITLE
chore: make getters for grid attributes public and update inline docs

### DIFF
--- a/core/grid.ts
+++ b/core/grid.ts
@@ -66,10 +66,24 @@ export class Grid {
     this.update(this.scale);
   }
 
+  /**
+   * Get the spacing of the grid points (in px).
+   *
+   * @returns The spacing of the grid points.
+   */
+  getSpacing(): number {
+    return this.spacing;
+  }
+
   /** Sets the length of the grid lines. */
   setLength(length: number) {
     this.length = length;
     this.update(this.scale);
+  }
+
+  /** Get the length of the grid lines (in px). */
+  getLength(): number {
+    return this.length;
   }
 
   /**
@@ -85,23 +99,12 @@ export class Grid {
   }
 
   /**
-   * Whether blocks should snap to the grid, based on the initial configuration.
+   * Whether blocks should snap to the grid.
    *
    * @returns True if blocks should snap, false otherwise.
-   * @internal
    */
   shouldSnap(): boolean {
     return this.snapToGrid;
-  }
-
-  /**
-   * Get the spacing of the grid points (in px).
-   *
-   * @returns The spacing of the grid points.
-   * @internal
-   */
-  getSpacing(): number {
-    return this.spacing;
   }
 
   /**


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes N/A

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
Makes getters for the grid attributes public and updates the inline docs. I don't know why this would need to be queried, but Mark (App Inventor) requested that the `shouldSnap` method be public, so I just added getters for everything.

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->
N/A

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->
N/A

### Additional Information

<!-- Anything else we should know? -->
N/A
