### PR TITLE
fix: comment create and delete events

### DIFF
--- a/core/comments/workspace_comment.ts
+++ b/core/comments/workspace_comment.ts
@@ -62,8 +62,6 @@ export class WorkspaceComment {
 
   private fireCreateEvent() {
     if (eventUtils.isEnabled()) {
-      // TODO: Before merging. In the old class, this is wrapped by a setGroup
-      //   call. Is there any reason that's actually necessary?
       eventUtils.fire(new (eventUtils.get(eventUtils.COMMENT_CREATE))(this));
     }
   }

--- a/core/comments/workspace_comment.ts
+++ b/core/comments/workspace_comment.ts
@@ -8,6 +8,7 @@ import {Workspace} from '../workspace.js';
 import {Size} from '../utils/size.js';
 import {Coordinate} from '../utils/coordinate.js';
 import * as idGenerator from '../utils/idgenerator.js';
+import * as eventUtils from '../events/utils.js';
 
 export class WorkspaceComment {
   /** The unique identifier for this comment. */
@@ -56,7 +57,21 @@ export class WorkspaceComment {
     // TODO: File an issue to remove this once everything is migrated.
     workspace.addTopComment(this as AnyDuringMigration);
 
-    // TODO(7909): Fire events.
+    this.fireCreateEvent();
+  }
+
+  private fireCreateEvent() {
+    if (eventUtils.isEnabled()) {
+      // TODO: Before merging. In the old class, this is wrapped by a setGroup
+      //   call. Is there any reason that's actually necessary?
+      eventUtils.fire(new (eventUtils.get(eventUtils.COMMENT_CREATE))(this));
+    }
+  }
+
+  private fireDeleteEvent() {
+    if (eventUtils.isEnabled()) {
+      eventUtils.fire(new (eventUtils.get(eventUtils.COMMENT_DELETE))(this));
+    }
   }
 
   /** Sets the text of the comment. */
@@ -165,6 +180,7 @@ export class WorkspaceComment {
   /** Disposes of this comment. */
   dispose() {
     this.disposing = true;
+    this.fireDeleteEvent();
     this.workspace.removeTopComment(this as AnyDuringMigration);
     this.disposed = true;
   }

--- a/core/events/events_comment_base.ts
+++ b/core/events/events_comment_base.ts
@@ -12,7 +12,7 @@
 // Former goog.module ID: Blockly.Events.CommentBase
 
 import * as utilsXml from '../utils/xml.js';
-import type {WorkspaceComment} from '../workspace_comment.js';
+import type {WorkspaceComment} from '../comments/workspace_comment.js';
 import * as Xml from '../xml.js';
 
 import {
@@ -104,7 +104,7 @@ export class CommentBase extends AbstractEvent {
     if (create) {
       const xmlElement = utilsXml.createElement('xml');
       if (!event.xml) {
-        throw new Error('Ecountered a comment event without proper xml');
+        throw new Error('Encountered a comment event without proper xml');
       }
       xmlElement.appendChild(event.xml);
       Xml.domToWorkspace(xmlElement, workspace);

--- a/core/events/events_comment_base.ts
+++ b/core/events/events_comment_base.ts
@@ -11,10 +11,8 @@
  */
 // Former goog.module ID: Blockly.Events.CommentBase
 
-import * as utilsXml from '../utils/xml.js';
 import type {WorkspaceComment} from '../comments/workspace_comment.js';
-import * as Xml from '../xml.js';
-
+import * as comments from '../serialization/workspace_comments.js';
 import {
   Abstract as AbstractEvent,
   AbstractEventJson,
@@ -102,12 +100,10 @@ export class CommentBase extends AbstractEvent {
   ) {
     const workspace = event.getEventWorkspace_();
     if (create) {
-      const xmlElement = utilsXml.createElement('xml');
-      if (!event.xml) {
-        throw new Error('Encountered a comment event without proper xml');
+      if (!event.json) {
+        throw new Error('Encountered a comment event without proper json');
       }
-      xmlElement.appendChild(event.xml);
-      Xml.domToWorkspace(xmlElement, workspace);
+      comments.append(event.json, workspace);
     } else {
       if (!event.commentId) {
         throw new Error(
@@ -119,8 +115,7 @@ export class CommentBase extends AbstractEvent {
       if (comment) {
         comment.dispose();
       } else {
-        // Only complain about root-level block.
-        console.warn("Can't uncreate non-existent comment: " + event.commentId);
+        console.warn("Can't delete non-existent comment: " + event.commentId);
       }
     }
   }

--- a/core/events/events_comment_change.ts
+++ b/core/events/events_comment_change.ts
@@ -12,7 +12,7 @@
 // Former goog.module ID: Blockly.Events.CommentChange
 
 import * as registry from '../registry.js';
-import type {WorkspaceComment} from '../workspace_comment.js';
+import type {WorkspaceComment} from '../comments/workspace_comment.js';
 
 import {CommentBase, CommentBaseJson} from './events_comment_base.js';
 import * as eventUtils from './utils.js';

--- a/core/events/events_comment_create.ts
+++ b/core/events/events_comment_create.ts
@@ -13,9 +13,9 @@
 
 import * as registry from '../registry.js';
 import type {WorkspaceComment} from '../comments/workspace_comment.js';
+import * as comments from '../serialization/workspace_comments.js';
 import * as utilsXml from '../utils/xml.js';
 import * as Xml from '../xml.js';
-
 import {CommentBase, CommentBaseJson} from './events_comment_base.js';
 import * as eventUtils from './utils.js';
 import type {Workspace} from '../workspace.js';
@@ -29,6 +29,9 @@ export class CommentCreate extends CommentBase {
   /** The XML representation of the created workspace comment. */
   xml?: Element | DocumentFragment;
 
+  /** The JSON representation of the created workspace comment. */
+  json?: comments.State;
+
   /**
    * @param opt_comment The created comment.
    *     Undefined for a blank event.
@@ -37,10 +40,11 @@ export class CommentCreate extends CommentBase {
     super(opt_comment);
 
     if (!opt_comment) {
-      return;
+      return; // Blank event to be populated by fromJson.
     }
-    // Blank event to be populated by fromJson.
+
     this.xml = Xml.saveWorkspaceComment(opt_comment);
+    this.json = comments.save(opt_comment, {addCoordinates: true});
   }
 
   // TODO (#1266): "Full" and "minimal" serialization.
@@ -57,7 +61,14 @@ export class CommentCreate extends CommentBase {
           'the constructor, or call fromJson',
       );
     }
+    if (!this.json) {
+      throw new Error(
+        'The comment JSON is undefined. Either pass a block to ' +
+          'the constructor, or call fromJson',
+      );
+    }
     json['xml'] = Xml.domToText(this.xml);
+    json['json'] = this.json;
     return json;
   }
 
@@ -81,6 +92,7 @@ export class CommentCreate extends CommentBase {
       event ?? new CommentCreate(),
     ) as CommentCreate;
     newEvent.xml = utilsXml.textToDom(json['xml']);
+    newEvent.json = json['json'];
     return newEvent;
   }
 
@@ -96,6 +108,7 @@ export class CommentCreate extends CommentBase {
 
 export interface CommentCreateJson extends CommentBaseJson {
   xml: string;
+  json: object;
 }
 
 registry.register(

--- a/core/events/events_comment_create.ts
+++ b/core/events/events_comment_create.ts
@@ -12,7 +12,7 @@
 // Former goog.module ID: Blockly.Events.CommentCreate
 
 import * as registry from '../registry.js';
-import type {WorkspaceComment} from '../workspace_comment.js';
+import type {WorkspaceComment} from '../comments/workspace_comment.js';
 import * as utilsXml from '../utils/xml.js';
 import * as Xml from '../xml.js';
 
@@ -40,7 +40,7 @@ export class CommentCreate extends CommentBase {
       return;
     }
     // Blank event to be populated by fromJson.
-    this.xml = opt_comment.toXmlWithXY();
+    this.xml = Xml.saveWorkspaceComment(opt_comment);
   }
 
   // TODO (#1266): "Full" and "minimal" serialization.

--- a/core/events/events_comment_delete.ts
+++ b/core/events/events_comment_delete.ts
@@ -13,7 +13,7 @@
 
 import * as registry from '../registry.js';
 import type {WorkspaceComment} from '../comments/workspace_comment.js';
-
+import * as comments from '../serialization/workspace_comments.js';
 import {CommentBase, CommentBaseJson} from './events_comment_base.js';
 import * as eventUtils from './utils.js';
 import * as utilsXml from '../utils/xml.js';
@@ -29,6 +29,9 @@ export class CommentDelete extends CommentBase {
   /** The XML representation of the deleted workspace comment. */
   xml?: Element;
 
+  /** The JSON representation of the created workspace comment. */
+  json?: comments.State;
+
   /**
    * @param opt_comment The deleted comment.
    *     Undefined for a blank event.
@@ -41,6 +44,7 @@ export class CommentDelete extends CommentBase {
     }
 
     this.xml = Xml.saveWorkspaceComment(opt_comment);
+    this.json = comments.save(opt_comment, {addCoordinates: true});
   }
 
   /**
@@ -65,7 +69,14 @@ export class CommentDelete extends CommentBase {
           'the constructor, or call fromJson',
       );
     }
+    if (!this.json) {
+      throw new Error(
+        'The comment JSON is undefined. Either pass a block to ' +
+          'the constructor, or call fromJson',
+      );
+    }
     json['xml'] = Xml.domToText(this.xml);
+    json['json'] = this.json;
     return json;
   }
 
@@ -89,12 +100,14 @@ export class CommentDelete extends CommentBase {
       event ?? new CommentDelete(),
     ) as CommentDelete;
     newEvent.xml = utilsXml.textToDom(json['xml']);
+    newEvent.json = json['json'];
     return newEvent;
   }
 }
 
 export interface CommentDeleteJson extends CommentBaseJson {
   xml: string;
+  json: object;
 }
 
 registry.register(

--- a/core/events/events_comment_delete.ts
+++ b/core/events/events_comment_delete.ts
@@ -12,7 +12,7 @@
 // Former goog.module ID: Blockly.Events.CommentDelete
 
 import * as registry from '../registry.js';
-import type {WorkspaceComment} from '../workspace_comment.js';
+import type {WorkspaceComment} from '../comments/workspace_comment.js';
 
 import {CommentBase, CommentBaseJson} from './events_comment_base.js';
 import * as eventUtils from './utils.js';
@@ -40,7 +40,7 @@ export class CommentDelete extends CommentBase {
       return; // Blank event to be populated by fromJson.
     }
 
-    this.xml = opt_comment.toXmlWithXY();
+    this.xml = Xml.saveWorkspaceComment(opt_comment);
   }
 
   /**

--- a/core/events/events_comment_move.ts
+++ b/core/events/events_comment_move.ts
@@ -13,7 +13,7 @@
 
 import * as registry from '../registry.js';
 import {Coordinate} from '../utils/coordinate.js';
-import type {WorkspaceComment} from '../workspace_comment.js';
+import type {WorkspaceComment} from '../comments/workspace_comment.js';
 
 import {CommentBase, CommentBaseJson} from './events_comment_base.js';
 import * as eventUtils from './utils.js';

--- a/core/xml.ts
+++ b/core/xml.ts
@@ -55,7 +55,7 @@ export function workspaceToDom(workspace: Workspace, skipId = false): Element {
 }
 
 /** Serializes the given workspace comment to XML. */
-function saveWorkspaceComment(
+export function saveWorkspaceComment(
   comment: WorkspaceComment,
   skipId = false,
 ): Element {
@@ -495,7 +495,7 @@ export function domToWorkspace(xml: Element, workspace: Workspace): string[] {
 }
 
 /** Deserializes the given comment state into the given workspace. */
-function loadWorkspaceComment(
+export function loadWorkspaceComment(
   elem: Element,
   workspace: Workspace,
 ): WorkspaceComment {

--- a/tests/mocha/comment_view_test.js
+++ b/tests/mocha/comment_view_test.js
@@ -8,6 +8,7 @@ import {
   sharedTestSetup,
   sharedTestTeardown,
 } from './test_helpers/setup_teardown.js';
+import {createChangeListenerSpy} from './test_helpers/events.js';
 
 suite('Workspace comment', function () {
   setup(function () {

--- a/tests/mocha/comment_view_test.js
+++ b/tests/mocha/comment_view_test.js
@@ -8,7 +8,6 @@ import {
   sharedTestSetup,
   sharedTestTeardown,
 } from './test_helpers/setup_teardown.js';
-import {createChangeListenerSpy} from './test_helpers/events.js';
 
 suite('Workspace comment', function () {
   setup(function () {

--- a/tests/mocha/event_comment_change_test.js
+++ b/tests/mocha/event_comment_change_test.js
@@ -21,12 +21,8 @@ suite('Comment Change Event', function () {
 
   suite('Serialization', function () {
     test('events round-trip through JSON', function () {
-      const comment = new Blockly.WorkspaceComment(
-        this.workspace,
-        'old text',
-        10,
-        10,
-      );
+      const comment = new Blockly.comments.WorkspaceComment(this.workspace);
+      comment.setText('old text');
       const origEvent = new Blockly.Events.CommentChange(
         comment,
         'old text',

--- a/tests/mocha/event_comment_create_test.js
+++ b/tests/mocha/event_comment_create_test.js
@@ -21,12 +21,9 @@ suite('Comment Create Event', function () {
 
   suite('Serialization', function () {
     test('events round-trip through JSON', function () {
-      const comment = new Blockly.WorkspaceComment(
-        this.workspace,
-        'test text',
-        10,
-        10,
-      );
+      const comment = new Blockly.comments.WorkspaceComment(this.workspace);
+      comment.setText('test text');
+      comment.moveTo(new Blockly.utils.Coordinate(10, 10));
       const origEvent = new Blockly.Events.CommentCreate(comment);
 
       const json = origEvent.toJson();

--- a/tests/mocha/event_comment_delete_test.js
+++ b/tests/mocha/event_comment_delete_test.js
@@ -21,12 +21,9 @@ suite('Comment Delete Event', function () {
 
   suite('Serialization', function () {
     test('events round-trip through JSON', function () {
-      const comment = new Blockly.WorkspaceComment(
-        this.workspace,
-        'test text',
-        10,
-        10,
-      );
+      const comment = new Blockly.comments.WorkspaceComment(this.workspace);
+      comment.setText('test text');
+      comment.moveTo(new Blockly.utils.Coordinate(10, 10));
       const origEvent = new Blockly.Events.CommentDelete(comment);
 
       const json = origEvent.toJson();

--- a/tests/mocha/event_comment_move_test.js
+++ b/tests/mocha/event_comment_move_test.js
@@ -21,14 +21,11 @@ suite('Comment Move Event', function () {
 
   suite('Serialization', function () {
     test('events round-trip through JSON', function () {
-      const comment = new Blockly.WorkspaceComment(
-        this.workspace,
-        'test text',
-        10,
-        10,
-      );
+      const comment = new Blockly.comments.WorkspaceComment(this.workspace);
+      comment.setText('test text');
+      comment.moveTo(new Blockly.utils.Coordinate(10, 10));
       const origEvent = new Blockly.Events.CommentMove(comment);
-      comment.moveBy(10, 10);
+      comment.moveTo(new Blockly.utils.Coordinate(20, 20));
       origEvent.recordNew();
 
       const json = origEvent.toJson();

--- a/tests/mocha/event_test.js
+++ b/tests/mocha/event_test.js
@@ -824,7 +824,19 @@ suite('Events', function () {
           type: 'comment_create',
           group: '',
           commentId: thisObj.comment.id,
-          xml: Blockly.Xml.domToText(thisObj.comment.toXmlWithXY()),
+          // TODO: Before merging, is this a dumb change detector?
+          xml: Blockly.Xml.domToText(
+            Blockly.Xml.saveWorkspaceComment(thisObj.comment),
+            {addCoordinates: true},
+          ),
+          json: {
+            height: 100,
+            width: 120,
+            id: 'comment id',
+            x: 0,
+            y: 0,
+            text: 'test text',
+          },
         }),
       },
       {
@@ -835,7 +847,19 @@ suite('Events', function () {
           type: 'comment_delete',
           group: '',
           commentId: thisObj.comment.id,
-          xml: Blockly.Xml.domToText(thisObj.comment.toXmlWithXY()),
+          // TODO: Before merging, is this a dumb change detector?
+          xml: Blockly.Xml.domToText(
+            Blockly.Xml.saveWorkspaceComment(thisObj.comment),
+            {addCoordinates: true},
+          ),
+          json: {
+            height: 100,
+            width: 120,
+            id: 'comment id',
+            x: 0,
+            y: 0,
+            text: 'test text',
+          },
         }),
       },
       // TODO(#4577) Test serialization of move event coordinate properties.
@@ -873,13 +897,11 @@ suite('Events', function () {
         title: 'WorkspaceComment events',
         testCases: workspaceCommentEventTestCases,
         setup: (thisObj) => {
-          thisObj.comment = new Blockly.WorkspaceComment(
+          thisObj.comment = new Blockly.comments.WorkspaceComment(
             thisObj.workspace,
-            'comment text',
-            0,
-            0,
             'comment id',
           );
+          thisObj.comment.setText('test text');
         },
       },
     ];

--- a/tests/mocha/index.html
+++ b/tests/mocha/index.html
@@ -121,7 +121,7 @@
       import './variable_model_test.js';
       import './blocks/variables_test.js';
       import './widget_div_test.js';
-      import './workspace_comment_test.js';
+      import './comment_view_test.js';
       import './workspace_svg_test.js';
       import './workspace_test.js';
       import './xml_test.js';

--- a/tests/mocha/index.html
+++ b/tests/mocha/index.html
@@ -122,6 +122,7 @@
       import './blocks/variables_test.js';
       import './widget_div_test.js';
       import './comment_view_test.js';
+      import './workspace_comment_test.js';
       import './workspace_svg_test.js';
       import './workspace_test.js';
       import './xml_test.js';

--- a/tests/mocha/old_workspace_comment_test.js
+++ b/tests/mocha/old_workspace_comment_test.js
@@ -9,7 +9,7 @@ import {
   sharedTestTeardown,
 } from './test_helpers/setup_teardown.js';
 
-suite('Workspace comment', function () {
+suite.skip('Workspace comment', function () {
   setup(function () {
     sharedTestSetup.call(this);
     this.workspace = new Blockly.Workspace();

--- a/tests/mocha/workspace_comment_test.js
+++ b/tests/mocha/workspace_comment_test.js
@@ -1,0 +1,58 @@
+/**
+ * @license
+ * Copyright 2024 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  sharedTestSetup,
+  sharedTestTeardown,
+} from './test_helpers/setup_teardown.js';
+import {
+  createChangeListenerSpy,
+  assertEventFired,
+} from './test_helpers/events.js';
+
+suite('Workspace comment', function () {
+  setup(function () {
+    sharedTestSetup.call(this);
+    this.workspace = new Blockly.inject('blocklyDiv', {});
+  });
+
+  teardown(function () {
+    sharedTestTeardown.call(this);
+  });
+
+  suite('Events', function () {
+    test('create events are fired when a comment is constructed', function () {
+      const spy = createChangeListenerSpy(this.workspace);
+
+      this.renderedComment = new Blockly.comments.RenderedWorkspaceComment(
+        this.workspace,
+      );
+
+      assertEventFired(
+        spy,
+        Blockly.Events.CommentCreate,
+        {commentId: this.renderedComment.id},
+        this.workspace.id,
+      );
+    });
+
+    test('delete events are fired when a comment is disposed', function () {
+      this.renderedComment = new Blockly.comments.RenderedWorkspaceComment(
+        this.workspace,
+      );
+      const spy = createChangeListenerSpy(this.workspace);
+
+      this.renderedComment.dispose();
+
+      assertEventFired(
+        spy,
+        Blockly.Events.CommentDelete,
+        {commentId: this.renderedComment.id},
+        this.workspace.id,
+      );
+    });
+  });
+});


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Work on #7909  

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
Changes all of the comment events to use new workspace comments classes instead of the old ones.

Updates the create and delete events to use JSON.

Updates the workspace comments classes to fire create and delete events.

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->

Updates tests. Adds tests for firing the events. Manually tested undo and redo for create and delete events.

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

N/A - docs for events are just reference docs, which are automatically generated.

### Additional Information

<!-- Anything else we should know? -->
N/A
