### PR TITLE
fix: fixed ctrl+click for right click on mac

### DIFF
--- a/core/browser_events.ts
+++ b/core/browser_events.ts
@@ -187,7 +187,7 @@ export function isTargetInput(e: Event): boolean {
  * @returns True if right-click.
  */
 export function isRightButton(e: MouseEvent): boolean {
-  if (e.ctrlKey && userAgent.MAC) {
+  if ((e.metaKey || e.ctrlKey) && userAgent.MAC) {
     // Control-clicking on Mac OS X is treated as a right-click.
     // WebKit on Mac OS X fails to change button to 2 (but Gecko does).
     return true;

--- a/core/browser_events.ts
+++ b/core/browser_events.ts
@@ -7,7 +7,6 @@
 // Former goog.module ID: Blockly.browserEvents
 
 import * as Touch from './touch.js';
-import * as userAgent from './utils/useragent.js';
 
 /**
  * Blockly opaque event data used to unbind events when using
@@ -187,13 +186,14 @@ export function isTargetInput(e: Event): boolean {
  * @returns True if right-click.
  */
 export function isRightButton(e: MouseEvent): boolean {
-  if ((e.metaKey || e.ctrlKey) && userAgent.MAC) {
-    // Control-clicking on Mac OS X is treated as a right-click.
-    // WebKit on Mac OS X fails to change button to 2 (but Gecko does).
-    return true;
-  }
   return e.button === 2;
 }
+
+// REVIEW NOTE: Not needed unless funneled through a common space, like
+// 'handleWsStart'. If we confirm this isn't needed, will remove.
+// export function isContextMenu(e: PointerEvent): boolean {
+//   return e.type === 'contextmenu';
+// }
 
 /**
  * Returns the converted coordinates of the given mouse event.

--- a/core/bubbles/textinput_bubble.ts
+++ b/core/bubbles/textinput_bubble.ts
@@ -251,6 +251,9 @@ export class TextInputBubble extends Bubble {
     this.bringToFront();
     if (browserEvents.isRightButton(e)) {
       e.stopPropagation();
+      // REVIEW NOTE: Only triggered on 'pointerdown', so can never be context
+      // menu event. Similar to other sections - is there another reason why
+      // stopping propagation is important here?
       return;
     }
 

--- a/core/gesture.ts
+++ b/core/gesture.ts
@@ -492,9 +492,21 @@ export class Gesture {
     }
 
     if (browserEvents.isRightButton(e)) {
-      this.handleRightClick(e);
+      // Right-click.
+      // Context menus are activated through 'contextmenu' event.
+      e.stopPropagation();
+      // REVIEW NOTE: Is stopping propagation important here? Only including if
+      // it's needed still in `scrollbar.ts`, for example.
       return;
     }
+
+    // REVIEW NOTE: No way to detect ctrl + left click on Mac, so contextmenu
+    // event bypasses this section since it's otherwise blocked by the click
+    // event triggering in this section.
+    // if (browserEvents.isContextMenu(e)) {
+    //   console.log('handle context menu!');
+    //   this.handleContextMenu(e);
+    // }
 
     if (e.type.toLowerCase() === 'pointerdown' && e.pointerType !== 'mouse') {
       Touch.longStart(e, this);
@@ -800,12 +812,12 @@ export class Gesture {
   }
 
   /**
-   * Handle a real or faked right-click event by showing a context menu.
+   * Handle the context menu event.
    *
    * @param e A pointerdown event.
    * @internal
    */
-  handleRightClick(e: PointerEvent) {
+  handleContextMenu(e: Event) {
     if (this.targetBlock) {
       this.bringBlockToFront();
       this.targetBlock.workspace.hideChaff(!!this.flyout);
@@ -817,7 +829,6 @@ export class Gesture {
       this.startWorkspace_.showContextMenu(e);
     }
 
-    // TODO: Handle right-click on a bubble.
     e.preventDefault();
     e.stopPropagation();
 

--- a/core/scrollbar.ts
+++ b/core/scrollbar.ts
@@ -716,6 +716,9 @@ export class Scrollbar {
       // Right-click.
       // Scrollbars have no context menu.
       e.stopPropagation();
+      // REVIEW NOTE: Is stopping propagation important here? Stopping wrapping
+      // right click events seems irrelevant at a glance - especially with right
+      // click not being used for anything internally except context menu.
       return;
     }
     const mouseXY = browserEvents.mouseToSvg(
@@ -758,6 +761,9 @@ export class Scrollbar {
       // Right-click.
       // Scrollbars have no context menu.
       e.stopPropagation();
+      // REVIEW NOTE: Is stopping propagation important here? Stopping wrapping
+      // right click events seems irrelevant at a glance - especially with right
+      // click not being used for anything internally except context menu.
       return;
     }
     // Look up the current translation and record it.

--- a/core/touch.ts
+++ b/core/touch.ts
@@ -67,7 +67,7 @@ export function longStart(e: PointerEvent, gesture: Gesture) {
   longPid_ = setTimeout(function () {
     // Let the gesture route the right-click correctly.
     if (gesture) {
-      gesture.handleRightClick(e);
+      gesture.handleContextMenu(e);
     }
   }, LONGPRESS);
 }

--- a/core/workspace_comment_svg.ts
+++ b/core/workspace_comment_svg.ts
@@ -806,6 +806,9 @@ export class WorkspaceCommentSvg
     if (browserEvents.isRightButton(e)) {
       // No right-click.
       e.stopPropagation();
+      // REVIEW NOTE: Only triggered on 'pointerdown', so can never be context
+      // menu event. Similar to other sections - is there another reason why
+      // stopping propagation is important here?
       return;
     }
     // Left-click (or middle click)

--- a/core/workspace_svg.ts
+++ b/core/workspace_svg.ts
@@ -783,6 +783,16 @@ export class WorkspaceSvg extends Workspace implements IASTNodeLocationSvg {
     this.svgBubbleCanvas_ = this.layerManager.getBubbleLayer();
 
     if (!this.isFlyout) {
+      // Handle the 'contextmenu' event.
+      // NOTE: ctrlKey is not detectable on Mac on a click event, though
+      // 'contextmenu' is available across systems & browsers.
+      browserEvents.conditionalBind(
+        this.svgGroup_,
+        'contextmenu',
+        this,
+        this.onContextMenu,
+      );
+
       browserEvents.conditionalBind(
         this.svgGroup_,
         'pointerdown',
@@ -1608,6 +1618,25 @@ export class WorkspaceSvg extends Workspace implements IASTNodeLocationSvg {
     const gesture = this.getGesture(e);
     if (gesture) {
       gesture.handleWsStart(e, this);
+    }
+  }
+
+  /**
+   * Handle a pointerdown on SVG drawing surface.
+   *
+   * @param e Pointer down event.
+   */
+  private onContextMenu(e: PointerEvent) {
+    // REVIEW NOTE: Rename to "onContextMenu_"? Or fine to leave as is? I'm
+    // assuming the "_" is that just a remnant of JS naming where "private"
+    // wasn't available.
+    const gesture = this.getGesture(e);
+    if (gesture) {
+      // REVIEW NOTE: `pointerdown` triggers before 'contextmenu', and we cannot
+      // reliably determine on Mac that a click event is a ctrl + left click.
+      // Bypass `handleWsStart` and directly handle the context menu. Do we
+      // forsee any issues with this?
+      gesture.handleContextMenu(e);
     }
   }
 


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

Fixes https://github.com/google/blockly/issues/7979

### Proposed Changes

Updated in `browser_events.ts` the `isRightButton` to allow command + click on Mac.

There's two relevant documents for this issue:
- https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/metaKey
- https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/ctrlKey

I don't use a Mac personally, so this will need to be verified. When using **BrowserStack**, though, `ctrl` activates `metaKey`, implying that it's translated to the `command` key. There are two important notes from the documentation above:
- The `command` key gets translated to `metaKey`. If this is what the issue is really about, perfect!
- The `control` key is not detectable alongside a click event, so `ctrlKey` should never be `true` for a click event on any browser on Mac.

### Reason for Changes

To fix the ctrl + click issue on Mac.

### Test Coverage

None

### Documentation

None

### Additional Information

<!-- Anything else we should know? -->
