### PR TITLE
feat: support dragging comments in the gesture

### DIFF
--- a/core/comments/rendered_workspace_comment.ts
+++ b/core/comments/rendered_workspace_comment.ts
@@ -15,6 +15,7 @@ import {IRenderedElement} from '../interfaces/i_rendered_element.js';
 import * as dom from '../utils/dom.js';
 import {IDraggable} from '../interfaces/i_draggable.js';
 import {CommentDragStrategy} from '../dragging/comment_drag_strategy.js';
+import * as browserEvents from '../browser_events.js';
 
 export class RenderedWorkspaceComment
   extends WorkspaceComment
@@ -39,6 +40,13 @@ export class RenderedWorkspaceComment
     this.view.setEditable(this.isEditable());
 
     this.addModelUpdateBindings();
+
+    browserEvents.conditionalBind(
+      this.view.getSvgRoot(),
+      'pointerdown',
+      this,
+      this.startGesture,
+    );
   }
 
   /**
@@ -142,6 +150,17 @@ export class RenderedWorkspaceComment
     this.disposing = true;
     if (!this.view.isDeadOrDying()) this.view.dispose();
     super.dispose();
+  }
+
+  /**
+   * Starts a gesture because we detected a pointer down on the comment
+   * (that wasn't otherwise gobbled up, e.g. by resizing).
+   */
+  private startGesture(e: PointerEvent) {
+    const gesture = this.workspace.getGesture(e);
+    if (gesture) {
+      gesture.handleCommentStart(e, this);
+    }
   }
 
   /** Returns whether this comment is movable or not. */

--- a/core/gesture.ts
+++ b/core/gesture.ts
@@ -454,7 +454,7 @@ export class Gesture {
     this.dragger.onDrag(e, this.currentDragDeltaXY);
   }
 
-  /** Start dragging the selected bubble. */
+  /** Start dragging the selected comment. */
   private startDraggingComment(e: PointerEvent) {
     if (!this.startComment) {
       throw new Error(
@@ -464,7 +464,7 @@ export class Gesture {
     }
     if (!this.startWorkspace_) {
       throw new Error(
-        'Cannot update dragging the bubble because the start ' +
+        'Cannot update dragging the comment because the start ' +
           'workspace is undefined',
       );
     }
@@ -951,7 +951,7 @@ export class Gesture {
   handleCommentStart(e: PointerEvent, comment: RenderedWorkspaceComment) {
     if (this.gestureHasStarted) {
       throw Error(
-        'Tried to call gesture.handleBubbleStart, ' +
+        'Tried to call gesture.handleCommentStart, ' +
           'but the gesture had already been started.',
       );
     }


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes N/A

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
Makes it so the gesture handles starting drags on comments. The code for starting drags is going to get refactored an unified in a bit, but I wanted to be able to test the comment dragging before then.

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->
Manually tested, and drags to occur!

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->
N/A

### Additional Information

<!-- Anything else we should know? -->
N/A
