### PR TITLE
fix: paste in a better spot

### DIFF
--- a/core/clipboard/block_paster.ts
+++ b/core/clipboard/block_paster.ts
@@ -72,6 +72,10 @@ export class BlockPaster implements IPaster<BlockCopyData, BlockSvg> {
 export function moveBlockToNotConflict(block: BlockSvg, coord: Coordinate) {
   const workspace = block.workspace;
   const snapRadius = config.snapRadius;
+  const bumpOffset = Coordinate.difference(
+    coord,
+    block.getRelativeToSurfaceXY(),
+  );
   const offset = new Coordinate(0, 0);
   // getRelativeToSurfaceXY is really expensive, so we want to cache this.
   const otherCoords = workspace
@@ -81,7 +85,7 @@ export function moveBlockToNotConflict(block: BlockSvg, coord: Coordinate) {
 
   while (
     blockOverlapsOtherExactly(Coordinate.sum(coord, offset), otherCoords) ||
-    blockIsInSnapRadius(block, offset, snapRadius)
+    blockIsInSnapRadius(block, Coordinate.sum(bumpOffset, offset), snapRadius)
   ) {
     if (workspace.RTL) {
       offset.translate(-snapRadius, snapRadius * 2);

--- a/core/clipboard/block_paster.ts
+++ b/core/clipboard/block_paster.ts
@@ -30,11 +30,21 @@ export class BlockPaster implements IPaster<BlockCopyData, BlockSvg> {
       copyData.blockState['y'] = coordinate.y;
     }
 
+    // After appending the block to the workspace, it will be bumped from its neighbors
+    // However, the algorithm for deciding where to paste a block depends on
+    // the starting position of the copied block, so we'll pass those coordinates along
+    const initialCoordinates =
+      coordinate ||
+      new Coordinate(
+        copyData.blockState['x'] || 0,
+        copyData.blockState['y'] || 0,
+      );
+
     eventUtils.disable();
     let block;
     try {
       block = append(copyData.blockState, workspace) as BlockSvg;
-      moveBlockToNotConflict(block);
+      moveBlockToNotConflict(block, initialCoordinates);
     } finally {
       eventUtils.enable();
     }
@@ -56,12 +66,12 @@ export class BlockPaster implements IPaster<BlockCopyData, BlockSvg> {
  * Exported for testing.
  *
  * @param block The block to move to an unambiguous location.
+ * @param coord The initial coordinate to start searching from.
  * @internal
  */
-export function moveBlockToNotConflict(block: BlockSvg) {
+export function moveBlockToNotConflict(block: BlockSvg, coord: Coordinate) {
   const workspace = block.workspace;
   const snapRadius = config.snapRadius;
-  const coord = block.getRelativeToSurfaceXY();
   const offset = new Coordinate(0, 0);
   // getRelativeToSurfaceXY is really expensive, so we want to cache this.
   const otherCoords = workspace

--- a/core/clipboard/block_paster.ts
+++ b/core/clipboard/block_paster.ts
@@ -66,14 +66,18 @@ export class BlockPaster implements IPaster<BlockCopyData, BlockSvg> {
  * Exported for testing.
  *
  * @param block The block to move to an unambiguous location.
- * @param coord The initial coordinate to start searching from.
+ * @param originalPosition The initial coordinate to start searching from,
+ *    likely the position of the copied block.
  * @internal
  */
-export function moveBlockToNotConflict(block: BlockSvg, coord: Coordinate) {
+export function moveBlockToNotConflict(
+  block: BlockSvg,
+  originalPosition: Coordinate,
+) {
   const workspace = block.workspace;
   const snapRadius = config.snapRadius;
   const bumpOffset = Coordinate.difference(
-    coord,
+    originalPosition,
     block.getRelativeToSurfaceXY(),
   );
   const offset = new Coordinate(0, 0);
@@ -84,7 +88,10 @@ export function moveBlockToNotConflict(block: BlockSvg, coord: Coordinate) {
     .map((b) => b.getRelativeToSurfaceXY());
 
   while (
-    blockOverlapsOtherExactly(Coordinate.sum(coord, offset), otherCoords) ||
+    blockOverlapsOtherExactly(
+      Coordinate.sum(originalPosition, offset),
+      otherCoords,
+    ) ||
     blockIsInSnapRadius(block, Coordinate.sum(bumpOffset, offset), snapRadius)
   ) {
     if (workspace.RTL) {
@@ -94,7 +101,7 @@ export function moveBlockToNotConflict(block: BlockSvg, coord: Coordinate) {
     }
   }
 
-  block!.moveTo(Coordinate.sum(coord, offset));
+  block!.moveTo(Coordinate.sum(originalPosition, offset));
 }
 
 /**


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #8099 ... sort of

### Proposed Changes

- Ignores the original `bumpNeighbors` that now happens when a block is deserialized from pasting.

### Reason for Changes

The original bad behavior was caused by https://github.com/google/blockly/pull/7748 (confirmed via git bisect) which changes when the bumpNeighbors logic triggers. However, this PR doesn't fully restore the old behavior. In particular, pasting a block that is the child of another block performs differently than before, and it's still somewhat easy to get blocks that substantially overlap each other instead of being pasted in a nice diagonal line. I don't know why this is the case. I think someone else should look into this but if we can't figure it out, this is at least an improvement over doing nothing.

### Test Coverage

![image](https://github.com/google/blockly/assets/8573958/cedca23e-3617-4014-8060-86ab3c3e31e4)


### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
