### PR TITLE
fix: Don't record undo events for enable/disable

### DIFF
--- a/blocks/loops.ts
+++ b/blocks/loops.ts
@@ -20,6 +20,7 @@ import {
   createBlockDefinitionsFromJsonArray,
   defineBlocks,
 } from '../core/common.js';
+import * as eventUtils from '../core/events/utils.js';
 import '../core/field_dropdown.js';
 import '../core/field_label.js';
 import '../core/field_number.js';
@@ -372,12 +373,16 @@ const CONTROL_FLOW_IN_LOOP_CHECK_MIXIN = {
     this.setWarningText(
       enabled ? null : Msg['CONTROLS_FLOW_STATEMENTS_WARNING'],
     );
+
     if (!this.isInFlyout) {
-      const group = Events.getGroup();
-      // Makes it so the move and the disable event get undone together.
-      Events.setGroup(e.group);
-      this.setEnabled(enabled);
-      Events.setGroup(group);
+      try {
+        // There is no need to record the enable/disable change on the undo/redo
+        // list since the change will be automatically recreated when replayed.
+        eventUtils.setRecordUndo(false);
+        this.setEnabled(enabled);
+      } finally {
+        eventUtils.setRecordUndo(true);
+      }
     }
   },
 };

--- a/blocks/procedures.ts
+++ b/blocks/procedures.ts
@@ -25,6 +25,7 @@ import type {
   ContextMenuOption,
   LegacyContextMenuOption,
 } from '../core/contextmenu_registry.js';
+import * as eventUtils from '../core/events/utils.js';
 import {FieldCheckbox} from '../core/field_checkbox.js';
 import {FieldLabel} from '../core/field_label.js';
 import {FieldTextInput} from '../core/field_textinput.js';
@@ -1316,12 +1317,16 @@ const PROCEDURES_IFRETURN = {
     } else {
       this.setWarningText(Msg['PROCEDURES_IFRETURN_WARNING']);
     }
+
     if (!this.isInFlyout) {
-      const group = Events.getGroup();
-      // Makes it so the move and the disable event get undone together.
-      Events.setGroup(e.group);
-      this.setEnabled(legal);
-      Events.setGroup(group);
+      try {
+        // There is no need to record the enable/disable change on the undo/redo
+        // list since the change will be automatically recreated when replayed.
+        eventUtils.setRecordUndo(false);
+        this.setEnabled(legal);
+      } finally {
+        eventUtils.setRecordUndo(true);
+      }
     }
   },
   /**


### PR DESCRIPTION
There's no need to record and replay these events since the change will happen automatically anyway.

Resolves #7951