### PR TITLE
fix: workspace comment bounding box affecting RTL zoom

### DIFF
--- a/core/comments/rendered_workspace_comment.ts
+++ b/core/comments/rendered_workspace_comment.ts
@@ -124,7 +124,16 @@ export class RenderedWorkspaceComment
   getBoundingRectangle(): Rect {
     const loc = this.getRelativeToSurfaceXY();
     const size = this.getSize();
-    return new Rect(loc.y, loc.y + size.height, loc.x, loc.x + size.width);
+    let left;
+    let right;
+    if (this.workspace.RTL) {
+      left = loc.x - size.width;
+      right = loc.x;
+    } else {
+      left = loc.x;
+      right = loc.x + size.width;
+    }
+    return new Rect(loc.y, loc.y + size.height, left, right);
   }
 
   /** Move the comment by the given amounts in workspace coordinates. */


### PR DESCRIPTION
## The basics

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

Fixes #8117

### Proposed Changes

Return the appropriate bounding box if the workspace is in RTL or not

### Reason for Changes

Fixing bug

### Test Coverage

Tested in playground

### Additional Information
