### PR TITLE
fix: insertion marker drag scaling

### DIFF
--- a/core/block_dragger.ts
+++ b/core/block_dragger.ts
@@ -205,6 +205,7 @@ export class BlockDragger implements IBlockDragger {
   }
 
   /**
+   * @param draggingBlock The block being dragged.
    * @param dragDelta How far the pointer has moved from the position
    *     at the start of the drag, in pixel units.
    */
@@ -228,6 +229,8 @@ export class BlockDragger implements IBlockDragger {
    * Returns true if we would delete the block if it was dropped at this time,
    * false otherwise.
    *
+   * @param e The most recent move event.
+   * @param draggingBlock The block being dragged.
    * @param delta How far the pointer has moved from the position
    *     at the start of the drag, in pixel units.
    */
@@ -253,6 +256,7 @@ export class BlockDragger implements IBlockDragger {
   }
 
   /**
+   * @param draggingBlock The block being dragged.
    * @param dragDelta How far the pointer has moved from the position
    *     at the start of the drag, in pixel units.
    */

--- a/core/block_dragger.ts
+++ b/core/block_dragger.ts
@@ -204,6 +204,10 @@ export class BlockDragger implements IBlockDragger {
     this.updateConnectionPreview(block, delta);
   }
 
+  /**
+   * @param dragDelta How far the pointer has moved from the position
+   *     at the start of the drag, in pixel units.
+   */
   private moveBlock(draggingBlock: BlockSvg, dragDelta: Coordinate) {
     const delta = this.pixelsToWorkspaceUnits_(dragDelta);
     const newLoc = Coordinate.sum(this.startXY_, delta);
@@ -223,6 +227,9 @@ export class BlockDragger implements IBlockDragger {
   /**
    * Returns true if we would delete the block if it was dropped at this time,
    * false otherwise.
+   *
+   * @param delta How far the pointer has moved from the position
+   *     at the start of the drag, in pixel units.
    */
   private wouldDeleteBlock(
     e: PointerEvent,
@@ -245,7 +252,15 @@ export class BlockDragger implements IBlockDragger {
     );
   }
 
-  private updateConnectionPreview(draggingBlock: BlockSvg, delta: Coordinate) {
+  /**
+   * @param dragDelta How far the pointer has moved from the position
+   *     at the start of the drag, in pixel units.
+   */
+  private updateConnectionPreview(
+    draggingBlock: BlockSvg,
+    dragDelta: Coordinate,
+  ) {
+    const delta = this.pixelsToWorkspaceUnits_(dragDelta);
     const currCandidate = this.connectionCandidate;
     const newCandidate = this.getConnectionCandidate(draggingBlock, delta);
     if (!newCandidate) {


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #7871 

### Proposed Changes + Reasons

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
Properly take into account workspace scaling to avoid buggies.

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->
manually testing that scale does not affect insertion marker connection previewing range any longer.

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->
N/A

### Additional Information

<!-- Anything else we should know? -->
N/A
