### PR TITLE
fix: connection dancing

### DIFF
--- a/core/insertion_marker_previewer.ts
+++ b/core/insertion_marker_previewer.ts
@@ -89,6 +89,10 @@ export class InsertionMarkerPreviewer implements IConnectionPreviewer {
     try {
       this.hidePreview();
 
+      // TODO(7898): Instead of special casing, we should change the dragger to
+      //   track the change in distance between the dragged connection and the
+      //   static connection, so that it doesn't disconnect  unless that
+      //   (+ a bit) has been exceeded.
       if (this.shouldUseMarkerPreview(draggedConn, staticConn)) {
         this.markerConn = this.previewMarker(draggedConn, staticConn);
       }

--- a/core/insertion_marker_previewer.ts
+++ b/core/insertion_marker_previewer.ts
@@ -12,6 +12,8 @@ import * as eventUtils from './events/utils.js';
 import * as constants from './constants.js';
 import * as renderManagement from './render_management.js';
 import * as registry from './registry.js';
+import {Renderer as ZelosRenderer} from './renderers/zelos/renderer.js';
+import {ConnectionType} from './connection_type.js';
 
 /**
  * An error message to throw if the block created by createMarkerBlock_ is
@@ -86,50 +88,67 @@ export class InsertionMarkerPreviewer implements IConnectionPreviewer {
     eventUtils.disable();
     try {
       this.hidePreview();
-      const dragged = draggedConn.getSourceBlock();
-      const marker = this.createInsertionMarker(dragged);
-      const markerConn = this.getMatchingConnection(
-        dragged,
-        marker,
-        draggedConn,
-      );
-      if (!markerConn) {
-        throw Error('Could not create insertion marker to preview connection');
+
+      if (this.shouldUseMarkerPreview(draggedConn, staticConn)) {
+        this.markerConn = this.previewMarker(draggedConn, staticConn);
       }
-
-      // Render disconnected from everything else so that we have a valid
-      // connection location.
-      marker.queueRender();
-      renderManagement.triggerQueuedRenders();
-
-      // Connect() also renders the insertion marker.
-      markerConn.connect(staticConn);
-
-      const originalOffsetToTarget = {
-        x: staticConn.x - markerConn.x,
-        y: staticConn.y - markerConn.y,
-      };
-      const originalOffsetInBlock = markerConn.getOffsetInBlock().clone();
-      renderManagement.finishQueuedRenders().then(() => {
-        // Position so that the existing block doesn't move.
-        marker?.positionNearConnection(
-          markerConn,
-          originalOffsetToTarget,
-          originalOffsetInBlock,
-        );
-        marker?.getSvgRoot().setAttribute('visibility', 'visible');
-      });
 
       if (this.workspace.getRenderer().shouldHighlightConnection(staticConn)) {
         staticConn.highlight();
       }
 
-      this.markerConn = markerConn;
       this.draggedConn = draggedConn;
       this.staticConn = staticConn;
     } finally {
       eventUtils.enable();
     }
+  }
+
+  private shouldUseMarkerPreview(
+    _draggedConn: RenderedConnection,
+    staticConn: RenderedConnection,
+  ): boolean {
+    return (
+      staticConn.type === ConnectionType.PREVIOUS_STATEMENT ||
+      staticConn.type === ConnectionType.NEXT_STATEMENT ||
+      !(this.workspace.getRenderer() instanceof ZelosRenderer)
+    );
+  }
+
+  private previewMarker(
+    draggedConn: RenderedConnection,
+    staticConn: RenderedConnection,
+  ): RenderedConnection {
+    const dragged = draggedConn.getSourceBlock();
+    const marker = this.createInsertionMarker(dragged);
+    const markerConn = this.getMatchingConnection(dragged, marker, draggedConn);
+    if (!markerConn) {
+      throw Error('Could not create insertion marker to preview connection');
+    }
+
+    // Render disconnected from everything else so that we have a valid
+    // connection location.
+    marker.queueRender();
+    renderManagement.triggerQueuedRenders();
+
+    // Connect() also renders the insertion marker.
+    markerConn.connect(staticConn);
+
+    const originalOffsetToTarget = {
+      x: staticConn.x - markerConn.x,
+      y: staticConn.y - markerConn.y,
+    };
+    const originalOffsetInBlock = markerConn.getOffsetInBlock().clone();
+    renderManagement.finishQueuedRenders().then(() => {
+      // Position so that the existing block doesn't move.
+      marker?.positionNearConnection(
+        markerConn,
+        originalOffsetToTarget,
+        originalOffsetInBlock,
+      );
+      marker?.getSvgRoot().setAttribute('visibility', 'visible');
+    });
+    return markerConn;
   }
 
   private createInsertionMarker(origBlock: BlockSvg) {


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
"Fixes" https://github.com/google/blockly/issues/7898 by not having zelos use insertion blocks for inputs and outputs (instead we just highlight). Going to leave a comment on that issue with a more proper fix we should do in the future.

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->
Manually tested that zelos shows insertion markers for stack blocks.
Manually tested that zelos does not show insertion markers for row blocks.
Manually tested that geras shows insertion markers in all cases.

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->
N/A

### Additional Information

<!-- Anything else we should know? -->
We should release a patch for this.
