### PR TITLE
fix(generators): Make `scrub_` `public`

### DIFF
--- a/core/generator.ts
+++ b/core/generator.ts
@@ -578,7 +578,7 @@ export class CodeGenerator {
    * @param _opt_thisOnly True to generate code for only this statement.
    * @returns Code with comments and subsequent blocks added.
    */
-  protected scrub_(
+  scrub_(
     _block: Block,
     code: string,
     _opt_thisOnly?: boolean,

--- a/core/generator.ts
+++ b/core/generator.ts
@@ -578,11 +578,7 @@ export class CodeGenerator {
    * @param _opt_thisOnly True to generate code for only this statement.
    * @returns Code with comments and subsequent blocks added.
    */
-  scrub_(
-    _block: Block,
-    code: string,
-    _opt_thisOnly?: boolean,
-  ): string {
+  scrub_(_block: Block, code: string, _opt_thisOnly?: boolean): string {
     // Optionally override
     return code;
   }

--- a/generators/javascript/javascript_generator.ts
+++ b/generators/javascript/javascript_generator.ts
@@ -251,7 +251,6 @@ export class JavascriptGenerator extends CodeGenerator {
    * @param code The JavaScript code created for this block.
    * @param thisOnly True to generate code for only this statement.
    * @returns JavaScript code with comments and subsequent blocks added.
-   * @protected
    */
   scrub_(block: Block, code: string, thisOnly = false): string {
     let commentCode = '';

--- a/generators/python/python_generator.ts
+++ b/generators/python/python_generator.ts
@@ -276,7 +276,6 @@ export class PythonGenerator extends CodeGenerator {
    * @param code The Python code created for this block.
    * @param thisOnly True to generate code for only this statement.
    * @returns Python code with comments and subsequent blocks added.
-
    */
   scrub_(block: Block, code: string, thisOnly = false): string {
     let commentCode = '';


### PR DESCRIPTION
## The basics

- [X] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

Fixes #2156

### Proposed Changes

Make remove `protected` access modifier from `CodeGenerator.prototype.scrub_`, making it public.

### Reason for Changes

In PRs #7602, #7616, #7646, #7647 and #7654 the `@protected` access modifier on `scrub_` overrides subclasse of `CodeGenerator` not transcribed to the new typescript signature.  I was going to re-add it, but this breaks some of the procedure block generator functions which rely on it, and then @BeksOmega pointed out that this might be one of the CodeGenerator API functions which we had already decided should be public—and lo and behold I found #2156.

Per discussion amongst team, I am not renaming it to scrub at this time.

### Test Coverage

Passes `npm test`.

### Documentation

Documentation will need updating in the usual way.
