### PR TITLE
feat: allow duplicate registry values

### DIFF
--- a/core/registry.ts
+++ b/core/registry.ts
@@ -162,8 +162,13 @@ export function register<T>(
   // Validate that the given class has all the required properties.
   validate(type, registryItem);
 
-  // Don't throw an error if opt_allowOverrides is true.
-  if (!opt_allowOverrides && typeRegistry[caselessName]) {
+  // Don't throw an error if opt_allowOverrides is true,
+  // or if we're trying to register the same item.
+  if (
+    !opt_allowOverrides &&
+    typeRegistry[caselessName] &&
+    typeRegistry[caselessName] !== registryItem
+  ) {
     throw Error(
       'Name "' +
         caselessName +

--- a/tests/mocha/registry_test.js
+++ b/tests/mocha/registry_test.js
@@ -47,6 +47,15 @@ suite('Registry', function () {
     test('Overwrite a Key', function () {
       Blockly.registry.register('test', 'test_name', TestClass);
       chai.assert.throws(function () {
+        // Registers a different object under the same name
+        Blockly.registry.register('test', 'test_name', {});
+      }, 'already registered');
+    });
+
+    test('Register a Duplicate Item', function () {
+      Blockly.registry.register('test', 'test_name', TestClass);
+      chai.assert.doesNotThrow(function () {
+        // Registering the same object under the same name is allowed
         Blockly.registry.register('test', 'test_name', TestClass);
       }, 'already registered');
     });


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #7924 

### Proposed Changes

Does not throw an error if you attempt to register the same object twice (under the same type and case-insensitive name)

### Reason for Changes

This is similar to #7983. The difference in behavior is subtle:

In this PR: If you try to register the same `TestObject` twice, first under the name `test` and second under the name `Test`, then we'll allow you to register the object without throwing an error and we'll also update the cased name to be `Test`, which only matters if you later call `getAllItems(type, true)` where we give you the most-recently used cased version of the name. This is consistent with how it works if you pass a different object, same name, and pass the `opt_allowOverrides` parameter: we'll update the case of the stored name.

In #7983: If you try to register the same `TestObject` twice, first under the name `test` and second under the name `Test`, then we'll allow you to register the object without throwing an error. But we won't update the most-recently-cased version of the name. This is *inconsistent* with how it works if you pass a different object, same name, and pass the `opt_allowOverrides`. It's also a behavior change where previously, you could register the same object and intentionally change the case by passing the `opt_allowOverrides` flag.

I think maintaining consistency with how the overrides flag works is better, and it makes it easier to explain the "last used case" part of the registry that keeps track of the case-sensitive name you registered an item under. That's why I think this PR should be merged instead of #7983 (or #7982)

### Test Coverage

Added unit test for this case.

### Documentation

Maybe? We don't really explain the registry anywhere. The most likely place this gets explained is in the documentation about how installing fields/blocks plugins works.

### Additional Information

See https://github.com/google/blockly/pull/7924 and https://github.com/google/blockly/issues/7987 for related discussion.
