### PR TITLE
fix: bubbles not being returned to the correct layer after drag

### DIFF
--- a/core/dragging/bubble_drag_strategy.ts
+++ b/core/dragging/bubble_drag_strategy.ts
@@ -42,7 +42,7 @@ export class BubbleDragStrategy implements IDragStrategy {
 
     this.workspace
       .getLayerManager()
-      ?.moveOffDragLayer(this.bubble, layers.BLOCK);
+      ?.moveOffDragLayer(this.bubble, layers.BUBBLE);
     this.bubble.setDragging(false);
   }
 


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes N/A

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
Bubbles were being returned to the `BLOCK` layer when they should have been returned to the `BUBBLE` layer.

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->
Tested that bubbles are now properly always on top of blocks.

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->
N/A

### Additional Information

<!-- Anything else we should know? -->
N/A
