### PR TITLE
fix!: classes on text input bubble to match comment view

### DIFF
--- a/core/bubbles/bubble.ts
+++ b/core/bubbles/bubble.ts
@@ -90,7 +90,11 @@ export abstract class Bubble implements IBubble {
     protected anchor: Coordinate,
     protected ownerRect?: Rect,
   ) {
-    this.svgRoot = dom.createSvgElement(Svg.G, {}, workspace.getBubbleCanvas());
+    this.svgRoot = dom.createSvgElement(
+      Svg.G,
+      {'class': 'blocklyBubble'},
+      workspace.getBubbleCanvas(),
+    );
     const embossGroup = dom.createSvgElement(
       Svg.G,
       {
@@ -100,7 +104,11 @@ export abstract class Bubble implements IBubble {
       },
       this.svgRoot,
     );
-    this.tail = dom.createSvgElement(Svg.PATH, {}, embossGroup);
+    this.tail = dom.createSvgElement(
+      Svg.PATH,
+      {'class': 'blocklyBubbleTail'},
+      embossGroup,
+    );
     this.background = dom.createSvgElement(
       Svg.RECT,
       {

--- a/core/bubbles/textinput_bubble.ts
+++ b/core/bubbles/textinput_bubble.ts
@@ -75,10 +75,11 @@ export class TextInputBubble extends Bubble {
     protected ownerRect?: Rect,
   ) {
     super(workspace, anchor, ownerRect);
+    dom.addClass(this.svgRoot, 'blocklyTextInputBubble');
     ({inputRoot: this.inputRoot, textArea: this.textArea} = this.createEditor(
       this.contentContainer,
     ));
-    this.resizeGroup = this.createResizeHandle(this.svgRoot);
+    this.resizeGroup = this.createResizeHandle(this.svgRoot, workspace);
     this.setSize(this.DEFAULT_SIZE, true);
   }
 
@@ -126,7 +127,7 @@ export class TextInputBubble extends Bubble {
       dom.HTML_NS,
       'textarea',
     ) as HTMLTextAreaElement;
-    textArea.className = 'blocklyCommentTextarea';
+    textArea.className = 'blocklyTextarea blocklyText';
     textArea.setAttribute('dir', this.workspace.RTL ? 'RTL' : 'LTR');
 
     body.appendChild(textArea);
@@ -158,51 +159,27 @@ export class TextInputBubble extends Bubble {
   }
 
   /** Creates the resize handler elements and binds events to them. */
-  private createResizeHandle(container: SVGGElement): SVGGElement {
-    const resizeGroup = dom.createSvgElement(
-      Svg.G,
+  private createResizeHandle(
+    container: SVGGElement,
+    workspace: WorkspaceSvg,
+  ): SVGGElement {
+    const resizeHandle = dom.createSvgElement(
+      Svg.IMAGE,
       {
-        'class': this.workspace.RTL ? 'blocklyResizeSW' : 'blocklyResizeSE',
+        'class': 'blocklyResizeHandle',
+        'href': `${workspace.options.pathToMedia}resize-handle.svg`,
       },
       container,
     );
-    const size = 2 * Bubble.BORDER_WIDTH;
-    dom.createSvgElement(
-      Svg.POLYGON,
-      {'points': `0,${size} ${size},${size} ${size},0`},
-      resizeGroup,
-    );
-    dom.createSvgElement(
-      Svg.LINE,
-      {
-        'class': 'blocklyResizeLine',
-        'x1': size / 3,
-        'y1': size - 1,
-        'x2': size - 1,
-        'y2': size / 3,
-      },
-      resizeGroup,
-    );
-    dom.createSvgElement(
-      Svg.LINE,
-      {
-        'class': 'blocklyResizeLine',
-        'x1': (size * 2) / 3,
-        'y1': size - 1,
-        'x2': size - 1,
-        'y2': (size * 2) / 3,
-      },
-      resizeGroup,
-    );
 
     browserEvents.conditionalBind(
-      resizeGroup,
+      resizeHandle,
       'pointerdown',
       this,
       this.onResizePointerDown,
     );
 
-    return resizeGroup;
+    return resizeHandle;
   }
 
   /**


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes N/A

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
Makes the text input bubble css consistent with the workspace comment css. Yay for styling.


### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->
Manually checked that everything still looks correct in LTR and RTL.

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->
Will need to start documenting CSS classes somewhere.

### Additional Information

<!-- Anything else we should know? -->
If/when we move the workspace comments into  a plugin, we'll need to do something with the CSS for the resize handle because right now the text input bubble is relying on it. One option is to just move that CSS into the text input bubble class.
