### PR TITLE
fix: comment icon interface re serialization

### DIFF
--- a/core/icons/comment_icon.ts
+++ b/core/icons/comment_icon.ts
@@ -349,10 +349,18 @@ export class CommentIcon extends Icon implements IHasBubble, ISerializable {
   }
 }
 
+/** The save state format for a comment icon. */
 export interface CommentState {
+  /** The text of the comment. */
   text?: string;
+
+  /** True if the comment is open, false otherwise. */
   pinned?: boolean;
+
+  /** The height of the comment bubble. */
   height?: number;
+
+  /** The width of the comment bubble. */
   width?: number;
 }
 

--- a/core/interfaces/i_comment_icon.ts
+++ b/core/interfaces/i_comment_icon.ts
@@ -4,12 +4,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {IconType} from '../icons.js';
+import {IconType} from '../icons/icon_types.js';
+import {CommentState} from '../icons/comment_icon.js';
 import {IIcon, isIcon} from './i_icon.js';
 import {Size} from '../utils/size.js';
 import {IHasBubble, hasBubble} from './i_has_bubble.js';
+import {ISerializable, isSerializable} from './i_serializable.js';
 
-export interface ICommentIcon extends IIcon, IHasBubble {
+export interface ICommentIcon extends IIcon, IHasBubble, ISerializable {
   setText(text: string): void;
 
   getText(): string;
@@ -17,6 +19,10 @@ export interface ICommentIcon extends IIcon, IHasBubble {
   setBubbleSize(size: Size): void;
 
   getBubbleSize(): Size;
+
+  saveState(): CommentState;
+
+  loadState(state: CommentState): void;
 }
 
 /** Checks whether the given object is an ICommentIcon. */
@@ -24,6 +30,7 @@ export function isCommentIcon(obj: Object): obj is ICommentIcon {
   return (
     isIcon(obj) &&
     hasBubble(obj) &&
+    isSerializable(obj) &&
     (obj as any)['setText'] !== undefined &&
     (obj as any)['getText'] !== undefined &&
     (obj as any)['setBubbleSize'] !== undefined &&

--- a/tests/mocha/block_test.js
+++ b/tests/mocha/block_test.js
@@ -1392,6 +1392,12 @@ suite('Blocks', function () {
         }
 
         setBubbleVisible() {}
+
+        saveState() {
+          return {};
+        }
+
+        loadState() {}
       }
 
       setup(function () {


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes N/A

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
When writing up docs for how to override comment icons I realized that the interface didn't really deal with serialization, when it should. These edits remedy that.

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->
N/A

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->
This is for docs!

### Additional Information

<!-- Anything else we should know? -->
N/A
