### PR TITLE
fix: prevent default undo

### DIFF
--- a/core/shortcut_items.ts
+++ b/core/shortcut_items.ts
@@ -221,10 +221,11 @@ export function registerUndo() {
     preconditionFn(workspace) {
       return !workspace.options.readOnly && !Gesture.inProgress();
     },
-    callback(workspace) {
+    callback(workspace, e) {
       // 'z' for undo 'Z' is for redo.
       (workspace as WorkspaceSvg).hideChaff();
       workspace.undo(false);
+      e.preventDefault()
       return true;
     },
     keyCodes: [ctrlZ, altZ, metaZ],
@@ -259,10 +260,11 @@ export function registerRedo() {
     preconditionFn(workspace) {
       return !Gesture.inProgress() && !workspace.options.readOnly;
     },
-    callback(workspace) {
+    callback(workspace, e) {
       // 'z' for undo 'Z' is for redo.
       (workspace as WorkspaceSvg).hideChaff();
       workspace.undo(true);
+      e.preventDefault();
       return true;
     },
     keyCodes: [ctrlShiftZ, altShiftZ, metaShiftZ, ctrlY],

--- a/core/shortcut_items.ts
+++ b/core/shortcut_items.ts
@@ -225,7 +225,7 @@ export function registerUndo() {
       // 'z' for undo 'Z' is for redo.
       (workspace as WorkspaceSvg).hideChaff();
       workspace.undo(false);
-      e.preventDefault()
+      e.preventDefault();
       return true;
     },
     keyCodes: [ctrlZ, altZ, metaZ],


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [ ] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes https://github.com/google/blockly/issues/1915

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
Prevents default actions for events where we trigger undo or redo.

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->
Tested with my next PR, which relies on this behavior. (Undoing and redoing comment change events, which edit a text area)

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->
N/A

### Additional Information

<!-- Anything else we should know? -->
N/A
