### PR TITLE
fix: statement input blocks disappearing

### DIFF
--- a/core/dragging/block_drag_strategy.ts
+++ b/core/dragging/block_drag_strategy.ts
@@ -99,6 +99,7 @@ export class BlockDragStrategy implements IDragStrategy {
 
     this.startLoc = this.block.getRelativeToSurfaceXY();
 
+    this.connectionCandidate = null;
     const previewerConstructor = registry.getClassFromOptions(
       registry.Type.CONNECTION_PREVIEWER,
       this.workspace.options,


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes https://github.com/google/blockly/issues/8189

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
The issue was we weren't properly clearing the state of the current candidate connection, so the preview was incorrect causing blocks to disconnect and disappear, because the place they were trying to be inserted was invalid.

To explain that slightly more linearly:
1) You start with a nested stack of 3 statement blocks, built from the inside out.
2) The middle block's current candidate connection is its child, because the state from when it connected to its child was never cleared.
3) You disconnect the middle block, and it finds the parent as the valid candidate, but the current candidate (its child) is better (I.e. closer) because its state was never cleared. So we use the current candidate instead.
4) The child blocks gets disconnected and set its parent to `null` so it can preview, but when that happens it tries to reorder its DOM position, which doesn't work because it's already on the drag layer, where it's not expected to be, causing the error from the original issue.

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->
Manually tested.

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->
N/A
### Additional Information

<!-- Anything else we should know? -->
We should put out a patch for this.