### PR TITLE
fix: comment highlight being positioned incorrectly in RTL

### DIFF
--- a/core/comments/comment_view.ts
+++ b/core/comments/comment_view.ts
@@ -311,9 +311,8 @@ export class CommentView implements IRenderedElement {
 
     this.svgRoot.setAttribute('height', `${size.height}`);
     this.svgRoot.setAttribute('width', `${size.width}`);
-    this.highlightRect.setAttribute('height', `${size.height}`);
-    this.highlightRect.setAttribute('width', `${size.width}`);
 
+    this.updateHighlightRect(size);
     this.updateTopBarSize(size);
     this.updateTextAreaSize(size, topBarSize);
     this.updateDeleteIconPosition(size, topBarSize, deleteSize);
@@ -375,6 +374,15 @@ export class CommentView implements IRenderedElement {
   /** Calculates the margin that should exist around the foldout icon. */
   private calcFoldoutMargin(topBarSize: Size, foldoutSize: Size) {
     return (topBarSize.height - foldoutSize.height) / 2;
+  }
+
+  /** Updates the size of the highlight rect to reflect the new size. */
+  private updateHighlightRect(size: Size) {
+    this.highlightRect.setAttribute('height', `${size.height}`);
+    this.highlightRect.setAttribute('width', `${size.width}`);
+    if (this.workspace.RTL) {
+      this.highlightRect.setAttribute('x', `${-size.width}`);
+    }
   }
 
   /** Updates the size of the top bar to reflect the new size. */


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [ ] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes N/A

### Proposed Changes

The comment highlight was being positioned incorrectly in RTL mode (it was to the right of where it should be. Now it is properly positioned.

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->
Manually tested that the highlight is positioned correctly in RTL.

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
