### PR TITLE
fix: Properly size comments.

### DIFF
--- a/core/bubbles/textinput_bubble.ts
+++ b/core/bubbles/textinput_bubble.ts
@@ -143,7 +143,7 @@ export class TextInputBubble extends Bubble {
 
   /** Binds events to the text area element. */
   private bindTextAreaEvents(textArea: HTMLTextAreaElement) {
-    // Don't zoom with mousewheel.
+    // Don't zoom with mousewheel; let it scroll instead.
     browserEvents.conditionalBind(textArea, 'wheel', this, (e: Event) => {
       e.stopPropagation();
     });

--- a/core/bubbles/textinput_bubble.ts
+++ b/core/bubbles/textinput_bubble.ts
@@ -199,7 +199,7 @@ export class TextInputBubble extends Bubble {
     this.inputRoot.setAttribute('width', `${widthMinusBorder}`);
     this.inputRoot.setAttribute('height', `${heightMinusBorder}`);
     this.textArea.style.width = `${widthMinusBorder - 4}px`;
-    this.textArea.style.height = `${heightMinusBorder - 4}px`;
+    this.textArea.style.height = '100%';
 
     this.resizeGroup.setAttribute('y', `${heightMinusBorder}`);
     if (this.workspace.RTL) {
@@ -310,6 +310,5 @@ Css.register(`
   outline: 0;
   padding: 3px;
   resize: none;
-  text-overflow: hidden;
 }
 `);

--- a/core/bubbles/textinput_bubble.ts
+++ b/core/bubbles/textinput_bubble.ts
@@ -198,8 +198,6 @@ export class TextInputBubble extends Bubble {
     const heightMinusBorder = size.height - Bubble.DOUBLE_BORDER;
     this.inputRoot.setAttribute('width', `${widthMinusBorder}`);
     this.inputRoot.setAttribute('height', `${heightMinusBorder}`);
-    this.textArea.style.width = `${widthMinusBorder - 4}px`;
-    this.textArea.style.height = '100%';
 
     this.resizeGroup.setAttribute('y', `${heightMinusBorder}`);
     if (this.workspace.RTL) {
@@ -310,5 +308,7 @@ Css.register(`
   outline: 0;
   padding: 3px;
   resize: none;
+  width: 100%;
+  height: 100%;
 }
 `);

--- a/core/comments/comment_view.ts
+++ b/core/comments/comment_view.ts
@@ -405,7 +405,7 @@ export class CommentView implements IRenderedElement {
       this.foreignObject.setAttribute('x', `${-size.width}`);
     }
     this.textArea.style.width = `${size.width}px`;
-    this.textArea.style.height = `${size.height}px`;
+    this.textArea.style.height = '100%';
   }
 
   /**
@@ -778,7 +778,6 @@ css.register(`
   border: 1px solid var(--commentBorderColour);
   outline: 0;
   resize: none;
-  overflow: hidden;
   box-sizing: border-box;
   padding: 8px;
   width: 100%;

--- a/core/comments/comment_view.ts
+++ b/core/comments/comment_view.ts
@@ -404,8 +404,6 @@ export class CommentView implements IRenderedElement {
     if (this.workspace.RTL) {
       this.foreignObject.setAttribute('x', `${-size.width}`);
     }
-    this.textArea.style.width = `${size.width}px`;
-    this.textArea.style.height = '100%';
   }
 
   /**

--- a/core/comments/rendered_workspace_comment.ts
+++ b/core/comments/rendered_workspace_comment.ts
@@ -66,7 +66,7 @@ export class RenderedWorkspaceComment
       this,
       this.startGesture,
     );
-    // Don't zoom with mousewheel.
+    // Don't zoom with mousewheel; let it scroll instead.
     browserEvents.conditionalBind(
       this.view.getSvgRoot(),
       'wheel',

--- a/core/comments/rendered_workspace_comment.ts
+++ b/core/comments/rendered_workspace_comment.ts
@@ -70,11 +70,11 @@ export class RenderedWorkspaceComment
     browserEvents.conditionalBind(
       this.view.getSvgRoot(),
       'wheel',
-      this, (e: Event) => {
+      this,
+      (e: Event) => {
         e.stopPropagation();
-      }
+      },
     );
-
   }
 
   /**

--- a/core/comments/rendered_workspace_comment.ts
+++ b/core/comments/rendered_workspace_comment.ts
@@ -66,6 +66,15 @@ export class RenderedWorkspaceComment
       this,
       this.startGesture,
     );
+    // Don't zoom with mousewheel.
+    browserEvents.conditionalBind(
+      this.view.getSvgRoot(),
+      'wheel',
+      this, (e: Event) => {
+        e.stopPropagation();
+      }
+    );
+
   }
 
   /**


### PR DESCRIPTION
Fixes multiple rendering and sizing issues across different browsers.

Tip: `text-overflow: hidden;` is not legal CSS and did nothing.

Resolves #8142
