### PR TITLE
fix: change which element keydown is bound to from document to injection div

### DIFF
--- a/core/inject.ts
+++ b/core/inject.ts
@@ -78,7 +78,6 @@ export function inject(
   });
 
   browserEvents.conditionalBind(subContainer, 'keydown', null, onKeyDown);
-  // subContainer.addEventListener('keydown', onKeyDown);
 
   return workspace;
 }

--- a/core/inject.ts
+++ b/core/inject.ts
@@ -77,7 +77,8 @@ export function inject(
     common.setMainWorkspace(workspace);
   });
 
-  subContainer.addEventListener('keydown', onKeyDown);
+  browserEvents.conditionalBind(subContainer, 'keydown', null, onKeyDown);
+  // subContainer.addEventListener('keydown', onKeyDown);
 
   return workspace;
 }

--- a/core/inject.ts
+++ b/core/inject.ts
@@ -77,6 +77,8 @@ export function inject(
     common.setMainWorkspace(workspace);
   });
 
+  subContainer.addEventListener('keydown', onKeyDown);
+
   return workspace;
 }
 
@@ -320,8 +322,6 @@ let documentEventsBound = false;
  * Most of these events should be bound to the SVG's surface.
  * However, 'mouseup' has to be on the whole document so that a block dragged
  * out of bounds and released will know that it has been released.
- * Also, 'keydown' has to be on the whole document since the browser doesn't
- * understand a concept of focus on the SVG image.
  */
 function bindDocumentEvents() {
   if (!documentEventsBound) {
@@ -333,7 +333,6 @@ function bindDocumentEvents() {
         }
       }
     });
-    browserEvents.conditionalBind(document, 'keydown', null, onKeyDown);
     // longStop needs to run to stop the context menu from showing up.  It
     // should run regardless of what other touch event handlers have run.
     browserEvents.bind(document, 'touchend', null, Touch.longStop);

--- a/tests/mocha/keydown_test.js
+++ b/tests/mocha/keydown_test.js
@@ -16,6 +16,7 @@ suite('Key Down', function () {
   setup(function () {
     sharedTestSetup.call(this);
     this.workspace = Blockly.inject('blocklyDiv', {});
+    this.injectionDiv = this.workspace.getInjectionDiv();
   });
   teardown(function () {
     sharedTestTeardown.call(this);
@@ -42,7 +43,7 @@ suite('Key Down', function () {
     const name = opt_name ? opt_name : 'Not called when readOnly is true';
     test(name, function () {
       this.workspace.options.readOnly = true;
-      document.dispatchEvent(keyEvent);
+      this.injectionDiv.dispatchEvent(keyEvent);
       sinon.assert.notCalled(this.hideChaffSpy);
     });
   }
@@ -56,7 +57,7 @@ suite('Key Down', function () {
       );
     });
     test('Simple', function () {
-      document.dispatchEvent(this.event);
+      this.injectionDiv.dispatchEvent(this.event);
       sinon.assert.calledOnce(this.hideChaffSpy);
     });
     runReadOnlyTest(createKeyDownEvent(Blockly.utils.KeyCodes.ESC));
@@ -68,7 +69,7 @@ suite('Key Down', function () {
     });
     test('Not called on hidden workspaces', function () {
       this.workspace.isVisible_ = false;
-      document.dispatchEvent(this.event);
+      this.injectionDiv.dispatchEvent(this.event);
       sinon.assert.notCalled(this.hideChaffSpy);
     });
   });
@@ -92,7 +93,7 @@ suite('Key Down', function () {
         const testCaseName = testCase[0];
         const keyEvent = testCase[1];
         test(testCaseName, function () {
-          document.dispatchEvent(keyEvent);
+          this.injectionDiv.dispatchEvent(keyEvent);
           sinon.assert.calledOnce(this.hideChaffSpy);
           sinon.assert.calledOnce(this.deleteSpy);
         });
@@ -143,7 +144,7 @@ suite('Key Down', function () {
         const testCaseName = testCase[0];
         const keyEvent = testCase[1];
         test(testCaseName, function () {
-          document.dispatchEvent(keyEvent);
+          this.injectionDiv.dispatchEvent(keyEvent);
           sinon.assert.calledOnce(this.copySpy);
           sinon.assert.calledOnce(this.hideChaffSpy);
         });
@@ -164,7 +165,7 @@ suite('Key Down', function () {
         const keyEvent = testCase[1];
         test(testCaseName, function () {
           sinon.stub(Blockly.Gesture, 'inProgress').returns(true);
-          document.dispatchEvent(keyEvent);
+          this.injectionDiv.dispatchEvent(keyEvent);
           sinon.assert.notCalled(this.copySpy);
           sinon.assert.notCalled(this.hideChaffSpy);
         });
@@ -179,7 +180,7 @@ suite('Key Down', function () {
           sinon
             .stub(Blockly.common.getSelected(), 'isDeletable')
             .returns(false);
-          document.dispatchEvent(keyEvent);
+          this.injectionDiv.dispatchEvent(keyEvent);
           sinon.assert.notCalled(this.copySpy);
           sinon.assert.notCalled(this.hideChaffSpy);
         });
@@ -192,7 +193,7 @@ suite('Key Down', function () {
         const keyEvent = testCase[1];
         test(testCaseName, function () {
           sinon.stub(Blockly.common.getSelected(), 'isMovable').returns(false);
-          document.dispatchEvent(keyEvent);
+          this.injectionDiv.dispatchEvent(keyEvent);
           sinon.assert.notCalled(this.copySpy);
           sinon.assert.notCalled(this.hideChaffSpy);
         });
@@ -234,7 +235,7 @@ suite('Key Down', function () {
         const testCaseName = testCase[0];
         const keyEvent = testCase[1];
         test(testCaseName, function () {
-          document.dispatchEvent(keyEvent);
+          this.injectionDiv.dispatchEvent(keyEvent);
           sinon.assert.calledOnce(this.undoSpy);
           sinon.assert.calledWith(this.undoSpy, false);
           sinon.assert.calledOnce(this.hideChaffSpy);
@@ -248,7 +249,7 @@ suite('Key Down', function () {
         const keyEvent = testCase[1];
         test(testCaseName, function () {
           sinon.stub(Blockly.Gesture, 'inProgress').returns(true);
-          document.dispatchEvent(keyEvent);
+          this.injectionDiv.dispatchEvent(keyEvent);
           sinon.assert.notCalled(this.undoSpy);
           sinon.assert.notCalled(this.hideChaffSpy);
         });
@@ -301,7 +302,7 @@ suite('Key Down', function () {
         const testCaseName = testCase[0];
         const keyEvent = testCase[1];
         test(testCaseName, function () {
-          document.dispatchEvent(keyEvent);
+          this.injectionDiv.dispatchEvent(keyEvent);
           sinon.assert.calledOnce(this.redoSpy);
           sinon.assert.calledWith(this.redoSpy, true);
           sinon.assert.calledOnce(this.hideChaffSpy);
@@ -315,7 +316,7 @@ suite('Key Down', function () {
         const keyEvent = testCase[1];
         test(testCaseName, function () {
           sinon.stub(Blockly.Gesture, 'inProgress').returns(true);
-          document.dispatchEvent(keyEvent);
+          this.injectionDiv.dispatchEvent(keyEvent);
           sinon.assert.notCalled(this.redoSpy);
           sinon.assert.notCalled(this.hideChaffSpy);
         });
@@ -343,14 +344,14 @@ suite('Key Down', function () {
       );
     });
     test('Simple', function () {
-      document.dispatchEvent(this.ctrlYEvent);
+      this.injectionDiv.dispatchEvent(this.ctrlYEvent);
       sinon.assert.calledOnce(this.undoSpy);
       sinon.assert.calledWith(this.undoSpy, true);
       sinon.assert.calledOnce(this.hideChaffSpy);
     });
     test('Not called when a gesture is in progress', function () {
       sinon.stub(Blockly.Gesture, 'inProgress').returns(true);
-      document.dispatchEvent(this.ctrlYEvent);
+      this.injectionDiv.dispatchEvent(this.ctrlYEvent);
       sinon.assert.notCalled(this.undoSpy);
       sinon.assert.notCalled(this.hideChaffSpy);
     });


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #8187

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->

Bind the keydown event to the workspace's injection div rather than the HTML document

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

See #8187 for details.

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->

I modified the unit tests which deal with keydown events.  I also tested it manually in Chrome, Firefox and Safari on a Mac.

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

The docstring for `bindDocumentEvents` was changed to reflect the change in the code.  I don't believe that that docstring is exposed in the reference documentation.

### Additional Information

<!-- Anything else we should know? -->

In theory, this might be considered a breaking change, in that a developer might be depending on the current behavior, even though it is undocumented and possibly confusing to their users.  It is also possible that a developer might have some code which, for some reason, is expecting the event to be bound to the document.