### PR TITLE
fix: comment min size

### DIFF
--- a/core/comments/comment_view.ts
+++ b/core/comments/comment_view.ts
@@ -13,7 +13,6 @@ import * as css from '../css.js';
 import {Coordinate, Size, browserEvents} from '../utils.js';
 import * as touch from '../touch.js';
 
-const MIN_SIZE = new Size(100, 60);
 export class CommentView implements IRenderedElement {
   /** The root group element of the comment view. */
   private svgRoot: SVGGElement;
@@ -257,18 +256,18 @@ export class CommentView implements IRenderedElement {
    * elements to reflect the new size.
    */
   setSize(size: Size) {
-    size = new Size(
-      Math.max(size.width, MIN_SIZE.width),
-      Math.max(size.height, MIN_SIZE.height),
-    );
-
-    const oldSize = this.size;
-    this.size = size;
     const topBarSize = this.topBar.getBBox();
     const deleteSize = this.deleteIcon.getBBox();
     const foldoutSize = this.foldoutIcon.getBBox();
     const textPreviewSize = this.textPreview.getBBox();
     const resizeSize = this.resizeHandle.getBBox();
+
+    size = Size.max(
+      size,
+      this.calcMinSize(topBarSize, foldoutSize, deleteSize),
+    );
+    const oldSize = this.size;
+    this.size = size;
 
     this.svgRoot.setAttribute('height', `${size.height}`);
     this.svgRoot.setAttribute('width', `${size.width}`);
@@ -292,6 +291,51 @@ export class CommentView implements IRenderedElement {
     this.onSizeChange(oldSize, this.size);
   }
 
+  /**
+   * Calculates the minimum size for the uncollapsed comment based on text
+   * size and visible icons.
+   *
+   * The minimum width is based on the width of the truncated preview text.
+   *
+   * The minimum height is based on the height of the top bar.
+   */
+  private calcMinSize(
+    topBarSize: Size,
+    foldoutSize: Size,
+    deleteSize: Size,
+  ): Size {
+    this.updateTextPreview(this.textArea.value ?? '');
+    const textPreviewWidth = dom.getTextWidth(this.textPreview);
+
+    const foldoutMargin = this.calcFoldoutMargin(topBarSize, foldoutSize);
+    const deleteMargin = this.calcDeleteMargin(topBarSize, deleteSize);
+
+    let width = textPreviewWidth;
+    if (this.foldoutIcon.checkVisibility()) {
+      width += foldoutSize.width + foldoutMargin * 2;
+    } else if (textPreviewWidth) {
+      width += 4; // Arbitrary margin before text.
+    }
+    if (this.deleteIcon.checkVisibility()) {
+      width += deleteSize.width + deleteMargin * 2;
+    } else if (textPreviewWidth) {
+      width += 4; // Arbitrary margin after text.
+    }
+
+    // Arbitrary additional height.
+    const height = topBarSize.height + 20;
+
+    return new Size(width, height);
+  }
+
+  private calcDeleteMargin(topBarSize: Size, deleteSize: Size) {
+    return (topBarSize.height - deleteSize.height) / 2;
+  }
+
+  private calcFoldoutMargin(topBarSize: Size, foldoutSize: Size) {
+    return (topBarSize.height - foldoutSize.height) / 2;
+  }
+
   /** Updates the size of the text area elements to reflect the new size. */
   private updateTextAreaSize(size: Size, topBarSize: Size) {
     this.foreignObject.setAttribute(
@@ -313,7 +357,7 @@ export class CommentView implements IRenderedElement {
     topBarSize: Size,
     deleteSize: Size,
   ) {
-    const deleteMargin = (topBarSize.height - deleteSize.height) / 2;
+    const deleteMargin = this.calcDeleteMargin(topBarSize, deleteSize);
     this.deleteIcon.setAttribute('y', `${deleteMargin}`);
     this.deleteIcon.setAttribute(
       'x',
@@ -325,7 +369,7 @@ export class CommentView implements IRenderedElement {
    * Updates the position of the foldout icon elements to reflect the new size.
    */
   private updateFoldoutIconPosition(topBarSize: Size, foldoutSize: Size) {
-    const foldoutMargin = (topBarSize.height - foldoutSize.height) / 2;
+    const foldoutMargin = this.calcFoldoutMargin(topBarSize, foldoutSize);
     this.foldoutIcon.setAttribute('y', `${foldoutMargin}`);
     this.foldoutIcon.setAttribute('x', `${foldoutMargin}`);
   }
@@ -341,8 +385,8 @@ export class CommentView implements IRenderedElement {
     foldoutSize: Size,
   ) {
     const textPreviewMargin = (topBarSize.height - textPreviewSize.height) / 2;
-    const deleteMargin = (topBarSize.height - deleteSize.height) / 2;
-    const foldoutMargin = (topBarSize.height - foldoutSize.height) / 2;
+    const deleteMargin = this.calcDeleteMargin(topBarSize, deleteSize);
+    const foldoutMargin = this.calcFoldoutMargin(topBarSize, foldoutSize);
 
     const textPreviewWidth =
       size.width -
@@ -578,11 +622,17 @@ export class CommentView implements IRenderedElement {
   private onTextChange() {
     const oldText = this.text;
     this.text = this.textArea.value;
-    this.textPreviewNode.textContent = this.truncateText(this.text);
+    this.updateTextPreview(this.text);
+    // Update size in case our minimum size increased.
+    this.setSize(this.size);
     // Loop through listeners backwards in case they remove themselves.
     for (let i = this.textChangeListeners.length - 1; i >= 0; i--) {
       this.textChangeListeners[i](oldText, this.text);
     }
+  }
+
+  private updateTextPreview(text: string) {
+    this.textPreviewNode.textContent = this.truncateText(text);
   }
 
   /** Truncates the text to fit within the top view. */
@@ -703,11 +753,11 @@ css.register(`
 .blocklyComment .blocklyCommentPreview.blocklyText {
   fill: var(--commentIconColour);
   dominant-baseline: middle;
-  display: none;
+  visibility: hidden;
 }
 
 .blocklyCollapsed.blocklyComment .blocklyCommentPreview {
-  display: block;
+  visibility: visible;
 }
 
 .blocklyCollapsed.blocklyComment .blocklyCommentForeignObject,

--- a/core/comments/comment_view.ts
+++ b/core/comments/comment_view.ts
@@ -328,10 +328,12 @@ export class CommentView implements IRenderedElement {
     return new Size(width, height);
   }
 
+  /** Calculates the margin that should exist around the delete icon. */
   private calcDeleteMargin(topBarSize: Size, deleteSize: Size) {
     return (topBarSize.height - deleteSize.height) / 2;
   }
 
+  /** Calculates the margin that should exist around the foldout icon. */
   private calcFoldoutMargin(topBarSize: Size, foldoutSize: Size) {
     return (topBarSize.height - foldoutSize.height) / 2;
   }
@@ -631,6 +633,7 @@ export class CommentView implements IRenderedElement {
     }
   }
 
+  /** Updates the preview text element to reflect the given text. */
   private updateTextPreview(text: string) {
     this.textPreviewNode.textContent = this.truncateText(text);
   }

--- a/core/utils/size.ts
+++ b/core/utils/size.ts
@@ -43,4 +43,20 @@ export class Size {
     }
     return a.width === b.width && a.height === b.height;
   }
+
+  /**
+   * Returns a new size with the maximum width and heigh values out of both
+   * sizes.
+   */
+  static max(a: Size, b: Size): Size {
+    return new Size(Math.max(a.width, b.width), Math.max(a.height, b.height));
+  }
+
+  /**
+   * Returns a new size with the minimum width and heigh values out of both
+   * sizes.
+   */
+  static min(a: Size, b: Size): Size {
+    return new Size(Math.min(a.width, b.width), Math.min(a.height, b.height));
+  }
 }

--- a/core/utils/size.ts
+++ b/core/utils/size.ts
@@ -45,7 +45,7 @@ export class Size {
   }
 
   /**
-   * Returns a new size with the maximum width and heigh values out of both
+   * Returns a new size with the maximum width and height values out of both
    * sizes.
    */
   static max(a: Size, b: Size): Size {
@@ -53,7 +53,7 @@ export class Size {
   }
 
   /**
-   * Returns a new size with the minimum width and heigh values out of both
+   * Returns a new size with the minimum width and height values out of both
    * sizes.
    */
   static min(a: Size, b: Size): Size {


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes N/A 

### Proposed Changes + Reasons

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
Makes it so we calculate the minimum size of the comment based on the size of the preview text. This way we'll never get preview text hanging off the edge of the comment.

Alternatively, I could have tried to truncate the preview text to fit within the available area, but this is super inefficient because it requires continual trial and error and layout recalculation. So instead of fitting the text to the area, I fit the area to the text.

Ideally the browser would just truncate the preview and add ellipses for us (then we could fit the text to the area), but SVG doesn't support that! So instead we have to do this complicated madness :P

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->

Tested that the minimum size is properly set with different text width, and with or without the delete icon.

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->
N/A

### Additional Information

<!-- Anything else we should know? -->
This doesn't work exactly like MakeCode's setup. For them, they always set the width to a specific width when collapsing (the length of 12 `m` characters, plus the ellipse) which causes a bug where it overlaps their icons. Instead when collapsing, we keep the width of the comment the same, just hide the text area.

They are able to implement their behavior using the `onCollapse` listener to set the width explicitly. So this  isn't a blocker even though it's a difference in behavior.

~But writing this did make me realize that I might need to change the calculation for positioning the preview text slightly to do what they want, so I'll look into that in a follow up.~ Tested and the current setup should be fine.