### PR TITLE
fix!: add getContents to IFlyout

### DIFF
--- a/core/flyout_base.ts
+++ b/core/flyout_base.ts
@@ -566,16 +566,7 @@ export abstract class Flyout
    * @param contents - The array of items for the flyout.
    */
   setContents(contents: FlyoutItem[]): void {
-    const blocksAndButtons = contents.map((item) => {
-      if (item.type === 'block' && item.block) {
-        return item.block as BlockSvg;
-      }
-      if (item.type === 'button' && item.button) {
-        return item.button as FlyoutButton;
-      }
-    });
-
-    this.contents = blocksAndButtons as FlyoutItem[];
+    this.contents = contents;
   }
   /**
    * Update the display property of the flyout based whether it thinks it should

--- a/core/interfaces/i_flyout.ts
+++ b/core/interfaces/i_flyout.ts
@@ -12,6 +12,7 @@ import type {Coordinate} from '../utils/coordinate.js';
 import type {FlyoutDefinition} from '../utils/toolbox.js';
 import type {Svg} from '../utils/svg.js';
 import type {IRegistrable} from './i_registrable.js';
+import {FlyoutItem} from '../flyout_base.js';
 
 /**
  * Interface for a flyout.
@@ -116,6 +117,16 @@ export interface IFlyout extends IRegistrable {
    *     of the dynamic category.
    */
   show(flyoutDef: FlyoutDefinition | string): void;
+
+  /**
+   * Returns the list of flyout items currently present in the flyout.
+   * The `show` method parses the flyout definition into a list of actual
+   * flyout items. This method should return those concrete items, which
+   * may be used for e.g. keyboard navigation.
+   *
+   * @returns List of flyout items.
+   */
+  getContents(): FlyoutItem[];
 
   /**
    * Create a copy of this block on the workspace.


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #8063 

### Proposed Changes

- Adds `getContents` method to the `IFlyout` interface (breaking change)
- Removes casts for `Flyout` and `FlyoutItem[]`
- Adjusts the `getContents` method in `flyout_base` to return an actual `FlyoutItem[]` instead of saying it does that, but is actually `Array<Block | FlyoutItem>` (note that this method exists in develop but hasn't been released yet so this isn't the breaking change)

### Reason for Changes

- In Blockly v10, flyouts never store a list of their contents. Whenever `show` is called, the flyout definition is passed to the method, that definition is parsed, and the blocks, buttons, and gaps are laid out in the flyout. The actual blocks and buttons created are never stored anywhere.
- For keyboard navigation to be able to navigate flyouts including buttons, we need to know what is currently in the flyout. Simply inspecting the workspace is not enough, as buttons are not a first class object stored on the workspace like blocks are. You can't get a list of buttons on the workspace. Therefore, we need to store what is currently being shown in the flyout.
- This was initially implemented in #7852. Initially, the `getContents` method was only added to the abstract `Flyout` class, and not the `IFlyout` interface. However, custom flyouts are only required to implement the `IFlyout` interface and are not required to extend our base class.
- Also, in this PR, the `getContents` method was typed as returning an array of `FlyoutItem`s, but it didn't actually return those, and used casts to fake it, both when setting the contents and using them. The reason I'm fixing this by actually using `FlyoutItem` instead of just changing the type is because using `FlyoutItem` is more future-compatible. If we ever extend the flyout definition to include a third type of object that might be keyboard-navigable, we won't need to change the type or implementation of `getContents` (just the implementation of `ASTNode` to handle the new item).

### Test Coverage

I haven't been able to link this to samples to test keyboard navigation, but I'll try that again before submitting this PR.

### Documentation

N/A, we don't document how to create a custom flyout at this time.

## Breaking changes / To fix

- `getContents` is now required to be implemented in the `IFlyout` interface. This is important to support our goal of improving accessibility in Blockly.
- If you do not use a custom flyout, you do not need to take any action.
- If you use a custom flyout that extends `Blockly.Flyout`, `Blockly.HorizontalFlyout`, `Blockly.VerticalFlyout`, or the `ContinuousFlyout` from the continuous-toolbox plugin, you may not need to take any action. The `getContents` method has been implemented in the abstract base class.
    - If your subclass overrides the `show` method, ensure that it sets the `contents` property of the flyout as the base class implementation does. 
- If you use a custom flyout that implements the `IFlyout` interface and does not extend the abstract `Flyout` class, you will need to add an implementation for `getContents` to your flyout. This method should return a list of all `FlyoutItem`s (at this time, that includes `Block`s and `FlyoutButton`s) that are present in the current flyout. 
