### PR TITLE
fix:  drag cursor being incorrect for flyout blocks

### DIFF
--- a/core/block_svg.ts
+++ b/core/block_svg.ts
@@ -208,7 +208,7 @@ export class BlockSvg
       icon.updateEditable();
     }
     this.applyColour();
-    this.pathObject.updateMovable(this.isMovable());
+    this.pathObject.updateMovable(this.isMovable() || this.isInFlyout);
     const svg = this.getSvgRoot();
     if (!this.workspace.options.readOnly && svg) {
       browserEvents.conditionalBind(


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #8102 

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
Makes it so that blocks in the flyout have the `blocklyDraggable` CSS class, even though they aren't actually draggable. The flyout detects a drag, duplicates the block, and then starts a drag on the new block.

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
Buggy fixing.

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->
Manually tested and all tests pass.

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->
N/A

### Additional Information

<!-- Anything else we should know? -->
I'm not 100% sure that we actually want blocks in the flyout to have the `blocklyDraggable` class since they are draggable but also kind of aren't. But we can deal with that in V12 with the CSS refactor.
