### PR TITLE
fix: dragging blocks by shadows to delete

### DIFF
--- a/core/block.ts
+++ b/core/block.ts
@@ -676,6 +676,17 @@ export class Block implements IASTNodeLocation {
   }
 
   /**
+   * Returns this block if it is a shadow block, or the first non-shadow parent.
+   *
+   * @internal
+   */
+  getFirstNonShadowBlock(): this {
+    if (!this.isShadow()) return this;
+    // We can assert the parent is non-null because shadows must have parents.
+    return this.getParent()!.getFirstNonShadowBlock();
+  }
+
+  /**
    * Find all the blocks that are directly nested inside this one.
    * Includes value and statement inputs, as well as any following statement.
    * Excludes any connection on an output tab or any preceding statement.

--- a/core/block_svg.ts
+++ b/core/block_svg.ts
@@ -245,8 +245,8 @@ export class BlockSvg
 
   /** Selects this block. Highlights the block visually. */
   select() {
-    if (this.isShadow() && this.getParent()) {
-      this.getParent()!.select();
+    if (this.isShadow()) {
+      this.getParent()?.select();
       return;
     }
     this.addSelect();
@@ -254,8 +254,8 @@ export class BlockSvg
 
   /** Unselects this block. Unhighlights the blockv visually.   */
   unselect() {
-    if (this.isShadow() && this.getParent()) {
-      this.getParent()!.unselect();
+    if (this.isShadow()) {
+      this.getParent()?.unselect();
       return;
     }
     this.removeSelect();

--- a/core/block_svg.ts
+++ b/core/block_svg.ts
@@ -245,8 +245,9 @@ export class BlockSvg
 
   /** Selects this block. Highlights the block visually. */
   select() {
-    if (this.isShadow()) {
-      this.getParent()?.select();
+    if (this.isShadow() && this.getParent()) {
+      // Shadow blocks should not be selected.
+      this.getParent()!.select();
       return;
     }
     this.addSelect();
@@ -254,10 +255,6 @@ export class BlockSvg
 
   /** Unselects this block. Unhighlights the blockv visually.   */
   unselect() {
-    if (this.isShadow()) {
-      this.getParent()?.unselect();
-      return;
-    }
     this.removeSelect();
   }
 

--- a/core/block_svg.ts
+++ b/core/block_svg.ts
@@ -246,7 +246,6 @@ export class BlockSvg
   /** Selects this block. Highlights the block visually. */
   select() {
     if (this.isShadow() && this.getParent()) {
-      // Shadow blocks should not be selected.
       this.getParent()!.select();
       return;
     }
@@ -255,6 +254,10 @@ export class BlockSvg
 
   /** Unselects this block. Unhighlights the blockv visually.   */
   unselect() {
+    if (this.isShadow() && this.getParent()) {
+      this.getParent()!.unselect();
+      return;
+    }
     this.removeSelect();
   }
 

--- a/core/gesture.ts
+++ b/core/gesture.ts
@@ -1015,7 +1015,7 @@ export class Gesture {
     // If the gesture already went through a bubble, don't set the start block.
     if (!this.startBlock && !this.startBubble) {
       this.startBlock = block;
-      common.setSelected(this.startBlock);
+      common.setSelected(this.startBlock.getFirstNonShadowBlock());
       if (block.isInFlyout && block !== block.getRootBlock()) {
         this.setTargetBlock(block.getRootBlock());
       } else {


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [ ] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes https://github.com/google/blockly/issues/8137

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
Reverts the old code for dragging shadows, which delegated to parents, and instead just select the parent from the beginning.

Click events still get fired on the shadow though because that's based on the start blocks not the selection.

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->
Manually tested dragging and deleting by shadows.

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->
N/A

### Additional Information

<!-- Anything else we should know? -->
N/A
