### PR TITLE
fix: restore respecting snap radius

### DIFF
--- a/core/block_dragger.ts
+++ b/core/block_dragger.ts
@@ -352,7 +352,9 @@ export class BlockDragger implements IBlockDragger {
     delta: Coordinate,
   ): ConnectionCandidate | null {
     const localConns = this.getLocalConnections(draggingBlock);
-    let radius = config.snapRadius;
+    let radius = this.connectionCandidate
+      ? config.connectingSnapRadius
+      : config.snapRadius;
     let candidate = null;
 
     for (const conn of localConns) {


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #7872 

### Proposed Changes + reasons

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
Restores respecting the connecting snap radius. I didn't realize that the `config` was actually something we allowed folks to overwrite. I thought it was just some place we dumped values.

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->
Manually tested that having a larger connecting snap radius means we stay previewing the current connection for a greater distance.

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->
N/A
### Additional Information

<!-- Anything else we should know? -->
Originally broken in https://github.com/google/blockly/pull/7793/files#diff-788430e802e06b0327df87b7fec2bd6ef4685901b8e9daf14ad9bb48da9698c9