### PR TITLE
fix: JSON deserialization not firing variable create events for blocks

### DIFF
--- a/core/serialization/blocks.ts
+++ b/core/serialization/blocks.ts
@@ -29,6 +29,7 @@ import {
 } from './exceptions.js';
 import * as priorities from './priorities.js';
 import * as serializationRegistry from './registry.js';
+import * as Variables from '../../core/variables.js';
 
 // TODO(#5160): Remove this once lint is fixed.
 /* eslint-disable no-use-before-define */
@@ -417,6 +418,7 @@ export function appendInternal(
   }
   eventUtils.disable();
 
+  const variablesBeforeCreation = workspace.getAllVariables();
   let block;
   try {
     block = appendPrivate(state, workspace, {parentConnection, isShadow});
@@ -425,6 +427,19 @@ export function appendInternal(
   }
 
   if (eventUtils.isEnabled()) {
+    const newVariables = Variables.getAddedVariables(
+      workspace,
+      variablesBeforeCreation,
+    );
+    // Fire a VarCreate event for each (if any) new variable created.
+    for (let i = 0; i < newVariables.length; i++) {
+      const thisVariable = newVariables[i];
+      eventUtils.fire(
+        new (eventUtils.get(eventUtils.VAR_CREATE))(thisVariable),
+      );
+    }
+    // Block events come after var events, in case they refer to newly created
+    // variables.
     eventUtils.fire(new (eventUtils.get(eventUtils.BLOCK_CREATE))(block));
   }
   eventUtils.setGroup(existingGroup);


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x ] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes https://github.com/google/blockly/issues/7599

### Proposed Changes

Add code to fire VAR_CREATE event when a JSON is serialized and new variables are created while creating a block.
<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->

### Reason for Changes

Fixes the bug of variable create event not being fired, even though a variable is created when a block is created through JSON serialization.
<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage

Manually tested that the VAR_CREATE event fires when a variable is created during JSON serialization.

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->

### Documentation

N/A

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

N/A

<!-- Anything else we should know? -->
