### PR TITLE
fix: Assign to containerDiv blockyWidgetDiv if it already exists

### DIFF
--- a/core/widgetdiv.ts
+++ b/core/widgetdiv.ts
@@ -61,7 +61,6 @@ export function createDom() {
     containerDiv = document.querySelector('.' + containerClassName);
     const container = common.getParentContainer() || document.body;
     container.appendChild(containerDiv!);
-    return; // Already created.
   }
 
   containerDiv = document.createElement('div') as HTMLDivElement;

--- a/core/widgetdiv.ts
+++ b/core/widgetdiv.ts
@@ -61,12 +61,12 @@ export function createDom() {
     containerDiv = document.querySelector('.' + containerClassName);
     const container = common.getParentContainer() || document.body;
     container.appendChild(containerDiv!);
+  } else {
+    containerDiv = document.createElement('div') as HTMLDivElement;
+    containerDiv.className = containerClassName;
+    const container = common.getParentContainer() || document.body;
+    container.appendChild(containerDiv); 
   }
-
-  containerDiv = document.createElement('div') as HTMLDivElement;
-  containerDiv.className = containerClassName;
-  const container = common.getParentContainer() || document.body;
-  container.appendChild(containerDiv);
 }
 
 /**

--- a/core/widgetdiv.ts
+++ b/core/widgetdiv.ts
@@ -65,7 +65,7 @@ export function createDom() {
     containerDiv = document.createElement('div') as HTMLDivElement;
     containerDiv.className = containerClassName;
     const container = common.getParentContainer() || document.body;
-    container.appendChild(containerDiv); 
+    container.appendChild(containerDiv);
   }
 }
 

--- a/core/widgetdiv.ts
+++ b/core/widgetdiv.ts
@@ -58,6 +58,9 @@ export function testOnly_setDiv(newDiv: HTMLDivElement | null) {
  */
 export function createDom() {
   if (document.querySelector('.' + containerClassName)) {
+    containerDiv = document.querySelector('.' + containerClassName);
+    const container = common.getParentContainer() || document.body;
+    container.appendChild(containerDiv!);
     return; // Already created.
   }
 

--- a/core/widgetdiv.ts
+++ b/core/widgetdiv.ts
@@ -57,16 +57,16 @@ export function testOnly_setDiv(newDiv: HTMLDivElement | null) {
  * Create the widget div and inject it onto the page.
  */
 export function createDom() {
+  const container = common.getParentContainer() || document.body;
+
   if (document.querySelector('.' + containerClassName)) {
     containerDiv = document.querySelector('.' + containerClassName);
-    const container = common.getParentContainer() || document.body;
-    container.appendChild(containerDiv!);
   } else {
     containerDiv = document.createElement('div') as HTMLDivElement;
     containerDiv.className = containerClassName;
-    const container = common.getParentContainer() || document.body;
-    container.appendChild(containerDiv);
   }
+
+  container.appendChild(containerDiv!);
 }
 
 /**


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Work on #7819

### Proposed Changes
If the div `blockyWidgetDiv` already exists, store it inside `containerDiv` doing the same `document.querySelector`, creating the constant `container` and appeding the already existing `containerDiv` as a child.

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->

### Reason for Changes
Covered in #7819

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage
Same tests passed before and after the PR.
<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->

### Documentation
N/A
<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information
N/A
<!-- Anything else we should know? -->
