### PR TITLE
feat: have blocks use drag strategy

### DIFF
--- a/core/block_svg.ts
+++ b/core/block_svg.ts
@@ -36,7 +36,7 @@ import type {Input} from './inputs/input.js';
 import type {IASTNodeLocationSvg} from './interfaces/i_ast_node_location_svg.js';
 import type {IBoundedElement} from './interfaces/i_bounded_element.js';
 import type {ICopyable} from './interfaces/i_copyable.js';
-import type {IDraggable} from './interfaces/i_draggable.old.js';
+import type {IDragStrategy, IDraggable} from './interfaces/i_draggable.js';
 import {IIcon} from './interfaces/i_icon.js';
 import * as internalConstants from './internal_constants.js';
 import {ASTNode} from './keyboard_nav/ast_node.js';
@@ -60,6 +60,7 @@ import type {WorkspaceSvg} from './workspace_svg.js';
 import * as renderManagement from './render_management.js';
 import {IconType} from './icons/icon_types.js';
 import {BlockCopyData, BlockPaster} from './clipboard/block_paster.js';
+import {BlockDragStrategy} from './dragging/block_drag_strategy.js';
 
 /**
  * Class for a block's SVG representation.
@@ -153,6 +154,8 @@ export class BlockSvg
    * @internal
    */
   relativeCoords = new Coordinate(0, 0);
+
+  private dragStrategy: IDragStrategy = new BlockDragStrategy(this);
 
   /**
    * @param workspace The block's workspace.
@@ -1621,5 +1624,35 @@ export class BlockSvg
       conn,
       add,
     );
+  }
+
+  /** Sets the drag strategy for this block. */
+  setDragStrategy(dragStrategy: IDragStrategy) {
+    this.dragStrategy = dragStrategy;
+  }
+
+  /** Returns whether this block is movable or not. */
+  override isMovable(): boolean {
+    return this.dragStrategy.isMovable();
+  }
+
+  /** Starts a drag on the block. */
+  startDrag(e?: PointerEvent): void {
+    this.dragStrategy.startDrag(e);
+  }
+
+  /** Drags the block to the given location. */
+  drag(newLoc: Coordinate, e?: PointerEvent): void {
+    this.dragStrategy.drag(newLoc, e);
+  }
+
+  /** Ends the drag on the block. */
+  endDrag(e?: PointerEvent): void {
+    this.dragStrategy.endDrag(e);
+  }
+
+  /** Moves the block back to where it was at the start of a drag. */
+  revertDrag(): void {
+    this.dragStrategy.revertDrag();
   }
 }

--- a/core/dragging/block_drag_strategy.ts
+++ b/core/dragging/block_drag_strategy.ts
@@ -390,6 +390,9 @@ export class BlockDragStrategy implements IDragStrategy {
       );
     }
 
+    this.startChildConn = null;
+    this.startParentConn = null;
+
     this.connectionPreviewer!.hidePreview();
     this.connectionCandidate = null;
 


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [ ] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #7841 

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. --> 
Has the `BlockSvg` delegate to a `IDragStrategy` (which external devs can supply). This makes the blocks use the new drag system, and allows external devs to customize how blocks handle drags.

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->

Tested manually with a following PR that updates the gesture system to use the dragger and raggables.

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->
N/A

### Additional Information

<!-- Anything else we should know? -->
N/A
