### PR TITLE
fix: lang file imports

### DIFF
--- a/scripts/gulpfiles/build_tasks.js
+++ b/scripts/gulpfiles/build_tasks.js
@@ -677,12 +677,13 @@ async function buildLangfileShims() {
     // its named exports.
     const cjsPath = `./${lang}.js`;
     const wrapperPath = path.join(RELEASE_DIR, 'msg', `${lang}.mjs`);
+    const safeLang = lang.replace(/-/g, '_');
 
     await fsPromises.writeFile(wrapperPath,
-        `import ${lang} from '${cjsPath}';
+        `import ${safeLang} from '${cjsPath}';
 export const {
 ${exportedNames.map((name) => `  ${name},`).join('\n')}
-} = ${lang};
+} = ${safeLang};
 `);
   }));
 }


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes https://github.com/google/blockly/issues/8174

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
Makes it so that lang files with dashses can be imported properly by changing the name of the import we use to use underscores instead.

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->
https://github.com/google/blockly/issues/8174 no longer reproduces.

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->
N/A

### Additional Information

<!-- Anything else we should know? -->
This needs to go in the patch this week.
