### PR TITLE
fix: CSS for selected collapsed comments

### DIFF
--- a/core/comments/comment_view.ts
+++ b/core/comments/comment_view.ts
@@ -845,4 +845,13 @@ css.register(`
   stroke: #fc3;
   stroke-width: 3px;
 }
+
+.blocklyCollapsed.blocklySelected .blocklyCommentHighlight {
+  stroke: none;
+}
+
+.blocklyCollapsed.blocklySelected .blocklyCommentTopbarBackground {
+  stroke: #fc3;
+  stroke-width: 3px;
+}
 `);


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes N/A

### Proposed Changes

Before the selected highlight would still be the same size as the uncollapsed comment even when the comment was collapsed. Now the highlight changes when the comment is collapsed.

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
Old:
![Screen recording 2024-04-16 1 50 29 PM](https://github.com/google/blockly/assets/25440652/d56fc0eb-39f2-440d-8817-9f2b01e210a9)

New:
![Screen recording 2024-04-16 1 49 19 PM](https://github.com/google/blockly/assets/25440652/5db18200-4eed-46b1-932a-1d2d68eb4dde)


### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->

See gifs.

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->
N/A

### Additional Information

<!-- Anything else we should know? -->
N/A
