### PR TITLE
chore(build): Set `"type": "commonjs"` in `dist/package.json`

### DIFF
--- a/scripts/gulpfiles/package_tasks.js
+++ b/scripts/gulpfiles/package_tasks.js
@@ -178,6 +178,12 @@ function packageJSON(done) {
   const json = JSON.parse(JSON.stringify(getPackageJson()));
   // Remove unwanted entries.
   delete json['scripts'];
+  // Set "type": "commonjs", since that's what .js files in the
+  // package root are.  This should be a no-op since that's the
+  // default, but by setting it explicitly we ensure that any chage to
+  // the repository top-level package.json to set "type": "module"
+  // won't break the published package accidentally.
+  json.type = 'commonjs';
   // Write resulting package.json file to release directory.
   if (!fs.existsSync(RELEASE_DIR)) {
     fs.mkdirSync(RELEASE_DIR, {recursive: true});


### PR DESCRIPTION
## The basics

- [X] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Proposed Changes

Set `"type": "commonjs"` in the generated `dist/package.json` file, since the `.js` files in the package root are CJS.  This should be a no-op since that's the default, but by setting it explicitly we ensure that any change to the repository top-level package.json to set "type": "module" won't break the published package accidentally.

### Reason for Changes

As described this should be a no-op, but by publishing it now in v11 it will help discover any compatibility issues with 3rd party build tools that might change how the process the package when it is present.

### Test Coverage

* Passes `npm test`
* Passes `npm test` in blockly-samples when linked against a `dist/` build with this change.
* Passes manual test of importing and requiring blockly in node.js.

No changes to manual test procedures needed.