### PR TITLE
fix: improve types in FieldRegistry

### DIFF
--- a/core/field.ts
+++ b/core/field.ts
@@ -1419,6 +1419,19 @@ export abstract class Field<T = any>
       workspace.getMarker(MarkerManager.LOCAL_MARKER)!.draw();
     }
   }
+
+  /**
+   * Subclasses should reimplement this method to construct their Field
+   * subclass from a JSON arg object.
+   *
+   * It is an error to attempt to register a field subclass in the
+   * FieldRegistry if that subclass has not overridden this method.
+   */
+  static fromJson(_options: FieldConfig): Field {
+    throw new Error(
+      `Attempted to instantiate a field from the registry that hasn't defined a 'fromJson' method.`,
+    );
+  }
 }
 
 /**
@@ -1429,12 +1442,14 @@ export interface FieldConfig {
 }
 
 /**
- * For use by Field and descendants of Field. Constructors can change
+ * Represents an object that has all the prototype properties of the `Field`
+ * class. This is necessary because constructors can change
  * in descendants, though they should contain all of Field's prototype methods.
  *
- * @internal
+ * This type should only be used in places where we directly access the prototype
+ * of a Field class or subclass.
  */
-export type FieldProto = Pick<typeof Field, 'prototype'>;
+type FieldProto = Pick<typeof Field, 'prototype'>;
 
 /**
  * Represents an error where the field is trying to access its block or

--- a/core/field.ts
+++ b/core/field.ts
@@ -1426,6 +1426,9 @@ export abstract class Field<T = any>
    *
    * It is an error to attempt to register a field subclass in the
    * FieldRegistry if that subclass has not overridden this method.
+   *
+   * @param _options JSON configuration object with properties needed
+   *    to configure a specific field.
    */
   static fromJson(_options: FieldConfig): Field {
     throw new Error(

--- a/core/field_angle.ts
+++ b/core/field_angle.ts
@@ -516,7 +516,7 @@ export class FieldAngle extends FieldInput<number> {
    * @nocollapse
    * @internal
    */
-  static fromJson(options: FieldAngleFromJsonConfig): FieldAngle {
+  static override fromJson(options: FieldAngleFromJsonConfig): FieldAngle {
     // `this` might be a subclass of FieldAngle if that class doesn't override
     // the static fromJson method.
     return new this(options.angle, undefined, options);

--- a/core/field_checkbox.ts
+++ b/core/field_checkbox.ts
@@ -226,7 +226,9 @@ export class FieldCheckbox extends Field<CheckboxBool> {
    * @nocollapse
    * @internal
    */
-  static fromJson(options: FieldCheckboxFromJsonConfig): FieldCheckbox {
+  static override fromJson(
+    options: FieldCheckboxFromJsonConfig,
+  ): FieldCheckbox {
     // `this` might be a subclass of FieldCheckbox if that class doesn't
     // 'override' the static fromJson method.
     return new this(options.checked, undefined, options);

--- a/core/field_colour.ts
+++ b/core/field_colour.ts
@@ -641,7 +641,7 @@ export class FieldColour extends Field<string> {
    * @nocollapse
    * @internal
    */
-  static fromJson(options: FieldColourFromJsonConfig): FieldColour {
+  static override fromJson(options: FieldColourFromJsonConfig): FieldColour {
     // `this` might be a subclass of FieldColour if that class doesn't override
     // the static fromJson method.
     return new this(options.colour, undefined, options);

--- a/core/field_dropdown.ts
+++ b/core/field_dropdown.ts
@@ -647,7 +647,9 @@ export class FieldDropdown extends Field<string> {
    * @nocollapse
    * @internal
    */
-  static fromJson(options: FieldDropdownFromJsonConfig): FieldDropdown {
+  static override fromJson(
+    options: FieldDropdownFromJsonConfig,
+  ): FieldDropdown {
     if (!options.options) {
       throw new Error(
         'options are required for the dropdown field. The ' +

--- a/core/field_image.ts
+++ b/core/field_image.ts
@@ -250,7 +250,7 @@ export class FieldImage extends Field<string> {
    * @nocollapse
    * @internal
    */
-  static fromJson(options: FieldImageFromJsonConfig): FieldImage {
+  static override fromJson(options: FieldImageFromJsonConfig): FieldImage {
     if (!options.src || !options.width || !options.height) {
       throw new Error(
         'src, width, and height values for an image field are' +

--- a/core/field_label.ts
+++ b/core/field_label.ts
@@ -117,7 +117,7 @@ export class FieldLabel extends Field<string> {
    * @nocollapse
    * @internal
    */
-  static fromJson(options: FieldLabelFromJsonConfig): FieldLabel {
+  static override fromJson(options: FieldLabelFromJsonConfig): FieldLabel {
     const text = parsing.replaceMessageReferences(options.text);
     // `this` might be a subclass of FieldLabel if that class doesn't override
     // the static fromJson method.

--- a/core/field_number.ts
+++ b/core/field_number.ts
@@ -315,7 +315,7 @@ export class FieldNumber extends FieldInput<number> {
    * @nocollapse
    * @internal
    */
-  static fromJson(options: FieldNumberFromJsonConfig): FieldNumber {
+  static override fromJson(options: FieldNumberFromJsonConfig): FieldNumber {
     // `this` might be a subclass of FieldNumber if that class doesn't override
     // the static fromJson method.
     return new this(

--- a/core/field_textinput.ts
+++ b/core/field_textinput.ts
@@ -73,7 +73,9 @@ export class FieldTextInput extends FieldInput<string> {
    * @nocollapse
    * @internal
    */
-  static fromJson(options: FieldTextInputFromJsonConfig): FieldTextInput {
+  static override fromJson(
+    options: FieldTextInputFromJsonConfig,
+  ): FieldTextInput {
     const text = parsing.replaceMessageReferences(options.text);
     // `this` might be a subclass of FieldTextInput if that class doesn't
     // override the static fromJson method.

--- a/tests/mocha/field_registry_test.js
+++ b/tests/mocha/field_registry_test.js
@@ -42,12 +42,10 @@ suite('Field Registry', function () {
       }, 'Invalid name');
     });
     test('No fromJson', function () {
-      const fromJson = CustomFieldType.fromJson;
-      delete CustomFieldType.fromJson;
+      class IncorrectField {}
       chai.assert.throws(function () {
-        Blockly.fieldRegistry.register('field_custom_test', CustomFieldType);
+        Blockly.fieldRegistry.register('field_custom_test', IncorrectField);
       }, 'must have a fromJson function');
-      CustomFieldType.fromJson = fromJson;
     });
     test('fromJson not a function', function () {
       const fromJson = CustomFieldType.fromJson;
@@ -96,6 +94,22 @@ suite('Field Registry', function () {
 
       chai.assert.isNotNull(field);
       chai.assert.equal(field.getValue(), 'ok');
+    });
+    test('Did not override fromJson', function () {
+      // This class will have a fromJson method, so it can be registered
+      // but it doesn't override the abstract class's method so it throws
+      class IncorrectField extends Blockly.Field {}
+
+      Blockly.fieldRegistry.register('field_custom_test', IncorrectField);
+
+      const json = {
+        type: 'field_custom_test',
+        value: 'ok',
+      };
+
+      chai.assert.throws(function () {
+        Blockly.fieldRegistry.fromJson(json);
+      }, 'Attempted to instantiate a field from the registry');
     });
   });
 });


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #8059, to the extent that we're going to fix it anyway

### Proposed Changes

- Creates & exports a new `RegistrableField` interface that represents a constructor for a Field class or subclass, and requires that constructed class also have a static `fromJson` method.
    - This type will be available as `Blockly.fieldRegistry.RegistrableField`.
    - This is exported because it is used as a parameter to the `register` function. Any functions in the public API should use and return accessible types, for the benefit of developers using TS. This solves the original issue reported by code.org.
    - See [these docs](https://www.typescriptlang.org/docs/handbook/interfaces.html#difference-between-the-static-and-instance-sides-of-classes) for more information about this type
- Adjusted `RegistryOptions` type a bit.
    - Adds more comments to the RegistryOptions type. tbh this type is weird and needed more explanation.
    - Made the type actually be compatible with the type required by the field's `fromJson` method, because we are just passing this object directly into that function.
-  Stopped exporting the `FieldProto` type from `field.js`
    - because we're only using it in that file now
    - We were never exporting this from the top level of blockly, so this doesn't change the public API
    - Added additional comments to explain what this is for so it doesn't get misused again. 
- Added static `fromJson` to the base `Field` class
    - It doesn't return anything, it just throws an error if the method is called and was never overridden by a child class.
    - The method has to exist on any field that is registered so this gives us more accurate types then
    - This isn't a breaking change because either a custom field doesn't use the registry, in which case they'll never see the error, or it does use the registry and therefore already implements `fromJson` 
- Adjusted the casts in the `fromJson` method of FieldRegistry.
    - Unfortunately casts are still required, as explained below. But I think this one is better.
    - Also removed the error that references an interface that doesn't exist.  


### Reason for Changes
Explained inline above.

### Test Coverage

Added/fixed as necessary

### Documentation

No

### Additional Information

The types in the registry are still pretty wrong. The registry claims that what we'll get back from the `getObject` function is a `Field`. Unfortunately that's not correct. We'll get back a `Field` constructor, which as discussed in the [docs also linked above](https://www.typescriptlang.org/docs/handbook/interfaces.html#difference-between-the-static-and-instance-sides-of-classes), needs to be typed differently if we're actually referencing the constructor as a type.

The thing we get back from the `getObject` method should be a field constructor and it should have a `fromJson` method. This is the same exact type as what we pass into `register`, which makes sense. So we cast to that same type. Ideally the registry's generic types would have used these constructor interfaces instead of lying and saying they return `Field` instances. But fixing that is a bigger deal and would need to be fixed for other constructable objects, not just fields.

Also, the types of the `fromJson` method are also a bit sad, which is why the `RegistryOptions` type has to allow unknown keys. Each subclass of `Field` has its own `fromJson` method and this method takes its own `FooConfigOptions` type as a parameter, because each field has different things that need to be configured from json. If the `Field` class had the type of its `fromJson` method as a parameterized generic type, that would allow us to say "hey whatever Field subclass we're working with, it should call `fromJson` with its own `FieldConfig` type." Since we haven't done that, we can't type check the object passed to `fromJson` in the registry.

And, the `RegistryOptions` is a bit weird too. Your field's `fromJson` method better not expect a `type` property in the options object. Because we call the registry's `fromJson` method with only one parameter (which *should* have a `type` property) and then pass that same parameter directly into the field's `fromJson` method. That's a bit weird. I think ideally the field registry's `fromJson` method should have had `type` as a separate parameter, so that we aren't mixing in additional properties into the actual Field's config. But too late for that now.
