### PR TITLE
fix: revert dragger name

### DIFF
--- a/core/dragging/dragger.ts
+++ b/core/dragging/dragger.ts
@@ -139,4 +139,4 @@ export class Dragger implements IDragger {
   }
 }
 
-registry.register(registry.Type.DRAGGER, registry.DEFAULT, Dragger);
+registry.register(registry.Type.BLOCK_DRAGGER, registry.DEFAULT, Dragger);

--- a/core/gesture.ts
+++ b/core/gesture.ts
@@ -360,7 +360,7 @@ export class Gesture {
     workspace: WorkspaceSvg,
   ): IDragger {
     const DraggerClass = registry.getClassFromOptions(
-      registry.Type.DRAGGER,
+      registry.Type.BLOCK_DRAGGER,
       this.creatorWorkspace.options,
       true,
     );

--- a/core/registry.ts
+++ b/core/registry.ts
@@ -95,7 +95,11 @@ export class Type<_T> {
 
   static METRICS_MANAGER = new Type<IMetricsManager>('metricsManager');
 
-  static DRAGGER = new Type<IDragger>('dragger');
+  /**
+   * Type for an IDragger. Formerly behavior was mostly covered by
+   * BlockDraggeers, which is why the name is inaccurate.
+   */
+  static BLOCK_DRAGGER = new Type<IDragger>('blockDragger');
 
   /** @internal */
   static SERIALIZER = new Type<ISerializer>('serializer');


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes N/A

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
Discussed over standup, and everyone had very small opinions about how this should be named. I ended up reverting draggers back to have the inaccurate "BLOCK_DRAGGER" name because I think there are more people using the scroll options plugin than there are people implementing their own blocks draggers. And this decreases the burder on the scroll-options folks.

For folks that are implementing their own block draggers it will be a bit annoying because the registry's types are so lax  they won't get a compiler warning, so they'll have to find out their stuff is broken at run time.

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->
Build passes.

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->
Updated pending docs change.

### Additional Information

<!-- Anything else we should know? -->
