### PR TITLE
feat: make comment a draggable

### DIFF
--- a/core/comments/rendered_workspace_comment.ts
+++ b/core/comments/rendered_workspace_comment.ts
@@ -12,6 +12,8 @@ import {Rect} from '../utils/rect.js';
 import {Size} from '../utils/size.js';
 import {IBoundedElement} from '../interfaces/i_bounded_element.js';
 import {IRenderedElement} from '../interfaces/i_rendered_element.js';
+import * as dom from '../utils/dom.js';
+import {IDraggable} from '../interfaces/i_draggable.js';
 
 export class RenderedWorkspaceComment
   extends WorkspaceComment
@@ -103,6 +105,29 @@ export class RenderedWorkspaceComment
   override moveTo(location: Coordinate): void {
     super.moveTo(location);
     this.view.moveTo(location);
+  }
+
+  /**
+   * Moves the comment during a drag. Doesn't fire move events.
+   *
+   * @internal
+   */
+  moveDuringDrag(location: Coordinate): void {
+    this.location = location;
+    this.view.moveTo(location);
+  }
+
+  /**
+   * Adds the dragging CSS class to this comment.
+   *
+   * @internal
+   */
+  setDragging(dragging: boolean): void {
+    if (dragging) {
+      dom.addClass(this.getSvgRoot(), 'blocklyDragging');
+    } else {
+      dom.removeClass(this.getSvgRoot(), 'blocklyDragging');
+    }
   }
 
   /** Disposes of the view. */

--- a/core/comments/rendered_workspace_comment.ts
+++ b/core/comments/rendered_workspace_comment.ts
@@ -14,17 +14,24 @@ import {IBoundedElement} from '../interfaces/i_bounded_element.js';
 import {IRenderedElement} from '../interfaces/i_rendered_element.js';
 import * as dom from '../utils/dom.js';
 import {IDraggable} from '../interfaces/i_draggable.js';
+import {CommentDragStrategy} from '../dragging/comment_drag_strategy.js';
 
 export class RenderedWorkspaceComment
   extends WorkspaceComment
-  implements IBoundedElement, IRenderedElement
+  implements IBoundedElement, IRenderedElement, IDraggable
 {
   /** The class encompassing the svg elements making up the workspace comment. */
   private view: CommentView;
 
+  public readonly workspace: WorkspaceSvg;
+
+  private dragStrategy = new CommentDragStrategy(this);
+
   /** Constructs the workspace comment, including the view. */
   constructor(workspace: WorkspaceSvg, id?: string) {
     super(workspace, id);
+
+    this.workspace = workspace;
 
     this.view = new CommentView(workspace);
     // Set the size to the default size as defined in the superclass.
@@ -135,5 +142,30 @@ export class RenderedWorkspaceComment
     this.disposing = true;
     if (!this.view.isDeadOrDying()) this.view.dispose();
     super.dispose();
+  }
+
+  /** Returns whether this comment is movable or not. */
+  isMovable(): boolean {
+    return this.dragStrategy.isMovable();
+  }
+
+  /** Starts a drag on the comment. */
+  startDrag(): void {
+    this.dragStrategy.startDrag();
+  }
+
+  /** Drags the comment to the given location. */
+  drag(newLoc: Coordinate): void {
+    this.dragStrategy.drag(newLoc);
+  }
+
+  /** Ends the drag on the comment. */
+  endDrag(): void {
+    this.dragStrategy.endDrag();
+  }
+
+  /** Moves the comment back to where it was at the start of a drag. */
+  revertDrag(): void {
+    this.dragStrategy.revertDrag();
   }
 }

--- a/core/comments/workspace_comment.ts
+++ b/core/comments/workspace_comment.ts
@@ -32,7 +32,7 @@ export class WorkspaceComment {
   private deletable = true;
 
   /** The location of the comment in workspace coordinates. */
-  private location = new Coordinate(0, 0);
+  protected location = new Coordinate(0, 0);
 
   /** Whether this comment has been disposed or not. */
   protected disposed = false;

--- a/core/dragging/comment_drag_strategy.ts
+++ b/core/dragging/comment_drag_strategy.ts
@@ -14,10 +14,11 @@ import {WorkspaceSvg} from '../workspace_svg.js';
 export class CommentDragStrategy implements IDragStrategy {
   private startLoc: Coordinate | null = null;
 
-  constructor(
-    private comment: RenderedWorkspaceComment,
-    private workspace: WorkspaceSvg,
-  ) {}
+  private workspace: WorkspaceSvg;
+
+  constructor(private comment: RenderedWorkspaceComment) {
+    this.workspace = comment.workspace;
+  }
 
   isMovable(): boolean {
     return this.comment.isOwnMovable() && !this.workspace.options.readOnly;

--- a/core/dragging/comment_drag_strategy.ts
+++ b/core/dragging/comment_drag_strategy.ts
@@ -1,0 +1,53 @@
+/**
+ * @license
+ * Copyright 2024 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {IDragStrategy} from '../interfaces/i_draggable.js';
+import {Coordinate} from '../utils.js';
+import * as eventUtils from '../events/utils.js';
+import * as layers from '../layers.js';
+import {RenderedWorkspaceComment} from '../comments.js';
+import {WorkspaceSvg} from '../workspace_svg.js';
+
+export class CommentDragStrategy implements IDragStrategy {
+  private startLoc: Coordinate | null = null;
+
+  constructor(
+    private comment: RenderedWorkspaceComment,
+    private workspace: WorkspaceSvg,
+  ) {}
+
+  isMovable(): boolean {
+    return this.comment.isOwnMovable() && !this.workspace.options.readOnly;
+  }
+
+  startDrag(): void {
+    if (!eventUtils.getGroup()) {
+      eventUtils.setGroup(true);
+    }
+    this.startLoc = this.comment.getRelativeToSurfaceXY();
+    this.workspace.setResizesEnabled(false);
+    this.workspace.getLayerManager()?.moveToDragLayer(this.comment);
+    this.comment.setDragging(true);
+  }
+
+  drag(newLoc: Coordinate): void {
+    this.comment.moveDuringDrag(newLoc);
+  }
+
+  endDrag(): void {
+    this.workspace.setResizesEnabled(true);
+    eventUtils.setGroup(false);
+
+    this.workspace
+      .getLayerManager()
+      ?.moveOffDragLayer(this.comment, layers.BLOCK);
+    this.comment.setDragging(false);
+  }
+
+  revertDrag(): void {
+    if (this.startLoc) this.comment.moveDuringDrag(this.startLoc);
+  }
+}


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #7842 

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
Moves workspace comments to use the new dragging API. This does not actually enable dragging because this also needs fixes in the gesture (next PR)

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->
Tested with the next PR that dragging does work - although I messed something up with the CSS :P

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->
N/A

### Additional Information

<!-- Anything else we should know? -->
N/A
