### PR TITLE
fix: undoing block delete over trashcan creates block in wrong place

### DIFF
--- a/core/dragging/dragger.ts
+++ b/core/dragging/dragger.ts
@@ -13,6 +13,7 @@ import {WorkspaceSvg} from '../workspace_svg.js';
 import {ComponentManager} from '../component_manager.js';
 import {IDeleteArea} from '../interfaces/i_delete_area.js';
 import * as registry from '../registry.js';
+import * as eventUtils from '../events/utils.js';
 
 export class Dragger implements IDragger {
   protected startLoc: Coordinate;
@@ -94,6 +95,7 @@ export class Dragger implements IDragger {
 
   /** Handles any drag cleanup. */
   onDragEnd(e: PointerEvent) {
+    const origGroup = eventUtils.getGroup();
     const dragTarget = this.workspace.getDragTarget(e);
     if (dragTarget) {
       this.dragTarget?.onDrop(this.draggable);
@@ -109,7 +111,12 @@ export class Dragger implements IDragger {
       isDeletable(this.draggable) &&
       this.wouldDeleteDraggable(e, this.draggable)
     ) {
+      // We want to make sure the delete gets grouped with any possible
+      // move event.
+      const newGroup = eventUtils.getGroup();
+      eventUtils.setGroup(origGroup);
       this.draggable.dispose();
+      eventUtils.setGroup(newGroup);
     }
   }
 


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Work on https://github.com/google/blockly/issues/8124

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
Makes it so that any possible delete events fired by `disposed` are grouped with any possible move events fired by draggables.

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
Makes it so when you undo a deleted that happened over a drag targets the draggable gets returned to its original location at the start of the drag.

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->
Manual testing.

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
Fixes blocks but workspace comments are still broken. I think that's because of https://github.com/google/blockly/issues/8112
