### PR TITLE
chore: fix playground context menu

### DIFF
--- a/tests/playgrounds/advanced_playground.html
+++ b/tests/playgrounds/advanced_playground.html
@@ -26,7 +26,6 @@
 
       function createWorkspace(blocklyDiv, options) {
         var workspace = Blockly.inject(blocklyDiv, options);
-        workspace.configureContextMenu = configureContextMenu.bind(workspace);
         return workspace;
       }
 
@@ -101,6 +100,8 @@
           },
         };
 
+        Blockly.ContextMenuItems.registerCommentOptions();
+
         createPlayground(
           document.getElementById('root'),
           createWorkspace,
@@ -124,23 +125,6 @@
         ) {
           document.body.style.backgroundColor = '#d6d6ff'; // Familliar lilac.
         }
-      }
-
-      function configureContextMenu(menuOptions, e) {
-        var workspace = this;
-        var screenshotOption = {
-          text: 'Download Screenshot',
-          enabled: workspace.getTopBlocks().length,
-          callback: function () {
-            downloadScreenshot(workspace);
-          },
-        };
-        menuOptions.push(screenshotOption);
-
-        // Adds a default-sized workspace comment to the workspace.
-        menuOptions.push(
-          Blockly.ContextMenu.workspaceCommentOption(workspace, e),
-        );
       }
       start();
     </script>


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #8108 

### Proposed Changes

- Removes "Download screenshot" option as that's already part of the advanced playground so it was showing up twice
- Removes old option to add a workspace comment
- Registers the new shiny way to add workspace comments as suggested by our documentation

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
bug fixin

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
