### PR TITLE
fix: connection db error for insertion markers

### DIFF
--- a/core/insertion_marker_previewer.ts
+++ b/core/insertion_marker_previewer.ts
@@ -154,6 +154,7 @@ export class InsertionMarkerPreviewer implements IConnectionPreviewer {
     };
     const originalOffsetInBlock = markerConn.getOffsetInBlock().clone();
     renderManagement.finishQueuedRenders().then(() => {
+      if (marker.isDeadOrDying()) return;
       eventUtils.disable();
       try {
         // Position so that the existing block doesn't move.


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes https://github.com/google/blockly/issues/8096

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
Returns early before positioning the insertion marker if the insertion marker is ded.

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
Deals with race condition where sometimes the insertion marker can be hidden before a queued positioning of it occurs, which causes an error.

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->
Neil said he'd test this for me since it's easier for him to reproduce the race condition!

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->
N/A

### Additional Information

<!-- Anything else we should know? -->
I don't think this is a race condition we can fix by being clever. I think this is just the cost of waiting for the browser to queue an animation frame before rendering.
