### PR TITLE
fix: comment keyboard shortcuts

### DIFF
--- a/core/shortcut_items.ts
+++ b/core/shortcut_items.ts
@@ -161,19 +161,32 @@ export function registerCut() {
         !workspace.options.readOnly &&
         !Gesture.inProgress() &&
         selected != null &&
-        selected instanceof BlockSvg &&
+        isDeletable(selected) &&
         selected.isDeletable() &&
+        isDraggable(selected) &&
         selected.isMovable() &&
         !selected.workspace!.isFlyout
       );
     },
     callback(workspace) {
       const selected = common.getSelected();
-      if (!selected || !isCopyable(selected)) return false;
-      copyData = selected.toCopyData();
-      copyWorkspace = workspace;
-      (selected as BlockSvg).checkAndDelete();
-      return true;
+
+      if (selected instanceof BlockSvg) {
+        copyData = selected.toCopyData();
+        copyWorkspace = workspace;
+        selected.checkAndDelete();
+        return true;
+      } else if (
+        isDeletable(selected) &&
+        selected.isDeletable() &&
+        isCopyable(selected)
+      ) {
+        copyData = selected.toCopyData();
+        copyWorkspace = workspace;
+        selected.dispose();
+        return true;
+      }
+      return false;
     },
     keyCodes: [ctrlX, altX, metaX],
   };


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #8006 

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
Fixes the cut keyboard shortcuts to work with workspace comments.

Other shortcuts were fixed by other incremental fixes (e.g. fixing copy paste).

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->
Manually tested that delete, copy, cut, and paste all work with workspace comments.

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->
N/A

### Additional Information

<!-- Anything else we should know? -->
Dependent on https://github.com/google/blockly/pull/8035