### PR TITLE
fix: prevent duplication of comment icon bubbles

### DIFF
--- a/core/icons/comment_icon.ts
+++ b/core/icons/comment_icon.ts
@@ -264,14 +264,17 @@ export class CommentIcon extends Icon implements IHasBubble, ISerializable {
   }
 
   async setBubbleVisible(visible: boolean): Promise<void> {
-    if (visible && (this.textBubble || this.textInputBubble)) return;
-    if (!visible && !(this.textBubble || this.textInputBubble)) return;
-
+    if (this.bubbleVisiblity === visible) return;
     this.bubbleVisiblity = visible;
 
-    if (!this.sourceBlock.rendered || this.sourceBlock.isInFlyout) return;
-
     await renderManagement.finishQueuedRenders();
+
+    if (
+      !this.sourceBlock.rendered ||
+      this.sourceBlock.isInFlyout ||
+      this.sourceBlock.isInsertionMarker()
+    )
+      return;
 
     if (visible) {
       if (this.sourceBlock.isEditable()) {


### PR DESCRIPTION
Discussed this fix offline with @BeksOmega.

Fixes two related issues: 
* Comment bubbles were being duplicated when a workspace is loaded with a comment that is already expanded
* Comment bubbles were being created and orphaned whenever insertion markers were being created by the InsertionMarkerPreviewer
