### PR TITLE
fix: dragging and disposing of shadows

### DIFF
--- a/core/block.ts
+++ b/core/block.ts
@@ -676,17 +676,6 @@ export class Block implements IASTNodeLocation {
   }
 
   /**
-   * Returns this block if it is a shadow block, or the first non-shadow parent.
-   *
-   * @internal
-   */
-  getFirstNonShadowBlock(): this {
-    if (!this.isShadow()) return this;
-    // We can assert the parent is non-null because shadows must have parents.
-    return this.getParent()!.getFirstNonShadowBlock();
-  }
-
-  /**
    * Find all the blocks that are directly nested inside this one.
    * Includes value and statement inputs, as well as any following statement.
    * Excludes any connection on an output tab or any preceding statement.

--- a/core/dragging/block_drag_strategy.ts
+++ b/core/dragging/block_drag_strategy.ts
@@ -55,15 +55,24 @@ export class BlockDragStrategy implements IDragStrategy {
 
   private dragging = false;
 
+  /**
+   * If this is a shadow block, the offset between this block and the parent
+   * block, to add to the drag location. In workspace units.
+   */
+  private dragOffset = new Coordinate(0, 0);
+
   constructor(private block: BlockSvg) {
     this.workspace = block.workspace;
   }
 
   /** Returns true if the block is currently movable. False otherwise. */
   isMovable(): boolean {
+    if (this.block.isShadow()) {
+      return this.block.getParent()?.isMovable() ?? false;
+    }
+
     return (
       this.block.isOwnMovable() &&
-      !this.block.isShadow() &&
       !this.block.isDeadOrDying() &&
       !this.workspace.options.readOnly &&
       // We never drag blocks in the flyout, only create new blocks that are
@@ -77,6 +86,11 @@ export class BlockDragStrategy implements IDragStrategy {
    * from any parent blocks.
    */
   startDrag(e?: PointerEvent): void {
+    if (this.block.isShadow()) {
+      this.startDraggingShadow(e);
+      return;
+    }
+
     this.dragging = true;
     if (!eventUtils.getGroup()) {
       eventUtils.setGroup(true);
@@ -104,6 +118,22 @@ export class BlockDragStrategy implements IDragStrategy {
     }
     this.block.setDragging(true);
     this.workspace.getLayerManager()?.moveToDragLayer(this.block);
+  }
+
+  /** Starts a drag on a shadow, recording the drag offset. */
+  private startDraggingShadow(e?: PointerEvent) {
+    const parent = this.block.getParent();
+    if (!parent) {
+      throw new Error(
+        'Tried to drag a shadow block with no parent. ' +
+          'Shadow blocks should always have parents.',
+      );
+    }
+    this.dragOffset = Coordinate.difference(
+      parent.getRelativeToSurfaceXY(),
+      this.block.getRelativeToSurfaceXY(),
+    );
+    parent.startDrag(e);
   }
 
   /**
@@ -174,6 +204,11 @@ export class BlockDragStrategy implements IDragStrategy {
 
   /** Moves the block and updates any connection previews. */
   drag(newLoc: Coordinate): void {
+    if (this.block.isShadow()) {
+      this.block.getParent()?.drag(Coordinate.sum(newLoc, this.dragOffset));
+      return;
+    }
+
     this.block.moveDuringDrag(newLoc);
     this.updateConnectionPreview(
       this.block,
@@ -317,7 +352,12 @@ export class BlockDragStrategy implements IDragStrategy {
    * Cleans up any state at the end of the drag. Applies any pending
    * connections.
    */
-  endDrag(): void {
+  endDrag(e?: PointerEvent): void {
+    if (this.block.isShadow()) {
+      this.block.getParent()?.endDrag(e);
+      return;
+    }
+
     this.fireDragEndEvent();
     this.fireMoveEvent();
 
@@ -373,6 +413,11 @@ export class BlockDragStrategy implements IDragStrategy {
    * including reconnecting connections.
    */
   revertDrag(): void {
+    if (this.block.isShadow()) {
+      this.block.getParent()?.revertDrag();
+      return;
+    }
+
     this.startChildConn?.connect(this.block.nextConnection);
     if (this.startParentConn) {
       switch (this.startParentConn.type) {

--- a/core/gesture.ts
+++ b/core/gesture.ts
@@ -1015,7 +1015,7 @@ export class Gesture {
     // If the gesture already went through a bubble, don't set the start block.
     if (!this.startBlock && !this.startBubble) {
       this.startBlock = block;
-      common.setSelected(this.startBlock.getFirstNonShadowBlock());
+      common.setSelected(this.startBlock);
       if (block.isInFlyout && block !== block.getRootBlock()) {
         this.setTargetBlock(block.getRootBlock());
       } else {


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes https://github.com/google/blockly/issues/8171

### Background

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
This handles shadow block dragging behavior in a very non-generalized but backwards compatible way. As far as I can think, there's no way for it to be both generalized and backwards compatible, so I chose backwards compatibility.

Our requirements are:
  1) We need shadows to be the thing being dragged, so that custom draggables can duplicate instead of dragging shadows.
  2) We need non-customized shadow blocks to drag their parent blocks.
  3) We need non-customized shadow blocks to dispose of their root blocks when they're dragged over a delete area.

Our constraints are:
  1) We can't change the signature of `dispose` in `IDeletable` because it would with the block `dispose` parameters.
  5) We can't change anything else about `IDeletable` either because  because it would be breaking.
  5) We can't change what we expect to be returned from `IDeleteArea`s. It is not technically binary breaking, but changing what we expect could be behaviorally breaking, the worst kind of breaking.

So unless we want to break something, our only option is to special case for blocks for now, and reevaluate for V12.

### Proposed changes

So what we're doing is passing the root block to any delete area callbacks, and we're also disposing of the root block. Any draggable-specific hooks are still called on the draggable itself, not the root.

If the draggable is not a block, we just always use the draggable.

### Testing

Manually tested:

- Dragging shadows
- Dropping dragged shadows over delete areas
- Setting a duplicate-on-drag drag strategy on a shadow blocks duplicates the shadow on drag