### PR TITLE
fix(dev-tools): only initSvg on rendered blocks

### DIFF
--- a/demos/blockfactory/blocks.js
+++ b/demos/blockfactory/blocks.js
@@ -85,8 +85,8 @@ Blockly.Blocks['factory_base'] = {
     var type = this.workspace.newBlock('type_null');
     type.setShadow(true);
     type.outputConnection.connect(this.getInput(outputType).connection);
-    type.initSvg();
     if (this.rendered) {
+      type.initSvg();
       type.render();
     }
   },


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes an error in the legacy developer tools

### Proposed Changes

- only call `initSvg` if the block is rendered (note that legacy block factory is still using blockly v10.4 so this is still needed)

### Reason for Changes

- this was causing an error when serializing the block onto a headless workspace, which we do when exporting the block definition to convert to json

### Test Coverage

the export blocks button works now :)

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
