### PR TITLE
fix: draggable interface and concrete dragger

### DIFF
--- a/core/dragging/dragger.ts
+++ b/core/dragging/dragger.ts
@@ -103,7 +103,7 @@ export class Dragger implements IDragger {
     }
 
     if (this.shouldReturnToStart(e, this.draggable)) {
-      this.draggable.moveToStart();
+      this.draggable.revertDrag();
     }
 
     this.draggable.endDrag(e);

--- a/core/interfaces/i_deletable.ts
+++ b/core/interfaces/i_deletable.ts
@@ -17,3 +17,8 @@ export interface IDeletable {
    */
   isDeletable(): boolean;
 }
+
+/** Returns whether the given object is an IDeletable. */
+export function isDeletable(obj: any): obj is IDeletable {
+  return obj['isDeletable'] !== undefined;
+}

--- a/core/interfaces/i_draggable.ts
+++ b/core/interfaces/i_draggable.ts
@@ -56,5 +56,5 @@ export interface IDragStrategy {
   endDrag(e?: PointerEvent): void;
 
   /** Moves the draggable back to where it was at the start of the drag. */
-  moveToStart(): void;
+  revertDrag(): void;
 }

--- a/core/interfaces/i_draggable.ts
+++ b/core/interfaces/i_draggable.ts
@@ -5,33 +5,29 @@
  */
 
 import {Coordinate} from '../utils/coordinate';
-import {IDragTarget} from './i_drag_target';
 
 /**
  * Represents an object that can be dragged.
  */
 export interface IDraggable extends IDragStrategy {
-  /** Returns true iff the element is currently movable. */
-  isMovable(): boolean;
-
   /**
    * Returns the current location of the draggable in workspace
    * coordinates.
    *
    * @returns Coordinate of current location on workspace.
    */
-  getLocation(): Coordinate;
+  getRelativeToSurfaceXY(): Coordinate;
 }
 
-/**
- * Represents an object that can be dragged.
- */
 export interface IDragStrategy {
+  /** Returns true iff the element is currently movable. */
+  isMovable(): boolean;
+
   /**
    * Handles any drag startup (e.g moving elements to the front of the
    * workspace).
    *
-   * @param e PointerEvent that started the drag; could be used to
+   * @param e PointerEvent that started the drag; can be used to
    *     check modifier keys, etc.  May be missing when dragging is
    *     triggered programatically rather than by user.
    */
@@ -43,15 +39,10 @@ export interface IDragStrategy {
    *
    * @param newLoc Workspace coordinate to which the draggable has
    *     been dragged.
-   * @param e PointerEvent that continued the drag.  Should be used to
-   *     look up any IDragTarget the pointer is over; could also be
+   * @param e PointerEvent that continued the drag.  Can be
    *     used to check modifier keys, etc.
-   * @param target The drag target the pointer is over, if any.  Could
-   *     be supplied as an alternative to providing a PointerEvent for
-   *     programatic drags.
    */
   drag(newLoc: Coordinate, e?: PointerEvent): void;
-  drag(newLoc: Coordinate, target: IDragTarget): void;
 
   /**
    * Handles any drag cleanup, including e.g. connecting or deleting
@@ -59,13 +50,8 @@ export interface IDragStrategy {
    *
    * @param newLoc Workspace coordinate at which the drag finished.
    *     been dragged.
-   * @param e PointerEvent that finished the drag.  Should be used to
-   *     look up any IDragTarget the pointer is over; could also be
+   * @param e PointerEvent that finished the drag.  Can be
    *     used to check modifier keys, etc.
-   * @param target The drag target the pointer is over, if any.  Could
-   *     be supplied as an alternative to providing a PointerEvent for
-   *     programatic drags.
    */
   endDrag(newLoc: Coordinate, e?: PointerEvent): void;
-  endDrag(newLoc: Coordinate, target: IDragTarget): void;
 }

--- a/core/interfaces/i_draggable.ts
+++ b/core/interfaces/i_draggable.ts
@@ -53,5 +53,8 @@ export interface IDragStrategy {
    * @param e PointerEvent that finished the drag.  Can be
    *     used to check modifier keys, etc.
    */
-  endDrag(newLoc: Coordinate, e?: PointerEvent): void;
+  endDrag(e?: PointerEvent): void;
+
+  /** Moves the draggable back to where it was at the start of the drag. */
+  moveToStart(): void;
 }


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes N/A

### Proposed Changes + reasons

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
This refactors the implementation to match the agreed upon design with two changes:
1) Draggables won't take in `IDragTarget` objects. I don't know why I did that, since the dragger handles all interaction with drag targets.
2) We have a new `moveToStart` method that is (essentially) used to cancel a drag in the case that the `IDragTarget` returns `true` for `shouldPreventMove`. Before we were just moving the block back to the original coordinates, but that doesn't allow blocks to reattach to parents or children.

The agreed upon design has a good separation of concerns between the draggable and the dragger. Giving the draggable responsibility over handling drag targets confuses that, and breaks the single responsibility principle. It also makes it more likely for an external developer to handle the drag targets incorrectly, because there is some fiddliness about the order methods shouldb e called in.

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->
Manually tested this with following PRs.

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->
Yes this will all need docs. May end up happening after the v11 release though =(

### Additional Information

<!-- Anything else we should know? -->
N/A
