### PR TITLE
fix: correct dropdown arrow placement for Thrasos on Safari

### DIFF
--- a/core/field_dropdown.ts
+++ b/core/field_dropdown.ts
@@ -229,6 +229,9 @@ export class FieldDropdown extends Field<string> {
           : ' ' + FieldDropdown.ARROW_CHAR,
       ),
     );
+    if (this.getConstants()!.FIELD_TEXT_BASELINE_CENTER) {
+      this.arrow.setAttribute('dominant-baseline', 'central');
+    }
     if (this.getSourceBlock()?.RTL) {
       this.getTextElement().insertBefore(this.arrow, this.textContent_);
     } else {


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes https://github.com/google/blockly/issues/7890

### Proposed Changes

Ensure that the dominant baseline for the arrow symbol on dropdown fields is 'center'. The exception is when a field's text element's dominant baseline should not be centered. Previously this was true for certain browsers (IE and Edge), but now it's only true for the Geras renderer. (https://github.com/google/blockly/blob/9e05d69d2accba5dca97b39281b322a2ec0961d3/core/renderers/geras/constants.ts#L15)

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->

Screenshots are of the Advanced Playground, renderer set to Thrasos on Safari. No regressions found for other renderers or other browsers.

**Before:**
![image](https://github.com/google/blockly/assets/43474485/89ed7d28-d85a-465a-89c6-a73afd4c17d9)

**After:**
![image](https://github.com/google/blockly/assets/43474485/4854a6cb-fee3-452d-8c1b-679a685e364e)

### Reason for Changes

When using the Thrasos renderer on Safari, all arrows in dropdown fields appear too high. This is evidently because Safari does not inherit the property dominant-baseline: "central" from the parent element.
<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage

No test have been added.
<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->

### Documentation

I don't believe this warrants any updates to documentation.
<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
