### PR TITLE
feat: have RenderedWorkspaceComment implement IBoundedElement and IRenderedElement

### DIFF
--- a/core/comments/rendered_workspace_comment.ts
+++ b/core/comments/rendered_workspace_comment.ts
@@ -7,9 +7,13 @@
 import {WorkspaceComment} from './workspace_comment.js';
 import {WorkspaceSvg} from '../workspace_svg.js';
 import {CommentView} from './comment_view.js';
-import {Coordinate, Size} from '../utils.js';
+import {Coordinate, Rect, Size} from '../utils.js';
+import {IBoundedElement} from '../blockly.js';
 
-export class RenderedWorkspaceComment extends WorkspaceComment {
+export class RenderedWorkspaceComment
+  extends WorkspaceComment
+  implements IBoundedElement
+{
   /** The class encompassing the svg elements making up the workspace comment. */
   private view: CommentView;
 
@@ -70,6 +74,21 @@ export class RenderedWorkspaceComment extends WorkspaceComment {
     super.setEditable(editable);
     // Use isEditable rather than isOwnEditable to account for workspace state.
     this.view.setEditable(this.isEditable());
+  }
+
+  /** Returns the bounding rectangle of this comment in workspace coordinates. */
+  getBoundingRectangle(): Rect {
+    const loc = this.getRelativeToSurfaceXY();
+    const size = this.getSize();
+    return new Rect(loc.y, loc.y + size.height, loc.x, loc.x + size.width);
+  }
+
+  /** Move the comment by the given amounts in workspace coordinates. */
+  moveBy(dx: number, dy: number, _reason?: string[] | undefined): void {
+    // TODO(#7909): Deal with reason when we add events.
+    const loc = this.getRelativeToSurfaceXY();
+    const newLoc = new Coordinate(loc.x + dx, loc.y + dy);
+    this.moveTo(newLoc);
   }
 
   /** Moves the comment to the given location in workspace coordinates. */

--- a/core/comments/rendered_workspace_comment.ts
+++ b/core/comments/rendered_workspace_comment.ts
@@ -7,12 +7,15 @@
 import {WorkspaceComment} from './workspace_comment.js';
 import {WorkspaceSvg} from '../workspace_svg.js';
 import {CommentView} from './comment_view.js';
-import {Coordinate, Rect, Size} from '../utils.js';
-import {IBoundedElement} from '../blockly.js';
+import {Coordinate} from '../utils/coordinate.js';
+import {Rect} from '../utils/rect.js';
+import {Size} from '../utils/size.js';
+import {IBoundedElement} from '../interfaces/i_bounded_element.js';
+import {IRenderedElement} from '../interfaces/i_rendered_element.js';
 
 export class RenderedWorkspaceComment
   extends WorkspaceComment
-  implements IBoundedElement
+  implements IBoundedElement, IRenderedElement
 {
   /** The class encompassing the svg elements making up the workspace comment. */
   private view: CommentView;
@@ -74,6 +77,11 @@ export class RenderedWorkspaceComment
     super.setEditable(editable);
     // Use isEditable rather than isOwnEditable to account for workspace state.
     this.view.setEditable(this.isEditable());
+  }
+
+  /** Returns the root SVG element of this comment. */
+  getSvgRoot(): SVGElement {
+    return this.view.getSvgRoot();
   }
 
   /** Returns the bounding rectangle of this comment in workspace coordinates. */


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Work on #7907 

### Proposed Changes + Reasons

Adds support for these interfaces so that rendered workspace comments can be used in places where those interfaces are required (e.g. bumping elements into bounds).

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->
N/A

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->
N/A

### Additional Information

<!-- Anything else we should know? -->
N/A