### PR TITLE
fix: throwing errors for chameleon blocks

### DIFF
--- a/core/insertion_marker_previewer.ts
+++ b/core/insertion_marker_previewer.ts
@@ -132,13 +132,11 @@ export class InsertionMarkerPreviewer implements IConnectionPreviewer {
   private previewMarker(
     draggedConn: RenderedConnection,
     staticConn: RenderedConnection,
-  ): RenderedConnection {
+  ): RenderedConnection | null {
     const dragged = draggedConn.getSourceBlock();
     const marker = this.createInsertionMarker(dragged);
     const markerConn = this.getMatchingConnection(dragged, marker, draggedConn);
-    if (!markerConn) {
-      throw Error('Could not create insertion marker to preview connection');
-    }
+    if (!markerConn) return null;
 
     // Render disconnected from everything else so that we have a valid
     // connection location.
@@ -211,7 +209,7 @@ export class InsertionMarkerPreviewer implements IConnectionPreviewer {
     orig: BlockSvg,
     marker: BlockSvg,
     origConn: RenderedConnection,
-  ) {
+  ): RenderedConnection | null {
     const origConns = orig.getConnections_(true);
     const markerConns = marker.getConnections_(true);
     if (origConns.length !== markerConns.length) return null;


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes https://github.com/google/blockly/issues/8119

### Proposed Changes + reasons

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
Removes error throwing when connection counts are mismatched. We now expect this to happen for some blocks (like chameleon blocks) so no reason to throw.

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->
Manually tested and errors are no longer thrown.

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->
N/A

### Additional Information

<!-- Anything else we should know? -->
Chameleon blocks are blocks that have an output and previous connection when they are disconnected, but when they connecto to a parent they lose the other connection so we don't get cycles.
