### PR TITLE
feat: Add the possibility for the user to add his own generator function for block ID

### DIFF
--- a/core/block.ts
+++ b/core/block.ts
@@ -40,7 +40,6 @@ import type {MutatorIcon} from './icons/mutator_icon.js';
 import * as Tooltip from './tooltip.js';
 import * as arrayUtils from './utils/array.js';
 import {Coordinate} from './utils/coordinate.js';
-import * as idGenerator from './utils/idgenerator.js';
 import * as parsing from './utils/parsing.js';
 import * as registry from './registry.js';
 import {Size} from './utils/size.js';
@@ -236,7 +235,7 @@ export class Block implements IASTNodeLocation, IDeletable {
     this.workspace = workspace;
 
     this.id =
-      opt_id && !workspace.getBlockById(opt_id) ? opt_id : idGenerator.genUid();
+      opt_id && !workspace.getBlockById(opt_id) ? opt_id : workspace.genUid();
     workspace.setBlockById(this.id, this);
 
     /**

--- a/core/blockly_options.ts
+++ b/core/blockly_options.ts
@@ -18,6 +18,7 @@ export interface BlocklyOptions {
   comments?: boolean;
   css?: boolean;
   disable?: boolean;
+  genUid?: () => string;
   grid?: GridOptions;
   horizontalLayout?: boolean;
   maxBlocks?: number;

--- a/core/flyout_base.ts
+++ b/core/flyout_base.ts
@@ -370,6 +370,7 @@ export abstract class Flyout
   init(targetWorkspace: WorkspaceSvg) {
     this.targetWorkspace = targetWorkspace;
     this.workspace_.targetWorkspace = targetWorkspace;
+    this.workspace_.genUid = targetWorkspace.genUid;
 
     this.workspace_.scrollbar = new ScrollbarPair(
       this.workspace_,

--- a/core/options.ts
+++ b/core/options.ts
@@ -27,6 +27,7 @@ import type {WorkspaceSvg} from './workspace_svg.js';
  */
 export class Options {
   RTL: boolean;
+  genUid?: () => string;
   oneBasedIndex: boolean;
   collapse: boolean;
   comments: boolean;
@@ -88,6 +89,10 @@ export class Options {
     let hasComments = false;
     let hasDisable = false;
     let hasSounds = false;
+    if (options.genUid) {
+      this.genUid = options.genUid;
+    }
+
     const readOnly = !!options['readOnly'];
     if (!readOnly) {
       toolboxJsonDef = toolbox.convertToolboxDefToJson(

--- a/core/workspace.ts
+++ b/core/workspace.ts
@@ -109,6 +109,7 @@ export class Workspace implements IASTNodeLocation {
   private readonly typedBlocksDB = new Map<string, Block[]>();
   private variableMap: VariableMap;
   private procedureMap: IProcedureMap = new ObservableProcedureMap();
+  genUid: () => string = idGenerator.genUid;
 
   /**
    * Blocks in the flyout can refer to variables that don't exist in the main
@@ -128,6 +129,9 @@ export class Workspace implements IASTNodeLocation {
     this.RTL = !!this.options.RTL;
     this.horizontalLayout = !!this.options.horizontalLayout;
     this.toolboxPosition = this.options.toolboxPosition;
+    if (this.options.genUid) {
+      this.genUid = this.options.genUid;
+    }
 
     const connectionCheckerClass = registry.getClassFromOptions(
       registry.Type.CONNECTION_CHECKER,

--- a/tests/playground.html
+++ b/tests/playground.html
@@ -20,7 +20,7 @@
       await loadScript('../node_modules/@blockly/dev-tools/dist/index.js');
 
       var workspace = null;
-      var Next = 0;
+
       function start() {
         setBackgroundColour();
 
@@ -55,9 +55,6 @@
             scrollbars: true,
             drag: true,
             wheel: false,
-          },
-          genUid: () => {
-            return 'blala' + Next++;
           },
           toolbox: toolbox,
           toolboxPosition: 'start',
@@ -146,9 +143,6 @@
       }
 
       function initToolbox(workspace) {
-        workspace.genUid = () => {
-          return 'blal';
-        };
         var toolboxSuffix = getToolboxSuffix();
         if (
           toolboxSuffix == 'test-blocks' &&

--- a/tests/playground.html
+++ b/tests/playground.html
@@ -20,7 +20,7 @@
       await loadScript('../node_modules/@blockly/dev-tools/dist/index.js');
 
       var workspace = null;
-
+      var Next = 0;
       function start() {
         setBackgroundColour();
 
@@ -55,6 +55,9 @@
             scrollbars: true,
             drag: true,
             wheel: false,
+          },
+          genUid: () => {
+            return 'blala' + Next++;
           },
           toolbox: toolbox,
           toolboxPosition: 'start',
@@ -143,6 +146,9 @@
       }
 
       function initToolbox(workspace) {
+        workspace.genUid = () => {
+          return 'blal';
+        };
         var toolboxSuffix = getToolboxSuffix();
         if (
           toolboxSuffix == 'test-blocks' &&


### PR DESCRIPTION

feat: Add the possibility for the user to add his own generator function for block ID

https://groups.google.com/g/blockly/c/KVzFku2EpCU/m/HXCrUwoGAgAJ

<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics



- [ x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves
Fixes 

### Proposed Changes
Add the possibility for the user to add his own generator function to generate the block ID.
The custom functions needs to be added to the workspace
If no custom function is provided, Blockly will use the built-in function to not break the current functionality


### Reason for Changes

We will want to include the block ID and for this it will be useful to have human readable ID's 

### Test Coverage

The change was tested in the playground with and without a custom function and observe that without the custom function the blocks get ID's according to the built-in generator, and adding the custom function changes the blocks ID's .

### Documentation



### Additional Information


