### PR TITLE
feat(build)!: Introduce ESM entrypoints

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,6 +99,7 @@
     },
     "./msg/*": {
       "types": "./msg/*.d.ts",
+      "import": "./msg/*.mjs",
       "default": "./msg/*.js"
     }
   },

--- a/package.json
+++ b/package.json
@@ -63,30 +63,37 @@
     "./core": {
       "types": "./core.d.ts",
       "node": "./core-node.js",
+      "import": "./blockly.mjs",
       "default": "./blockly_compressed.js"
     },
     "./blocks": {
       "types": "./blocks.d.ts",
+      "import": "./blocks.mjs",
       "default": "./blocks_compressed.js"
     },
     "./dart": {
       "types": "./dart.d.ts",
+      "import": "./dart.mjs",
       "default": "./dart_compressed.js"
     },
     "./lua": {
       "types": "./lua.d.ts",
+      "import": "./lua.mjs",
       "default": "./lua_compressed.js"
     },
     "./javascript": {
       "types": "./javascript.d.ts",
+      "import": "./javascript.mjs",
       "default": "./javascript_compressed.js"
     },
     "./php": {
       "types": "./php.d.ts",
+      "import": "./php.mjs",
       "default": "./php_compressed.js"
     },
     "./python": {
       "types": "./python.d.ts",
+      "import": "./python.mjs",
       "default": "./python_compressed.js"
     },
     "./msg/*": {

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
   "exports": {
     ".": {
       "types": "./index.d.ts",
+      "import": "./index.mjs",
       "umd": "./blockly.min.js",
       "default": "./index.js"
     },

--- a/scripts/gulpfiles/build_tasks.js
+++ b/scripts/gulpfiles/build_tasks.js
@@ -600,6 +600,17 @@ ${exportedNames.map((name) => `  ${name},`).join('\n')}
 } = ${importName};
 `);
 
+    // For first chunk, write an additional ESM wrapper for 'blockly'
+    // entrypoint since it has the same exports as 'blockly/core'.
+    if (chunk.name === 'blockly') {
+      await fsPromises.writeFile(path.join(RELEASE_DIR, `index.mjs`),
+          `import Blockly from './index.js';
+export const {
+${exportedNames.map((name) => `  ${name},`).join('\n')}
+} = Blockly;
+`);
+    }
+
     // Write a loading shim that uses loadChunk to either import the
     // chunk's entrypoint (e.g. build/src/core/blockly.js) or load the
     // compressed chunk (e.g. dist/blockly_compressed.js) as a script.

--- a/typings/msg/yue.d.ts
+++ b/typings/msg/yue.d.ts
@@ -1,8 +1,0 @@
-/**
- * @license
- * Copyright 2022 Google LLC
- * SPDX-License-Identifier: Apache-2.0
- */
-
-export * from './msg';
-


### PR DESCRIPTION
## The basics

- [X] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

Work towards #7449

### Proposed Changes

Introduce an `import` conditional export for each of the entrypoints (`blockly`, `blockly/core`, `blockly/blocks`, `blockly/javascript`, etc., `blockly/msg/en`, `blockly/msg/fr`, etc.), and point these at wrappers created by `build_tasks.js`
that import the corresponding `index.js` / `<chunk>_compressed.js` / `msg/<lang>.js` CJS module and `export` its named exports.

### Reason for Changes

Providing ESM entrypoints, even ones that are just wrappers of the existing CJS entrypoints, is the first step towards publishing Blockly as a pure-ESM package.

### Test Coverage

* Verified that `npm test` runs successfully.
* Verified that `import * as … from 'blockly/…'` works correctly and as expected when run in node.js.
* Verified that `npm test` runs successfully in blockly-samples `rc/v11.0.0` branch, when linked against Blockly from this branch.

No changes to manual test procedures expected.

### Documentation

* Release notes should contain the breaking change notice below.
* We need to check our published documentation and code samples for any incorrect `import`s.  (The blockly-samples repository has already been checked and fixed in the `rc/v11.0.0` branch.)

### Additional Information

The ESM entrypoints provided by this PR are unfortunately still not directly `import`able by browsers, hence not being a complete fix for #7449.  This is due to them directly `import`ing the CJS (actually UMD) modules, which is supported by node.js and most build tooling but not by browsers, which do not natively support CJS.  It may be possible to fix this in a future commit by providing a `require` polyfill, but doing this in a way that is compatible with build tooling and does not re-introduce the [dual package hazard](https://nodejs.org/api/packages.html#dual-package-hazard) is not straightforward.

**BREAKING CHANGE:**

Importing Blockly via

    import Blockly from 'blockly';

(and similarly for the other entrypoints) has worked until now because most build tools (including webpack in particular)
fulfil the request for the default export of a CJS module by providing the `module.exports` object, rather than an explicitly-named `default` export as they would for an ES module.

Since `core/blockly.ts` (the notional entrypoint for `blockly/core`) and the other chunk entrypoints do not provide a `default` export, the wrappers created by this PR do not either.

Code of the above form will therefore break, and should be updated to use a wildcard:

    import * as Blockly from 'blockly';
