### PR TITLE
refactor: split out block serialization for creating new blocks from the flyout

### DIFF
--- a/core/flyout_base.ts
+++ b/core/flyout_base.ts
@@ -1301,14 +1301,18 @@ export abstract class Flyout
     }
 
     // Clone the block.
-    const json = blocks.save(oldBlock) as blocks.State;
-    // Normallly this resizes leading to weird jumps. Save it for terminateDrag.
+    const json = this.serializeBlock(oldBlock);
+    // Normally this resizes leading to weird jumps. Save it for terminateDrag.
     targetWorkspace.setResizesEnabled(false);
     const block = blocks.append(json, targetWorkspace) as BlockSvg;
 
     this.positionNewBlock(oldBlock, block);
 
     return block;
+  }
+  
+  protected serializeBlock(block: BlockSvg): blocks.State {
+    return blocks.save(block) as blocks.State;
   }
 
   /**

--- a/core/flyout_base.ts
+++ b/core/flyout_base.ts
@@ -1311,6 +1311,11 @@ export abstract class Flyout
     return block;
   }
   
+  /**
+   * Serialize a block to JSON.
+   * @param block The block to serialize.
+   * @returns A serialized representation of the block.
+   */
   protected serializeBlock(block: BlockSvg): blocks.State {
     return blocks.save(block) as blocks.State;
   }

--- a/core/flyout_base.ts
+++ b/core/flyout_base.ts
@@ -1310,9 +1310,10 @@ export abstract class Flyout
 
     return block;
   }
-  
+
   /**
    * Serialize a block to JSON.
+   *
    * @param block The block to serialize.
    * @returns A serialized representation of the block.
    */


### PR DESCRIPTION
This PR adds a method for serializing a block to the flyout, which is used during the block dragging/creation process. This will allow subclasses to override it to customize the block that gets created on the target workspace.

This is needed by scratch-blocks to ensure that newly created blocks have different IDs from their source blocks in the flyout, to allow uniquely identifying blocks.