### PR TITLE
fix: Normalize CSS between comment types

### DIFF
--- a/core/bubbles/textinput_bubble.ts
+++ b/core/bubbles/textinput_bubble.ts
@@ -303,10 +303,10 @@ Css.register(`
 .blocklyTextInputBubble .blocklyTextarea {
   background-color: var(--commentFillColour);
   border: 0;
+  box-sizing: border-box;
   display: block;
-  margin: 0;
   outline: 0;
-  padding: 3px;
+  padding: 5px;
   resize: none;
   width: 100%;
   height: 100%;

--- a/core/comments/comment_view.ts
+++ b/core/comments/comment_view.ts
@@ -774,13 +774,13 @@ css.register(`
 .blocklyComment .blocklyTextarea {
   background-color: var(--commentFillColour);
   border: 1px solid var(--commentBorderColour);
-  outline: 0;
-  resize: none;
   box-sizing: border-box;
-  padding: 8px;
+  display: block;
+  outline: 0;
+  padding: 5px;
+  resize: none;
   width: 100%;
   height: 100%;
-  display: block;
 }
 
 .blocklyReadonly.blocklyComment .blocklyTextarea {


### PR DESCRIPTION
Merge the CSS so that both comment types (block and workspace) are the same -- other than a border.

This also resolves some alignment issues that show up exclusively in Safari.