### PR TITLE
fix: insertion marker firing move event

### DIFF
--- a/core/insertion_marker_previewer.ts
+++ b/core/insertion_marker_previewer.ts
@@ -154,13 +154,18 @@ export class InsertionMarkerPreviewer implements IConnectionPreviewer {
     };
     const originalOffsetInBlock = markerConn.getOffsetInBlock().clone();
     renderManagement.finishQueuedRenders().then(() => {
-      // Position so that the existing block doesn't move.
-      marker?.positionNearConnection(
-        markerConn,
-        originalOffsetToTarget,
-        originalOffsetInBlock,
-      );
-      marker?.getSvgRoot().setAttribute('visibility', 'visible');
+      eventUtils.disable();
+      try {
+        // Position so that the existing block doesn't move.
+        marker?.positionNearConnection(
+          markerConn,
+          originalOffsetToTarget,
+          originalOffsetInBlock,
+        );
+        marker?.getSvgRoot().setAttribute('visibility', 'visible');
+      } finally {
+        eventUtils.enable();
+      }
     });
     return markerConn;
   }


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [ ] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes N/A

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
Insertion markers were firing move events when they became the top blocks in a stack. Insertion markers shouldn't fire events, so I disabled this.

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->
Tested that these erroneous events are no longer fired.

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->
N/A

### Additional Information

<!-- Anything else we should know? -->
N/A
