### PR TITLE
fix: blocks not being returned to the correct layer if their drag is reverted with no parent

### DIFF
--- a/core/dragging/block_drag_strategy.ts
+++ b/core/dragging/block_drag_strategy.ts
@@ -429,6 +429,9 @@ export class BlockDragStrategy implements IDragStrategy {
       }
     } else {
       this.block.moveTo(this.startLoc!, ['drag']);
+      this.workspace
+        .getLayerManager()
+        ?.moveOffDragLayer(this.block, layers.BLOCK);
       // Blocks dragged directly from a flyout may need to be bumped into
       // bounds.
       bumpObjects.bumpIntoBounds(

--- a/core/trashcan.ts
+++ b/core/trashcan.ts
@@ -697,6 +697,14 @@ export class Trashcan
     };
     return blockInfo;
   }
+
+  wouldDelete(_element: IDraggable): boolean {
+    return false;
+  }
+
+  shouldPreventMove(_dragElement: IDraggable): boolean {
+    return true;
+  }
 }
 
 /** Width of both the trash can and lid images. */

--- a/core/trashcan.ts
+++ b/core/trashcan.ts
@@ -697,14 +697,6 @@ export class Trashcan
     };
     return blockInfo;
   }
-
-  wouldDelete(_element: IDraggable): boolean {
-    return false;
-  }
-
-  shouldPreventMove(_dragElement: IDraggable): boolean {
-    return true;
-  }
 }
 
 /** Width of both the trash can and lid images. */


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes N/A

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
See PR title.

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->
Tested that blocks that didn't have parents when their drag started are properly returned to the `BLOCK` layer.

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->
N/A

### Additional Information

<!-- Anything else we should know? -->
N/A
