### PR TITLE
fix(build): Reintroduce shims for subpackage entrypoints

### DIFF
--- a/scripts/package/templates/node.template
+++ b/scripts/package/templates/node.template
@@ -1,5 +1,0 @@
-/* eslint-disable */
-(function (<%= param %>){
-<%= contents %>
-module.exports = <%= exports %>;
-})(<%= cjs %>);


### PR DESCRIPTION
## The basics

- [X] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

### Proposed Changes

Reintroduce  shims (`dist/core.js`, `dist/blocks.js`, `dist/javascript.js`, etc.) for submodule entrypoints in top level of package.  Have them created by `package_tasks.js` directly, rather than being copied from `scripts/package/`.

Assumptions:

- Such bundlers will _completely_ ignore the exports declaration.
- The bundles are intended to be used in a browser—or at least not in node.js—so the core entrypoint never needs to route to `core-node.js`.  This is reasonable since there's little reason to bundle code for node.js, and node.js has supported the exports clause since at least v12, considerably older than any version of node.js we officially support.
- It suffices to provide only a CJS entrypoint (because we can only provide CJS or ESM, not both.  (We could in future switch to providing only an ESM entrypoint instead, though.)

### Reason for Changes

The v11 beta breaks builds for external developers using browserify.

This change should solve issues encountered by users of bundlers that don't support `exports` at all (e.g. [browserify](https://browserify.org/)) as well as ones that don't support it in certain circumstances (e.g., when using webpack's [`resolve.alias] configuration option](https://webpack.js.org/configuration/resolve/#resolvealias) to alias 'blockly' to 'node_modules/blockly', as we formerly did in most plugins, which causes webpack to ignore blockly's `package.json` entirely).

### Documentation

We should mention in next beta release notes that even bundlers that do not support `exports` should continue to work.

### Additional Information

This is in effect a partial rollback of PR #7822.
