### PR TITLE
fix: updated field_dropdown to properly infer its Field type with TS 5.3.3

### DIFF
--- a/core/field_dropdown.ts
+++ b/core/field_dropdown.ts
@@ -408,9 +408,7 @@ export class FieldDropdown extends Field<string> {
    * @param newValue The input value.
    * @returns A valid language-neutral option, or null if invalid.
    */
-  protected override doClassValidation_(
-    newValue: string,
-  ): string | null | undefined;
+  protected override doClassValidation_(newValue: string): string | null;
   protected override doClassValidation_(newValue?: string): string | null;
   protected override doClassValidation_(newValue?: string): string | null {
     const options = this.getOptions(true);

--- a/core/field_dropdown.ts
+++ b/core/field_dropdown.ts
@@ -408,6 +408,10 @@ export class FieldDropdown extends Field<string> {
    * @param newValue The input value.
    * @returns A valid language-neutral option, or null if invalid.
    */
+  protected override doClassValidation_(
+    newValue: string,
+  ): string | null | undefined;
+  protected override doClassValidation_(newValue?: string): string | null;
   protected override doClassValidation_(newValue?: string): string | null {
     const options = this.getOptions(true);
     const isValueValid = options.some((option) => option[1] === newValue);

--- a/core/field_dropdown.ts
+++ b/core/field_dropdown.ts
@@ -408,9 +408,13 @@ export class FieldDropdown extends Field<string> {
    * @param newValue The input value.
    * @returns A valid language-neutral option, or null if invalid.
    */
-  protected override doClassValidation_(newValue: string): string | null;
+  protected override doClassValidation_(
+    newValue: string,
+  ): string | null | undefined;
   protected override doClassValidation_(newValue?: string): string | null;
-  protected override doClassValidation_(newValue?: string): string | null {
+  protected override doClassValidation_(
+    newValue?: string,
+  ): string | null | undefined {
     const options = this.getOptions(true);
     const isValueValid = options.some((option) => option[1] === newValue);
 
@@ -428,7 +432,7 @@ export class FieldDropdown extends Field<string> {
       }
       return null;
     }
-    return newValue as string;
+    return newValue;
   }
 
   /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -48,7 +48,7 @@
         "prettier": "3.2.5",
         "readline-sync": "^1.4.10",
         "rimraf": "^5.0.0",
-        "typescript": "^5.0.2",
+        "typescript": "^5.3.3",
         "webdriverio": "^8.32.2",
         "yargs": "^17.2.1"
       }
@@ -10885,9 +10885,9 @@
       "dev": true
     },
     "node_modules/typescript": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
-      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
+      "version": "5.4.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.2.tgz",
+      "integrity": "sha512-+2/g0Fds1ERlP6JsakQQDXjZdZMM+rqpamFZJEKh4kwTIn3iDkgKtby0CeNd5ATNZ4Ry1ax15TMx0W2V+miizQ==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",

--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "prettier": "3.2.5",
     "readline-sync": "^1.4.10",
     "rimraf": "^5.0.0",
-    "typescript": "^5.0.2",
+    "typescript": "^5.3.3",
     "webdriverio": "^8.32.2",
     "yargs": "^17.2.1"
   },


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

Fixes https://github.com/google/blockly/issues/7715

### Proposed Changes

Update `FieldDropdown`'s type information for `doClassValidation` to match the template in `Field` so it properly infers `FieldDropdown` as `Field<string>` instead of `Field<string|undefined>`.

### Reason for Changes

To enable Blockly to update to TypeScript 5.3.3 and beyond.

### Test Coverage

N/A

### Documentation

N/A

### Additional Information

None
