### PR TITLE
feat(dragging): Introduce `DragStrategy` and `BlockDragStrategy` [WIP]

### DIFF
--- a/core/dragging/block_drag_strategy.ts
+++ b/core/dragging/block_drag_strategy.ts
@@ -1,0 +1,127 @@
+/**
+ * @license
+ * Copyright 2024 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as blockAnimation from '../block_animations.js';
+import * as dom from '../utils/dom.js';
+import * as registry from '../registry.js';
+import * as eventUtils from '../events/utils.js';
+import type {BlockSvg} from '../block_svg.js';
+import {DragStrategy} from './drag_strategy.js';
+import type {IConnectionPreviewer} from '../interfaces/i_connection_previewer.js';
+import type {RenderedConnection} from '../rendered_connection.js';
+import type {WorkspaceSvg} from '../workspace_svg.js';
+
+/** Represents a nearby valid connection. */
+interface ConnectionCandidate {
+  /** A connection on the dragging stack that is compatible with neighbour. */
+  local: RenderedConnection;
+
+  /** A nearby connection that is compatible with local. */
+  neighbour: RenderedConnection;
+
+  /** The distance between the local connection and the neighbour connection. */
+  distance: number;
+}
+
+/**
+ * Class for a block drag stragetgy.  It moves its block (and any
+ * attached child blocks) around the workspaceg when they are being
+ * dragged by a mouse or touch.
+ */
+export class BlockDragStrategy extends DragStrategy<BlockSvg> {
+  private connectionPreviewer: IConnectionPreviewer;
+
+  private connectionCandidate: ConnectionCandidate | null = null;
+
+  /** The parent block at the start of the drag. */
+  private startParentConn: RenderedConnection | null = null;
+
+  /**
+   * The child block at the start of the drag. Only gets set if
+   * `healStack` is true.
+   */
+  private startChildConn: RenderedConnection | null = null;
+
+  /**
+   * @param block The block to drag.
+   * @param workspace The workspace to drag on.
+   */
+  constructor(block: BlockSvg, workspace: WorkspaceSvg) {
+    super(block, workspace);
+
+    const previewerConstructor = registry.getClassFromOptions(
+      registry.Type.CONNECTION_PREVIEWER,
+      this.workspace.options,
+    );
+    this.connectionPreviewer = new previewerConstructor!(block);
+  }
+
+  startDragInner(e?: PointerEvent): void {
+    const healStack = Boolean(e?.altKey || e?.ctrlKey || e?.metaKey);
+
+    // The z-order of blocks depends on their order in the SVG, so move the
+    // block being dragged to the front so that it will appear atop other blocks
+    // in the workspace.
+    this.draggable.bringToFront(true);
+
+    // During a drag there may be a lot of rerenders, but not field changes.
+    // Turn the cache on so we don't do spurious remeasures during the drag.
+    dom.startTextWidthCache();
+    this.workspace.setResizesEnabled(false);
+    blockAnimation.disconnectUiStop();
+
+    if (this.shouldDisconnect(healStack)) {
+      // Save parent / child connections.
+      this.startParentConn =
+        this.draggable.outputConnection?.targetConnection ??
+        this.draggable.previousConnection?.targetConnection;
+      if (healStack) {
+        this.startChildConn = this.draggable.nextConnection?.targetConnection;
+      }
+      this.disconnectBlock(healStack);
+    }
+    this.draggable.setDragging(true);
+  }
+
+  /**
+   * Returns truee iff the block should be disconnected when the drag
+   * is started.
+   *
+   * @param healStack Should stack be healed after disconnecting?
+   * @returns True iff the block should be disconnected.
+   */
+  protected shouldDisconnect(healStack: boolean): boolean {
+    return Boolean(
+      this.draggable.getParent() ||
+        (healStack &&
+          this.draggable.nextConnection &&
+          this.draggable.nextConnection.targetBlock()),
+    );
+  }
+
+  /**
+   * Disconnects the block.
+   *
+   * @param healStack Whether or not to heal the stack after disconnecting.
+   */
+  protected disconnectBlock(healStack: boolean) {
+    this.draggable.unplug(healStack);
+    // TODO(cpcallen): Will this animatino actually be seen if the
+    // block is immediately moved via .drag()?  In the old
+    // BlockDragger we did the initial disconnect translation before
+    // firing the disconnectUieEffect.
+    blockAnimation.disconnectUiEffect(this.draggable);
+  }
+
+  protected fireDragStartEvent() {
+    const event = new (eventUtils.get(eventUtils.BLOCK_DRAG))(
+      this.draggable,
+      true,
+      this.draggable.getDescendants(false),
+    );
+    eventUtils.fire(event);
+  }
+}

--- a/core/dragging/drag_strategy.ts
+++ b/core/dragging/drag_strategy.ts
@@ -1,0 +1,122 @@
+/**
+ * @license
+ * Copyright 2024 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as eventUtils from '../events/utils.js';
+import type {Coordinate} from '../utils/coordinate.js';
+import type {IDragTarget} from '../interfaces/i_drag_target.js';
+import type {IDraggable} from '../interfaces/i_draggable.js';
+import type {IDragStrategy} from '../interfaces/i_draggable.js';
+import type {WorkspaceSvg} from '../workspace_svg.js';
+
+export abstract class DragStrategy<T extends IDraggable>
+  implements IDragStrategy
+{
+  /**
+   * The location of the origin of the draggabele (e.g. top left
+   * corner of the block being dragged) at the beginning of the drag
+   * in workspace coordinates.
+   */
+  private startLoc: Coordinate | null = null;
+
+  /** Which drag area the mouse pointer has is over, if any. */
+  private dragTarget: IDragTarget | null = null;
+
+  constructor(
+    /** The item being dragged. */
+    protected draggable: T,
+    /** The workspace on which it is being dragged. */
+    protected workspace: WorkspaceSvg,
+  ) {}
+
+  /**
+   * Handles any drag startup (e.g moving elements to the front of the
+   * workspace).
+   *
+   * Does only generic work that should apply to most
+   * IDraggables; consider overriding dragStartInner instead of this
+   * method to do work needed for particular types of draggable.
+   *
+   * @param e PointerEvent that started the drag; could be used to
+   *     check modifier keys, etc.  May be missing when dragging is
+   *     triggered programatically rather than by user.
+   */
+  startDrag(e?: PointerEvent): void {
+    this.startLoc = this.draggable.getLocation();
+    if (!eventUtils.getGroup()) eventUtils.setGroup(true);
+    this.fireDragStartEvent();
+    this.startDragInner(e);
+    this.workspace.getLayerManager()?.moveToDragLayer(this.draggable);
+  }
+
+  /**
+   * Handles moving elements to the new location, and updating any
+   * visuals based on that (e.g connection previews for blocks).
+   *
+   * Does only generic work that should apply to most IDraggables;
+   * consider overriding dragInner instead of this method to do
+   * work needed for particular types of draggable.
+   *
+   * @param newLoc Workspace coordinate to which the draggable has
+   *     been dragged.
+   * @param eOrTarget PointerEvent that continued the drag (could be
+   *     used to look up any IDragTarget the pointer is over, check
+   *     modifier keys, etc.)  or the drag target the pointer is over,
+   *     if any.
+   */
+  drag(newLoc: Coordinate, eOrTarget?: PointerEvent | IDragTarget): void {
+    const _target = this.getDragTarget(eOrTarget);
+  }
+
+  /**
+   * Handles any drag cleanup, including e.g. connecting or deleting
+   * blocks.
+   *
+   * @param newLoc Workspace coordinate at which the drag finished.
+   *     been dragged.
+   * @param e PointerEvent that finished the drag; could be used to
+   *     look up any IDragTarget the pointer is over, check modifier
+   *     keys, etc.
+   * @param target The drag target the pointer is over, if any.  Could
+   *     be supplied as an alternative to providing a PointerEvent for
+   *     programatic drags.
+   */
+  endDrag(newLoc: Coordinate, eOrTarget?: PointerEvent | IDragTarget): void {
+    const _target = this.getDragTarget(eOrTarget);
+  }
+
+  /**
+   * Does any type-specific drag startup (e.g. disconnecting
+   * blocks).
+   *
+   * @param e PointerEvent that started the drag; could be used to
+   *     check modifier keys, etc.  May be missing when dragging is
+   *     triggered programatically rather than by user.
+   */
+  protected startDragInner(_e?: PointerEvent): void {}
+
+  /** Fire a UI event at the start of a block drag. */
+  protected fireDragStartEvent(): void {}
+
+  /**
+   * Find drag target or use provided one.
+   * blocks.
+   *
+   * @param eOrTarget An IDragTarget, or a PointerEvent to use to look for one
+   *     on the workspace.
+   * @returns The drag target or null if there is none.
+   */
+  protected getDragTarget(
+    eOrTarget?: PointerEvent | IDragTarget,
+  ): IDragTarget | null {
+    if (eOrTarget instanceof PointerEvent) {
+      return this.workspace.getDragTarget(eOrTarget);
+    } else if (eOrTarget) {
+      return eOrTarget;
+    } else {
+      return null;
+    }
+  }
+}

--- a/core/interfaces/i_deletable.ts
+++ b/core/interfaces/i_deletable.ts
@@ -17,3 +17,8 @@ export interface IDeletable {
    */
   isDeletable(): boolean;
 }
+
+/** Returns whether the given object is an IDeletable. */
+export function isDeletable(obj: any): obj is IDeletable {
+  return obj['isDeletable'] !== undefined;
+}

--- a/core/interfaces/i_draggable.ts
+++ b/core/interfaces/i_draggable.ts
@@ -5,12 +5,17 @@
  */
 
 import {Coordinate} from '../utils/coordinate';
+import {IDeletable} from './i_deletable';
 import {IDragTarget} from './i_drag_target';
+import {IRenderedElement} from './i_rendered_element';
 
 /**
  * Represents an object that can be dragged.
  */
-export interface IDraggable extends IDragStrategy {
+export interface IDraggable
+  extends IDragStrategy,
+    IRenderedElement,
+    IDeletable {
   /** Returns true iff the element is currently movable. */
   isMovable(): boolean;
 


### PR DESCRIPTION
## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [ ] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

Fixes #7840.

### Proposed Changes

Introduce two new classes: the abstract `DragStrategy`, which is contains the parts of the drag strategy that are needed to deal with general dragging including interaction with delete areas, and `BlockDragStrategy`, which additionally handles connecting and disconnecting blocks.

### Reason for Changes

Most of the stuff that workspace comments will need re: drag strategy will also be needed by blocks.  (Bubbles might be a bit different if they can't be deleted.)

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

* The `dragStart` methods are more or less complete; `drag` and `dragEnd` are not yet done.

* I wonder about the memory cost of keeping a `BlockDragStrategy` for ever block, especially when each one contains a connection previewer, etc.  Might we be able to reuse some of these, somehow?

* I don't think it will be necessary to remove the `couldConnect` parameter from `IDeleteArea`'s `wouldDelete` method, as was proposed in c1411dd44 (on Beka's `fix/would-delete` branch).