### PR TITLE
fix: shouldPreventMove not being respected

### DIFF
--- a/core/block_dragger.ts
+++ b/core/block_dragger.ts
@@ -71,7 +71,17 @@ export class BlockDragger implements IBlockDragger {
 
   /** Whether the block would be deleted if dropped immediately. */
   protected wouldDeleteBlock_ = false;
+
   protected startXY_: Coordinate;
+
+  /** The parent block at the start of the drag. */
+  private startParentConn: RenderedConnection | null = null;
+
+  /**
+   * The child block at the start of the drag. Only gets set if
+   * `healStack` is true.
+   */
+  private startChildConn: RenderedConnection | null = null;
 
   /**
    * @deprecated To be removed in v11. Updating icons is now handled by the
@@ -137,6 +147,13 @@ export class BlockDragger implements IBlockDragger {
     blockAnimation.disconnectUiStop();
 
     if (this.shouldDisconnect_(healStack)) {
+      this.startParentConn =
+        this.draggingBlock_.outputConnection?.targetConnection ??
+        this.draggingBlock_.previousConnection?.targetConnection;
+      if (healStack) {
+        this.startChildConn =
+          this.draggingBlock_.nextConnection?.targetConnection;
+      }
       this.disconnectBlock_(healStack, currentDragDeltaXY);
     }
     this.draggingBlock_.setDragging(true);
@@ -424,17 +441,10 @@ export class BlockDragger implements IBlockDragger {
         .getLayerManager()
         ?.moveOffDragLayer(this.draggingBlock_, layers.BLOCK);
       this.draggingBlock_.setDragging(false);
-      if (delta) {
-        // !preventMove
+      if (preventMove) {
+        this.moveToOriginalPosition();
+      } else if (delta) {
         this.updateBlockAfterMove_();
-      } else {
-        // Blocks dragged directly from a flyout may need to be bumped into
-        // bounds.
-        bumpObjects.bumpIntoBounds(
-          this.draggingBlock_.workspace,
-          this.workspace_.getMetricsManager().getScrollMetrics(true),
-          this.draggingBlock_,
-        );
       }
     }
     // Must dispose after `updateBlockAfterMove_` is called to not break the
@@ -443,6 +453,32 @@ export class BlockDragger implements IBlockDragger {
     this.workspace_.setResizesEnabled(true);
 
     eventUtils.setGroup(false);
+  }
+
+  /**
+   * Moves the dragged block back to its original position before the start of
+   * the drag. Reconnects any parent and child blocks.\
+   */
+  private moveToOriginalPosition() {
+    this.startChildConn?.connect(this.draggingBlock_.nextConnection);
+    if (this.startParentConn) {
+      switch (this.startParentConn?.type) {
+        case ConnectionType.INPUT_VALUE:
+          this.startParentConn?.connect(this.draggingBlock_.outputConnection);
+          break;
+        case ConnectionType.NEXT_STATEMENT:
+          this.startParentConn?.connect(this.draggingBlock_.previousConnection);
+      }
+    } else {
+      this.draggingBlock_.moveTo(this.startXY_, ['drag']);
+      // Blocks dragged directly from a flyout may need to be bumped into
+      // bounds.
+      bumpObjects.bumpIntoBounds(
+        this.draggingBlock_.workspace,
+        this.workspace_.getMetricsManager().getScrollMetrics(true),
+        this.draggingBlock_,
+      );
+    }
   }
 
   /**

--- a/core/block_dragger.ts
+++ b/core/block_dragger.ts
@@ -457,17 +457,17 @@ export class BlockDragger implements IBlockDragger {
 
   /**
    * Moves the dragged block back to its original position before the start of
-   * the drag. Reconnects any parent and child blocks.\
+   * the drag. Reconnects any parent and child blocks.
    */
   private moveToOriginalPosition() {
     this.startChildConn?.connect(this.draggingBlock_.nextConnection);
     if (this.startParentConn) {
-      switch (this.startParentConn?.type) {
+      switch (this.startParentConn.type) {
         case ConnectionType.INPUT_VALUE:
-          this.startParentConn?.connect(this.draggingBlock_.outputConnection);
+          this.startParentConn.connect(this.draggingBlock_.outputConnection);
           break;
         case ConnectionType.NEXT_STATEMENT:
-          this.startParentConn?.connect(this.draggingBlock_.previousConnection);
+          this.startParentConn.connect(this.draggingBlock_.previousConnection);
       }
     } else {
       this.draggingBlock_.moveTo(this.startXY_, ['drag']);


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes N/A

https://github.com/google/blockly/pull/4886 never actually worked.

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
Makes it so that `shouldPreventMove` is actually respected.

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->
Manually tested by linking to the backpack plugin.

* Dragging an orphaned block moves it back to the old location on the workspace.
* Dragging a child block reattaches it to parent.
* Dragging a parent block (holding ctrl to heal stack) reattaches to child.
* Dragging a middle block (holding ctrl to heal stack) reattaches to parent and child.
* Dragging from the simple flyout toolbox bumps blocks into bounds.

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->
N/A

### Additional Information

<!-- Anything else we should know? -->
I'm going to release a beta of 10.5 for this for app inventor so they can test with it.
