### PR TITLE
chore: tsdoc for generator exceptions

### DIFF
--- a/core/generator.ts
+++ b/core/generator.ts
@@ -295,8 +295,8 @@ export class CodeGenerator {
    * @param name The name of the input.
    * @param outerOrder The maximum binding strength (minimum order value) of any
    *     operators adjacent to "block".
-   * @returns Generated code or '' if no blocks are connected or the specified
-   *     input does not exist.
+   * @returns Generated code or '' if no blocks are connected
+   * @throws ReferenceError if the specified input does not exist.
    */
   valueToCode(block: Block, name: string, outerOrder: number): string {
     if (isNaN(outerOrder)) {
@@ -381,6 +381,7 @@ export class CodeGenerator {
    * @param block The block containing the input.
    * @param name The name of the input.
    * @returns Generated code or '' if no blocks are connected.
+   * @throws ReferenceError if the specified input does not exist.
    */
   statementToCode(block: Block, name: string): string {
     const targetBlock = block.getInputTargetBlock(name);

--- a/core/generator.ts
+++ b/core/generator.ts
@@ -295,7 +295,7 @@ export class CodeGenerator {
    * @param name The name of the input.
    * @param outerOrder The maximum binding strength (minimum order value) of any
    *     operators adjacent to "block".
-   * @returns Generated code or '' if no blocks are connected
+   * @returns Generated code or '' if no blocks are connected.
    * @throws ReferenceError if the specified input does not exist.
    */
   valueToCode(block: Block, name: string, outerOrder: number): string {


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes incorrect tsdoc for `CodeGenerator`

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->

### Reason for Changes

The tsdoc said it would return `''` if the input doesn't exist, but that is now incorrect

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->

### Documentation

The reference docs for these functions will now have a section that looks like:

```
## Exceptions

ReferenceError if the specified input does not exist.
```

(I checked)

### Additional Information

<!-- Anything else we should know? -->
