### PR TITLE
fix: comment handle position in RTL

### DIFF
--- a/core/bubbles/textinput_bubble.ts
+++ b/core/bubbles/textinput_bubble.ts
@@ -201,16 +201,11 @@ export class TextInputBubble extends Bubble {
     this.textArea.style.width = `${widthMinusBorder - 4}px`;
     this.textArea.style.height = `${heightMinusBorder - 4}px`;
 
+    this.resizeGroup.setAttribute('y', `${heightMinusBorder}`);
     if (this.workspace.RTL) {
-      this.resizeGroup.setAttribute(
-        'transform',
-        `translate(${Bubble.DOUBLE_BORDER}, ${heightMinusBorder}) scale(-1 1)`,
-      );
+      this.resizeGroup.setAttribute('x', `${-Bubble.DOUBLE_BORDER}`);
     } else {
-      this.resizeGroup.setAttribute(
-        'transform',
-        `translate(${widthMinusBorder}, ${heightMinusBorder})`,
-      );
+      this.resizeGroup.setAttribute('x', `${widthMinusBorder}`);
     }
 
     super.setSize(size, relayout);


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes https://github.com/google/blockly/issues/8144

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
Rearranges some transforms to make it compatible with how the resize handle is styled now. (scale is applied via css transform so we need to apply the position via X and Y attributes)

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->
Manually tested, comment and block resize handles are correctly positioned in RTL and LTR.

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->
N/A

### Additional Information

<!-- Anything else we should know? -->
N/A
