### PR TITLE
fix!: remove couldConnect parameter from wouldDelete

### DIFF
--- a/core/block_dragger.ts
+++ b/core/block_dragger.ts
@@ -205,7 +205,7 @@ export class BlockDragger implements IBlockDragger {
     const block = this.draggingBlock_;
     this.moveBlock(block, delta);
     this.updateDragTargets(e, block);
-    this.wouldDeleteBlock_ = this.wouldDeleteBlock(e, block, delta);
+    this.wouldDeleteBlock_ = this.wouldDeleteBlock(e, block);
     this.updateCursorDuringBlockDrag_();
     this.updateConnectionPreview(block, delta);
   }
@@ -237,14 +237,8 @@ export class BlockDragger implements IBlockDragger {
    *
    * @param e The most recent move event.
    * @param draggingBlock The block being dragged.
-   * @param delta How far the pointer has moved from the position
-   *     at the start of the drag, in pixel units.
    */
-  private wouldDeleteBlock(
-    e: PointerEvent,
-    draggingBlock: BlockSvg,
-    delta: Coordinate,
-  ): boolean {
+  private wouldDeleteBlock(e: PointerEvent, draggingBlock: BlockSvg): boolean {
     const dragTarget = this.workspace_.getDragTarget(e);
     if (!dragTarget) return false;
 
@@ -255,10 +249,7 @@ export class BlockDragger implements IBlockDragger {
     );
     if (!isDeleteArea) return false;
 
-    return (dragTarget as IDeleteArea).wouldDelete(
-      draggingBlock,
-      !!this.getConnectionCandidate(draggingBlock, delta),
-    );
+    return (dragTarget as IDeleteArea).wouldDelete(draggingBlock);
   }
 
   /**

--- a/core/bubble_dragger.ts
+++ b/core/bubble_dragger.ts
@@ -116,7 +116,7 @@ export class BubbleDragger {
         ComponentManager.Capability.DELETE_AREA,
       );
       if (isDeleteArea) {
-        return (dragTarget as IDeleteArea).wouldDelete(this.bubble, false);
+        return (dragTarget as IDeleteArea).wouldDelete(this.bubble);
       }
     }
     return false;

--- a/core/config.ts
+++ b/core/config.ts
@@ -47,8 +47,6 @@ export const config: Config = {
   /**
    * Maximum misalignment between connections for them to snap together.
    * This should be the same as the snap radius.
-   *
-   * @deprecated v11 - This is no longer used. Use snapRadius instead.
    */
   connectingSnapRadius: DEFAULT_SNAP_RADIUS,
   /**

--- a/core/delete_area.ts
+++ b/core/delete_area.ts
@@ -51,15 +51,14 @@ export class DeleteArea extends DragTarget implements IDeleteArea {
    * before onDragEnter/onDragOver/onDragExit.
    *
    * @param element The block or bubble currently being dragged.
-   * @param couldConnect Whether the element could could connect to another.
    * @returns Whether the element provided would be deleted if dropped on this
    *     area.
    */
-  wouldDelete(element: IDraggable, couldConnect: boolean): boolean {
+  wouldDelete(element: IDraggable): boolean {
     if (element instanceof BlockSvg) {
       const block = element;
       const couldDeleteBlock = !block.getParent() && block.isDeletable();
-      this.updateWouldDelete_(couldDeleteBlock && !couldConnect);
+      this.updateWouldDelete_(couldDeleteBlock);
     } else {
       this.updateWouldDelete_(element.isDeletable());
     }

--- a/core/dragging/dragger.ts
+++ b/core/dragging/dragger.ts
@@ -88,11 +88,7 @@ export class Dragger implements IDragger {
     );
     if (!isDeleteArea) return false;
 
-    return (dragTarget as IDeleteArea).wouldDelete(
-      draggable,
-      false,
-      // !!this.getConnectionCandidate(draggable, delta),
-    );
+    return (dragTarget as IDeleteArea).wouldDelete(draggable);
   }
 
   /** Handles any drag cleanup. */

--- a/core/insertion_marker_manager.ts
+++ b/core/insertion_marker_manager.ts
@@ -384,10 +384,7 @@ export class InsertionMarkerManager {
         ComponentManager.Capability.DELETE_AREA,
       );
       if (isDeleteArea) {
-        return (dragTarget as IDeleteArea).wouldDelete(
-          this.topBlock,
-          newCandidate,
-        );
+        return (dragTarget as IDeleteArea).wouldDelete(this.topBlock);
       }
     }
     return false;

--- a/core/interfaces/i_delete_area.ts
+++ b/core/interfaces/i_delete_area.ts
@@ -21,9 +21,8 @@ export interface IDeleteArea extends IDragTarget {
    * before onDragEnter/onDragOver/onDragExit.
    *
    * @param element The block or bubble currently being dragged.
-   * @param couldConnect Whether the element could could connect to another.
    * @returns Whether the element provided would be deleted if dropped on this
    *     area.
    */
-  wouldDelete(element: IDraggable, couldConnect: boolean): boolean;
+  wouldDelete(element: IDraggable): boolean;
 }

--- a/core/toolbox/toolbox.ts
+++ b/core/toolbox/toolbox.ts
@@ -532,14 +532,12 @@ export class Toolbox
    * before onDragEnter/onDragOver/onDragExit.
    *
    * @param element The block or bubble currently being dragged.
-   * @param _couldConnect Whether the element could could connect to another.
    * @returns Whether the element provided would be deleted if dropped on this
    *     area.
    */
-  override wouldDelete(element: IDraggable, _couldConnect: boolean): boolean {
+  override wouldDelete(element: IDraggable): boolean {
     if (element instanceof BlockSvg) {
       const block = element;
-      // Prefer dragging to the toolbox over connecting to other blocks.
       this.updateWouldDelete_(!block.getParent() && block.isDeletable());
     } else {
       this.updateWouldDelete_(element.isDeletable());


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes N/A

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
Removes the `couldConnect` parameter from `wouldDelete` since that doesn't really make sense in the context of generic `IDraggable` implementations.

In practice, the only thing this changes is that if you're dragging over the trashcan and the block could connect to something, the block will now be deleted instead of connecting.

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->
N/A

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->
N/A

### Additional Information

<!-- Anything else we should know? -->
This is a dupe of https://github.com/google/blockly/pull/7848

Dependent on https://github.com/google/blockly/pull/7967