### PR TITLE
fix: comment text area size in samples

### DIFF
--- a/core/comments/comment_view.ts
+++ b/core/comments/comment_view.ts
@@ -393,6 +393,8 @@ export class CommentView implements IRenderedElement {
     if (this.workspace.RTL) {
       this.foreignObject.setAttribute('x', `${-size.width}`);
     }
+    this.textArea.style.width = `${size.width}px`;
+    this.textArea.style.height = `${size.height}px`;
   }
 
   /**


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes N/A

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
In samples the comment text areas weren't the correct height.

In core they were because the playground sets:
```css
html, body {
  height: 100%;
}
```

Disguising the issue.

I didn't want to change the CSS for a core class (like `blocklyMinimalBody`) to also declare height 100% because that could break other random implementations. Instead I set the height and width on the text area explicitly, which is also what the `TextInputBubble` does to handle this same problem.

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->
Tested by linking with samples.

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->
 N/A

### Additional Information

<!-- Anything else we should know? -->
N/A
