### PR TITLE
chore: fix comments being resizable when readonly

### DIFF
--- a/core/comments/comment_view.ts
+++ b/core/comments/comment_view.ts
@@ -495,6 +495,8 @@ export class CommentView implements IRenderedElement {
    * comment.
    */
   private onResizePointerDown(e: PointerEvent) {
+    if (!this.isEditable()) return;
+
     this.bringToFront();
     if (browserEvents.isRightButton(e)) {
       e.stopPropagation();
@@ -794,6 +796,9 @@ css.register(`
   width: 12px;
   height: 12px;
   cursor: se-resize;
+}
+.blocklyReadonly.blocklyComment .blocklyResizeHandle {
+  cursor: inherit;
 }
 
 .blocklyCommentTopbarBackground {

--- a/tests/playground.html
+++ b/tests/playground.html
@@ -251,7 +251,8 @@
         if (sessionStorage) {
           sessionStorage.setItem('logFlyoutEvents', Number(state));
         }
-        var flyoutWorkspace = workspace.getFlyout().getWorkspace();
+        var flyoutWorkspace = workspace.getFlyout()?.getWorkspace();
+        if (!flyoutWorkspace) return;
         if (state) {
           flyoutWorkspace.addChangeListener(logger);
         } else {


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes N/A

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
Makes it so that comments can not be resized unless the comment is editable.

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->
Manually tested that the comment cannot be resized. Tested that the cursor looks correct (default) in LTR and RTL.

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
The playground was actually broken in read-only mode because it was trying to access a flyout that didn't exist :P So I'm just fixing that as part of this.