### PR TITLE
fix: Fix block disposal animations

### DIFF
--- a/core/block_animations.ts
+++ b/core/block_animations.ts
@@ -9,7 +9,6 @@
 import type {BlockSvg} from './block_svg.js';
 import * as dom from './utils/dom.js';
 import {Svg} from './utils/svg.js';
-import * as svgMath from './utils/svg_math.js';
 
 /** A bounding box for a cloned block. */
 interface CloneRect {

--- a/core/block_animations.ts
+++ b/core/block_animations.ts
@@ -45,7 +45,9 @@ export function disposeUiEffect(block: BlockSvg) {
   clone.setAttribute('transform', 'translate(' + xy.x + ',' + xy.y + ')');
   if (workspace.isDragging()) {
     workspace.getLayerManager()?.moveToDragLayer({
-      getSvgRoot: () => { return clone; }
+      getSvgRoot: () => {
+        return clone;
+      },
     });
   } else {
     workspace.getLayerManager()?.getBlockLayer().appendChild(clone);
@@ -79,10 +81,9 @@ function disposeUiStep(
   if (percent > 1) {
     dom.removeNode(clone);
   } else {
-    const x =
-      rect.x + (((rtl ? -1 : 1) * rect.width) / 2) * percent;
-    const y = rect.y + rect.height / 2 * percent;
-    const scale = (1 - percent);
+    const x = rect.x + (((rtl ? -1 : 1) * rect.width) / 2) * percent;
+    const y = rect.y + (rect.height / 2) * percent;
+    const scale = 1 - percent;
     clone.setAttribute(
       'transform',
       'translate(' + x + ',' + y + ')' + ' scale(' + scale + ')',

--- a/core/block_animations.ts
+++ b/core/block_animations.ts
@@ -57,7 +57,7 @@ export function disposeUiEffect(block: BlockSvg) {
     'width': block.width,
     'height': block.height,
   };
-  disposeUiStep(clone, cloneRect, workspace.RTL, new Date(), workspace.scale);
+  disposeUiStep(clone, cloneRect, workspace.RTL, new Date());
 }
 /**
  * Animate a cloned block and eventually dispose of it.


### PR DESCRIPTION
## The basics
- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details

### Proposed Changes
This PR addresses several issues with the block deletion animation:
* When the workspace is at a scale other than 1.0, the animation is offset (or invisible) from the location of the block being deleted when deleting a block by dragging it to the toolbox
* The deletion animation is obscured by the toolbox, so that only that portion of the block within the workspace bounds when the block is dropped in the toolbox has its animation visible, even though the whole block was visible atop the toolbox when the drag was ongoing

### Reason for Changes
These changes make the deletion animation when disposing of a block into the toolbox smoother and more natural.

Note that there is still some offsetting when the workspace is zoomed out, a block is dragged in, the workspace is zoomed in, and the block is disposed of into the toolbox. I'm sending this PR now because it's a strict improvement on the current state of affairs, and that issue is pretty edge-casey.