### PR TITLE
feat: Redeclaration of regristry entries (case)

### DIFF
--- a/core/registry.ts
+++ b/core/registry.ts
@@ -159,6 +159,14 @@ export function register<T>(
     nameRegistry = nameMap[type] = Object.create(null);
   }
 
+  // Allow the same item to be registered more than once.
+  if (
+    nameRegistry[caselessName] === name &&
+    typeRegistry[caselessName] === registryItem
+  ) {
+    return;
+  }
+
   // Validate that the given class has all the required properties.
   validate(type, registryItem);
 

--- a/core/toolbox/separator.ts
+++ b/core/toolbox/separator.ts
@@ -25,6 +25,7 @@ import {ToolboxItem} from './toolbox_item.js';
  */
 export class ToolboxSeparator extends ToolboxItem {
   /** Name used for registering a toolbox separator. */
+  /** Must be lowercase. */
   static registrationName = 'sep';
 
   /** All the CSS class names that are used to create a separator. */

--- a/tests/mocha/registry_test.js
+++ b/tests/mocha/registry_test.js
@@ -45,9 +45,17 @@ suite('Registry', function () {
     });
 
     test('Overwrite a Key', function () {
+      // Set entry the first time.
       Blockly.registry.register('test', 'test_name', TestClass);
+      // Overwrite with same case, same object.
+      Blockly.registry.register('test', 'test_name', TestClass);
+      // Throw with same case, different object.
       chai.assert.throws(function () {
-        Blockly.registry.register('test', 'test_name', TestClass);
+        Blockly.registry.register('test', 'test_name', {});
+      }, 'already registered');
+      // Throw with different case, same object.
+      chai.assert.throws(function () {
+        Blockly.registry.register('test', 'TEST_NAME', TestClass);
       }, 'already registered');
     });
 


### PR DESCRIPTION
This PR is an alternative approach for allowing redeclaration of registry entries.  It assumes all keys are case-sensitive, even if the registry is being used in an case-insensitive manner.

I do NOT recommend merging this PR.  It expands upon an already inconsistent API and makes it even less intuitive.

Related to #7924