### PR TITLE
fix: comment position in RTL

### DIFF
--- a/core/comments/workspace_comment.ts
+++ b/core/comments/workspace_comment.ts
@@ -48,7 +48,7 @@ export class WorkspaceComment {
    *     be generated.
    */
   constructor(
-    protected readonly workspace: Workspace,
+    public readonly workspace: Workspace,
     id?: string,
   ) {
     this.id = id && !workspace.getCommentById(id) ? id : idGenerator.genUid();

--- a/core/serialization/workspace_comments.ts
+++ b/core/serialization/workspace_comments.ts
@@ -39,6 +39,7 @@ export function save(
     saveIds?: boolean;
   } = {},
 ): State {
+  const workspace = comment.workspace;
   const state: State = Object.create(null);
 
   state.height = comment.getSize().height;
@@ -46,8 +47,9 @@ export function save(
 
   if (saveIds) state.id = comment.id;
   if (addCoordinates) {
-    state.x = comment.getRelativeToSurfaceXY().x;
-    state.y = comment.getRelativeToSurfaceXY().y;
+    const loc = comment.getRelativeToSurfaceXY();
+    state.x = workspace.RTL ? workspace.getWidth() - loc.x : loc.x;
+    state.y = loc.y;
   }
 
   if (comment.getText()) state.text = comment.getText();
@@ -76,9 +78,10 @@ export function append(
   if (state.text !== undefined) comment.setText(state.text);
   if (state.x !== undefined || state.y !== undefined) {
     const defaultLoc = comment.getRelativeToSurfaceXY();
-    comment.moveTo(
-      new Coordinate(state.x ?? defaultLoc.x, state.y ?? defaultLoc.y),
-    );
+    let x = state.x ?? defaultLoc.x;
+    x = workspace.RTL ? workspace.getWidth() - x : x;
+    const y = state.y ?? defaultLoc.y;
+    comment.moveTo(new Coordinate(x, y));
   }
   if (state.width !== undefined || state.height) {
     const defaultSize = comment.getSize();

--- a/core/xml.ts
+++ b/core/xml.ts
@@ -62,8 +62,11 @@ function saveWorkspaceComment(
   const elem = utilsXml.createElement('comment');
   if (!skipId) elem.setAttribute('id', comment.id);
 
-  elem.setAttribute('x', `${comment.getRelativeToSurfaceXY().x}`);
-  elem.setAttribute('y', `${comment.getRelativeToSurfaceXY().y}`);
+  const workspace = comment.workspace;
+  const loc = comment.getRelativeToSurfaceXY();
+  loc.x = workspace.RTL ? workspace.getWidth() - loc.x : loc.x;
+  elem.setAttribute('x', `${loc.x}`);
+  elem.setAttribute('y', `${loc.y}`);
   elem.setAttribute('w', `${comment.getSize().width}`);
   elem.setAttribute('h', `${comment.getSize().height}`);
 
@@ -503,9 +506,12 @@ function loadWorkspaceComment(
 
   comment.setText(elem.textContent ?? '');
 
-  const x = parseInt(elem.getAttribute('x') ?? '', 10);
+  let x = parseInt(elem.getAttribute('x') ?? '', 10);
   const y = parseInt(elem.getAttribute('y') ?? '', 10);
-  if (!isNaN(x) && !isNaN(y)) comment.moveTo(new Coordinate(x, y));
+  if (!isNaN(x) && !isNaN(y)) {
+    x = workspace.RTL ? workspace.getWidth() - x : x;
+    comment.moveTo(new Coordinate(x, y));
+  }
 
   const w = parseInt(elem.getAttribute('w') ?? '', 10);
   const h = parseInt(elem.getAttribute('h') ?? '', 10);


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes comments being positioning incorrectly when loading from XML in RTL mode

### Proposed Changes + Reasons

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
Makes it so that comments are positioned relative to the toolbox when loading in RTL mode, to match blocks.

To get this to work the same as blocks I had to change how I was handling RTL in the comment view. We can't apply the scale at the top level because that messes up the transform (we still want +x to go right and +y to go down in RTL mode to match blocks). So I need to apply it to the sub elements of the icon. And to get rotating the foldout icon to work, that meant I needed an element to encompass the elements of the top bar.

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->
Manually tested loading and saving in RLT and LTR in JSON and XML

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->
N/A

### Additional Information

<!-- Anything else we should know? -->
N/A