### PR TITLE
feat: add ability to delete workspace comments

### DIFF
--- a/core/comments/rendered_workspace_comment.ts
+++ b/core/comments/rendered_workspace_comment.ts
@@ -18,10 +18,16 @@ import {CommentDragStrategy} from '../dragging/comment_drag_strategy.js';
 import * as browserEvents from '../browser_events.js';
 import * as common from '../common.js';
 import {ISelectable} from '../interfaces/i_selectable.js';
+import {IDeletable} from '../interfaces/i_deletable.js';
 
 export class RenderedWorkspaceComment
   extends WorkspaceComment
-  implements IBoundedElement, IRenderedElement, IDraggable, ISelectable
+  implements
+    IBoundedElement,
+    IRenderedElement,
+    IDraggable,
+    ISelectable,
+    IDeletable
 {
   /** The class encompassing the svg elements making up the workspace comment. */
   private view: CommentView;
@@ -162,6 +168,20 @@ export class RenderedWorkspaceComment
     if (gesture) {
       gesture.handleCommentStart(e, this);
       common.setSelected(this);
+    }
+  }
+
+  /** Returns whether this comment is deletable or not. */
+  isDeletable(): boolean {
+    return !this.workspace.options.readOnly;
+  }
+
+  /** Visually indicates that this comment would be deleted if dropped. */
+  setDeleteStyle(wouldDelete: boolean): void {
+    if (wouldDelete) {
+      dom.addClass(this.getSvgRoot(), 'blocklyDraggingDelete');
+    } else {
+      dom.removeClass(this.getSvgRoot(), 'blocklyDraggingDelete');
     }
   }
 

--- a/core/shortcut_items.ts
+++ b/core/shortcut_items.ts
@@ -16,6 +16,7 @@ import {KeyboardShortcut, ShortcutRegistry} from './shortcut_registry.js';
 import {KeyCodes} from './utils/keycodes.js';
 import type {WorkspaceSvg} from './workspace_svg.js';
 import {isDraggable} from './interfaces/i_draggable.js';
+import * as eventUtils from './events/utils.js';
 
 /**
  * Object holding the names of the default shortcut items.
@@ -75,7 +76,14 @@ export function registerDelete() {
       if (Gesture.inProgress()) {
         return false;
       }
-      (common.getSelected() as BlockSvg).checkAndDelete();
+      const selected = common.getSelected();
+      if (selected instanceof BlockSvg) {
+        selected.checkAndDelete();
+      } else if (isDeletable(selected) && selected.isDeletable()) {
+        eventUtils.setGroup(true);
+        selected.dispose();
+        eventUtils.setGroup(false);
+      }
       return true;
     },
     keyCodes: [KeyCodes.DELETE, KeyCodes.BACKSPACE],


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

N/A
Related to #8006

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
Makes it so the rendered workspace comment implements the `IDeletable` interface. The comment will now be deleted if you drag it over the toolbox or trashcan, or if you use the delete key while it is selected.

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->
Manually tested that deleting works in the three outlined cases:
  * Deleting over the toolbox.
  * Deleting over the trashcan.
  * Deleting using the keyboard shortcut.

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->
N/A

### Additional Information

<!-- Anything else we should know? -->
Going to fix the context menu option separately, since that needs more work.
