### PR TITLE
fix: creating comments in RTL

### DIFF
--- a/core/comments/rendered_workspace_comment.ts
+++ b/core/comments/rendered_workspace_comment.ts
@@ -134,7 +134,7 @@ export class RenderedWorkspaceComment
    */
   getBoundingRectangle(): Rect {
     const loc = this.getRelativeToSurfaceXY();
-    const size = this.view.getSize();
+    const size = this.view?.getSize() ?? this.getSize();
     let left;
     let right;
     if (this.workspace.RTL) {


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [ ] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes https://github.com/google/blockly/issues/8159#issue-2306127588
Broken by https://github.com/google/blockly/pull/8136

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
Makes it so we don't error if the view is undefined.

So what happens is we have this stack trace:
```
rendered_workspace_comment.ts:136 console.trace
getBoundingRectangle	@	rendered_workspace_comment.ts:136
getBlocksBoundingBox	@	workspace_svg.ts:1619
getContentMetrics	@	metrics_manager.ts:195
getMetrics	@	metrics_manager.ts:393
getWidth	@	workspace_svg.ts:1216
saveWorkspaceComment	@	xml.ts:68
CommentCreate	@	events_comment_create.ts:46
fireCreateEvent	@	workspace_comment.ts:65
WorkspaceComment	@	workspace_comment.ts:60
RenderedWorkspaceComment	@	rendered_workspace_comment.ts:52
callback	@	contextmenu_items.ts:619
(anonymous)	@	contextmenu.ts:124
setTimeout (async)		
(anonymous)	@	contextmenu.ts:119
requestAnimationFrame (async)		
actionHandler	@	contextmenu.ts:118
performAction	@	menuitem.ts:236
handleClick	@	menu.ts:369
wrapFunc	@	browser_events.ts:63
```
Creating the rendered workspace comment constructs a create event. This event serializes the comment to XML. Because of the funky way we've historically done RTL coordinates, this requires us to get the width of the workspace. That requires  the workspace to calculate its content bounds. That requires the comment to know its bounds. But its bounds are based on the bounds of the view, which doesn't get constructed until later.

So if we don't have a view we need to fallback to just using the comment size.

This doesn't cause typescript errors because this problem is caused by a cascade of side effects, which typescript can't track. The view is constructed in the constructor, so typescript allows us to treat it as non-nullable.

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->
Manually tested that constructing a comment in RTL works.

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
