### PR TITLE
fix: comment size not respecting collapsed-ness

### DIFF
--- a/core/comments/comment_view.ts
+++ b/core/comments/comment_view.ts
@@ -286,9 +286,12 @@ export class CommentView implements IRenderedElement {
     return this.svgRoot;
   }
 
-  /** Returns the current size of the comment in workspace units. */
+  /**
+   * Returns the current size of the comment in workspace units.
+   * Respects collapsing.
+   */
   getSize(): Size {
-    return this.size;
+    return this.collapsed ? this.topBarBackground.getBBox() : this.size;
   }
 
   /**

--- a/core/comments/rendered_workspace_comment.ts
+++ b/core/comments/rendered_workspace_comment.ts
@@ -120,10 +120,21 @@ export class RenderedWorkspaceComment
     return this.view.getSvgRoot();
   }
 
-  /** Returns the bounding rectangle of this comment in workspace coordinates. */
+  /**
+   * Returns the comment's size in workspace units.
+   * Does not respect collapsing.
+   */
+  getSize(): Size {
+    return super.getSize();
+  }
+
+  /**
+   * Returns the bounding rectangle of this comment in workspace coordinates.
+   * Respects collapsing.
+   */
   getBoundingRectangle(): Rect {
     const loc = this.getRelativeToSurfaceXY();
-    const size = this.getSize();
+    const size = this.view.getSize();
     let left;
     let right;
     if (this.workspace.RTL) {

--- a/tests/mocha/workspace_comment_test.js
+++ b/tests/mocha/workspace_comment_test.js
@@ -15,7 +15,7 @@ import {
 
 suite('Workspace comment', function () {
   setup(function () {
-    sharedTestSetup.call(this);
+    this.clock = sharedTestSetup.call(this, {fireEventsNow: false}).clock;
     this.workspace = new Blockly.inject('blocklyDiv', {});
   });
 
@@ -30,6 +30,8 @@ suite('Workspace comment', function () {
       this.renderedComment = new Blockly.comments.RenderedWorkspaceComment(
         this.workspace,
       );
+
+      this.clock.runAll();
 
       assertEventFired(
         spy,
@@ -47,6 +49,8 @@ suite('Workspace comment', function () {
 
       this.renderedComment.dispose();
 
+      this.clock.runAll();
+
       assertEventFired(
         spy,
         Blockly.Events.CommentDelete,
@@ -62,6 +66,8 @@ suite('Workspace comment', function () {
       const spy = createChangeListenerSpy(this.workspace);
 
       this.renderedComment.moveTo(new Blockly.utils.Coordinate(42, 42));
+
+      this.clock.runAll();
 
       assertEventFired(
         spy,
@@ -83,6 +89,8 @@ suite('Workspace comment', function () {
 
       this.renderedComment.setText('test text');
 
+      this.clock.runAll();
+
       assertEventFired(
         spy,
         Blockly.Events.CommentChange,
@@ -103,6 +111,8 @@ suite('Workspace comment', function () {
 
       this.renderedComment.setCollapsed(true);
 
+      this.clock.runAll();
+
       assertEventFired(
         spy,
         Blockly.Events.CommentCollapse,
@@ -122,6 +132,8 @@ suite('Workspace comment', function () {
       const spy = createChangeListenerSpy(this.workspace);
 
       this.renderedComment.setCollapsed(false);
+
+      this.clock.runAll();
 
       assertEventFired(
         spy,


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [ ] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes https://github.com/google/blockly/issues/8115

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
Makes it so the bounding rect of the comment is properly reported when it is collapsed.

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->
Manual testing.

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->
N/A

### Additional Information

<!-- Anything else we should know? -->
N/A