### PR TITLE
feat: add headless workspace comment class

### DIFF
--- a/core/comments.ts
+++ b/core/comments.ts
@@ -5,3 +5,4 @@
  */
 
 export {CommentView} from './comments/comment_view.js';
+export {WorkspaceComment} from './comments/workspace_comment.js';

--- a/core/comments/workspace_comment.ts
+++ b/core/comments/workspace_comment.ts
@@ -12,6 +12,15 @@ import * as idGenerator from '../utils/idgenerator.js';
 export class WorkspaceComment {
   public readonly id: string;
 
+  private text = '';
+  private size = new Size(120, 100);
+  private collapsed = false;
+  private editable = true;
+  private movable = true;
+  private deletable = true;
+  private location = new Coordinate(0, 0);
+  private disposed = false;
+
   constructor(
     protected readonly workspace: Workspace,
     id?: string,
@@ -25,33 +34,67 @@ export class WorkspaceComment {
     // TODO(7909): Fire events.
   }
 
-  setText(text: string) {}
+  setText(text: string) {
+    this.text = text;
+  }
 
-  getText(): string;
+  getText(): string {
+    return this.text;
+  }
 
-  setSize(size: Size) {}
+  setSize(size: Size) {
+    this.size = size;
+  }
 
-  getSize(): Size {}
+  getSize(): Size {
+    return this.size;
+  }
 
-  setCollapsed(collapsed: boolean) {}
+  setCollapsed(collapsed: boolean) {
+    this.collapsed = collapsed;
+  }
 
-  isCollapssed(): boolean {}
+  isCollapssed(): boolean {
+    return this.collapsed;
+  }
 
-  setEditable(editable: boolean) {}
+  setEditable(editable: boolean) {
+    this.editable = editable;
+  }
 
-  isEditable(): boolean {}
+  isEditable(): boolean {
+    return this.editable && !this.workspace.options.readOnly;
+  }
 
-  setMovable(movable: boolean) {}
+  setMovable(movable: boolean) {
+    this.movable = movable;
+  }
 
-  isMovable() {}
+  isMovable() {
+    return this.movable && !this.workspace.options.readOnly;
+  }
 
-  setDeletable(deletable: boolean) {}
+  setDeletable(deletable: boolean) {
+    this.deletable = deletable;
+  }
 
-  isDeletable(): boolean {}
+  isDeletable(): boolean {
+    return this.deletable && !this.workspace.options.readOnly;
+  }
 
-  moveTo(loc: Coordinate) {}
+  moveTo(location: Coordinate) {
+    this.location = location;
+  }
 
-  getRelativetoSurfaceXY(): Coordinate {}
+  getRelativetoSurfaceXY(): Coordinate {
+    return this.location;
+  }
 
-  dispose() {}
+  dispose() {
+    this.disposed = true;
+  }
+
+  isDisposed() {
+    return this.disposed;
+  }
 }

--- a/core/comments/workspace_comment.ts
+++ b/core/comments/workspace_comment.ts
@@ -1,0 +1,43 @@
+/**
+ * @license
+ * Copyright 2024 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {Workspace} from '../workspace.js';
+import {Size} from '../utils/size.js';
+import {Coordinate} from '../utils/coordinate.js';
+
+class WorkspaceComment {
+  constructor(workspace: Workspace, id?: string) {}
+
+  setText(text: string) {}
+
+  getText(): string;
+
+  setSize(size: Size) {}
+
+  getSize(): Size {}
+
+  setCollapsed(collapsed: boolean) {}
+
+  isCollapssed(): boolean {}
+
+  setEditable(editable: boolean) {}
+
+  isEditable(): boolean {}
+
+  setMovable(movable: boolean) {}
+
+  isMovable() {}
+
+  setDeletable(deletable: boolean) {}
+
+  isDeletable(): boolean {}
+
+  moveTo(loc: Coordinate) {}
+
+  getRelativetoSurfaceXY(): Coordinate {}
+
+  dispose() {}
+}

--- a/core/comments/workspace_comment.ts
+++ b/core/comments/workspace_comment.ts
@@ -63,7 +63,11 @@ export class WorkspaceComment {
   }
 
   isEditable(): boolean {
-    return this.editable && !this.workspace.options.readOnly;
+    return this.isOwnEditable() && !this.workspace.options.readOnly;
+  }
+
+  isOwnEditable(): boolean {
+    return this.editable;
   }
 
   setMovable(movable: boolean) {
@@ -71,7 +75,11 @@ export class WorkspaceComment {
   }
 
   isMovable() {
-    return this.movable && !this.workspace.options.readOnly;
+    return this.isOwnMovable() && !this.workspace.options.readOnly;
+  }
+
+  isOwnMovable() {
+    return this.movable;
   }
 
   setDeletable(deletable: boolean) {
@@ -79,7 +87,11 @@ export class WorkspaceComment {
   }
 
   isDeletable(): boolean {
-    return this.deletable && !this.workspace.options.readOnly;
+    return this.isOwnDeletable() && !this.workspace.options.readOnly;
+  }
+
+  isOwnDeletable(): boolean {
+    return this.deletable;
   }
 
   moveTo(location: Coordinate) {

--- a/core/comments/workspace_comment.ts
+++ b/core/comments/workspace_comment.ts
@@ -7,9 +7,23 @@
 import {Workspace} from '../workspace.js';
 import {Size} from '../utils/size.js';
 import {Coordinate} from '../utils/coordinate.js';
+import * as idGenerator from '../utils/idgenerator.js';
 
-class WorkspaceComment {
-  constructor(workspace: Workspace, id?: string) {}
+export class WorkspaceComment {
+  public readonly id: string;
+
+  constructor(
+    protected readonly workspace: Workspace,
+    id?: string,
+  ) {
+    // TODO: Before merging, file issue to update getCommentById.
+    this.id = id && !workspace.getCommentById(id) ? id : idGenerator.genUid();
+
+    // TODO: Before merging, file issue to add top comment.
+    // workspace.addTopComment(this);
+
+    // TODO(7909): Fire events.
+  }
 
   setText(text: string) {}
 

--- a/core/comments/workspace_comment.ts
+++ b/core/comments/workspace_comment.ts
@@ -10,17 +10,40 @@ import {Coordinate} from '../utils/coordinate.js';
 import * as idGenerator from '../utils/idgenerator.js';
 
 export class WorkspaceComment {
+  /** The unique identifier for this comment. */
   public readonly id: string;
 
+  /** The text of the comment. */
   private text = '';
+
+  /** The size of the comment in workspace units. */
   private size = new Size(120, 100);
+
+  /** Whether the comment is collapsed or not. */
   private collapsed = false;
+
+  /** Whether the comment is editable or not. */
   private editable = true;
+
+  /** Whether the comment is movable or not. */
   private movable = true;
+
+  /** Whether the comment is deletable or not. */
   private deletable = true;
+
+  /** The location of the comment in workspace coordinates. */
   private location = new Coordinate(0, 0);
+
+  /** Whether this comment has been disposed or not. */
   private disposed = false;
 
+  /**
+   * Constructs the comment.
+   *
+   * @param workspace The workspace to construct the comment in.
+   * @param id An optional ID to give to the comment. If not provided, one will
+   *     be generated.
+   */
   constructor(
     protected readonly workspace: Workspace,
     id?: string,
@@ -34,78 +57,115 @@ export class WorkspaceComment {
     // TODO(7909): Fire events.
   }
 
+  /** Sets the text of the comment. */
   setText(text: string) {
     this.text = text;
   }
 
+  /** Returns the text of the comment. */
   getText(): string {
     return this.text;
   }
 
+  /** Sets the comment's size in workspace units. */
   setSize(size: Size) {
     this.size = size;
   }
 
+  /** Returns the comment's size in workspace units. */
   getSize(): Size {
     return this.size;
   }
 
+  /** Sets whether the comment is collapsed or not. */
   setCollapsed(collapsed: boolean) {
     this.collapsed = collapsed;
   }
 
+  /** Returns whether the comment is collapsed or not. */
   isCollapssed(): boolean {
     return this.collapsed;
   }
 
+  /** Sets whether the comment is editable or not. */
   setEditable(editable: boolean) {
     this.editable = editable;
   }
 
+  /**
+   * Returns whether the comment is editable or not, respecting whether the
+   * workspace is read-only.
+   */
   isEditable(): boolean {
     return this.isOwnEditable() && !this.workspace.options.readOnly;
   }
 
+  /**
+   * Returns whether the comment is editable or not, only examining its own
+   * state and ignoring the state of the workspace.
+   */
   isOwnEditable(): boolean {
     return this.editable;
   }
 
+  /** Sets whether the comment is movable or not. */
   setMovable(movable: boolean) {
     this.movable = movable;
   }
 
+  /**
+   * Returns whether the comment is movable or not, respecting whether the
+   * workspace is read-only.
+   */
   isMovable() {
     return this.isOwnMovable() && !this.workspace.options.readOnly;
   }
 
+  /**
+   * Returns whether the comment is movable or not, only examining its own
+   * state and ignoring the state of the workspace.
+   */
   isOwnMovable() {
     return this.movable;
   }
 
+  /** Sets whether the comment is deletable or not. */
   setDeletable(deletable: boolean) {
     this.deletable = deletable;
   }
 
+  /**
+   * Returns whether the comment is deletable or not, respecting whether the
+   * workspace is read-only.
+   */
   isDeletable(): boolean {
     return this.isOwnDeletable() && !this.workspace.options.readOnly;
   }
 
+  /**
+   * Returns whether the comment is deletable or not, only examining its own
+   * state and ignoring the state of the workspace.
+   */
   isOwnDeletable(): boolean {
     return this.deletable;
   }
 
+  /** Moves the comment to the given location in workspace coordinates. */
   moveTo(location: Coordinate) {
     this.location = location;
   }
 
+  /** Returns the position of the comment in workspace coordinates. */
   getRelativetoSurfaceXY(): Coordinate {
     return this.location;
   }
 
+  /** Disposes of this comment. */
   dispose() {
     this.disposed = true;
   }
 
+  /** Returns whether teh comment has been disposed or not. */
   isDisposed() {
     return this.disposed;
   }

--- a/core/comments/workspace_comment.ts
+++ b/core/comments/workspace_comment.ts
@@ -48,11 +48,7 @@ export class WorkspaceComment {
     protected readonly workspace: Workspace,
     id?: string,
   ) {
-    // TODO: Before merging, file issue to update getCommentById.
     this.id = id && !workspace.getCommentById(id) ? id : idGenerator.genUid();
-
-    // TODO: Before merging, file issue to add top comment.
-    // workspace.addTopComment(this);
 
     // TODO(7909): Fire events.
   }

--- a/core/comments/workspace_comment.ts
+++ b/core/comments/workspace_comment.ts
@@ -83,7 +83,7 @@ export class WorkspaceComment {
   }
 
   /** Returns whether the comment is collapsed or not. */
-  isCollapssed(): boolean {
+  isCollapsed(): boolean {
     return this.collapsed;
   }
 
@@ -156,7 +156,7 @@ export class WorkspaceComment {
   }
 
   /** Returns the position of the comment in workspace coordinates. */
-  getRelativetoSurfaceXY(): Coordinate {
+  getRelativeToSurfaceXY(): Coordinate {
     return this.location;
   }
 
@@ -165,7 +165,7 @@ export class WorkspaceComment {
     this.disposed = true;
   }
 
-  /** Returns whether teh comment has been disposed or not. */
+  /** Returns whether the comment has been disposed or not. */
   isDisposed() {
     return this.disposed;
   }


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #7906 

### Proposed Changes + reasons

Adds a headless workspace comment class (just holds data, doesn't refer to any view elements) to support headless mode. 

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->
No testing, because this is just a bunch of data storage methods. These methods will be covered by later serialization tests.

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->
N/A

### Additional Information

<!-- Anything else we should know? -->
N/A