### PR TITLE
fix: libraryBlocks exports

### DIFF
--- a/blocks/blocks.ts
+++ b/blocks/blocks.ts
@@ -20,6 +20,7 @@ import type {BlockDefinition} from '../core/blocks.js';
 export {
   colour,
   lists,
+  logic,
   loops,
   math,
   procedures,
@@ -40,6 +41,7 @@ export const blocks: {[key: string]: BlockDefinition} = Object.assign(
   loops.blocks,
   math.blocks,
   procedures.blocks,
+  texts.blocks,
   variables.blocks,
   variablesDynamic.blocks,
 );


### PR DESCRIPTION
## The basics

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

Fixes N/A

### Proposed Changes + reasons

`Blockly.libraryBlocks` and `Blockly.libraryBlocks.blocks` were missing `logic` blocks and `texts` blocks respectively. They should be exported to ensure completeness and consistency. This PR addresses this issue.

### Test Coverage

`npm test` succeeds.

### Documentation

N/A

### Additional Information

N/A
