### PR TITLE
feat(tests): Browser test helper to get workspace svg root

### DIFF
--- a/tests/browser/test/field_edits_test.js
+++ b/tests/browser/test/field_edits_test.js
@@ -14,7 +14,7 @@ const {
   testFileLocations,
   dragBlockTypeFromFlyout,
   screenDirection,
-  PAUSE_TIME,
+  clickWorkspace,
 } = require('./test_setup');
 const {Key} = require('webdriverio');
 
@@ -48,9 +48,7 @@ async function testFieldEdits(browser, direction) {
   await browser.keys(['1093']);
 
   // Click on the workspace to exit the field editor
-  const workspace = await browser.$('#blocklyDiv > div > svg.blocklySvg > g');
-  await workspace.click();
-  await browser.pause(PAUSE_TIME);
+  await clickWorkspace(browser);
 
   const fieldValue = await browser.execute((id) => {
     return Blockly.getMainWorkspace()

--- a/tests/browser/test/test_setup.js
+++ b/tests/browser/test/test_setup.js
@@ -210,6 +210,22 @@ async function clickWorkspace(browser) {
 }
 
 /**
+ * Clicks on the svg root of the first mutator workspace found.
+ * @param browser The active WebdriverIO Browser object.
+ * @return A Promise that resolves when the actions are completed.
+ * @throws If the mutator workspace cannot be found.
+ */
+async function clickMutatorWorkspace(browser) {
+  const hasMutator = await browser.$('.blocklyMutatorBackground');
+  if (!hasMutator) {
+    throw new Error('No mutator workspace found');
+  }
+  const workspace = await browser.$('.blocklyMutatorBackground').closest('g.blocklyWorkspace');
+  await workspace.click();
+  await browser.pause(PAUSE_TIME);
+}
+
+/**
  * @param browser The active WebdriverIO Browser object.
  * @param categoryName The name of the toolbox category to find.
  * @return A Promise that resolves to the root element of the toolbox
@@ -561,6 +577,7 @@ module.exports = {
   getBlockElementById,
   clickBlock,
   clickWorkspace,
+  clickMutatorWorkspace,
   getCategory,
   getNthBlockOfCategory,
   getBlockTypeFromCategory,

--- a/tests/browser/test/test_setup.js
+++ b/tests/browser/test/test_setup.js
@@ -220,7 +220,9 @@ async function clickMutatorWorkspace(browser) {
   if (!hasMutator) {
     throw new Error('No mutator workspace found');
   }
-  const workspace = await browser.$('.blocklyMutatorBackground').closest('g.blocklyWorkspace');
+  const workspace = await browser
+    .$('.blocklyMutatorBackground')
+    .closest('g.blocklyWorkspace');
   await workspace.click();
   await browser.pause(PAUSE_TIME);
 }

--- a/tests/browser/test/test_setup.js
+++ b/tests/browser/test/test_setup.js
@@ -199,6 +199,17 @@ async function clickBlock(browser, block, clickOptions) {
 }
 
 /**
+ * Clicks on the svg root of the main workspace.
+ * @param browser The active WebdriverIO Browser object.
+ * @return A Promise that resolves when the actions are completed.
+ */
+async function clickWorkspace(browser) {
+  const workspace = await browser.$('#blocklyDiv > div > svg.blocklySvg > g');
+  await workspace.click();
+  await browser.pause(PAUSE_TIME);
+}
+
+/**
  * @param browser The active WebdriverIO Browser object.
  * @param categoryName The name of the toolbox category to find.
  * @return A Promise that resolves to the root element of the toolbox
@@ -549,6 +560,7 @@ module.exports = {
   getSelectedBlockId,
   getBlockElementById,
   clickBlock,
+  clickWorkspace,
   getCategory,
   getNthBlockOfCategory,
   getBlockTypeFromCategory,


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes https://github.com/google/blockly/issues/7332

### Proposed Changes

1. Add helper to get the svg root of the main blockly workspace to be clicked on
2. Add helper to get the svg root of the mutator workspace to be clicked on

### Reason for Changes

To make a helper that can be used to click the main workspace or the mutator workspace
<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage

Manually tested that the clickWorkspace and clickMutatorWorkspace functions click on the main workspace svg root and the mutator workspace svg root respectively

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->

### Documentation
N/A
<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information
N/A
<!-- Anything else we should know? -->
