### PR TITLE
feat(scripts): Create script to help with CJS -> ESM migration

### DIFF
--- a/scripts/migration/cjs2esm
+++ b/scripts/migration/cjs2esm
@@ -1,0 +1,99 @@
+#!/usr/bin/env node
+
+const fs = require('fs');
+const path = require('path');
+
+const filenames = process.argv.slice(2); // Trim off node and script name.
+
+/** Absolute path of repository root. */
+const repoPath = path.resolve(__dirname, '..', '..');
+
+//////////////////////////////////////////////////////////////////////
+// Process files mentioned on the command line.
+//////////////////////////////////////////////////////////////////////
+
+/** RegExp matching require statements. */
+const requireRE =
+  /(?:const\s+(?:([$\w]+)|(\{[^}]*\}))\s+=\s+)?require\('([^']+)'\);/g;
+
+/** RegExp matching key: value pairs in destructuring assignments. */
+const keyValueRE = /([$\w]+)\s*:\s*([$\w]+)\s*(?=,|})/g;
+
+for (const filename of filenames) {
+  let contents = null;
+  try {
+    contents = String(fs.readFileSync(filename));
+  } catch (e) {
+    console.error(`error while reading ${filename}: ${e.message}`);
+    continue;
+  }
+  console.log(`Converting ${filename} from require to import...`);
+
+  // Remove "use strict".
+  contents = contents.replace(/^\s*["']use strict["']\s*; *\n/m, '');
+
+  // Migrate from require to import.
+  contents = contents.replace(
+    requireRE,
+    function (
+      orig, // Whole statement to be replaced.
+      name, // Name of named import of whole module (if applicable).
+      names, // {}-enclosed list of destructured imports.
+      moduleName, // Imported module name or path.
+    ) {
+      if (moduleName[0] === '.') {
+        // Relative path.  Could check and add '.mjs' suffix if desired.
+      }
+      if (name) {
+        return `import * as ${name} from '${moduleName}';`;
+      } else if (names) {
+        names = names.replace(keyValueRE, '$1 as $2');
+        return `import ${names} from '${moduleName}';`;
+      } else {
+        // Side-effect only require.
+        return `import '${moduleName}';`;
+      }
+    },
+  );
+
+  // Find and update or remove old-style export assignemnts.
+  /** @type {!Array<{name: string, re: RegExp>}>} */
+  const easyExports = [];
+  contents = contents.replace(
+    /^\s*exports\.([$\w]+)\s*=\s*([$\w]+)\s*;\n/gm,
+    function (
+      orig, // Whole statement to be replaced.
+      exportName, // Name to export item as.
+      declName, // Already-declared name for item being exported.
+    ) {
+      // Renamed exports have to be transalted as-is.
+      if (exportName !== declName) {
+        return `export {${declName} as ${exportName}};\n`;
+      }
+      // OK, we're doing "export.foo = foo;".  Can we update the
+      // declaration?  We can't actualy modify it yet as we're in
+      // the middle of a search-and-replace on contents already, but
+      // we can delete the old export and later update the
+      // declaration into an export.
+      const declRE = new RegExp(
+        `^(\\s*)((?:const|let|var|function|class)\\s+${declName})\\b`,
+        'gm',
+      );
+      if (contents.match(declRE)) {
+        easyExports.push({exportName, declRE});
+        return ''; // Delete existing export assignment.
+      } else {
+        return `export ${exportName};\n`; // Safe fallback.
+      }
+    },
+  );
+  // Add 'export' to existing declarations where appropriate.
+  for (const {exportName, declRE} of easyExports) {
+    contents = contents.replace(declRE, '$1export $2');
+  }
+
+  // Write converted file with new extension.
+  const newFilename = filename.replace(/.c?js$/, '.mjs');
+  fs.writeFileSync(newFilename, contents);
+  console.log(`Wrote ${newFilename}.`);
+}


### PR DESCRIPTION
## The basics

- [X] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Proposed Changes

Create script to help with CJS -> ESM migration.

### Reason for Changes

We need to finish migrating tests to ESM as the latest version of chai no longer supports loading via require()—see PR #8092.

### Test Coverage

Some very cursory manual testing of this script has been done.  No changes to testing of Blockly anticipated.

### Additional Information

This is based on js2ts, but considerably simplified since we no longer need to deal with goog.module IDs.
