### PR TITLE
fix: comment colours when dragging

### DIFF
--- a/core/comments/comment_view.ts
+++ b/core/comments/comment_view.ts
@@ -733,7 +733,7 @@ export class CommentView implements IRenderedElement {
 }
 
 css.register(`
-.blocklyWorkspace {
+.injectionDiv {
   --commentFillColour: #FFFCC7;
   --commentBorderColour: #F2E49B;
 }
@@ -758,6 +758,7 @@ css.register(`
 .blocklyDeleteIcon {
   width: 20px;
   height: 20px;
+  display: none;
   cursor: pointer;
 }
 


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes N/A

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
I set the scope for the comment colour variables to be a bit too restrictive :P The drag surface is not part of the workspace because then we wouldn't be able to drag over the trashcan! So when we moved the comment to the drag surface it lost its colours.

Also at some point the delete icon was made visible by default which we don't want.

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->
Tested that comments are still properly colourful 🌈 when dragging.

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->
N/A

### Additional Information

<!-- Anything else we should know? -->
N/A
