### PR TITLE
fix: comment text area bottom border hidden

### DIFF
--- a/core/comments/comment_view.ts
+++ b/core/comments/comment_view.ts
@@ -404,8 +404,6 @@ export class CommentView implements IRenderedElement {
     if (this.workspace.RTL) {
       this.foreignObject.setAttribute('x', `${-size.width}`);
     }
-    this.textArea.style.width = `${size.width}px`;
-    this.textArea.style.height = `${size.height}px`;
   }
 
   /**


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [ ] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes https://github.com/google/blockly/issues/8116

### Proposed Changes

For some reason we were setting the size of the text area even though it's already set to `100%` of parent. The explicit setting of the size wasn't accounting for the height of the top bar, which is why the bottom border was hidden.

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->
Manually tested, and bottom border appears correctly.

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
