### PR TITLE
fix: Move right-clicking to 'contextmenu' event

### DIFF
--- a/core/block_svg.ts
+++ b/core/block_svg.ts
@@ -219,7 +219,13 @@ export class BlockSvg
         svg,
         'pointerdown',
         this,
-        this.onMouseDown_,
+        this.onPointerdown_,
+      );
+      browserEvents.conditionalBind(
+        svg,
+        'contextmenu',
+        this,
+        this.onContextmenu_,
       );
     }
     this.eventsInit_ = true;
@@ -603,10 +609,23 @@ export class BlockSvg
    *
    * @param e Pointer down event.
    */
-  private onMouseDown_(e: PointerEvent) {
+  private onPointerdown_(e: PointerEvent) {
     const gesture = this.workspace.getGesture(e);
     if (gesture) {
       gesture.handleBlockStart(e, this);
+    }
+  }
+
+  /**
+   * Handle a contextMenu on an SVG block.
+   *
+   * @param e Pointer contextmenu event.
+   */
+  private onContextmenu_(e: PointerEvent) {
+    const gesture = this.workspace.getGesture(e);
+    if (gesture) {
+      gesture.handleBlockStart(e, this);
+      gesture.handleRightClick(e);
     }
   }
 

--- a/core/gesture.ts
+++ b/core/gesture.ts
@@ -492,7 +492,7 @@ export class Gesture {
     }
 
     if (browserEvents.isRightButton(e)) {
-      this.handleRightClick(e);
+      e.stopPropagation();
       return;
     }
 

--- a/core/workspace_svg.ts
+++ b/core/workspace_svg.ts
@@ -794,7 +794,7 @@ export class WorkspaceSvg extends Workspace implements IASTNodeLocationSvg {
         this.svgGroup_,
         'contextmenu',
         this,
-        this.onContextmenu_
+        this.onContextmenu_,
       );
       // This no-op works around https://bugs.webkit.org/show_bug.cgi?id=226683,
       // which otherwise prevents zoom/scroll events from being observed in
@@ -2505,7 +2505,7 @@ export class WorkspaceSvg extends Workspace implements IASTNodeLocationSvg {
       this.clearGesture();
       gesture = null;
     }
-    const isStart = (e.type === 'pointerdown' || e.type === 'contextmenu');
+    const isStart = e.type === 'pointerdown' || e.type === 'contextmenu';
     if (gesture) {
       if (isStart && gesture.hasStarted()) {
         console.warn('Tried to start the same gesture twice.');


### PR DESCRIPTION
Resolves #7979

Events are not consistent between platforms.  This needs testing on every platform we can get our hands on.

To do (takes about 20 seconds per browser):
* Right-click on the workspace, expect workspace context menu.
* Right-click on a block, expect block context menu (make sure it's not the workspace context menu).
* Repeat both the above with any alternative right-click gestures for your platform (on the Mac it is CTRL-click).
* Verify that left-click and drag works as expected on blocks and workspace.

- [x] Firefox Mac
- [x] Safari Mac
- [x] Chrome Mac
- [x] Opera Mac

- [x] Firefox Windows
- [x] Chrome Windows
- [x] Edge Windows

- [ ] Firefox Linux
- [ ] Chrome Linux

- [x] Mobile Android
- [ ] Mobile iOS

- [x] ChromeOS

Add any other browsers you have.

