### PR TITLE
feat: export FieldProto

### DIFF
--- a/core/blockly.ts
+++ b/core/blockly.ts
@@ -47,6 +47,7 @@ import * as Extensions from './extensions.js';
 import {
   Field,
   FieldConfig,
+  FieldProto,
   FieldValidator,
   UnattachedFieldError,
 } from './field.js';
@@ -518,7 +519,7 @@ export {Cursor};
 export {DeleteArea};
 export {DragTarget};
 export const DropDownDiv = dropDownDiv;
-export {Field, FieldConfig, FieldValidator, UnattachedFieldError};
+export {Field, FieldConfig, FieldProto, FieldValidator, UnattachedFieldError};
 export {
   FieldAngle,
   FieldAngleConfig,

--- a/core/field.ts
+++ b/core/field.ts
@@ -1431,8 +1431,6 @@ export interface FieldConfig {
 /**
  * For use by Field and descendants of Field. Constructors can change
  * in descendants, though they should contain all of Field's prototype methods.
- *
- * @internal
  */
 export type FieldProto = Pick<typeof Field, 'prototype'>;
 


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes unexported type

### Proposed Changes

Exports the `FieldProto` type and removes the `@internal` annotation.

### Reason for Changes

`FieldProto` is used in places where you need to reference a type that refers to a field or any subclass of `Field`. Since constructors in field subclasses do not all have the same signature, `typeof Field` is not sufficient as it does not satisfy the TS compiler.

When we added this type, we decided not to export it unless we found that external developers needed it. Code.org is using TypeScript and they have a couple places where they need to refer to "a field or any subclass" so they're currently using this by deep importing the type from `blockly/core/field.js` but that has never been supported and will throw an error if building with webpack in v11.

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->

### Documentation

This will automatically be added to the reference docs since I removed the `@internal` annotation.

### Additional Information

<!-- Anything else we should know? -->
