### PR TITLE
feat: add block factory export in json

### DIFF
--- a/demos/blockfactory/app_controller.js
+++ b/demos/blockfactory/app_controller.js
@@ -126,6 +126,16 @@ AppController.prototype.exportBlockLibraryToFile = function() {
   }
 };
 
+AppController.prototype.exportBlockLibraryAsJson = function() {
+  const blockJson = this.blockLibraryController.getBlockLibraryAsJson();
+  if (blockJson.length === 0) {
+    alert('No blocks in library to export');
+    return;
+  }
+  const filename = 'legacy_block_factory_export.txt';
+  FactoryUtils.createAndDownloadFile(JSON.stringify(blockJson), filename, 'plain');
+};
+
 /**
  * Converts an object mapping block type to XML to text file for output.
  * @param {!Object} blockXmlMap Object mapping block type to XML.
@@ -490,6 +500,10 @@ AppController.prototype.assignBlockFactoryClickHandlers = function() {
       .addEventListener('click', function() {
         self.exportBlockLibraryToFile();
       });
+
+  document.getElementById('exportAsJson').addEventListener('click', function() {
+    self.exportBlockLibraryAsJson();
+  });
 
   document.getElementById('helpButton').addEventListener('click',
       function() {

--- a/demos/blockfactory/block_library_controller.js
+++ b/demos/blockfactory/block_library_controller.js
@@ -174,6 +174,29 @@ BlockLibraryController.prototype.getBlockLibrary = function() {
 };
 
 /**
+ * @return {Object[]} Array of JSON data, where each item is the data for one block type.
+ */
+BlockLibraryController.prototype.getBlockLibraryAsJson = function() {
+  const xmlBlocks = this.storage.getBlockXmlMap(this.storage.getBlockTypes());
+  const jsonBlocks = [];
+  const headlessWorkspace = new Blockly.Workspace();
+
+  for (const blockName in xmlBlocks) {
+    // Load the block XML into a workspace so we can save it as JSON
+    headlessWorkspace.clear();
+    const blockXml = xmlBlocks[blockName];
+    Blockly.Xml.domToWorkspace(blockXml, headlessWorkspace);
+    const block = headlessWorkspace.getBlocksByType('factory_base', false)[0];
+
+    if (!block) continue;
+
+    const json = Blockly.serialization.blocks.save(block, {addCoordinates: false, saveIds: false});
+    jsonBlocks.push(json);
+  }
+  return jsonBlocks;
+}
+
+/**
  * Return stored XML of a given block type.
  * @param {string} blockType The type of block.
  * @return {!Element} XML element of a given block type or null.

--- a/demos/blockfactory/index.html
+++ b/demos/blockfactory/index.html
@@ -339,6 +339,9 @@
               <button id="localSaveButton" title="Save block library XML to a local file.">
                 <span>Download Block Library</span>
               </button>
+              <button id="exportAsJson" title="Export block library for import into the new Block Factory.">
+                <span>Export Block Library</span>
+              </button>
             </td>
           </tr>
         </table>


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Needed for https://github.com/google/blockly-samples/issues/2291

### Proposed Changes

Adds an "Export Block Library" button that downloads the block factory blocks in JSON format.

### Reason for Changes

- This is needed to support uploading blocks to the new tool.
- Unfortunately I had to add a new button because using XML won't work. The block definitions used in this tool are not directly compatible with the ones in the new tool. Adjusting the JSON by hand to make them load-able in the new tool is 1000% easier than adjusting the XML by hand.
- I will add documentation explaining how to get blocks from one tool into the other.
- See also https://github.com/google/blockly-samples/pull/2336 for how this file is used

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->

### Documentation

Coming soon!

### Additional Information

<!-- Anything else we should know? -->
