### PR TITLE
fix: Remove deprecation warnings for 'disabled'.

### DIFF
--- a/core/serialization/blocks.ts
+++ b/core/serialization/blocks.ts
@@ -523,12 +523,8 @@ function loadAttributes(block: Block, state: State) {
     block.setEditable(false);
   }
   if (state['enabled'] === false) {
-    deprecation.warn(
-      'enabled',
-      'v11',
-      'v12',
-      'disabledReasons with the value ["' + MANUALLY_DISABLED + '"]',
-    );
+    // Before May 2024 we just used 'enabled', with no reasons.
+    // Contiune to support this syntax.
     block.setDisabledReason(true, MANUALLY_DISABLED);
   }
   if (Array.isArray(state['disabledReasons'])) {

--- a/core/serialization/blocks.ts
+++ b/core/serialization/blocks.ts
@@ -10,7 +10,6 @@ import type {Block} from '../block.js';
 import type {BlockSvg} from '../block_svg.js';
 import type {Connection} from '../connection.js';
 import {MANUALLY_DISABLED} from '../constants.js';
-import * as deprecation from '../utils/deprecation.js';
 import * as eventUtils from '../events/utils.js';
 import {inputTypes} from '../inputs/input_types.js';
 import {isSerializable} from '../interfaces/i_serializable.js';

--- a/core/xml.ts
+++ b/core/xml.ts
@@ -1023,12 +1023,8 @@ function domToBlockHeadless(
   }
   const disabled = xmlBlock.getAttribute('disabled');
   if (disabled) {
-    deprecation.warn(
-      'disabled',
-      'v11',
-      'v12',
-      'disabled-reasons with the value "' + MANUALLY_DISABLED + '"',
-    );
+    // Before May 2024 we just used 'disabled', with no reasons.
+    // Contiune to support this syntax.
     block.setDisabledReason(
       disabled === 'true' || disabled === 'disabled',
       MANUALLY_DISABLED,

--- a/core/xml.ts
+++ b/core/xml.ts
@@ -10,7 +10,6 @@ import type {Block} from './block.js';
 import type {BlockSvg} from './block_svg.js';
 import type {Connection} from './connection.js';
 import {MANUALLY_DISABLED} from './constants.js';
-import * as deprecation from './utils/deprecation.js';
 import * as eventUtils from './events/utils.js';
 import type {Field} from './field.js';
 import {IconType} from './icons/icon_types.js';


### PR DESCRIPTION
We must continue to support existing XML and JSON serialization formats since they are in external databases.

The decision was taken not to make the save formats compatible with older versions of Blockly.  We could not think of a convincing use-case for a newer Blockly's output to be read by an older Blockly.  If such a case appears, then our decision should change.

Resolves #8095.