### PR TITLE
fix: Restore resize corner UI

### DIFF
--- a/media/resize-handle.svg
+++ b/media/resize-handle.svg
@@ -1,3 +1,7 @@
-<svg xmlns="http://www.w3.org/2000/svg" height="8" viewBox="0 0 8 8" width="8" fill="#041E49" stroke="#000">
-<g><line x1="2.6666666666666665" y1="7" x2="7" y2="2.6666666666666665"></line><line x1="5.333333333333333" y1="7" x2="7" y2="5.333333333333333"></line></g>
+<svg xmlns="http://www.w3.org/2000/svg" height="8" viewBox="0 0 8 8" width="8" fill="none" stroke="#515A5A" stroke-width="0.7">
+  <g>
+    <polygon points="0,8 8,8 8,0" fill="#aaa" stroke="none"></polygon>
+    <line x1="2.6" y1="7.4" x2="7.4" y2="2.6"></line>
+    <line x1="5.5" y1="7.4" x2="7.4" y2="5.5"></line>
+  </g>
 </svg>


### PR DESCRIPTION
The corner UI for comment resizing got rewritten for V11.  This new UI is just two very short diagonal lines.  This isn't as clear, and a survey of other existant resizing UIs don't reveal any that are this minimal, and none that are on a rounded corner.  This PR restores the original look.

This is the V11 UI:

<img width="421" alt="Screenshot 2024-05-17 at 17 30 34" src="https://github.com/google/blockly/assets/250480/7072dcbc-16f6-4d08-a88c-01b05c17c953">

This PR restores the original UI:

<img width="439" alt="Screenshot 2024-05-17 at 17 35 40" src="https://github.com/google/blockly/assets/250480/b492fd47-be21-40b6-a521-244233e9cd0c">
