### PR TITLE
fix(tests): Migrate all usage of chai to ESM

### DIFF
--- a/tests/browser/.mocharc.js
+++ b/tests/browser/.mocharc.js
@@ -2,5 +2,5 @@
 
 module.exports = {
   ui: 'tdd',
-  require: __dirname + '/test/hooks.js',
+  require: __dirname + '/test/hooks.mjs',
 };

--- a/tests/browser/test/basic_block_factory_test.mjs
+++ b/tests/browser/test/basic_block_factory_test.mjs
@@ -8,8 +8,8 @@
  * @fileoverview Node.js script to run Automated tests in Chrome, via webdriver.
  */
 
-const chai = require('chai');
-const {testSetup, testFileLocations} = require('./test_setup');
+import * as chai from 'chai';
+import {testSetup, testFileLocations} from './test_setup.mjs';
 
 suite('Testing Connecting Blocks', function (done) {
   // Setting timeout to unlimited as the webdriver takes a longer time to run than most mocha test

--- a/tests/browser/test/basic_block_test.mjs
+++ b/tests/browser/test/basic_block_test.mjs
@@ -9,14 +9,14 @@
  * webdriver, of basic Blockly block functionality.
  */
 
-const chai = require('chai');
-const {
+import * as chai from 'chai';
+import {
   testSetup,
   testFileLocations,
   getAllBlocks,
   dragNthBlockFromFlyout,
-} = require('./test_setup');
-const {Key} = require('webdriverio');
+} from './test_setup.mjs';
+import {Key} from 'webdriverio';
 
 suite('Basic block tests', function (done) {
   // Setting timeout to unlimited as the webdriver takes a longer time

--- a/tests/browser/test/basic_playground_test.mjs
+++ b/tests/browser/test/basic_playground_test.mjs
@@ -8,8 +8,8 @@
  * @fileoverview Node.js script to run Automated tests in Chrome, via webdriver.
  */
 
-const chai = require('chai');
-const {
+import * as chai from 'chai';
+import {
   testSetup,
   testFileLocations,
   dragNthBlockFromFlyout,
@@ -17,7 +17,7 @@ const {
   connect,
   contextMenuSelect,
   PAUSE_TIME,
-} = require('./test_setup');
+} from './test_setup.mjs';
 
 async function getIsCollapsed(browser, blockId) {
   return await browser.execute((blockId) => {

--- a/tests/browser/test/block_undo_test.mjs
+++ b/tests/browser/test/block_undo_test.mjs
@@ -8,15 +8,15 @@
  * @fileoverview Node.js script to run Automated tests in Chrome, via webdriver.
  */
 
-const chai = require('chai');
-const {Key} = require('webdriverio');
-const {
+import * as chai from 'chai';
+import {Key} from 'webdriverio';
+import {
   testSetup,
   testFileLocations,
   dragBlockTypeFromFlyout,
   screenDirection,
   getAllBlocks,
-} = require('./test_setup');
+} from './test_setup.mjs';
 
 suite('Testing undo block movement', function (done) {
   // Setting timeout to unlimited as the webdriver takes a longer time to run than most mocha test

--- a/tests/browser/test/delete_blocks_test.mjs
+++ b/tests/browser/test/delete_blocks_test.mjs
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-const chai = require('chai');
-const {
+import * as chai from 'chai';
+import {
   testSetup,
   testFileLocations,
   getAllBlocks,
@@ -13,8 +13,8 @@ const {
   clickBlock,
   contextMenuSelect,
   PAUSE_TIME,
-} = require('./test_setup');
-const {Key} = require('webdriverio');
+} from './test_setup.mjs';
+import {Key} from 'webdriverio';
 
 const firstBlockId = 'root_block';
 const startBlocks = {

--- a/tests/browser/test/extensive_test.mjs
+++ b/tests/browser/test/extensive_test.mjs
@@ -8,15 +8,15 @@
  * @fileoverview Node.js script to run Automated tests in Chrome, via webdriver.
  */
 
-const chai = require('chai');
-const {
+import * as chai from 'chai';
+import {
   testSetup,
   testFileLocations,
   getBlockElementById,
   getAllBlocks,
   PAUSE_TIME,
-} = require('./test_setup');
-const {Key} = require('webdriverio');
+} from './test_setup.mjs';
+import {Key} from 'webdriverio';
 
 suite('This tests loading Large Configuration and Deletion', function (done) {
   // Setting timeout to unlimited as the webdriver takes a longer time to run than most mocha test

--- a/tests/browser/test/field_edits_test.mjs
+++ b/tests/browser/test/field_edits_test.mjs
@@ -8,15 +8,15 @@
  * @fileoverview Node.js script to run Automated tests in Chrome, via webdriver.
  */
 
-const chai = require('chai');
-const {
+import * as chai from 'chai';
+import {
   testSetup,
   testFileLocations,
   dragBlockTypeFromFlyout,
   screenDirection,
   clickWorkspace,
-} = require('./test_setup');
-const {Key} = require('webdriverio');
+} from './test_setup.mjs';
+import {Key} from 'webdriverio';
 
 suite('Testing Field Edits', function (done) {
   // Setting timeout to unlimited as the webdriver takes a longer time to run than most mocha test

--- a/tests/browser/test/hooks.mjs
+++ b/tests/browser/test/hooks.mjs
@@ -9,9 +9,9 @@
  * These create a shared chromedriver instance, so we don't have to fire up
  * a new one for every suite.
  */
-const {driverSetup, driverTeardown} = require('./test_setup');
+import {driverSetup, driverTeardown} from './test_setup.mjs';
 
-const mochaHooks = {
+export const mochaHooks = {
   async beforeAll() {
     // Set a long timeout for startup.
     this.timeout(10000);
@@ -22,4 +22,3 @@ const mochaHooks = {
   },
 };
 
-module.exports = {mochaHooks};

--- a/tests/browser/test/hooks.mjs
+++ b/tests/browser/test/hooks.mjs
@@ -21,4 +21,3 @@ export const mochaHooks = {
     return await driverTeardown();
   },
 };
-

--- a/tests/browser/test/mutator_test.mjs
+++ b/tests/browser/test/mutator_test.mjs
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-const chai = require('chai');
-const {
+import * as chai from 'chai';
+import {
   testSetup,
   testFileLocations,
   connect,
@@ -15,7 +15,7 @@ const {
   getBlockElementById,
   dragBlockFromMutatorFlyout,
   openMutatorForBlock,
-} = require('./test_setup');
+} from './test_setup.mjs';
 
 suite('Mutating a block', function (done) {
   this.timeout(0);

--- a/tests/browser/test/procedure_test.mjs
+++ b/tests/browser/test/procedure_test.mjs
@@ -8,8 +8,8 @@
  * @fileoverview Node.js script to run Automated tests in Chrome, via webdriver.
  */
 
-const chai = require('chai');
-const {
+import * as chai from 'chai';
+import {
   testSetup,
   testFileLocations,
   getSelectedBlockElement,
@@ -17,7 +17,7 @@ const {
   getBlockTypeFromCategory,
   connect,
   PAUSE_TIME,
-} = require('./test_setup');
+} from './test_setup.mjs';
 
 suite('Testing Connecting Blocks', function (done) {
   // Setting timeout to unlimited as the webdriver takes a longer time to run than most mocha test

--- a/tests/browser/test/test_setup.mjs
+++ b/tests/browser/test/test_setup.mjs
@@ -268,7 +268,11 @@ export async function getNthBlockOfCategory(browser, categoryName, n) {
  * @return A Promise that resolves to the root element of the first
  *     block with the given type in the given category.
  */
-export async function getBlockTypeFromCategory(browser, categoryName, blockType) {
+export async function getBlockTypeFromCategory(
+  browser,
+  categoryName,
+  blockType,
+) {
   if (categoryName) {
     const category = await getCategory(browser, categoryName);
     await category.click();
@@ -455,7 +459,13 @@ export async function dragNthBlockFromFlyout(browser, categoryName, n, x, y) {
  * @return A Promise that resolves to the root element of the newly
  *     created block.
  */
-export async function dragBlockTypeFromFlyout(browser, categoryName, type, x, y) {
+export async function dragBlockTypeFromFlyout(
+  browser,
+  categoryName,
+  type,
+  x,
+  y,
+) {
   const flyoutBlock = await getBlockTypeFromCategory(
     browser,
     categoryName,
@@ -480,7 +490,13 @@ export async function dragBlockTypeFromFlyout(browser, categoryName, type, x, y)
  * @return A Promise that resolves to the root element of the newly
  *     created block.
  */
-export async function dragBlockFromMutatorFlyout(browser, mutatorBlock, type, x, y) {
+export async function dragBlockFromMutatorFlyout(
+  browser,
+  mutatorBlock,
+  type,
+  x,
+  y,
+) {
   const id = await browser.execute(
     (mutatorBlockId, blockType) => {
       return Blockly.getMainWorkspace()

--- a/tests/browser/test/test_setup.mjs
+++ b/tests/browser/test/test_setup.mjs
@@ -16,9 +16,10 @@
  * identifiers that Selenium can use to find those elements.
  */
 
-const webdriverio = require('webdriverio');
-const path = require('path');
-const {posixPath} = require('../../../scripts/helpers');
+import * as webdriverio from 'webdriverio';
+import * as path from 'path';
+import {fileURLToPath} from 'url';
+import {posixPath} from '../../../scripts/helpers.js';
 
 let driver = null;
 
@@ -26,14 +27,14 @@ let driver = null;
  * The default amount of time to wait during a test. Increase this to make
  * tests easier to watch; decrease it to make tests run faster.
  */
-const PAUSE_TIME = 50;
+export const PAUSE_TIME = 50;
 
 /**
  * Start up the test page. This should only be done once, to avoid
  * constantly popping browser windows open and closed.
  * @return A Promsie that resolves to a webdriverIO browser that tests can manipulate.
  */
-async function driverSetup() {
+export async function driverSetup() {
   const options = {
     capabilities: {
       'browserName': 'chrome',
@@ -67,7 +68,7 @@ async function driverSetup() {
  * End the webdriverIO session.
  * @return A Promise that resolves after the actions have been completed.
  */
-async function driverTeardown() {
+export async function driverTeardown() {
   await driver.deleteSession();
   driver = null;
   return;
@@ -79,7 +80,7 @@ async function driverTeardown() {
  *     a Blockly playground with a workspace.
  * @return A Promsie that resolves to a webdriverIO browser that tests can manipulate.
  */
-async function testSetup(playgroundUrl) {
+export async function testSetup(playgroundUrl) {
   if (!driver) {
     await driverSetup();
   }
@@ -91,7 +92,9 @@ async function testSetup(playgroundUrl) {
   return driver;
 }
 
-const testFileLocations = {
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+export const testFileLocations = {
   BLOCK_FACTORY:
     'file://' +
     posixPath(path.join(__dirname, '..', '..', '..', 'demos', 'blockfactory')) +
@@ -116,7 +119,7 @@ const testFileLocations = {
  * @readonly
  * @enum {number}
  */
-const screenDirection = {
+export const screenDirection = {
   RTL: -1,
   LTR: 1,
 };
@@ -125,7 +128,7 @@ const screenDirection = {
  * @param browser The active WebdriverIO Browser object.
  * @return A Promise that resolves to the ID of the currently selected block.
  */
-async function getSelectedBlockId(browser) {
+export async function getSelectedBlockId(browser) {
   return await browser.execute(() => {
     // Note: selected is an ICopyable and I am assuming that it is a BlockSvg.
     return Blockly.common.getSelected()?.id;
@@ -137,7 +140,7 @@ async function getSelectedBlockId(browser) {
  * @return A Promise that resolves to the selected block's root SVG element,
  *     as an interactable browser element.
  */
-async function getSelectedBlockElement(browser) {
+export async function getSelectedBlockElement(browser) {
   const id = await getSelectedBlockId(browser);
   return getBlockElementById(browser, id);
 }
@@ -148,7 +151,7 @@ async function getSelectedBlockElement(browser) {
  * @return A Promise that resolves to the root SVG element of the block with
  *     the given ID, as an interactable browser element.
  */
-async function getBlockElementById(browser, id) {
+export async function getBlockElementById(browser, id) {
   const elem = await browser.$(`[data-id="${id}"]`);
   elem['id'] = id;
   return elem;
@@ -165,7 +168,7 @@ async function getBlockElementById(browser, id) {
  * @param clickOptions The options to pass to webdriverio's element.click function.
  * @return A Promise that resolves when the actions are completed.
  */
-async function clickBlock(browser, block, clickOptions) {
+export async function clickBlock(browser, block, clickOptions) {
   const findableId = 'clickTargetElement';
   // In the browser context, find the element that we want and give it a findable ID.
   await browser.execute(
@@ -203,7 +206,7 @@ async function clickBlock(browser, block, clickOptions) {
  * @param browser The active WebdriverIO Browser object.
  * @return A Promise that resolves when the actions are completed.
  */
-async function clickWorkspace(browser) {
+export async function clickWorkspace(browser) {
   const workspace = await browser.$('#blocklyDiv > div > svg.blocklySvg > g');
   await workspace.click();
   await browser.pause(PAUSE_TIME);
@@ -215,7 +218,7 @@ async function clickWorkspace(browser) {
  * @return A Promise that resolves when the actions are completed.
  * @throws If the mutator workspace cannot be found.
  */
-async function clickMutatorWorkspace(browser) {
+export async function clickMutatorWorkspace(browser) {
   const hasMutator = await browser.$('.blocklyMutatorBackground');
   if (!hasMutator) {
     throw new Error('No mutator workspace found');
@@ -234,7 +237,7 @@ async function clickMutatorWorkspace(browser) {
  *     category with the given name, as an interactable browser element.
  * @throws If the category cannot be found.
  */
-async function getCategory(browser, categoryName) {
+export async function getCategory(browser, categoryName) {
   const category = browser.$(`.blocklyToolboxCategory*=${categoryName}`);
   category.waitForExist();
 
@@ -248,7 +251,7 @@ async function getCategory(browser, categoryName) {
  * @return A Promise that resolves to the root element of the nth
  *     block in the given category.
  */
-async function getNthBlockOfCategory(browser, categoryName, n) {
+export async function getNthBlockOfCategory(browser, categoryName, n) {
   const category = await getCategory(browser, categoryName);
   await category.click();
   const block = await browser.$(
@@ -265,7 +268,7 @@ async function getNthBlockOfCategory(browser, categoryName, n) {
  * @return A Promise that resolves to the root element of the first
  *     block with the given type in the given category.
  */
-async function getBlockTypeFromCategory(browser, categoryName, blockType) {
+export async function getBlockTypeFromCategory(browser, categoryName, blockType) {
   if (categoryName) {
     const category = await getCategory(browser, categoryName);
     await category.click();
@@ -287,7 +290,7 @@ async function getBlockTypeFromCategory(browser, categoryName, blockType) {
  * @return A Promise that resolves to the root element of the block with the
  *     given position and type on the workspace.
  */
-async function getBlockTypeFromWorkspace(browser, blockType, position) {
+export async function getBlockTypeFromWorkspace(browser, blockType, position) {
   const id = await browser.execute(
     (blockType, position) => {
       return Blockly.getMainWorkspace().getBlocksByType(blockType, true)[
@@ -372,7 +375,7 @@ async function getLocationOfBlockConnection(
  * @param dragBlockSelector The selector of the block to drag
  * @return A Promise that resolves when the actions are completed.
  */
-async function connect(
+export async function connect(
   browser,
   draggedBlock,
   draggedConnection,
@@ -411,7 +414,7 @@ async function connect(
  * @param browser The active WebdriverIO Browser object.
  * @return A Promise that resolves when the actions are completed.
  */
-async function switchRTL(browser) {
+export async function switchRTL(browser) {
   const ltrForm = await browser.$('#options > select:nth-child(1)');
   await ltrForm.selectByIndex(1);
   await browser.pause(PAUSE_TIME + 450);
@@ -431,7 +434,7 @@ async function switchRTL(browser) {
  * @return A Promise that resolves to the root element of the newly
  *     created block.
  */
-async function dragNthBlockFromFlyout(browser, categoryName, n, x, y) {
+export async function dragNthBlockFromFlyout(browser, categoryName, n, x, y) {
   const flyoutBlock = await getNthBlockOfCategory(browser, categoryName, n);
   await flyoutBlock.dragAndDrop({x: x, y: y});
   return await getSelectedBlockElement(browser);
@@ -452,7 +455,7 @@ async function dragNthBlockFromFlyout(browser, categoryName, n, x, y) {
  * @return A Promise that resolves to the root element of the newly
  *     created block.
  */
-async function dragBlockTypeFromFlyout(browser, categoryName, type, x, y) {
+export async function dragBlockTypeFromFlyout(browser, categoryName, type, x, y) {
   const flyoutBlock = await getBlockTypeFromCategory(
     browser,
     categoryName,
@@ -477,7 +480,7 @@ async function dragBlockTypeFromFlyout(browser, categoryName, type, x, y) {
  * @return A Promise that resolves to the root element of the newly
  *     created block.
  */
-async function dragBlockFromMutatorFlyout(browser, mutatorBlock, type, x, y) {
+export async function dragBlockFromMutatorFlyout(browser, mutatorBlock, type, x, y) {
   const id = await browser.execute(
     (mutatorBlockId, blockType) => {
       return Blockly.getMainWorkspace()
@@ -505,7 +508,7 @@ async function dragBlockFromMutatorFlyout(browser, mutatorBlock, type, x, y) {
  * @param itemText The display text of the context menu item to click.
  * @return A Promise that resolves when the actions are completed.
  */
-async function contextMenuSelect(browser, block, itemText) {
+export async function contextMenuSelect(browser, block, itemText) {
   await clickBlock(browser, block, {button: 2});
 
   const item = await browser.$(`div=${itemText}`);
@@ -522,7 +525,7 @@ async function contextMenuSelect(browser, block, itemText) {
  * @param block The block to click, as an interactable element.
  * @return A Promise that resolves when the actions are complete.
  */
-async function openMutatorForBlock(browser, block) {
+export async function openMutatorForBlock(browser, block) {
   const icon = await browser.$(`[data-id="${block.id}"] > g.blocklyIconGroup`);
   await icon.click();
 }
@@ -535,7 +538,7 @@ async function openMutatorForBlock(browser, block) {
  * @param browser The active WebdriverIO Browser object.
  * @return A Promise that resolves to an array of blocks on the main workspace.
  */
-async function getAllBlocks(browser) {
+export async function getAllBlocks(browser) {
   return browser.execute(() => {
     return Blockly.getMainWorkspace()
       .getAllBlocks(false)
@@ -556,7 +559,7 @@ async function getAllBlocks(browser) {
  * @param yDelta How far to drag the flyout in the y direction. Positive is down.
  * @return A Promise that resolves when the actions are completed.
  */
-async function scrollFlyout(browser, xDelta, yDelta) {
+export async function scrollFlyout(browser, xDelta, yDelta) {
   // There are two flyouts on the playground workspace: one for the trash can
   // and one for the toolbox. We want the second one.
   // This assumes there is only one scrollbar handle in the flyout, but it could
@@ -568,31 +571,3 @@ async function scrollFlyout(browser, xDelta, yDelta) {
   await scrollbarHandle.dragAndDrop({x: xDelta, y: yDelta});
   await browser.pause(PAUSE_TIME);
 }
-
-module.exports = {
-  testSetup,
-  testFileLocations,
-  driverSetup,
-  driverTeardown,
-  getSelectedBlockElement,
-  getSelectedBlockId,
-  getBlockElementById,
-  clickBlock,
-  clickWorkspace,
-  clickMutatorWorkspace,
-  getCategory,
-  getNthBlockOfCategory,
-  getBlockTypeFromCategory,
-  dragNthBlockFromFlyout,
-  dragBlockTypeFromFlyout,
-  dragBlockFromMutatorFlyout,
-  connect,
-  switchRTL,
-  contextMenuSelect,
-  openMutatorForBlock,
-  screenDirection,
-  getBlockTypeFromWorkspace,
-  getAllBlocks,
-  scrollFlyout,
-  PAUSE_TIME,
-};

--- a/tests/browser/test/toolbox_drag_test.mjs
+++ b/tests/browser/test/toolbox_drag_test.mjs
@@ -8,15 +8,15 @@
  * @fileoverview Tests for the dragging out of the toolbox and flyout.
  */
 
-const chai = require('chai');
-const {
+import * as chai from 'chai';
+import {
   testSetup,
   testFileLocations,
   getCategory,
   scrollFlyout,
   screenDirection,
   PAUSE_TIME,
-} = require('./test_setup');
+} from './test_setup.mjs';
 
 // Categories in the basic toolbox.
 const basicCategories = [

--- a/tests/browser/test/workspace_comment_test.mjs
+++ b/tests/browser/test/workspace_comment_test.mjs
@@ -4,10 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-const chai = require('chai');
-const sinon = require('sinon');
-const {Key} = require('webdriverio');
-const {testSetup, testFileLocations} = require('./test_setup');
+import * as chai from 'chai';
+import * as sinon from 'sinon';
+import {Key} from 'webdriverio';
+import {testSetup, testFileLocations} from './test_setup.mjs';
 
 suite('Workspace comments', function () {
   // Setting timeout to unlimited as the webdriver takes a longer time

--- a/tests/mocha/astnode_test.js
+++ b/tests/mocha/astnode_test.js
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import {assert} from '../../node_modules/chai/chai.js';
 import {ASTNode} from '../../build/src/core/keyboard_nav/ast_node.js';
 import {
   sharedTestSetup,
@@ -110,7 +111,7 @@ suite('ASTNode', function () {
       const connection = input.connection;
       const node = ASTNode.createConnectionNode(connection);
       const newASTNode = node.findNextForInput(input);
-      chai.assert.equal(newASTNode.getLocation(), input2.connection);
+      assert.equal(newASTNode.getLocation(), input2.connection);
     });
 
     test('findPrevForInput', function () {
@@ -119,7 +120,7 @@ suite('ASTNode', function () {
       const connection = input2.connection;
       const node = ASTNode.createConnectionNode(connection);
       const newASTNode = node.findPrevForInput(input2);
-      chai.assert.equal(newASTNode.getLocation(), input.connection);
+      assert.equal(newASTNode.getLocation(), input.connection);
     });
 
     test('findNextForField', function () {
@@ -127,7 +128,7 @@ suite('ASTNode', function () {
       const field2 = this.blocks.statementInput1.inputList[0].fieldRow[1];
       const node = ASTNode.createFieldNode(field);
       const newASTNode = node.findNextForField(field);
-      chai.assert.equal(newASTNode.getLocation(), field2);
+      assert.equal(newASTNode.getLocation(), field2);
     });
 
     test('findPrevForField', function () {
@@ -135,7 +136,7 @@ suite('ASTNode', function () {
       const field2 = this.blocks.statementInput1.inputList[0].fieldRow[1];
       const node = ASTNode.createFieldNode(field2);
       const newASTNode = node.findPrevForField(field2);
-      chai.assert.equal(newASTNode.getLocation(), field);
+      assert.equal(newASTNode.getLocation(), field);
     });
 
     test('navigateBetweenStacks_Forward', function () {
@@ -144,7 +145,7 @@ suite('ASTNode', function () {
         this.blocks.statementInput1.nextConnection,
       );
       const newASTNode = node.navigateBetweenStacks(true);
-      chai.assert.equal(newASTNode.getLocation(), this.blocks.statementInput4);
+      assert.equal(newASTNode.getLocation(), this.blocks.statementInput4);
     });
 
     test('navigateBetweenStacks_Backward', function () {
@@ -153,7 +154,7 @@ suite('ASTNode', function () {
         this.blocks.statementInput4,
       );
       const newASTNode = node.navigateBetweenStacks(false);
-      chai.assert.equal(newASTNode.getLocation(), this.blocks.statementInput1);
+      assert.equal(newASTNode.getLocation(), this.blocks.statementInput1);
     });
     test('getOutAstNodeForBlock', function () {
       const node = new ASTNode(
@@ -163,7 +164,7 @@ suite('ASTNode', function () {
       const newASTNode = node.getOutAstNodeForBlock(
         this.blocks.statementInput2,
       );
-      chai.assert.equal(newASTNode.getLocation(), this.blocks.statementInput1);
+      assert.equal(newASTNode.getLocation(), this.blocks.statementInput1);
     });
     test('getOutAstNodeForBlock_OneBlock', function () {
       const node = new ASTNode(
@@ -173,7 +174,7 @@ suite('ASTNode', function () {
       const newASTNode = node.getOutAstNodeForBlock(
         this.blocks.statementInput4,
       );
-      chai.assert.equal(newASTNode.getLocation(), this.blocks.statementInput4);
+      assert.equal(newASTNode.getLocation(), this.blocks.statementInput4);
     });
     test('findFirstFieldOrInput_', function () {
       const node = new ASTNode(
@@ -184,7 +185,7 @@ suite('ASTNode', function () {
       const newASTNode = node.findFirstFieldOrInput(
         this.blocks.statementInput4,
       );
-      chai.assert.equal(newASTNode.getLocation(), field);
+      assert.equal(newASTNode.getLocation(), field);
     });
   });
 
@@ -345,31 +346,31 @@ suite('ASTNode', function () {
         const prevConnection = this.blocks.statementInput1.previousConnection;
         const node = ASTNode.createConnectionNode(prevConnection);
         const nextNode = node.next();
-        chai.assert.equal(nextNode.getLocation(), this.blocks.statementInput1);
+        assert.equal(nextNode.getLocation(), this.blocks.statementInput1);
       });
       test('fromBlockToNext', function () {
         const nextConnection = this.blocks.statementInput1.nextConnection;
         const node = ASTNode.createBlockNode(this.blocks.statementInput1);
         const nextNode = node.next();
-        chai.assert.equal(nextNode.getLocation(), nextConnection);
+        assert.equal(nextNode.getLocation(), nextConnection);
       });
       test('fromBlockToNull', function () {
         const node = ASTNode.createBlockNode(this.blocks.noNextConnection);
         const nextNode = node.next();
-        chai.assert.isNull(nextNode);
+        assert.isNull(nextNode);
       });
       test('fromNextToPrevious', function () {
         const nextConnection = this.blocks.statementInput1.nextConnection;
         const prevConnection = this.blocks.statementInput2.previousConnection;
         const node = ASTNode.createConnectionNode(nextConnection);
         const nextNode = node.next();
-        chai.assert.equal(nextNode.getLocation(), prevConnection);
+        assert.equal(nextNode.getLocation(), prevConnection);
       });
       test('fromNextToNull', function () {
         const nextConnection = this.blocks.statementInput2.nextConnection;
         const node = ASTNode.createConnectionNode(nextConnection);
         const nextNode = node.next();
-        chai.assert.isNull(nextNode);
+        assert.isNull(nextNode);
       });
       test('fromInputToInput', function () {
         const input = this.blocks.statementInput1.inputList[0];
@@ -377,7 +378,7 @@ suite('ASTNode', function () {
           this.blocks.statementInput1.inputList[1].connection;
         const node = ASTNode.createInputNode(input);
         const nextNode = node.next();
-        chai.assert.equal(nextNode.getLocation(), inputConnection);
+        assert.equal(nextNode.getLocation(), inputConnection);
       });
       test('fromInputToStatementInput', function () {
         const input = this.blocks.fieldAndInputs2.inputList[1];
@@ -385,26 +386,26 @@ suite('ASTNode', function () {
           this.blocks.fieldAndInputs2.inputList[2].connection;
         const node = ASTNode.createInputNode(input);
         const nextNode = node.next();
-        chai.assert.equal(nextNode.getLocation(), inputConnection);
+        assert.equal(nextNode.getLocation(), inputConnection);
       });
       test('fromInputToField', function () {
         const input = this.blocks.fieldAndInputs2.inputList[0];
         const field = this.blocks.fieldAndInputs2.inputList[1].fieldRow[0];
         const node = ASTNode.createInputNode(input);
         const nextNode = node.next();
-        chai.assert.equal(nextNode.getLocation(), field);
+        assert.equal(nextNode.getLocation(), field);
       });
       test('fromInputToNull', function () {
         const input = this.blocks.fieldAndInputs2.inputList[2];
         const node = ASTNode.createInputNode(input);
         const nextNode = node.next();
-        chai.assert.isNull(nextNode);
+        assert.isNull(nextNode);
       });
       test('fromOutputToBlock', function () {
         const output = this.blocks.fieldWithOutput.outputConnection;
         const node = ASTNode.createConnectionNode(output);
         const nextNode = node.next();
-        chai.assert.equal(nextNode.getLocation(), this.blocks.fieldWithOutput);
+        assert.equal(nextNode.getLocation(), this.blocks.fieldWithOutput);
       });
       test('fromFieldToInput', function () {
         const field = this.blocks.statementInput1.inputList[0].fieldRow[1];
@@ -412,31 +413,31 @@ suite('ASTNode', function () {
           this.blocks.statementInput1.inputList[0].connection;
         const node = ASTNode.createFieldNode(field);
         const nextNode = node.next();
-        chai.assert.equal(nextNode.getLocation(), inputConnection);
+        assert.equal(nextNode.getLocation(), inputConnection);
       });
       test('fromFieldToField', function () {
         const field = this.blocks.fieldAndInputs.inputList[0].fieldRow[0];
         const node = ASTNode.createFieldNode(field);
         const field2 = this.blocks.fieldAndInputs.inputList[1].fieldRow[0];
         const nextNode = node.next();
-        chai.assert.equal(nextNode.getLocation(), field2);
+        assert.equal(nextNode.getLocation(), field2);
       });
       test('fromFieldToNull', function () {
         const field = this.blocks.twoFields.inputList[0].fieldRow[0];
         const node = ASTNode.createFieldNode(field);
         const nextNode = node.next();
-        chai.assert.isNull(nextNode);
+        assert.isNull(nextNode);
       });
       test('fromStackToStack', function () {
         const node = ASTNode.createStackNode(this.blocks.statementInput1);
         const nextNode = node.next();
-        chai.assert.equal(nextNode.getLocation(), this.blocks.statementInput4);
-        chai.assert.equal(nextNode.getType(), ASTNode.types.STACK);
+        assert.equal(nextNode.getLocation(), this.blocks.statementInput4);
+        assert.equal(nextNode.getType(), ASTNode.types.STACK);
       });
       test('fromStackToNull', function () {
         const node = ASTNode.createStackNode(this.blocks.singleBlock);
         const nextNode = node.next();
-        chai.assert.isNull(nextNode);
+        assert.isNull(nextNode);
       });
     });
 
@@ -445,55 +446,55 @@ suite('ASTNode', function () {
         const prevConnection = this.blocks.statementInput1.previousConnection;
         const node = ASTNode.createConnectionNode(prevConnection);
         const prevNode = node.prev();
-        chai.assert.isNull(prevNode);
+        assert.isNull(prevNode);
       });
       test('fromPreviousToNext', function () {
         const prevConnection = this.blocks.statementInput2.previousConnection;
         const node = ASTNode.createConnectionNode(prevConnection);
         const prevNode = node.prev();
         const nextConnection = this.blocks.statementInput1.nextConnection;
-        chai.assert.equal(prevNode.getLocation(), nextConnection);
+        assert.equal(prevNode.getLocation(), nextConnection);
       });
       test('fromPreviousToInput', function () {
         const prevConnection = this.blocks.statementInput3.previousConnection;
         const node = ASTNode.createConnectionNode(prevConnection);
         const prevNode = node.prev();
-        chai.assert.isNull(prevNode);
+        assert.isNull(prevNode);
       });
       test('fromBlockToPrevious', function () {
         const node = ASTNode.createBlockNode(this.blocks.statementInput1);
         const prevNode = node.prev();
         const prevConnection = this.blocks.statementInput1.previousConnection;
-        chai.assert.equal(prevNode.getLocation(), prevConnection);
+        assert.equal(prevNode.getLocation(), prevConnection);
       });
       test('fromBlockToNull', function () {
         const node = ASTNode.createBlockNode(this.blocks.noPrevConnection);
         const prevNode = node.prev();
-        chai.assert.isNull(prevNode);
+        assert.isNull(prevNode);
       });
       test('fromBlockToOutput', function () {
         const node = ASTNode.createBlockNode(this.blocks.fieldWithOutput);
         const prevNode = node.prev();
         const outputConnection = this.blocks.fieldWithOutput.outputConnection;
-        chai.assert.equal(prevNode.getLocation(), outputConnection);
+        assert.equal(prevNode.getLocation(), outputConnection);
       });
       test('fromNextToBlock', function () {
         const nextConnection = this.blocks.statementInput1.nextConnection;
         const node = ASTNode.createConnectionNode(nextConnection);
         const prevNode = node.prev();
-        chai.assert.equal(prevNode.getLocation(), this.blocks.statementInput1);
+        assert.equal(prevNode.getLocation(), this.blocks.statementInput1);
       });
       test('fromInputToField', function () {
         const input = this.blocks.statementInput1.inputList[0];
         const node = ASTNode.createInputNode(input);
         const prevNode = node.prev();
-        chai.assert.equal(prevNode.getLocation(), input.fieldRow[1]);
+        assert.equal(prevNode.getLocation(), input.fieldRow[1]);
       });
       test('fromInputToNull', function () {
         const input = this.blocks.fieldAndInputs2.inputList[0];
         const node = ASTNode.createInputNode(input);
         const prevNode = node.prev();
-        chai.assert.isNull(prevNode);
+        assert.isNull(prevNode);
       });
       test('fromInputToInput', function () {
         const input = this.blocks.fieldAndInputs2.inputList[2];
@@ -501,19 +502,19 @@ suite('ASTNode', function () {
           this.blocks.fieldAndInputs2.inputList[1].connection;
         const node = ASTNode.createInputNode(input);
         const prevNode = node.prev();
-        chai.assert.equal(prevNode.getLocation(), inputConnection);
+        assert.equal(prevNode.getLocation(), inputConnection);
       });
       test('fromOutputToNull', function () {
         const output = this.blocks.fieldWithOutput.outputConnection;
         const node = ASTNode.createConnectionNode(output);
         const prevNode = node.prev();
-        chai.assert.isNull(prevNode);
+        assert.isNull(prevNode);
       });
       test('fromFieldToNull', function () {
         const field = this.blocks.statementInput1.inputList[0].fieldRow[0];
         const node = ASTNode.createFieldNode(field);
         const prevNode = node.prev();
-        chai.assert.isNull(prevNode);
+        assert.isNull(prevNode);
       });
       test('fromFieldToInput', function () {
         const field = this.blocks.fieldAndInputs2.inputList[1].fieldRow[0];
@@ -521,20 +522,20 @@ suite('ASTNode', function () {
           this.blocks.fieldAndInputs2.inputList[0].connection;
         const node = ASTNode.createFieldNode(field);
         const prevNode = node.prev();
-        chai.assert.equal(prevNode.getLocation(), inputConnection);
+        assert.equal(prevNode.getLocation(), inputConnection);
       });
       test('fromFieldToField', function () {
         const field = this.blocks.fieldAndInputs.inputList[1].fieldRow[0];
         const field2 = this.blocks.fieldAndInputs.inputList[0].fieldRow[0];
         const node = ASTNode.createFieldNode(field);
         const prevNode = node.prev();
-        chai.assert.equal(prevNode.getLocation(), field2);
+        assert.equal(prevNode.getLocation(), field2);
       });
       test('fromStackToStack', function () {
         const node = ASTNode.createStackNode(this.blocks.statementInput4);
         const prevNode = node.prev();
-        chai.assert.equal(prevNode.getLocation(), this.blocks.statementInput1);
-        chai.assert.equal(prevNode.getType(), ASTNode.types.STACK);
+        assert.equal(prevNode.getLocation(), this.blocks.statementInput1);
+        assert.equal(prevNode.getType(), ASTNode.types.STACK);
       });
     });
 
@@ -551,13 +552,13 @@ suite('ASTNode', function () {
         const node = ASTNode.createInputNode(input);
         const inNode = node.in();
         const outputConnection = this.blocks.fieldWithOutput.outputConnection;
-        chai.assert.equal(inNode.getLocation(), outputConnection);
+        assert.equal(inNode.getLocation(), outputConnection);
       });
       test('fromInputToNull', function () {
         const input = this.blocks.statementInput2.inputList[0];
         const node = ASTNode.createInputNode(input);
         const inNode = node.in();
-        chai.assert.isNull(inNode);
+        assert.isNull(inNode);
       });
       test('fromInputToPrevious', function () {
         const input = this.blocks.statementInput2.inputList[1];
@@ -565,60 +566,60 @@ suite('ASTNode', function () {
           this.blocks.statementInput3.previousConnection;
         const node = ASTNode.createInputNode(input);
         const inNode = node.in();
-        chai.assert.equal(inNode.getLocation(), previousConnection);
+        assert.equal(inNode.getLocation(), previousConnection);
       });
       test('fromBlockToInput', function () {
         const input = this.blocks.valueInput.inputList[0];
         const node = ASTNode.createBlockNode(this.blocks.valueInput);
         const inNode = node.in();
-        chai.assert.equal(inNode.getLocation(), input.connection);
+        assert.equal(inNode.getLocation(), input.connection);
       });
       test('fromBlockToField', function () {
         const node = ASTNode.createBlockNode(this.blocks.statementInput1);
         const inNode = node.in();
         const field = this.blocks.statementInput1.inputList[0].fieldRow[0];
-        chai.assert.equal(inNode.getLocation(), field);
+        assert.equal(inNode.getLocation(), field);
       });
       test('fromBlockToPrevious', function () {
         const prevConnection = this.blocks.statementInput4.previousConnection;
         const node = ASTNode.createStackNode(this.blocks.statementInput4);
         const inNode = node.in();
-        chai.assert.equal(inNode.getLocation(), prevConnection);
-        chai.assert.equal(inNode.getType(), ASTNode.types.PREVIOUS);
+        assert.equal(inNode.getLocation(), prevConnection);
+        assert.equal(inNode.getType(), ASTNode.types.PREVIOUS);
       });
       test('fromBlockToNull_DummyInput', function () {
         const node = ASTNode.createBlockNode(this.blocks.dummyInput);
         const inNode = node.in();
-        chai.assert.isNull(inNode);
+        assert.isNull(inNode);
       });
       test('fromBlockToInput_DummyInputValue', function () {
         const node = ASTNode.createBlockNode(this.blocks.dummyInputValue);
         const inputConnection =
           this.blocks.dummyInputValue.inputList[1].connection;
         const inNode = node.in();
-        chai.assert.equal(inNode.getLocation(), inputConnection);
+        assert.equal(inNode.getLocation(), inputConnection);
       });
       test('fromOuputToNull', function () {
         const output = this.blocks.fieldWithOutput.outputConnection;
         const node = ASTNode.createConnectionNode(output);
         const inNode = node.in();
-        chai.assert.isNull(inNode);
+        assert.isNull(inNode);
       });
       test('fromFieldToNull', function () {
         const field = this.blocks.statementInput1.inputList[0].fieldRow[0];
         const node = ASTNode.createFieldNode(field);
         const inNode = node.in();
-        chai.assert.isNull(inNode);
+        assert.isNull(inNode);
       });
       test('fromWorkspaceToStack', function () {
         const coordinate = new Blockly.utils.Coordinate(100, 100);
         const node = ASTNode.createWorkspaceNode(this.workspace, coordinate);
         const inNode = node.in();
-        chai.assert.equal(
+        assert.equal(
           inNode.getLocation(),
           this.workspace.getTopBlocks()[0],
         );
-        chai.assert.equal(inNode.getType(), ASTNode.types.STACK);
+        assert.equal(inNode.getType(), ASTNode.types.STACK);
       });
       test('fromWorkspaceToNull', function () {
         const coordinate = new Blockly.utils.Coordinate(100, 100);
@@ -627,27 +628,27 @@ suite('ASTNode', function () {
           coordinate,
         );
         const inNode = node.in();
-        chai.assert.isNull(inNode);
+        assert.isNull(inNode);
       });
       test('fromStackToPrevious', function () {
         const node = ASTNode.createStackNode(this.blocks.statementInput1);
         const previous = this.blocks.statementInput1.previousConnection;
         const inNode = node.in();
-        chai.assert.equal(inNode.getLocation(), previous);
-        chai.assert.equal(inNode.getType(), ASTNode.types.PREVIOUS);
+        assert.equal(inNode.getLocation(), previous);
+        assert.equal(inNode.getType(), ASTNode.types.PREVIOUS);
       });
       test('fromStackToOutput', function () {
         const node = ASTNode.createStackNode(this.blocks.fieldWithOutput2);
         const output = this.blocks.fieldWithOutput2.outputConnection;
         const inNode = node.in();
-        chai.assert.equal(inNode.getLocation(), output);
-        chai.assert.equal(inNode.getType(), ASTNode.types.OUTPUT);
+        assert.equal(inNode.getLocation(), output);
+        assert.equal(inNode.getType(), ASTNode.types.OUTPUT);
       });
       test('fromStackToBlock', function () {
         const node = ASTNode.createStackNode(this.blocks.dummyInput);
         const inNode = node.in();
-        chai.assert.equal(inNode.getLocation(), this.blocks.dummyInput);
-        chai.assert.equal(inNode.getType(), ASTNode.types.BLOCK);
+        assert.equal(inNode.getLocation(), this.blocks.dummyInput);
+        assert.equal(inNode.getType(), ASTNode.types.BLOCK);
       });
     });
 
@@ -667,15 +668,15 @@ suite('ASTNode', function () {
         const input = this.blocks.statementInput1.inputList[0];
         const node = ASTNode.createInputNode(input);
         const outNode = node.out();
-        chai.assert.equal(outNode.getType(), ASTNode.types.BLOCK);
-        chai.assert.equal(outNode.getLocation(), this.blocks.statementInput1);
+        assert.equal(outNode.getType(), ASTNode.types.BLOCK);
+        assert.equal(outNode.getLocation(), this.blocks.statementInput1);
       });
       test('fromOutputToInput', function () {
         const output = this.blocks.fieldWithOutput.outputConnection;
         const node = ASTNode.createConnectionNode(output);
         const outNode = node.out();
-        chai.assert.equal(outNode.getType(), ASTNode.types.INPUT);
-        chai.assert.equal(
+        assert.equal(outNode.getType(), ASTNode.types.INPUT);
+        assert.equal(
           outNode.getLocation(),
           this.blocks.statementInput1.inputList[0].connection,
         );
@@ -684,15 +685,15 @@ suite('ASTNode', function () {
         const output = this.blocks.fieldWithOutput2.outputConnection;
         const node = ASTNode.createConnectionNode(output);
         const outNode = node.out();
-        chai.assert.equal(outNode.getType(), ASTNode.types.STACK);
-        chai.assert.equal(outNode.getLocation(), this.blocks.fieldWithOutput2);
+        assert.equal(outNode.getType(), ASTNode.types.STACK);
+        assert.equal(outNode.getLocation(), this.blocks.fieldWithOutput2);
       });
       test('fromFieldToBlock', function () {
         const field = this.blocks.statementInput1.inputList[0].fieldRow[0];
         const node = ASTNode.createFieldNode(field);
         const outNode = node.out();
-        chai.assert.equal(outNode.getType(), ASTNode.types.BLOCK);
-        chai.assert.equal(outNode.getLocation(), this.blocks.statementInput1);
+        assert.equal(outNode.getType(), ASTNode.types.BLOCK);
+        assert.equal(outNode.getLocation(), this.blocks.statementInput1);
       });
       test('fromStackToWorkspace', function () {
         const stub = sinon
@@ -700,9 +701,9 @@ suite('ASTNode', function () {
           .returns({x: 10, y: 10});
         const node = ASTNode.createStackNode(this.blocks.statementInput4);
         const outNode = node.out();
-        chai.assert.equal(outNode.getType(), ASTNode.types.WORKSPACE);
-        chai.assert.equal(outNode.wsCoordinate.x, 10);
-        chai.assert.equal(outNode.wsCoordinate.y, -10);
+        assert.equal(outNode.getType(), ASTNode.types.WORKSPACE);
+        assert.equal(outNode.wsCoordinate.x, 10);
+        assert.equal(outNode.wsCoordinate.y, -10);
         stub.restore();
       });
       test('fromPreviousToInput', function () {
@@ -711,15 +712,15 @@ suite('ASTNode', function () {
           this.blocks.statementInput2.inputList[1].connection;
         const node = ASTNode.createConnectionNode(previous);
         const outNode = node.out();
-        chai.assert.equal(outNode.getType(), ASTNode.types.INPUT);
-        chai.assert.equal(outNode.getLocation(), inputConnection);
+        assert.equal(outNode.getType(), ASTNode.types.INPUT);
+        assert.equal(outNode.getLocation(), inputConnection);
       });
       test('fromPreviousToStack', function () {
         const previous = this.blocks.statementInput2.previousConnection;
         const node = ASTNode.createConnectionNode(previous);
         const outNode = node.out();
-        chai.assert.equal(outNode.getType(), ASTNode.types.STACK);
-        chai.assert.equal(outNode.getLocation(), this.blocks.statementInput1);
+        assert.equal(outNode.getType(), ASTNode.types.STACK);
+        assert.equal(outNode.getLocation(), this.blocks.statementInput1);
       });
       test('fromNextToInput', function () {
         const next = this.blocks.statementInput3.nextConnection;
@@ -727,22 +728,22 @@ suite('ASTNode', function () {
           this.blocks.statementInput2.inputList[1].connection;
         const node = ASTNode.createConnectionNode(next);
         const outNode = node.out();
-        chai.assert.equal(outNode.getType(), ASTNode.types.INPUT);
-        chai.assert.equal(outNode.getLocation(), inputConnection);
+        assert.equal(outNode.getType(), ASTNode.types.INPUT);
+        assert.equal(outNode.getLocation(), inputConnection);
       });
       test('fromNextToStack', function () {
         const next = this.blocks.statementInput2.nextConnection;
         const node = ASTNode.createConnectionNode(next);
         const outNode = node.out();
-        chai.assert.equal(outNode.getType(), ASTNode.types.STACK);
-        chai.assert.equal(outNode.getLocation(), this.blocks.statementInput1);
+        assert.equal(outNode.getType(), ASTNode.types.STACK);
+        assert.equal(outNode.getLocation(), this.blocks.statementInput1);
       });
       test('fromNextToStack_NoPreviousConnection', function () {
         const next = this.blocks.secondBlock.nextConnection;
         const node = ASTNode.createConnectionNode(next);
         const outNode = node.out();
-        chai.assert.equal(outNode.getType(), ASTNode.types.STACK);
-        chai.assert.equal(outNode.getLocation(), this.blocks.noPrevConnection);
+        assert.equal(outNode.getType(), ASTNode.types.STACK);
+        assert.equal(outNode.getLocation(), this.blocks.noPrevConnection);
       });
       /**
        * This is where there is a block with both an output connection and a
@@ -752,8 +753,8 @@ suite('ASTNode', function () {
         const next = this.blocks.outputNextBlock.nextConnection;
         const node = ASTNode.createConnectionNode(next);
         const outNode = node.out();
-        chai.assert.equal(outNode.getType(), ASTNode.types.INPUT);
-        chai.assert.equal(
+        assert.equal(outNode.getType(), ASTNode.types.INPUT);
+        assert.equal(
           outNode.getLocation(),
           this.blocks.secondBlock.inputList[0].connection,
         );
@@ -761,34 +762,34 @@ suite('ASTNode', function () {
       test('fromBlockToStack', function () {
         const node = ASTNode.createBlockNode(this.blocks.statementInput2);
         const outNode = node.out();
-        chai.assert.equal(outNode.getType(), ASTNode.types.STACK);
-        chai.assert.equal(outNode.getLocation(), this.blocks.statementInput1);
+        assert.equal(outNode.getType(), ASTNode.types.STACK);
+        assert.equal(outNode.getLocation(), this.blocks.statementInput1);
       });
       test('fromBlockToInput', function () {
         const input = this.blocks.statementInput2.inputList[1].connection;
         const node = ASTNode.createBlockNode(this.blocks.statementInput3);
         const outNode = node.out();
-        chai.assert.equal(outNode.getType(), ASTNode.types.INPUT);
-        chai.assert.equal(outNode.getLocation(), input);
+        assert.equal(outNode.getType(), ASTNode.types.INPUT);
+        assert.equal(outNode.getLocation(), input);
       });
       test('fromTopBlockToStack', function () {
         const node = ASTNode.createBlockNode(this.blocks.statementInput1);
         const outNode = node.out();
-        chai.assert.equal(outNode.getType(), ASTNode.types.STACK);
-        chai.assert.equal(outNode.getLocation(), this.blocks.statementInput1);
+        assert.equal(outNode.getType(), ASTNode.types.STACK);
+        assert.equal(outNode.getLocation(), this.blocks.statementInput1);
       });
       test('fromBlockToStack_OutputConnection', function () {
         const node = ASTNode.createBlockNode(this.blocks.fieldWithOutput2);
         const outNode = node.out();
-        chai.assert.equal(outNode.getType(), ASTNode.types.STACK);
-        chai.assert.equal(outNode.getLocation(), this.blocks.fieldWithOutput2);
+        assert.equal(outNode.getType(), ASTNode.types.STACK);
+        assert.equal(outNode.getLocation(), this.blocks.fieldWithOutput2);
       });
       test('fromBlockToInput_OutputConnection', function () {
         const node = ASTNode.createBlockNode(this.blocks.outputNextBlock);
         const inputConnection = this.blocks.secondBlock.inputList[0].connection;
         const outNode = node.out();
-        chai.assert.equal(outNode.getType(), ASTNode.types.INPUT);
-        chai.assert.equal(outNode.getLocation(), inputConnection);
+        assert.equal(outNode.getType(), ASTNode.types.INPUT);
+        assert.equal(outNode.getLocation(), inputConnection);
       });
     });
 
@@ -796,31 +797,31 @@ suite('ASTNode', function () {
       test('createFieldNode', function () {
         const field = this.blocks.statementInput1.inputList[0].fieldRow[0];
         const node = ASTNode.createFieldNode(field);
-        chai.assert.equal(node.getLocation(), field);
-        chai.assert.equal(node.getType(), ASTNode.types.FIELD);
-        chai.assert.isFalse(node.isConnection());
+        assert.equal(node.getLocation(), field);
+        assert.equal(node.getType(), ASTNode.types.FIELD);
+        assert.isFalse(node.isConnection());
       });
       test('createConnectionNode', function () {
         const prevConnection = this.blocks.statementInput4.previousConnection;
         const node = ASTNode.createConnectionNode(prevConnection);
-        chai.assert.equal(node.getLocation(), prevConnection);
-        chai.assert.equal(node.getType(), ASTNode.types.PREVIOUS);
-        chai.assert.isTrue(node.isConnection());
+        assert.equal(node.getLocation(), prevConnection);
+        assert.equal(node.getType(), ASTNode.types.PREVIOUS);
+        assert.isTrue(node.isConnection());
       });
       test('createInputNode', function () {
         const input = this.blocks.statementInput1.inputList[0];
         const node = ASTNode.createInputNode(input);
-        chai.assert.equal(node.getLocation(), input.connection);
-        chai.assert.equal(node.getType(), ASTNode.types.INPUT);
-        chai.assert.isTrue(node.isConnection());
+        assert.equal(node.getLocation(), input.connection);
+        assert.equal(node.getType(), ASTNode.types.INPUT);
+        assert.isTrue(node.isConnection());
       });
       test('createWorkspaceNode', function () {
         const coordinate = new Blockly.utils.Coordinate(100, 100);
         const node = ASTNode.createWorkspaceNode(this.workspace, coordinate);
-        chai.assert.equal(node.getLocation(), this.workspace);
-        chai.assert.equal(node.getType(), ASTNode.types.WORKSPACE);
-        chai.assert.equal(node.getWsCoordinate(), coordinate);
-        chai.assert.isFalse(node.isConnection());
+        assert.equal(node.getLocation(), this.workspace);
+        assert.equal(node.getType(), ASTNode.types.WORKSPACE);
+        assert.equal(node.getWsCoordinate(), coordinate);
+        assert.isFalse(node.isConnection());
       });
       test('createStatementConnectionNode', function () {
         const nextConnection =
@@ -828,24 +829,24 @@ suite('ASTNode', function () {
         const inputConnection =
           this.blocks.statementInput1.inputList[1].connection;
         const node = ASTNode.createConnectionNode(nextConnection);
-        chai.assert.equal(node.getLocation(), inputConnection);
-        chai.assert.equal(node.getType(), ASTNode.types.INPUT);
-        chai.assert.isTrue(node.isConnection());
+        assert.equal(node.getLocation(), inputConnection);
+        assert.equal(node.getType(), ASTNode.types.INPUT);
+        assert.isTrue(node.isConnection());
       });
       test('createTopNode-previous', function () {
         const block = this.blocks.statementInput1;
         const topNode = ASTNode.createTopNode(block);
-        chai.assert.equal(topNode.getLocation(), block.previousConnection);
+        assert.equal(topNode.getLocation(), block.previousConnection);
       });
       test('createTopNode-block', function () {
         const block = this.blocks.noPrevConnection;
         const topNode = ASTNode.createTopNode(block);
-        chai.assert.equal(topNode.getLocation(), block);
+        assert.equal(topNode.getLocation(), block);
       });
       test('createTopNode-output', function () {
         const block = this.blocks.outputNextBlock;
         const topNode = ASTNode.createTopNode(block);
-        chai.assert.equal(topNode.getLocation(), block.outputConnection);
+        assert.equal(topNode.getLocation(), block.outputConnection);
       });
     });
   });

--- a/tests/mocha/astnode_test.js
+++ b/tests/mocha/astnode_test.js
@@ -615,10 +615,7 @@ suite('ASTNode', function () {
         const coordinate = new Blockly.utils.Coordinate(100, 100);
         const node = ASTNode.createWorkspaceNode(this.workspace, coordinate);
         const inNode = node.in();
-        assert.equal(
-          inNode.getLocation(),
-          this.workspace.getTopBlocks()[0],
-        );
+        assert.equal(inNode.getLocation(), this.workspace.getTopBlocks()[0]);
         assert.equal(inNode.getType(), ASTNode.types.STACK);
       });
       test('fromWorkspaceToNull', function () {

--- a/tests/mocha/block_json_test.js
+++ b/tests/mocha/block_json_test.js
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import {assert} from '../../node_modules/chai/chai.js';
 import {Align} from '../../build/src/core/inputs/align.js';
 import {
   sharedTestSetup,
@@ -27,7 +28,7 @@ suite('Block JSON initialization', function () {
           type: 'test',
           validateTokens_: Blockly.Block.prototype.validateTokens_,
         };
-        chai.assert.throws(function () {
+        assert.throws(function () {
           block.validateTokens_(tokens, count);
         }, error);
       };
@@ -37,7 +38,7 @@ suite('Block JSON initialization', function () {
           type: 'test',
           validateTokens_: Blockly.Block.prototype.validateTokens_,
         };
-        chai.assert.doesNotThrow(function () {
+        assert.doesNotThrow(function () {
           block.validateTokens_(tokens, count);
         });
       };
@@ -105,7 +106,7 @@ suite('Block JSON initialization', function () {
           stringToFieldJson_: Blockly.Block.prototype.stringToFieldJson_,
           isInputKeyword_: Blockly.Block.prototype.isInputKeyword_,
         };
-        chai.assert.deepEqual(
+        assert.deepEqual(
           block.interpolateArguments_(tokens, args, lastAlign),
           elements,
         );
@@ -405,7 +406,7 @@ suite('Block JSON initialization', function () {
           fieldFromJson_: Blockly.Block.prototype.fieldFromJson_,
           stringToFieldJson_: Blockly.Block.prototype.stringToFieldJson_,
         };
-        chai.assert.strictEqual(block.fieldFromJson_(json), expectedType);
+        assert.strictEqual(block.fieldFromJson_(json), expectedType);
       };
     });
 
@@ -573,34 +574,34 @@ suite('Block JSON initialization', function () {
         const input = block.inputFromJson_(json);
         switch (type) {
           case 'input_dummy':
-            chai.assert.isTrue(
+            assert.isTrue(
               block.appendDummyInput.calledOnce,
               'Expected a dummy input to be created.',
             );
             break;
           case 'input_value':
-            chai.assert.isTrue(
+            assert.isTrue(
               block.appendValueInput.calledOnce,
               'Expected a value input to be created.',
             );
             break;
           case 'input_statement':
-            chai.assert.isTrue(
+            assert.isTrue(
               block.appendStatementInput.calledOnce,
               'Expected a statement input to be created.',
             );
             break;
           default:
-            chai.assert.isNull(input, 'Expected input to be null');
-            chai.assert.isTrue(
+            assert.isNull(input, 'Expected input to be null');
+            assert.isTrue(
               block.appendDummyInput.notCalled,
               'Expected no input to be created',
             );
-            chai.assert.isTrue(
+            assert.isTrue(
               block.appendValueInput.notCalled,
               'Expected no input to be created',
             );
-            chai.assert.isTrue(
+            assert.isTrue(
               block.appendStatementInput.notCalled,
               'Expected no input to be created',
             );
@@ -608,13 +609,13 @@ suite('Block JSON initialization', function () {
         }
         if (check) {
           if (Array.isArray(check)) {
-            chai.assert.deepEqual(check, input.connection.getCheck());
+            assert.deepEqual(check, input.connection.getCheck());
           } else {
-            chai.assert.deepEqual([check], input.connection.getCheck());
+            assert.deepEqual([check], input.connection.getCheck());
           }
         }
         if (align !== undefined) {
-          chai.assert.equal(align, input.align);
+          assert.equal(align, input.align);
         }
       };
     });
@@ -667,7 +668,7 @@ suite('Block JSON initialization', function () {
         );
         const block = this.workspace.newBlock('test_basic_empty');
         block.inputFromJson_({'type': 'custom'});
-        chai.assert.instanceOf(
+        assert.instanceOf(
           block.inputList[0],
           CustomInput,
           'Expected the registered input to be constructed',

--- a/tests/mocha/block_test.js
+++ b/tests/mocha/block_test.js
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import {assert} from '../../node_modules/chai/chai.js';
 import {ConnectionType} from '../../build/src/core/connection_type.js';
 import {createDeprecationWarningStub} from './test_helpers/warnings.js';
 import {createRenderedBlock} from './test_helpers/block_definitions.js';
@@ -80,7 +81,7 @@ suite('Blocks', function () {
       blockB.nextConnection.connect(blockC.previousConnection);
     }
 
-    chai.assert.equal(blockC.getParent(), blockB);
+    assert.equal(blockC.getParent(), blockB);
 
     return {
       A: blockA /* Parent */,
@@ -92,30 +93,30 @@ suite('Blocks', function () {
   suite('Unplug', function () {
     function assertUnpluggedNoheal(blocks) {
       // A has nothing connected to it.
-      chai.assert.equal(blocks.A.getChildren().length, 0);
+      assert.equal(blocks.A.getChildren().length, 0);
       // B and C are still connected.
-      chai.assert.equal(blocks.C.getParent(), blocks.B);
+      assert.equal(blocks.C.getParent(), blocks.B);
       // B is the top of its stack.
-      chai.assert.isNull(blocks.B.getParent());
+      assert.isNull(blocks.B.getParent());
     }
     function assertUnpluggedHealed(blocks) {
       // A and C are connected.
-      chai.assert.equal(blocks.A.getChildren().length, 1);
-      chai.assert.equal(blocks.C.getParent(), blocks.A);
+      assert.equal(blocks.A.getChildren().length, 1);
+      assert.equal(blocks.C.getParent(), blocks.A);
       // B has nothing connected to it.
-      chai.assert.equal(blocks.B.getChildren().length, 0);
+      assert.equal(blocks.B.getChildren().length, 0);
       // B is the top of its stack.
-      chai.assert.isNull(blocks.B.getParent());
+      assert.isNull(blocks.B.getParent());
     }
     function assertUnpluggedHealFailed(blocks) {
       // A has nothing connected to it.
-      chai.assert.equal(blocks.A.getChildren().length, 0);
+      assert.equal(blocks.A.getChildren().length, 0);
       // B has nothing connected to it.
-      chai.assert.equal(blocks.B.getChildren().length, 0);
+      assert.equal(blocks.B.getChildren().length, 0);
       // B is the top of its stack.
-      chai.assert.isNull(blocks.B.getParent());
+      assert.isNull(blocks.B.getParent());
       // C is the top of its stack.
-      chai.assert.isNull(blocks.C.getParent());
+      assert.isNull(blocks.C.getParent());
     }
 
     suite('Row', function () {
@@ -232,7 +233,7 @@ suite('Blocks', function () {
 
         this.block.dispose();
 
-        chai.assert.isTrue(spy.calledOnce, 'Expected destroy to be called.');
+        assert.isTrue(spy.calledOnce, 'Expected destroy to be called.');
       });
 
       test('disposing is set before destroy', function () {
@@ -243,7 +244,7 @@ suite('Blocks', function () {
 
         this.block.dispose();
 
-        chai.assert.isTrue(
+        assert.isTrue(
           disposing,
           'Expected disposing to be set to true before destroy is called.',
         );
@@ -257,7 +258,7 @@ suite('Blocks', function () {
 
         this.block.dispose();
 
-        chai.assert.isFalse(
+        assert.isFalse(
           disposed,
           'Expected disposed to be false when destroy is called',
         );
@@ -273,7 +274,7 @@ suite('Blocks', function () {
         this.block.dispose();
         this.clock.runAll();
 
-        chai.assert.isTrue(
+        assert.isTrue(
           spy.calledWith(mockEvent),
           'Expected to be able to fire events from destroy',
         );
@@ -293,7 +294,7 @@ suite('Blocks', function () {
         this.block.dispose();
         this.clock.runAll();
 
-        chai.assert.isTrue(
+        assert.isTrue(
           spy.calledWith(mockEvent),
           'Expected to be able to fire events from destroy',
         );
@@ -302,34 +303,34 @@ suite('Blocks', function () {
 
     suite('stack/row healing', function () {
       function assertDisposedNoheal(blocks) {
-        chai.assert.isFalse(blocks.A.disposed);
+        assert.isFalse(blocks.A.disposed);
         // A has nothing connected to it.
-        chai.assert.equal(blocks.A.getChildren().length, 0);
+        assert.equal(blocks.A.getChildren().length, 0);
         // B is disposed.
-        chai.assert.isTrue(blocks.B.disposed);
+        assert.isTrue(blocks.B.disposed);
         // And C is disposed.
-        chai.assert.isTrue(blocks.C.disposed);
+        assert.isTrue(blocks.C.disposed);
       }
 
       function assertDisposedHealed(blocks) {
-        chai.assert.isFalse(blocks.A.disposed);
-        chai.assert.isFalse(blocks.C.disposed);
+        assert.isFalse(blocks.A.disposed);
+        assert.isFalse(blocks.C.disposed);
         // A and C are connected.
-        chai.assert.equal(blocks.A.getChildren().length, 1);
-        chai.assert.equal(blocks.C.getParent(), blocks.A);
+        assert.equal(blocks.A.getChildren().length, 1);
+        assert.equal(blocks.C.getParent(), blocks.A);
         // B is disposed.
-        chai.assert.isTrue(blocks.B.disposed);
+        assert.isTrue(blocks.B.disposed);
       }
 
       function assertDisposedHealFailed(blocks) {
-        chai.assert.isFalse(blocks.A.disposed);
-        chai.assert.isFalse(blocks.C.disposed);
+        assert.isFalse(blocks.A.disposed);
+        assert.isFalse(blocks.C.disposed);
         // A has nothing connected to it.
-        chai.assert.equal(blocks.A.getChildren().length, 0);
+        assert.equal(blocks.A.getChildren().length, 0);
         // B is disposed.
-        chai.assert.isTrue(blocks.B.disposed);
+        assert.isTrue(blocks.B.disposed);
         // C is the top of its stack.
-        chai.assert.isNull(blocks.C.getParent());
+        assert.isNull(blocks.C.getParent());
       }
 
       suite('Row', function () {
@@ -469,7 +470,7 @@ suite('Blocks', function () {
 
       test('No Connected', function () {
         this.blockA.removeInput('VALUE');
-        chai.assert.isNull(this.blockA.getInput('VALUE'));
+        assert.isNull(this.blockA.getInput('VALUE'));
       });
       test('Block Connected', function () {
         const blockB = this.workspace.newBlock('row_block');
@@ -478,8 +479,8 @@ suite('Blocks', function () {
           .connection.connect(blockB.outputConnection);
 
         this.blockA.removeInput('VALUE');
-        chai.assert.isFalse(blockB.disposed);
-        chai.assert.equal(this.blockA.getChildren().length, 0);
+        assert.isFalse(blockB.disposed);
+        assert.equal(this.blockA.getChildren().length, 0);
       });
       test('Shadow Connected', function () {
         const blockB = this.workspace.newBlock('row_block');
@@ -489,8 +490,8 @@ suite('Blocks', function () {
           .connection.connect(blockB.outputConnection);
 
         this.blockA.removeInput('VALUE');
-        chai.assert.isTrue(blockB.disposed);
-        chai.assert.equal(this.blockA.getChildren().length, 0);
+        assert.isTrue(blockB.disposed);
+        assert.equal(this.blockA.getChildren().length, 0);
       });
     });
     suite('Statement', function () {
@@ -500,7 +501,7 @@ suite('Blocks', function () {
 
       test('No Connected', function () {
         this.blockA.removeInput('STATEMENT');
-        chai.assert.isNull(this.blockA.getInput('STATEMENT'));
+        assert.isNull(this.blockA.getInput('STATEMENT'));
       });
       test('Block Connected', function () {
         const blockB = this.workspace.newBlock('stack_block');
@@ -509,8 +510,8 @@ suite('Blocks', function () {
           .connection.connect(blockB.previousConnection);
 
         this.blockA.removeInput('STATEMENT');
-        chai.assert.isFalse(blockB.disposed);
-        chai.assert.equal(this.blockA.getChildren().length, 0);
+        assert.isFalse(blockB.disposed);
+        assert.equal(this.blockA.getChildren().length, 0);
       });
       test('Shadow Connected', function () {
         const blockB = this.workspace.newBlock('stack_block');
@@ -520,8 +521,8 @@ suite('Blocks', function () {
           .connection.connect(blockB.previousConnection);
 
         this.blockA.removeInput('STATEMENT');
-        chai.assert.isTrue(blockB.disposed);
-        chai.assert.equal(this.blockA.getChildren().length, 0);
+        assert.isTrue(blockB.disposed);
+        assert.equal(this.blockA.getChildren().length, 0);
       });
     });
   });
@@ -549,10 +550,10 @@ suite('Blocks', function () {
       };
 
       this.assertConnectionsEmpty = function () {
-        chai.assert.isEmpty(this.getInputs());
-        chai.assert.isEmpty(this.getOutputs());
-        chai.assert.isEmpty(this.getNext());
-        chai.assert.isEmpty(this.getPrevious());
+        assert.isEmpty(this.getInputs());
+        assert.isEmpty(this.getOutputs());
+        assert.isEmpty(this.getNext());
+        assert.isEmpty(this.getPrevious());
       };
     });
     teardown(function () {
@@ -572,8 +573,8 @@ suite('Blocks', function () {
         this.deserializationHelper(
           '<xml>' + '  <block type="stack_block"/>' + '</xml>',
         );
-        chai.assert.equal(this.getPrevious().length, 1);
-        chai.assert.equal(this.getNext().length, 1);
+        assert.equal(this.getPrevious().length, 1);
+        assert.equal(this.getNext().length, 1);
       });
       test('Multi-Stack', function () {
         this.deserializationHelper(
@@ -589,15 +590,15 @@ suite('Blocks', function () {
             '  </block>' +
             '</xml>',
         );
-        chai.assert.equal(this.getPrevious().length, 3);
-        chai.assert.equal(this.getNext().length, 3);
+        assert.equal(this.getPrevious().length, 3);
+        assert.equal(this.getNext().length, 3);
       });
       test('Collapsed Stack', function () {
         this.deserializationHelper(
           '<xml>' + '  <block type="stack_block" collapsed="true"/>' + '</xml>',
         );
-        chai.assert.equal(this.getPrevious().length, 1);
-        chai.assert.equal(this.getNext().length, 1);
+        assert.equal(this.getPrevious().length, 1);
+        assert.equal(this.getNext().length, 1);
       });
       test('Collapsed Multi-Stack', function () {
         this.deserializationHelper(
@@ -613,15 +614,15 @@ suite('Blocks', function () {
             '  </block>' +
             '</xml>',
         );
-        chai.assert.equal(this.getPrevious().length, 3);
-        chai.assert.equal(this.getNext().length, 3);
+        assert.equal(this.getPrevious().length, 3);
+        assert.equal(this.getNext().length, 3);
       });
       test('Row', function () {
         this.deserializationHelper(
           '<xml>' + '  <block type="row_block"/>' + '</xml>',
         );
-        chai.assert.equal(this.getOutputs().length, 1);
-        chai.assert.equal(this.getInputs().length, 1);
+        assert.equal(this.getOutputs().length, 1);
+        assert.equal(this.getInputs().length, 1);
       });
       test('Multi-Row', function () {
         this.deserializationHelper(
@@ -637,15 +638,15 @@ suite('Blocks', function () {
             '  </block>' +
             '</xml>',
         );
-        chai.assert.equal(this.getOutputs().length, 3);
-        chai.assert.equal(this.getInputs().length, 3);
+        assert.equal(this.getOutputs().length, 3);
+        assert.equal(this.getInputs().length, 3);
       });
       test('Collapsed Row', function () {
         this.deserializationHelper(
           '<xml>' + '  <block type="row_block" collapsed="true"/>' + '</xml>',
         );
-        chai.assert.equal(this.getOutputs().length, 1);
-        chai.assert.equal(this.getInputs().length, 0);
+        assert.equal(this.getOutputs().length, 1);
+        assert.equal(this.getInputs().length, 0);
       });
       test('Collapsed Multi-Row', function () {
         this.deserializationHelper(
@@ -661,8 +662,8 @@ suite('Blocks', function () {
             '  </block>' +
             '</xml>',
         );
-        chai.assert.equal(this.getOutputs().length, 1);
-        chai.assert.equal(this.getInputs().length, 0);
+        assert.equal(this.getOutputs().length, 1);
+        assert.equal(this.getInputs().length, 0);
       });
       test('Collapsed Multi-Row Middle', function () {
         Blockly.Xml.appendDomToWorkspace(
@@ -683,15 +684,15 @@ suite('Blocks', function () {
         );
         this.assertConnectionsEmpty();
         this.clock.runAll();
-        chai.assert.equal(this.getOutputs().length, 2);
-        chai.assert.equal(this.getInputs().length, 1);
+        assert.equal(this.getOutputs().length, 2);
+        assert.equal(this.getInputs().length, 1);
       });
       test('Statement', function () {
         this.deserializationHelper(
           '<xml>' + '  <block type="statement_block"/>' + '</xml>',
         );
-        chai.assert.equal(this.getPrevious().length, 1);
-        chai.assert.equal(this.getNext().length, 2);
+        assert.equal(this.getPrevious().length, 1);
+        assert.equal(this.getNext().length, 2);
       });
       test('Multi-Statement', function () {
         this.deserializationHelper(
@@ -707,8 +708,8 @@ suite('Blocks', function () {
             '  </block>' +
             '</xml>',
         );
-        chai.assert.equal(this.getPrevious().length, 3);
-        chai.assert.equal(this.getNext().length, 6);
+        assert.equal(this.getPrevious().length, 3);
+        assert.equal(this.getNext().length, 6);
       });
       test('Collapsed Statement', function () {
         this.deserializationHelper(
@@ -716,8 +717,8 @@ suite('Blocks', function () {
             '  <block type="statement_block" collapsed="true"/>' +
             '</xml>',
         );
-        chai.assert.equal(this.getPrevious().length, 1);
-        chai.assert.equal(this.getNext().length, 1);
+        assert.equal(this.getPrevious().length, 1);
+        assert.equal(this.getNext().length, 1);
       });
       test('Collapsed Multi-Statement', function () {
         this.deserializationHelper(
@@ -733,8 +734,8 @@ suite('Blocks', function () {
             '  </block>' +
             '</xml>',
         );
-        chai.assert.equal(this.getPrevious().length, 1);
-        chai.assert.equal(this.getNext().length, 1);
+        assert.equal(this.getPrevious().length, 1);
+        assert.equal(this.getNext().length, 1);
       });
       test('Collapsed Multi-Statement Middle', function () {
         this.deserializationHelper(
@@ -750,8 +751,8 @@ suite('Blocks', function () {
             '  </block>' +
             '</xml>',
         );
-        chai.assert.equal(this.getPrevious().length, 2);
-        chai.assert.equal(this.getNext().length, 3);
+        assert.equal(this.getPrevious().length, 2);
+        assert.equal(this.getNext().length, 3);
       });
     });
     suite('Programmatic Block Creation', function () {
@@ -761,8 +762,8 @@ suite('Blocks', function () {
         block.initSvg();
         block.render();
 
-        chai.assert.equal(this.getPrevious().length, 1);
-        chai.assert.equal(this.getNext().length, 1);
+        assert.equal(this.getPrevious().length, 1);
+        assert.equal(this.getNext().length, 1);
       });
       test('Row', function () {
         const block = this.workspace.newBlock('row_block');
@@ -770,8 +771,8 @@ suite('Blocks', function () {
         block.initSvg();
         block.render();
 
-        chai.assert.equal(this.getOutputs().length, 1);
-        chai.assert.equal(this.getInputs().length, 1);
+        assert.equal(this.getOutputs().length, 1);
+        assert.equal(this.getInputs().length, 1);
       });
       test('Statement', function () {
         const block = this.workspace.newBlock('statement_block');
@@ -779,8 +780,8 @@ suite('Blocks', function () {
         block.initSvg();
         block.render();
 
-        chai.assert.equal(this.getPrevious().length, 1);
-        chai.assert.equal(this.getNext().length, 2);
+        assert.equal(this.getPrevious().length, 1);
+        assert.equal(this.getNext().length, 2);
       });
     });
     suite('setCollapsed', function () {
@@ -790,16 +791,16 @@ suite('Blocks', function () {
           this.workspace,
         );
         this.clock.runAll();
-        chai.assert.equal(this.getPrevious().length, 1);
-        chai.assert.equal(this.getNext().length, 1);
+        assert.equal(this.getPrevious().length, 1);
+        assert.equal(this.getNext().length, 1);
 
         block.setCollapsed(true);
-        chai.assert.equal(this.getPrevious().length, 1);
-        chai.assert.equal(this.getNext().length, 1);
+        assert.equal(this.getPrevious().length, 1);
+        assert.equal(this.getNext().length, 1);
 
         block.setCollapsed(false);
-        chai.assert.equal(this.getPrevious().length, 1);
-        chai.assert.equal(this.getNext().length, 1);
+        assert.equal(this.getPrevious().length, 1);
+        assert.equal(this.getNext().length, 1);
       });
       test('Multi-Stack', function () {
         const block = Blockly.Xml.domToBlock(
@@ -818,16 +819,16 @@ suite('Blocks', function () {
         );
         this.assertConnectionsEmpty();
         this.clock.runAll();
-        chai.assert.equal(this.getPrevious().length, 3);
-        chai.assert.equal(this.getNext().length, 3);
+        assert.equal(this.getPrevious().length, 3);
+        assert.equal(this.getNext().length, 3);
 
         block.setCollapsed(true);
-        chai.assert.equal(this.getPrevious().length, 3);
-        chai.assert.equal(this.getNext().length, 3);
+        assert.equal(this.getPrevious().length, 3);
+        assert.equal(this.getNext().length, 3);
 
         block.setCollapsed(false);
-        chai.assert.equal(this.getPrevious().length, 3);
-        chai.assert.equal(this.getNext().length, 3);
+        assert.equal(this.getPrevious().length, 3);
+        assert.equal(this.getNext().length, 3);
       });
       test('Row', function () {
         const block = Blockly.Xml.domToBlock(
@@ -835,16 +836,16 @@ suite('Blocks', function () {
           this.workspace,
         );
         this.clock.runAll();
-        chai.assert.equal(this.getOutputs().length, 1);
-        chai.assert.equal(this.getInputs().length, 1);
+        assert.equal(this.getOutputs().length, 1);
+        assert.equal(this.getInputs().length, 1);
 
         block.setCollapsed(true);
-        chai.assert.equal(this.getOutputs().length, 1);
-        chai.assert.equal(this.getInputs().length, 0);
+        assert.equal(this.getOutputs().length, 1);
+        assert.equal(this.getInputs().length, 0);
 
         block.setCollapsed(false);
-        chai.assert.equal(this.getOutputs().length, 1);
-        chai.assert.equal(this.getInputs().length, 1);
+        assert.equal(this.getOutputs().length, 1);
+        assert.equal(this.getInputs().length, 1);
       });
       test('Multi-Row', function () {
         const block = Blockly.Xml.domToBlock(
@@ -862,16 +863,16 @@ suite('Blocks', function () {
           this.workspace,
         );
         this.clock.runAll();
-        chai.assert.equal(this.getOutputs().length, 3);
-        chai.assert.equal(this.getInputs().length, 3);
+        assert.equal(this.getOutputs().length, 3);
+        assert.equal(this.getInputs().length, 3);
 
         block.setCollapsed(true);
-        chai.assert.equal(this.getOutputs().length, 1);
-        chai.assert.equal(this.getInputs().length, 0);
+        assert.equal(this.getOutputs().length, 1);
+        assert.equal(this.getInputs().length, 0);
 
         block.setCollapsed(false);
-        chai.assert.equal(this.getOutputs().length, 3);
-        chai.assert.equal(this.getInputs().length, 3);
+        assert.equal(this.getOutputs().length, 3);
+        assert.equal(this.getInputs().length, 3);
       });
       test('Multi-Row Middle', function () {
         let block = Blockly.Xml.domToBlock(
@@ -889,17 +890,17 @@ suite('Blocks', function () {
           this.workspace,
         );
         this.clock.runAll();
-        chai.assert.equal(this.getOutputs().length, 3);
-        chai.assert.equal(this.getInputs().length, 3);
+        assert.equal(this.getOutputs().length, 3);
+        assert.equal(this.getInputs().length, 3);
 
         block = block.getInputTargetBlock('INPUT');
         block.setCollapsed(true);
-        chai.assert.equal(this.getOutputs().length, 2);
-        chai.assert.equal(this.getInputs().length, 1);
+        assert.equal(this.getOutputs().length, 2);
+        assert.equal(this.getInputs().length, 1);
 
         block.setCollapsed(false);
-        chai.assert.equal(this.getOutputs().length, 3);
-        chai.assert.equal(this.getInputs().length, 3);
+        assert.equal(this.getOutputs().length, 3);
+        assert.equal(this.getInputs().length, 3);
       });
       test('Multi-Row Double Collapse', function () {
         // Collapse middle -> Collapse top ->
@@ -919,25 +920,25 @@ suite('Blocks', function () {
           this.workspace,
         );
         this.clock.runAll();
-        chai.assert.equal(this.getOutputs().length, 3);
-        chai.assert.equal(this.getInputs().length, 3);
+        assert.equal(this.getOutputs().length, 3);
+        assert.equal(this.getInputs().length, 3);
 
         const middleBlock = block.getInputTargetBlock('INPUT');
         middleBlock.setCollapsed(true);
-        chai.assert.equal(this.getOutputs().length, 2);
-        chai.assert.equal(this.getInputs().length, 1);
+        assert.equal(this.getOutputs().length, 2);
+        assert.equal(this.getInputs().length, 1);
 
         block.setCollapsed(true);
-        chai.assert.equal(this.getOutputs().length, 1);
-        chai.assert.equal(this.getInputs().length, 0);
+        assert.equal(this.getOutputs().length, 1);
+        assert.equal(this.getInputs().length, 0);
 
         block.setCollapsed(false);
-        chai.assert.equal(this.getOutputs().length, 2);
-        chai.assert.equal(this.getInputs().length, 1);
+        assert.equal(this.getOutputs().length, 2);
+        assert.equal(this.getInputs().length, 1);
 
         middleBlock.setCollapsed(false);
-        chai.assert.equal(this.getOutputs().length, 3);
-        chai.assert.equal(this.getInputs().length, 3);
+        assert.equal(this.getOutputs().length, 3);
+        assert.equal(this.getInputs().length, 3);
       });
       test('Statement', function () {
         const block = Blockly.Xml.domToBlock(
@@ -945,16 +946,16 @@ suite('Blocks', function () {
           this.workspace,
         );
         this.clock.runAll();
-        chai.assert.equal(this.getPrevious().length, 1);
-        chai.assert.equal(this.getNext().length, 2);
+        assert.equal(this.getPrevious().length, 1);
+        assert.equal(this.getNext().length, 2);
 
         block.setCollapsed(true);
-        chai.assert.equal(this.getPrevious().length, 1);
-        chai.assert.equal(this.getNext().length, 1);
+        assert.equal(this.getPrevious().length, 1);
+        assert.equal(this.getNext().length, 1);
 
         block.setCollapsed(false);
-        chai.assert.equal(this.getPrevious().length, 1);
-        chai.assert.equal(this.getNext().length, 2);
+        assert.equal(this.getPrevious().length, 1);
+        assert.equal(this.getNext().length, 2);
       });
       test('Multi-Statement', function () {
         const block = Blockly.Xml.domToBlock(
@@ -973,16 +974,16 @@ suite('Blocks', function () {
         );
         this.assertConnectionsEmpty();
         this.clock.runAll();
-        chai.assert.equal(this.getPrevious().length, 3);
-        chai.assert.equal(this.getNext().length, 6);
+        assert.equal(this.getPrevious().length, 3);
+        assert.equal(this.getNext().length, 6);
 
         block.setCollapsed(true);
-        chai.assert.equal(this.getPrevious().length, 1);
-        chai.assert.equal(this.getNext().length, 1);
+        assert.equal(this.getPrevious().length, 1);
+        assert.equal(this.getNext().length, 1);
 
         block.setCollapsed(false);
-        chai.assert.equal(this.getPrevious().length, 3);
-        chai.assert.equal(this.getNext().length, 6);
+        assert.equal(this.getPrevious().length, 3);
+        assert.equal(this.getNext().length, 6);
       });
       test('Multi-Statement Middle', function () {
         let block = Blockly.Xml.domToBlock(
@@ -1001,17 +1002,17 @@ suite('Blocks', function () {
         );
         this.assertConnectionsEmpty();
         this.clock.runAll();
-        chai.assert.equal(this.getPrevious().length, 3);
-        chai.assert.equal(this.getNext().length, 6);
+        assert.equal(this.getPrevious().length, 3);
+        assert.equal(this.getNext().length, 6);
 
         block = block.getInputTargetBlock('STATEMENT');
         block.setCollapsed(true);
-        chai.assert.equal(this.getPrevious().length, 2);
-        chai.assert.equal(this.getNext().length, 3);
+        assert.equal(this.getPrevious().length, 2);
+        assert.equal(this.getNext().length, 3);
 
         block.setCollapsed(false);
-        chai.assert.equal(this.getPrevious().length, 3);
-        chai.assert.equal(this.getNext().length, 6);
+        assert.equal(this.getPrevious().length, 3);
+        assert.equal(this.getNext().length, 6);
       });
       test('Multi-Statement Double Collapse', function () {
         const block = Blockly.Xml.domToBlock(
@@ -1030,25 +1031,25 @@ suite('Blocks', function () {
         );
         this.assertConnectionsEmpty();
         this.clock.runAll();
-        chai.assert.equal(this.getPrevious().length, 3);
-        chai.assert.equal(this.getNext().length, 6);
+        assert.equal(this.getPrevious().length, 3);
+        assert.equal(this.getNext().length, 6);
 
         const middleBlock = block.getInputTargetBlock('STATEMENT');
         middleBlock.setCollapsed(true);
-        chai.assert.equal(this.getPrevious().length, 2);
-        chai.assert.equal(this.getNext().length, 3);
+        assert.equal(this.getPrevious().length, 2);
+        assert.equal(this.getNext().length, 3);
 
         block.setCollapsed(true);
-        chai.assert.equal(this.getPrevious().length, 1);
-        chai.assert.equal(this.getNext().length, 1);
+        assert.equal(this.getPrevious().length, 1);
+        assert.equal(this.getNext().length, 1);
 
         block.setCollapsed(false);
-        chai.assert.equal(this.getPrevious().length, 2);
-        chai.assert.equal(this.getNext().length, 3);
+        assert.equal(this.getPrevious().length, 2);
+        assert.equal(this.getNext().length, 3);
 
         middleBlock.setCollapsed(false);
-        chai.assert.equal(this.getPrevious().length, 3);
-        chai.assert.equal(this.getNext().length, 6);
+        assert.equal(this.getPrevious().length, 3);
+        assert.equal(this.getNext().length, 6);
       });
     });
     suite('Setting Parent Block', function () {
@@ -1074,14 +1075,14 @@ suite('Blocks', function () {
       });
 
       function assertBlockIsOnlyChild(parent, child, inputName) {
-        chai.assert.equal(parent.getChildren().length, 1);
-        chai.assert.equal(parent.getInputTargetBlock(inputName), child);
-        chai.assert.equal(child.getParent(), parent);
+        assert.equal(parent.getChildren().length, 1);
+        assert.equal(parent.getInputTargetBlock(inputName), child);
+        assert.equal(child.getParent(), parent);
       }
       function assertNonParentAndOrphan(nonParent, orphan, inputName) {
-        chai.assert.equal(nonParent.getChildren().length, 0);
-        chai.assert.isNull(nonParent.getInputTargetBlock('TEXT'));
-        chai.assert.isNull(orphan.getParent());
+        assert.equal(nonParent.getChildren().length, 0);
+        assert.isNull(nonParent.getInputTargetBlock('TEXT'));
+        assert.isNull(orphan.getParent());
       }
       function assertOriginalSetup() {
         assertBlockIsOnlyChild(this.printBlock, this.textJoinBlock, 'TEXT');
@@ -1089,7 +1090,7 @@ suite('Blocks', function () {
       }
 
       test('Setting to connected parent', function () {
-        chai.assert.doesNotThrow(
+        assert.doesNotThrow(
           this.textJoinBlock.setParent.bind(
             this.textJoinBlock,
             this.printBlock,
@@ -1102,19 +1103,19 @@ suite('Blocks', function () {
         this.textBlock.outputConnection.connect(
           this.printBlock.getInput('TEXT').connection,
         );
-        chai.assert.doesNotThrow(
+        assert.doesNotThrow(
           this.textBlock.setParent.bind(this.textBlock, this.printBlock),
         );
         assertBlockIsOnlyChild(this.printBlock, this.textBlock, 'TEXT');
       });
       test('Setting to new parent while connected to other block', function () {
         // Setting to grandparent with no available input connection.
-        chai.assert.throws(
+        assert.throws(
           this.textBlock.setParent.bind(this.textBlock, this.printBlock),
         );
         this.textJoinBlock.outputConnection.disconnect();
         // Setting to block with available input connection.
-        chai.assert.throws(
+        assert.throws(
           this.textBlock.setParent.bind(this.textBlock, this.printBlock),
         );
         assertNonParentAndOrphan(this.printBlock, this.textJoinBlock, 'TEXT');
@@ -1122,7 +1123,7 @@ suite('Blocks', function () {
       });
       test('Setting to same parent after disconnecting from it', function () {
         this.textJoinBlock.outputConnection.disconnect();
-        chai.assert.throws(
+        assert.throws(
           this.textJoinBlock.setParent.bind(
             this.textJoinBlock,
             this.printBlock,
@@ -1133,12 +1134,12 @@ suite('Blocks', function () {
       test('Setting to new parent when orphan', function () {
         this.textBlock.outputConnection.disconnect();
         // When new parent has no available input connection.
-        chai.assert.throws(
+        assert.throws(
           this.textBlock.setParent.bind(this.textBlock, this.printBlock),
         );
         this.textJoinBlock.outputConnection.disconnect();
         // When new parent has available input connection.
-        chai.assert.throws(
+        assert.throws(
           this.textBlock.setParent.bind(this.textBlock, this.printBlock),
         );
 
@@ -1148,13 +1149,13 @@ suite('Blocks', function () {
       });
       test('Setting parent to null after disconnecting', function () {
         this.textBlock.outputConnection.disconnect();
-        chai.assert.doesNotThrow(
+        assert.doesNotThrow(
           this.textBlock.setParent.bind(this.textBlock, null),
         );
         assertNonParentAndOrphan(this.textJoinBlock, this.textBlock, 'ADD0');
       });
       test('Setting parent to null without disconnecting', function () {
-        chai.assert.throws(this.textBlock.setParent.bind(this.textBlock, null));
+        assert.throws(this.textBlock.setParent.bind(this.textBlock, null));
         assertOriginalSetup.call(this);
       });
     });
@@ -1164,40 +1165,40 @@ suite('Blocks', function () {
 
         block.setOutput(false);
 
-        chai.assert.equal(this.getOutputs().length, 0);
-        chai.assert.equal(this.getInputs().length, 1);
+        assert.equal(this.getOutputs().length, 0);
+        assert.equal(this.getInputs().length, 1);
       });
       test('Value', function () {
         const block = createRenderedBlock(this.workspace, 'row_block');
 
         block.removeInput('INPUT');
 
-        chai.assert.equal(this.getOutputs().length, 1);
-        chai.assert.equal(this.getInputs().length, 0);
+        assert.equal(this.getOutputs().length, 1);
+        assert.equal(this.getInputs().length, 0);
       });
       test('Previous', function () {
         const block = createRenderedBlock(this.workspace, 'stack_block');
 
         block.setPreviousStatement(false);
 
-        chai.assert.equal(this.getPrevious().length, 0);
-        chai.assert.equal(this.getNext().length, 1);
+        assert.equal(this.getPrevious().length, 0);
+        assert.equal(this.getNext().length, 1);
       });
       test('Next', function () {
         const block = createRenderedBlock(this.workspace, 'stack_block');
 
         block.setNextStatement(false);
 
-        chai.assert.equal(this.getPrevious().length, 1);
-        chai.assert.equal(this.getNext().length, 0);
+        assert.equal(this.getPrevious().length, 1);
+        assert.equal(this.getNext().length, 0);
       });
       test('Statement', function () {
         const block = createRenderedBlock(this.workspace, 'statement_block');
 
         block.removeInput('STATEMENT');
 
-        chai.assert.equal(this.getPrevious().length, 1);
-        chai.assert.equal(this.getNext().length, 1);
+        assert.equal(this.getPrevious().length, 1);
+        assert.equal(this.getNext().length, 1);
       });
     });
     suite('Add Connections Programmatically', function () {
@@ -1208,7 +1209,7 @@ suite('Blocks', function () {
         this.clock.runAll();
 
         this.clock.runAll();
-        chai.assert.equal(this.getOutputs().length, 1);
+        assert.equal(this.getOutputs().length, 1);
       });
       test('Value', function () {
         const block = createRenderedBlock(this.workspace, 'empty_block');
@@ -1216,7 +1217,7 @@ suite('Blocks', function () {
         block.appendValueInput('INPUT');
 
         this.clock.runAll();
-        chai.assert.equal(this.getInputs().length, 1);
+        assert.equal(this.getInputs().length, 1);
       });
       test('Previous', function () {
         const block = createRenderedBlock(this.workspace, 'empty_block');
@@ -1225,7 +1226,7 @@ suite('Blocks', function () {
         this.clock.runAll();
 
         this.clock.runAll();
-        chai.assert.equal(this.getPrevious().length, 1);
+        assert.equal(this.getPrevious().length, 1);
       });
       test('Next', function () {
         const block = createRenderedBlock(this.workspace, 'empty_block');
@@ -1234,7 +1235,7 @@ suite('Blocks', function () {
         this.clock.runAll();
 
         this.clock.runAll();
-        chai.assert.equal(this.getNext().length, 1);
+        assert.equal(this.getNext().length, 1);
       });
       test('Statement', function () {
         const block = createRenderedBlock(this.workspace, 'empty_block');
@@ -1242,7 +1243,7 @@ suite('Blocks', function () {
         block.appendStatementInput('STATEMENT');
 
         this.clock.runAll();
-        chai.assert.equal(this.getNext().length, 1);
+        assert.equal(this.getNext().length, 1);
       });
     });
   });
@@ -1252,18 +1253,18 @@ suite('Blocks', function () {
       function assertCommentEvent(eventSpy, oldValue, newValue) {
         const calls = eventSpy.getCalls();
         const event = calls[calls.length - 1].args[0];
-        chai.assert.equal(event.type, eventUtils.BLOCK_CHANGE);
-        chai.assert.equal(
+        assert.equal(event.type, eventUtils.BLOCK_CHANGE);
+        assert.equal(
           event.element,
           'comment',
           'Expected the element to be a comment',
         );
-        chai.assert.equal(
+        assert.equal(
           event.oldValue,
           oldValue,
           'Expected the old values to match',
         );
-        chai.assert.equal(
+        assert.equal(
           event.newValue,
           newValue,
           'Expected the new values to match',
@@ -1272,7 +1273,7 @@ suite('Blocks', function () {
       function assertNoCommentEvent(eventSpy) {
         const calls = eventSpy.getCalls();
         const event = calls[calls.length - 1].args[0];
-        chai.assert.notEqual(event.type, eventUtils.BLOCK_CHANGE);
+        assert.notEqual(event.type, eventUtils.BLOCK_CHANGE);
       }
       setup(function () {
         this.eventsFireSpy = sinon.spy(eventUtils.TEST_ONLY, 'fireInternal');
@@ -1289,24 +1290,24 @@ suite('Blocks', function () {
         });
         test('Text', function () {
           this.block.setCommentText('test text');
-          chai.assert.equal(this.block.getCommentText(), 'test text');
+          assert.equal(this.block.getCommentText(), 'test text');
           assertCommentEvent(this.eventsFireSpy, null, 'test text');
         });
         test('Text Empty', function () {
           this.block.setCommentText('');
-          chai.assert.equal(this.block.getCommentText(), '');
+          assert.equal(this.block.getCommentText(), '');
           assertCommentEvent(this.eventsFireSpy, null, '');
         });
         test('Text Null', function () {
           this.block.setCommentText(null);
-          chai.assert.isNull(this.block.getCommentText());
+          assert.isNull(this.block.getCommentText());
           assertNoCommentEvent(this.eventsFireSpy);
         });
         test('Text -> Null', function () {
           this.block.setCommentText('first text');
 
           this.block.setCommentText(null);
-          chai.assert.isNull(this.block.getCommentText());
+          assert.isNull(this.block.getCommentText());
           assertCommentEvent(this.eventsFireSpy, 'first text', null);
         });
       });
@@ -1326,24 +1327,24 @@ suite('Blocks', function () {
         });
         test('Text', function () {
           this.block.setCommentText('test text');
-          chai.assert.equal(this.block.getCommentText(), 'test text');
+          assert.equal(this.block.getCommentText(), 'test text');
           assertCommentEvent(this.eventsFireSpy, null, 'test text');
         });
         test('Text Empty', function () {
           this.block.setCommentText('');
-          chai.assert.equal(this.block.getCommentText(), '');
+          assert.equal(this.block.getCommentText(), '');
           assertCommentEvent(this.eventsFireSpy, null, '');
         });
         test('Text Null', function () {
           this.block.setCommentText(null);
-          chai.assert.isNull(this.block.getCommentText());
+          assert.isNull(this.block.getCommentText());
           assertNoCommentEvent(this.eventsFireSpy);
         });
         test('Text -> Null', function () {
           this.block.setCommentText('first text');
 
           this.block.setCommentText(null);
-          chai.assert.isNull(this.block.getCommentText());
+          assert.isNull(this.block.getCommentText());
           assertCommentEvent(this.eventsFireSpy, 'first text', null);
         });
         test('Set While Visible - Editable', function () {
@@ -1352,7 +1353,7 @@ suite('Blocks', function () {
           icon.setBubbleVisible(true);
 
           this.block.setCommentText('test2');
-          chai.assert.equal(this.block.getCommentText(), 'test2');
+          assert.equal(this.block.getCommentText(), 'test2');
           assertCommentEvent(this.eventsFireSpy, 'test1', 'test2');
         });
         test('Set While Visible - NonEditable', function () {
@@ -1363,7 +1364,7 @@ suite('Blocks', function () {
           icon.setBubbleVisible(true);
 
           this.block.setCommentText('test2');
-          chai.assert.equal(this.block.getCommentText(), 'test2');
+          assert.equal(this.block.getCommentText(), 'test2');
           assertCommentEvent(this.eventsFireSpy, 'test1', 'test2');
         });
       });
@@ -1431,7 +1432,7 @@ suite('Blocks', function () {
 
         this.block.setCommentText('test text');
 
-        chai.assert.instanceOf(
+        assert.instanceOf(
           this.block.getIcon(Blockly.icons.IconType.COMMENT),
           MockComment,
         );
@@ -1442,7 +1443,7 @@ suite('Blocks', function () {
           Blockly.icons.IconType.COMMENT.toString(),
         );
 
-        chai.assert.throws(() => {
+        assert.throws(() => {
           this.block.setCommentText('test text');
         }, 'No comment icon class is registered, so a comment cannot be set');
       });
@@ -1456,7 +1457,7 @@ suite('Blocks', function () {
           MockIcon,
         );
 
-        chai.assert.throws(() => {
+        assert.throws(() => {
           this.block.setCommentText('test text');
         }, 'The class registered as a comment icon does not conform to the ICommentIcon interface');
       });
@@ -1479,13 +1480,13 @@ suite('Blocks', function () {
     });
 
     test('Getting Field', function () {
-      chai.assert.instanceOf(this.block.getField('TEXT'), Blockly.Field);
+      assert.instanceOf(this.block.getField('TEXT'), Blockly.Field);
     });
     test('Getting Field without Name', function () {
-      chai.assert.throws(this.block.getField.bind(this.block), TypeError);
+      assert.throws(this.block.getField.bind(this.block), TypeError);
     });
     test('Getting Value of Field without Name', function () {
-      chai.assert.throws(this.block.getFieldValue.bind(this.block), TypeError);
+      assert.throws(this.block.getFieldValue.bind(this.block), TypeError);
     });
     test('Getting Field with Wrong Type', function () {
       const testFunction = function () {
@@ -1499,7 +1500,7 @@ suite('Blocks', function () {
         ['TEXT'],
       ];
       for (let i = 0; i < inputs.length; i++) {
-        chai.assert.throws(
+        assert.throws(
           this.block.getField.bind(this.block, inputs[i]),
           TypeError,
         );
@@ -1517,19 +1518,19 @@ suite('Blocks', function () {
         ['TEXT'],
       ];
       for (let i = 0; i < inputs.length; i++) {
-        chai.assert.throws(
+        assert.throws(
           this.block.getFieldValue.bind(this.block, inputs[i]),
           TypeError,
         );
       }
     });
     test('Getting/Setting Field Value', function () {
-      chai.assert.equal(this.block.getFieldValue('TEXT'), 'test');
+      assert.equal(this.block.getFieldValue('TEXT'), 'test');
       this.block.setFieldValue('abc', 'TEXT');
-      chai.assert.equal(this.block.getFieldValue('TEXT'), 'abc');
+      assert.equal(this.block.getFieldValue('TEXT'), 'abc');
     });
     test('Setting Field without Name', function () {
-      chai.assert.throws(this.block.setFieldValue.bind(this.block, 'test'));
+      assert.throws(this.block.setFieldValue.bind(this.block, 'test'));
     });
     test('Setting Field with Wrong Type', function () {
       const testFunction = function () {
@@ -1543,7 +1544,7 @@ suite('Blocks', function () {
         ['TEXT'],
       ];
       for (let i = 0; i < inputs.length; i++) {
-        chai.assert.throws(
+        assert.throws(
           this.block.setFieldValue.bind(this.block, 'test', inputs[i]),
           TypeError,
         );
@@ -1589,7 +1590,7 @@ suite('Blocks', function () {
 
       test('icons get added to the block', function () {
         this.block.addIcon(new MockIconA());
-        chai.assert.isTrue(
+        assert.isTrue(
           this.block.hasIcon('A'),
           'Expected the icon to be added',
         );
@@ -1597,7 +1598,7 @@ suite('Blocks', function () {
 
       test('adding two icons of the same type throws', function () {
         this.block.addIcon(new MockIconA());
-        chai.assert.throws(
+        assert.throws(
           () => {
             this.block.addIcon(new MockIconA());
           },
@@ -1610,7 +1611,7 @@ suite('Blocks', function () {
       test('adding an icon triggers a render', function () {
         this.renderSpy.resetHistory();
         this.block.addIcon(new MockIconA());
-        chai.assert.isTrue(
+        assert.isTrue(
           this.renderSpy.calledOnce,
           'Expected adding an icon to trigger a render',
         );
@@ -1634,18 +1635,18 @@ suite('Blocks', function () {
 
       test('icons get removed from the block', function () {
         this.block.addIcon(new MockIconA());
-        chai.assert.isTrue(
+        assert.isTrue(
           this.block.removeIcon(new Blockly.icons.IconType('A')),
           'Expected removeIcon to return true',
         );
-        chai.assert.isFalse(
+        assert.isFalse(
           this.block.hasIcon('A'),
           'Expected the icon to be removed',
         );
       });
 
       test('removing an icon that does not exist returns false', function () {
-        chai.assert.isFalse(
+        assert.isFalse(
           this.block.removeIcon(new Blockly.icons.IconType('B')),
           'Expected removeIcon to return false',
         );
@@ -1655,7 +1656,7 @@ suite('Blocks', function () {
         this.block.addIcon(new MockIconA());
         this.renderSpy.resetHistory();
         this.block.removeIcon(new Blockly.icons.IconType('A'));
-        chai.assert.isTrue(
+        assert.isTrue(
           this.renderSpy.calledOnce,
           'Expected removing an icon to trigger a render',
         );
@@ -1672,7 +1673,7 @@ suite('Blocks', function () {
         const iconB = new MockIconB();
         this.block.addIcon(iconB);
         this.block.addIcon(iconA);
-        chai.assert.sameOrderedMembers(
+        assert.sameOrderedMembers(
           this.block.getIcons(),
           [iconA, iconB],
           'Expected getIcon to return both icons in order of weight',
@@ -1680,7 +1681,7 @@ suite('Blocks', function () {
       });
 
       test('if there are no icons, getIcons returns an empty array', function () {
-        chai.assert.isEmpty(
+        assert.isEmpty(
           this.block.getIcons(),
           'Expected getIcons to return an empty array ' +
             'for a block with no icons',
@@ -1688,7 +1689,7 @@ suite('Blocks', function () {
       });
 
       test('if there are no icons, getIcons returns an empty array', function () {
-        chai.assert.isEmpty(
+        assert.isEmpty(
           this.block.getIcons(),
           'Expected getIcons to return an empty array ' +
             'for a block with no icons',
@@ -1700,7 +1701,7 @@ suite('Blocks', function () {
         const iconB = new MockIconB();
         this.block.addIcon(iconA);
         this.block.addIcon(iconB);
-        chai.assert.equal(
+        assert.equal(
           this.block.getIcon('B'),
           iconB,
           'Expected getIcon to return the icon with the given type',
@@ -1709,7 +1710,7 @@ suite('Blocks', function () {
 
       test('if there is no matching icon, getIcon returns undefined', function () {
         this.block.addIcon(new MockIconA());
-        chai.assert.isUndefined(
+        assert.isUndefined(
           this.block.getIcon('B'),
           'Expected getIcon to return null if there is no ' +
             'icon with a matching type',
@@ -1733,7 +1734,7 @@ suite('Blocks', function () {
       test('Block with no warning text does not have warning icon', function () {
         const icon = this.block.getIcon(Blockly.icons.WarningIcon.TYPE);
 
-        chai.assert.isUndefined(
+        assert.isUndefined(
           icon,
           'Block with no warning should not have warning icon',
         );
@@ -1745,7 +1746,7 @@ suite('Blocks', function () {
         this.block.setWarningText(text);
 
         const icon = this.block.getIcon(Blockly.icons.WarningIcon.TYPE);
-        chai.assert.equal(
+        assert.equal(
           icon.getText(),
           text,
           'Expected warning icon text to be set',
@@ -1760,7 +1761,7 @@ suite('Blocks', function () {
         this.block.setWarningText(text2, '2');
 
         const icon = this.block.getIcon(Blockly.icons.WarningIcon.TYPE);
-        chai.assert.equal(icon.getText(), `${text1}\n${text2}`);
+        assert.equal(icon.getText(), `${text1}\n${text2}`);
       });
 
       test('Clearing all warning text deletes the warning icon', function () {
@@ -1770,7 +1771,7 @@ suite('Blocks', function () {
         this.block.setWarningText(null);
 
         const icon = this.block.getIcon(Blockly.icons.WarningIcon.TYPE);
-        chai.assert.isUndefined(
+        assert.isUndefined(
           icon,
           'Expected warning icon to be undefined after deleting all warning text',
         );
@@ -1785,7 +1786,7 @@ suite('Blocks', function () {
         this.block.setWarningText(null, '1');
 
         const icon = this.block.getIcon(Blockly.icons.WarningIcon.TYPE);
-        chai.assert.equal(
+        assert.equal(
           icon.getText(),
           text2,
           'Expected first warning text to be deleted',
@@ -1802,7 +1803,7 @@ suite('Blocks', function () {
         this.block.setWarningText(null, '2');
 
         const icon = this.block.getIcon(Blockly.icons.WarningIcon.TYPE);
-        chai.assert.isUndefined(
+        assert.isUndefined(
           icon,
           'Expected warning icon to be deleted after all warning text is cleared',
         );
@@ -1839,7 +1840,7 @@ suite('Blocks', function () {
 
         parentBlock.setCollapsed(true);
 
-        chai.assert.isFalse(
+        assert.isFalse(
           icon.bubbleIsVisible(),
           "Expected collapsing the parent block to hide the child block's " +
             "icon's bubble",
@@ -1865,7 +1866,7 @@ suite('Blocks', function () {
 
         parentBlock.setCollapsed(true);
 
-        chai.assert.isTrue(
+        assert.isTrue(
           icon.bubbleIsVisible(),
           'Expected collapsing the parent block to not hide the next ' +
             "block's bubble",
@@ -1876,45 +1877,45 @@ suite('Blocks', function () {
 
   suite('Collapsing and Expanding', function () {
     function assertCollapsed(block, opt_string) {
-      chai.assert.isTrue(block.isCollapsed());
+      assert.isTrue(block.isCollapsed());
       for (let i = 0, input; (input = block.inputList[i]); i++) {
         if (input.name == Blockly.Block.COLLAPSED_INPUT_NAME) {
           continue;
         }
-        chai.assert.isFalse(input.isVisible());
+        assert.isFalse(input.isVisible());
         for (let j = 0, field; (field = input.fieldRow[j]); j++) {
-          chai.assert.isFalse(field.isVisible());
+          assert.isFalse(field.isVisible());
         }
       }
       const icons = block.getIcons();
       for (let i = 0, icon; (icon = icons[i]); i++) {
-        chai.assert.isFalse(icon.bubbleIsVisible());
+        assert.isFalse(icon.bubbleIsVisible());
       }
 
       const input = block.getInput(Blockly.Block.COLLAPSED_INPUT_NAME);
-      chai.assert.isNotNull(input);
-      chai.assert.isTrue(input.isVisible());
+      assert.isNotNull(input);
+      assert.isTrue(input.isVisible());
       const field = block.getField(Blockly.Block.COLLAPSED_FIELD_NAME);
-      chai.assert.isNotNull(field);
-      chai.assert.isTrue(field.isVisible());
+      assert.isNotNull(field);
+      assert.isTrue(field.isVisible());
 
       if (opt_string) {
-        chai.assert.equal(field.getText(), opt_string);
+        assert.equal(field.getText(), opt_string);
       }
     }
     function assertNotCollapsed(block) {
-      chai.assert.isFalse(block.isCollapsed());
+      assert.isFalse(block.isCollapsed());
       for (let i = 0, input; (input = block.inputList[i]); i++) {
-        chai.assert.isTrue(input.isVisible());
+        assert.isTrue(input.isVisible());
         for (let j = 0, field; (field = input.fieldRow[j]); j++) {
-          chai.assert.isTrue(field.isVisible());
+          assert.isTrue(field.isVisible());
         }
       }
 
       const input = block.getInput(Blockly.Block.COLLAPSED_INPUT_NAME);
-      chai.assert.isNull(input);
+      assert.isNull(input);
       const field = block.getField(Blockly.Block.COLLAPSED_FIELD_NAME);
-      chai.assert.isNull(field);
+      assert.isNull(field);
     }
     function isBlockHidden(block) {
       let node = block.getSvgRoot();
@@ -1967,10 +1968,10 @@ suite('Blocks', function () {
         blockA.setCollapsed(true);
         assertCollapsed(blockA);
         blockA.getInput('INPUT').connection.connect(blockB.outputConnection);
-        chai.assert.isTrue(isBlockHidden(blockB));
+        assert.isTrue(isBlockHidden(blockB));
         blockA.setCollapsed(false);
         assertNotCollapsed(blockA);
-        chai.assert.isFalse(isBlockHidden(blockB));
+        assert.isFalse(isBlockHidden(blockB));
       });
       test('Connect Block to Statement Input', function () {
         const blockA = createRenderedBlock(this.workspace, 'statement_block');
@@ -1981,10 +1982,10 @@ suite('Blocks', function () {
         blockA
           .getInput('STATEMENT')
           .connection.connect(blockB.previousConnection);
-        chai.assert.isTrue(isBlockHidden(blockB));
+        assert.isTrue(isBlockHidden(blockB));
         blockA.setCollapsed(false);
         assertNotCollapsed(blockA);
-        chai.assert.isFalse(isBlockHidden(blockB));
+        assert.isFalse(isBlockHidden(blockB));
       });
       test('Connect Block to Child of Collapsed - Input', function () {
         const blockA = createRenderedBlock(this.workspace, 'row_block');
@@ -1994,14 +1995,14 @@ suite('Blocks', function () {
         blockA.getInput('INPUT').connection.connect(blockB.outputConnection);
         blockA.setCollapsed(true);
         assertCollapsed(blockA);
-        chai.assert.isTrue(isBlockHidden(blockB));
+        assert.isTrue(isBlockHidden(blockB));
         blockB.getInput('INPUT').connection.connect(blockC.outputConnection);
-        chai.assert.isTrue(isBlockHidden(blockC));
+        assert.isTrue(isBlockHidden(blockC));
 
         blockA.setCollapsed(false);
         assertNotCollapsed(blockA);
-        chai.assert.isFalse(isBlockHidden(blockB));
-        chai.assert.isFalse(isBlockHidden(blockC));
+        assert.isFalse(isBlockHidden(blockB));
+        assert.isFalse(isBlockHidden(blockC));
       });
       test('Connect Block to Child of Collapsed - Next', function () {
         const blockA = createRenderedBlock(this.workspace, 'statement_block');
@@ -2013,14 +2014,14 @@ suite('Blocks', function () {
           .connection.connect(blockB.previousConnection);
         blockA.setCollapsed(true);
         assertCollapsed(blockA);
-        chai.assert.isTrue(isBlockHidden(blockB));
+        assert.isTrue(isBlockHidden(blockB));
         blockB.nextConnection.connect(blockC.previousConnection);
-        chai.assert.isTrue(isBlockHidden(blockC));
+        assert.isTrue(isBlockHidden(blockC));
 
         blockA.setCollapsed(false);
         assertNotCollapsed(blockA);
-        chai.assert.isFalse(isBlockHidden(blockB));
-        chai.assert.isFalse(isBlockHidden(blockC));
+        assert.isFalse(isBlockHidden(blockB));
+        assert.isFalse(isBlockHidden(blockC));
       });
       test('Connect Block to Value Input Already Taken', function () {
         const blockA = createRenderedBlock(this.workspace, 'row_block');
@@ -2030,16 +2031,16 @@ suite('Blocks', function () {
         blockA.getInput('INPUT').connection.connect(blockB.outputConnection);
         blockA.setCollapsed(true);
         assertCollapsed(blockA);
-        chai.assert.isTrue(isBlockHidden(blockB));
+        assert.isTrue(isBlockHidden(blockB));
         blockA.getInput('INPUT').connection.connect(blockC.outputConnection);
-        chai.assert.isTrue(isBlockHidden(blockC));
+        assert.isTrue(isBlockHidden(blockC));
         // Still hidden after C is inserted between.
-        chai.assert.isTrue(isBlockHidden(blockB));
+        assert.isTrue(isBlockHidden(blockB));
 
         blockA.setCollapsed(false);
         assertNotCollapsed(blockA);
-        chai.assert.isFalse(isBlockHidden(blockB));
-        chai.assert.isFalse(isBlockHidden(blockC));
+        assert.isFalse(isBlockHidden(blockB));
+        assert.isFalse(isBlockHidden(blockC));
       });
       test('Connect Block to Statement Input Already Taken', function () {
         const blockA = createRenderedBlock(this.workspace, 'statement_block');
@@ -2051,18 +2052,18 @@ suite('Blocks', function () {
           .connection.connect(blockB.previousConnection);
         blockA.setCollapsed(true);
         assertCollapsed(blockA);
-        chai.assert.isTrue(isBlockHidden(blockB));
+        assert.isTrue(isBlockHidden(blockB));
         blockA
           .getInput('STATEMENT')
           .connection.connect(blockC.previousConnection);
-        chai.assert.isTrue(isBlockHidden(blockC));
+        assert.isTrue(isBlockHidden(blockC));
         // Still hidden after C is inserted between.
-        chai.assert.isTrue(isBlockHidden(blockB));
+        assert.isTrue(isBlockHidden(blockB));
 
         blockA.setCollapsed(false);
         assertNotCollapsed(blockA);
-        chai.assert.isFalse(isBlockHidden(blockB));
-        chai.assert.isFalse(isBlockHidden(blockC));
+        assert.isFalse(isBlockHidden(blockB));
+        assert.isFalse(isBlockHidden(blockC));
       });
       test('Connect Block with Child - Input', function () {
         const blockA = createRenderedBlock(this.workspace, 'row_block');
@@ -2073,13 +2074,13 @@ suite('Blocks', function () {
         blockA.setCollapsed(true);
         assertCollapsed(blockA);
         blockA.getInput('INPUT').connection.connect(blockB.outputConnection);
-        chai.assert.isTrue(isBlockHidden(blockC));
-        chai.assert.isTrue(isBlockHidden(blockB));
+        assert.isTrue(isBlockHidden(blockC));
+        assert.isTrue(isBlockHidden(blockB));
 
         blockA.setCollapsed(false);
         assertNotCollapsed(blockA);
-        chai.assert.isFalse(isBlockHidden(blockB));
-        chai.assert.isFalse(isBlockHidden(blockC));
+        assert.isFalse(isBlockHidden(blockB));
+        assert.isFalse(isBlockHidden(blockC));
       });
       test('Connect Block with Child - Statement', function () {
         const blockA = createRenderedBlock(this.workspace, 'statement_block');
@@ -2092,13 +2093,13 @@ suite('Blocks', function () {
         blockA
           .getInput('STATEMENT')
           .connection.connect(blockB.previousConnection);
-        chai.assert.isTrue(isBlockHidden(blockC));
-        chai.assert.isTrue(isBlockHidden(blockB));
+        assert.isTrue(isBlockHidden(blockC));
+        assert.isTrue(isBlockHidden(blockB));
 
         blockA.setCollapsed(false);
         assertNotCollapsed(blockA);
-        chai.assert.isFalse(isBlockHidden(blockB));
-        chai.assert.isFalse(isBlockHidden(blockC));
+        assert.isFalse(isBlockHidden(blockB));
+        assert.isFalse(isBlockHidden(blockC));
       });
       test('Disconnect Block from Value Input', function () {
         const blockA = createRenderedBlock(this.workspace, 'row_block');
@@ -2107,9 +2108,9 @@ suite('Blocks', function () {
         blockA.getInput('INPUT').connection.connect(blockB.outputConnection);
         blockA.setCollapsed(true);
         assertCollapsed(blockA);
-        chai.assert.isTrue(isBlockHidden(blockB));
+        assert.isTrue(isBlockHidden(blockB));
         blockB.outputConnection.disconnect();
-        chai.assert.isFalse(isBlockHidden(blockB));
+        assert.isFalse(isBlockHidden(blockB));
       });
       test('Disconnect Block from Statement Input', function () {
         const blockA = createRenderedBlock(this.workspace, 'statement_block');
@@ -2120,9 +2121,9 @@ suite('Blocks', function () {
           .connection.connect(blockB.previousConnection);
         blockA.setCollapsed(true);
         assertCollapsed(blockA);
-        chai.assert.isTrue(isBlockHidden(blockB));
+        assert.isTrue(isBlockHidden(blockB));
         blockB.previousConnection.disconnect();
-        chai.assert.isFalse(isBlockHidden(blockB));
+        assert.isFalse(isBlockHidden(blockB));
       });
       test('Disconnect Block from Child of Collapsed - Input', function () {
         const blockA = createRenderedBlock(this.workspace, 'row_block');
@@ -2133,11 +2134,11 @@ suite('Blocks', function () {
         blockB.getInput('INPUT').connection.connect(blockC.outputConnection);
         blockA.setCollapsed(true);
         assertCollapsed(blockA);
-        chai.assert.isTrue(isBlockHidden(blockB));
-        chai.assert.isTrue(isBlockHidden(blockC));
+        assert.isTrue(isBlockHidden(blockB));
+        assert.isTrue(isBlockHidden(blockC));
 
         blockC.outputConnection.disconnect();
-        chai.assert.isFalse(isBlockHidden(blockC));
+        assert.isFalse(isBlockHidden(blockC));
       });
       test('Disconnect Block from Child of Collapsed - Next', function () {
         const blockA = createRenderedBlock(this.workspace, 'statement_block');
@@ -2150,11 +2151,11 @@ suite('Blocks', function () {
         blockB.nextConnection.connect(blockC.previousConnection);
         blockA.setCollapsed(true);
         assertCollapsed(blockA);
-        chai.assert.isTrue(isBlockHidden(blockB));
-        chai.assert.isTrue(isBlockHidden(blockC));
+        assert.isTrue(isBlockHidden(blockB));
+        assert.isTrue(isBlockHidden(blockC));
 
         blockC.previousConnection.disconnect();
-        chai.assert.isFalse(isBlockHidden(blockC));
+        assert.isFalse(isBlockHidden(blockC));
       });
       test('Disconnect Block with Child - Input', function () {
         const blockA = createRenderedBlock(this.workspace, 'row_block');
@@ -2165,12 +2166,12 @@ suite('Blocks', function () {
         blockA.getInput('INPUT').connection.connect(blockB.outputConnection);
         blockA.setCollapsed(true);
         assertCollapsed(blockA);
-        chai.assert.isTrue(isBlockHidden(blockB));
-        chai.assert.isTrue(isBlockHidden(blockC));
+        assert.isTrue(isBlockHidden(blockB));
+        assert.isTrue(isBlockHidden(blockC));
 
         blockB.outputConnection.disconnect();
-        chai.assert.isFalse(isBlockHidden(blockB));
-        chai.assert.isFalse(isBlockHidden(blockC));
+        assert.isFalse(isBlockHidden(blockB));
+        assert.isFalse(isBlockHidden(blockC));
       });
       test('Disconnect Block with Child - Statement', function () {
         const blockA = createRenderedBlock(this.workspace, 'statement_block');
@@ -2183,12 +2184,12 @@ suite('Blocks', function () {
           .connection.connect(blockB.previousConnection);
         blockA.setCollapsed(true);
         assertCollapsed(blockA);
-        chai.assert.isTrue(isBlockHidden(blockC));
-        chai.assert.isTrue(isBlockHidden(blockB));
+        assert.isTrue(isBlockHidden(blockC));
+        assert.isTrue(isBlockHidden(blockB));
 
         blockB.previousConnection.disconnect();
-        chai.assert.isFalse(isBlockHidden(blockB));
-        chai.assert.isFalse(isBlockHidden(blockC));
+        assert.isFalse(isBlockHidden(blockB));
+        assert.isFalse(isBlockHidden(blockC));
       });
     });
     suite('Adding and Removing Block Parts', function () {
@@ -2198,7 +2199,7 @@ suite('Blocks', function () {
         assertCollapsed(blockA);
         blockA.setPreviousStatement(true);
         assertCollapsed(blockA);
-        chai.assert.isNotNull(blockA.previousConnection);
+        assert.isNotNull(blockA.previousConnection);
       });
       test('Add Next Connection', function () {
         const blockA = createRenderedBlock(this.workspace, 'empty_block');
@@ -2206,7 +2207,7 @@ suite('Blocks', function () {
         assertCollapsed(blockA);
         blockA.setNextStatement(true);
         assertCollapsed(blockA);
-        chai.assert.isNotNull(blockA.nextConnection);
+        assert.isNotNull(blockA.nextConnection);
       });
       test('Add Input', function () {
         const blockA = createRenderedBlock(this.workspace, 'empty_block');
@@ -2216,7 +2217,7 @@ suite('Blocks', function () {
 
         this.clock.runAll();
         assertCollapsed(blockA);
-        chai.assert.isNotNull(blockA.getInput('NAME'));
+        assert.isNotNull(blockA.getInput('NAME'));
       });
       test('Add Field', function () {
         const blockA = createRenderedBlock(this.workspace, 'empty_block');
@@ -2226,8 +2227,8 @@ suite('Blocks', function () {
         input.appendField(new Blockly.FieldLabel('test'), 'FIELD');
         assertCollapsed(blockA);
         const field = blockA.getField('FIELD');
-        chai.assert.isNotNull(field);
-        chai.assert.equal(field.getText(), 'test');
+        assert.isNotNull(field);
+        assert.equal(field.getText(), 'test');
       });
       test('Add Icon', function () {
         const blockA = createRenderedBlock(this.workspace, 'empty_block');
@@ -2243,7 +2244,7 @@ suite('Blocks', function () {
         assertCollapsed(blockA);
         blockA.setPreviousStatement(false);
         assertCollapsed(blockA);
-        chai.assert.isNull(blockA.previousConnection);
+        assert.isNull(blockA.previousConnection);
       });
       test('Remove Next Connection', function () {
         const blockA = createRenderedBlock(this.workspace, 'empty_block');
@@ -2252,7 +2253,7 @@ suite('Blocks', function () {
         assertCollapsed(blockA);
         blockA.setNextStatement(false);
         assertCollapsed(blockA);
-        chai.assert.isNull(blockA.nextConnection);
+        assert.isNull(blockA.nextConnection);
       });
       test('Remove Input', function () {
         const blockA = createRenderedBlock(this.workspace, 'empty_block');
@@ -2261,7 +2262,7 @@ suite('Blocks', function () {
         assertCollapsed(blockA);
         blockA.removeInput('NAME');
         assertCollapsed(blockA);
-        chai.assert.isNull(blockA.getInput('NAME'));
+        assert.isNull(blockA.getInput('NAME'));
       });
       test('Remove Field', function () {
         const blockA = createRenderedBlock(this.workspace, 'empty_block');
@@ -2272,7 +2273,7 @@ suite('Blocks', function () {
         input.removeField('FIELD');
         assertCollapsed(blockA);
         const field = blockA.getField('FIELD');
-        chai.assert.isNull(field);
+        assert.isNull(field);
       });
       test('Remove Icon', function () {
         const blockA = createRenderedBlock(this.workspace, 'empty_block');
@@ -2321,8 +2322,8 @@ suite('Blocks', function () {
         blockA.setCollapsed(false);
 
         // The child blocks should be enabled.
-        chai.assert.isTrue(blockB.isEnabled());
-        chai.assert.isFalse(
+        assert.isTrue(blockB.isEnabled());
+        assert.isFalse(
           blockB.getSvgRoot().classList.contains('blocklyDisabled'),
         );
       });
@@ -2345,7 +2346,7 @@ suite('Blocks', function () {
         blockA.setCollapsed(true);
 
         // Child blocks should stay disabled if they have been set.
-        chai.assert.isFalse(blockB.isEnabled());
+        assert.isFalse(blockB.isEnabled());
       });
       test('Disabled blocks from JSON should have proper disabled status', function () {
         // Nested c-shaped blocks, inner block is disabled
@@ -2364,11 +2365,11 @@ suite('Blocks', function () {
         const innerBlock = this.workspace
           .getTopBlocks(false)[0]
           .getChildren()[0];
-        chai.assert.isTrue(
+        assert.isTrue(
           innerBlock.visuallyDisabled,
           'block should have visuallyDisabled set because it is disabled',
         );
-        chai.assert.isFalse(
+        assert.isFalse(
           innerBlock.isEnabled(),
           'block should be marked disabled because enabled json property was set to false',
         );
@@ -2389,11 +2390,11 @@ suite('Blocks', function () {
         const innerBlock = this.workspace
           .getTopBlocks(false)[0]
           .getChildren()[0];
-        chai.assert.isTrue(
+        assert.isTrue(
           innerBlock.visuallyDisabled,
           'block should have visuallyDisabled set because it is disabled',
         );
-        chai.assert.isFalse(
+        assert.isFalse(
           innerBlock.isEnabled(),
           'block should be marked disabled because enabled xml property was set to false',
         );
@@ -2443,7 +2444,7 @@ suite('Blocks', function () {
           this.parent.setDisabledReason(true, 'test reason');
           await Blockly.renderManagement.finishQueuedRenders();
           for (const child of this.parent.getDescendants(false)) {
-            chai.assert.isTrue(
+            assert.isTrue(
               child.visuallyDisabled,
               `block ${child.id} should be visually disabled`,
             );
@@ -2456,38 +2457,38 @@ suite('Blocks', function () {
           await Blockly.renderManagement.finishQueuedRenders();
 
           // child2 is disabled, rest should be enabled
-          chai.assert.isTrue(
+          assert.isTrue(
             this.child1.isEnabled(),
             'child1 should be enabled',
           );
-          chai.assert.isFalse(
+          assert.isFalse(
             this.child1.visuallyDisabled,
             'child1 should not be visually disabled',
           );
 
-          chai.assert.isFalse(
+          assert.isFalse(
             this.child2.isEnabled(),
             'child2 should be disabled',
           );
-          chai.assert.isTrue(
+          assert.isTrue(
             this.child2.visuallyDisabled,
             'child2 should be visually disabled',
           );
 
-          chai.assert.isTrue(
+          assert.isTrue(
             this.child3.isEnabled(),
             'child3 should be enabled',
           );
-          chai.assert.isFalse(
+          assert.isFalse(
             this.child3.visuallyDisabled,
             'child3 should not be visually disabled',
           );
 
-          chai.assert.isTrue(
+          assert.isTrue(
             this.child4.isEnabled(),
             'child34 should be enabled',
           );
-          chai.assert.isFalse(
+          assert.isFalse(
             this.child4.visuallyDisabled,
             'child4 should not be visually disabled',
           );
@@ -2506,16 +2507,16 @@ suite('Blocks', function () {
       });
       test('Set colour', function () {
         this.block.setColour('20');
-        chai.assert.equal(this.block.getColour(), '#a5745b');
-        chai.assert.equal(this.block.colour_, this.block.getColour());
-        chai.assert.equal(this.block.hue_, '20');
+        assert.equal(this.block.getColour(), '#a5745b');
+        assert.equal(this.block.colour_, this.block.getColour());
+        assert.equal(this.block.hue_, '20');
       });
       test('Set style', function () {
         this.block.setStyle('styleOne');
-        chai.assert.equal(this.block.getStyleName(), 'styleOne');
-        chai.assert.isNull(this.block.hue_);
+        assert.equal(this.block.getStyleName(), 'styleOne');
+        assert.isNull(this.block.hue_);
         // Calling setStyle does not update the colour on a headless block.
-        chai.assert.equal(this.block.getColour(), '#000000');
+        assert.equal(this.block.getColour(), '#000000');
       });
     });
     suite('Rendered', function () {
@@ -2544,23 +2545,23 @@ suite('Blocks', function () {
       });
       test('Set colour hue', function () {
         this.block.setColour('20');
-        chai.assert.equal(this.block.getStyleName(), 'auto_#a5745b');
-        chai.assert.equal(this.block.getColour(), '#a5745b');
-        chai.assert.equal(this.block.colour_, this.block.getColour());
-        chai.assert.equal(this.block.hue_, '20');
+        assert.equal(this.block.getStyleName(), 'auto_#a5745b');
+        assert.equal(this.block.getColour(), '#a5745b');
+        assert.equal(this.block.colour_, this.block.getColour());
+        assert.equal(this.block.hue_, '20');
       });
       test('Set colour hex', function () {
         this.block.setColour('#000000');
-        chai.assert.equal(this.block.getStyleName(), 'auto_#000000');
-        chai.assert.equal(this.block.getColour(), '#000000');
-        chai.assert.equal(this.block.colour_, this.block.getColour());
-        chai.assert.isNull(this.block.hue_);
+        assert.equal(this.block.getStyleName(), 'auto_#000000');
+        assert.equal(this.block.getColour(), '#000000');
+        assert.equal(this.block.colour_, this.block.getColour());
+        assert.isNull(this.block.hue_);
       });
       test('Set style', function () {
         this.block.setStyle('styleOne');
-        chai.assert.equal(this.block.getStyleName(), 'styleOne');
-        chai.assert.equal(this.block.getColour(), '#000000');
-        chai.assert.equal(this.block.colour_, this.block.getColour());
+        assert.equal(this.block.getStyleName(), 'styleOne');
+        assert.equal(this.block.getColour(), '#000000');
+        assert.equal(this.block.colour_, this.block.getColour());
       });
     });
   });
@@ -2689,7 +2690,7 @@ suite('Blocks', function () {
           Blockly.utils.xml.textToDom(t.xml),
           this.workspace,
         );
-        chai.assert.equal(block.toString(), t.toString);
+        assert.equal(block.toString(), t.toString);
       });
     });
   });
@@ -2713,20 +2714,20 @@ suite('Blocks', function () {
         recordUndoDuringInit = eventUtils.getRecordUndo();
         throw new Error();
       };
-      chai.assert.throws(
+      assert.throws(
         function () {
           this.workspace.newBlock('init_test_block');
         }.bind(this),
       );
-      chai.assert.isFalse(
+      assert.isFalse(
         recordUndoDuringInit,
         'recordUndo should be false during block init function',
       );
-      chai.assert.isTrue(
+      assert.isTrue(
         eventUtils.getRecordUndo(),
         'recordUndo should be reset to true after init',
       );
-      chai.assert.isTrue(initCalled, 'expected init function to be called');
+      assert.isTrue(initCalled, 'expected init function to be called');
     });
   });
 
@@ -2742,12 +2743,12 @@ suite('Blocks', function () {
     });
     test('Newline is converted to an end-row input', function () {
       const block = this.workspace.newBlock('end_row_test_block');
-      chai.assert.equal(block.inputList[0].fieldRow[0].getValue(), 'Row1');
-      chai.assert.isTrue(
+      assert.equal(block.inputList[0].fieldRow[0].getValue(), 'Row1');
+      assert.isTrue(
         block.inputList[0] instanceof EndRowInput,
         'newline should be converted to an end-row input',
       );
-      chai.assert.equal(block.inputList[1].fieldRow[0].getValue(), 'Row2');
+      assert.equal(block.inputList[1].fieldRow[0].getValue(), 'Row2');
     });
   });
 });

--- a/tests/mocha/block_test.js
+++ b/tests/mocha/block_test.js
@@ -1590,10 +1590,7 @@ suite('Blocks', function () {
 
       test('icons get added to the block', function () {
         this.block.addIcon(new MockIconA());
-        assert.isTrue(
-          this.block.hasIcon('A'),
-          'Expected the icon to be added',
-        );
+        assert.isTrue(this.block.hasIcon('A'), 'Expected the icon to be added');
       });
 
       test('adding two icons of the same type throws', function () {
@@ -2457,37 +2454,25 @@ suite('Blocks', function () {
           await Blockly.renderManagement.finishQueuedRenders();
 
           // child2 is disabled, rest should be enabled
-          assert.isTrue(
-            this.child1.isEnabled(),
-            'child1 should be enabled',
-          );
+          assert.isTrue(this.child1.isEnabled(), 'child1 should be enabled');
           assert.isFalse(
             this.child1.visuallyDisabled,
             'child1 should not be visually disabled',
           );
 
-          assert.isFalse(
-            this.child2.isEnabled(),
-            'child2 should be disabled',
-          );
+          assert.isFalse(this.child2.isEnabled(), 'child2 should be disabled');
           assert.isTrue(
             this.child2.visuallyDisabled,
             'child2 should be visually disabled',
           );
 
-          assert.isTrue(
-            this.child3.isEnabled(),
-            'child3 should be enabled',
-          );
+          assert.isTrue(this.child3.isEnabled(), 'child3 should be enabled');
           assert.isFalse(
             this.child3.visuallyDisabled,
             'child3 should not be visually disabled',
           );
 
-          assert.isTrue(
-            this.child4.isEnabled(),
-            'child34 should be enabled',
-          );
+          assert.isTrue(this.child4.isEnabled(), 'child34 should be enabled');
           assert.isFalse(
             this.child4.visuallyDisabled,
             'child4 should not be visually disabled',

--- a/tests/mocha/blocks/lists_test.js
+++ b/tests/mocha/blocks/lists_test.js
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import {assert} from '../../../node_modules/chai/chai.js';
 import {runSerializationTestSuite} from '../test_helpers/serialization.js';
 import {
   sharedTestSetup,
@@ -37,8 +38,8 @@ suite('Lists', function () {
           fields: {MODE: 'GET', WHERE: 'FIRST'},
         },
         assertBlockStructure: (block) => {
-          chai.assert.equal(block.type, 'lists_getIndex');
-          chai.assert.exists(block.outputConnection);
+          assert.equal(block.type, 'lists_getIndex');
+          assert.exists(block.outputConnection);
         },
       },
       {
@@ -50,9 +51,9 @@ suite('Lists', function () {
           fields: {MODE: 'REMOVE', WHERE: 'FROM_START'},
         },
         assertBlockStructure: (block) => {
-          chai.assert.equal(block.type, 'lists_getIndex');
-          chai.assert.isNotTrue(block.outputConnection);
-          chai.assert.isTrue(
+          assert.equal(block.type, 'lists_getIndex');
+          assert.isNotTrue(block.outputConnection);
+          assert.isTrue(
             block.getInput('AT').type === ConnectionType.INPUT_VALUE,
           );
         },
@@ -122,7 +123,7 @@ suite('Lists', function () {
         title: 'JSON not requiring mutations',
         json: serializedJson,
         assertBlockStructure: (block) => {
-          chai.assert.equal(block.type, serializedJson.type);
+          assert.equal(block.type, serializedJson.type);
         },
       },
       {

--- a/tests/mocha/blocks/logic_ternary_test.js
+++ b/tests/mocha/blocks/logic_ternary_test.js
@@ -303,11 +303,7 @@ suite('Logic ternary', function () {
           null,
           string,
         );
-        assert.equal(
-          number.getRootBlock(),
-          number,
-          'Input THEN disconnected',
-        );
+        assert.equal(number.getRootBlock(), number, 'Input THEN disconnected');
       });
       test('Mismatch with else causes break with else', function () {
         const string = this.workspace.newBlock('text');
@@ -317,11 +313,7 @@ suite('Logic ternary', function () {
 
         const parent = this.workspace.newBlock('text_trim');
         connectParentAndCheckConnections(this.block, parent, 'TEXT', string);
-        assert.equal(
-          number.getRootBlock(),
-          number,
-          'Input ELSE disconnected',
-        );
+        assert.equal(number.getRootBlock(), number, 'Input ELSE disconnected');
       });
     });
   });

--- a/tests/mocha/blocks/logic_ternary_test.js
+++ b/tests/mocha/blocks/logic_ternary_test.js
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import {assert} from '../../../node_modules/chai/chai.js';
 import * as eventUtils from '../../../build/src/core/events/utils.js';
 import {runSerializationTestSuite} from '../test_helpers/serialization.js';
 import {
@@ -28,21 +29,21 @@ suite('Logic ternary', function () {
    *    inline.
    */
   function assertBlockStructure(block, inputsInline = false) {
-    chai.assert.equal(block.type, 'logic_ternary');
+    assert.equal(block.type, 'logic_ternary');
     const inputs = block.inputList;
-    chai.assert.exists(inputs, 'Has inputList');
-    chai.assert.lengthOf(inputs, 3);
+    assert.exists(inputs, 'Has inputList');
+    assert.lengthOf(inputs, 3);
     const ifInput = block.getInput('IF');
-    chai.assert.exists(ifInput, 'Has "IF" input');
+    assert.exists(ifInput, 'Has "IF" input');
     const checkList = ifInput.connection.getCheck();
-    chai.assert.equal(checkList.length, 1);
-    chai.assert.equal(checkList[0], 'Boolean');
-    chai.assert.exists(block.onchangeWrapper_, 'Has onchange handler');
+    assert.equal(checkList.length, 1);
+    assert.equal(checkList[0], 'Boolean');
+    assert.exists(block.onchangeWrapper_, 'Has onchange handler');
     if (inputsInline) {
-      chai.assert.isTrue(block.inputsInline);
+      assert.isTrue(block.inputsInline);
     } else {
       // inputsInline can be undefined
-      chai.assert.isNotTrue(block.inputsInline);
+      assert.isNotTrue(block.inputsInline);
     }
   }
 
@@ -90,20 +91,20 @@ suite('Logic ternary', function () {
         .getInput(parentInputName)
         .connection.connect(block.outputConnection);
       eventUtils.TEST_ONLY.fireNow(); // Force synchronous onchange() call.
-      chai.assert.equal(
+      assert.equal(
         block.getParent(),
         parent,
         'Successful connection to parent',
       );
       if (opt_thenInput) {
-        chai.assert.equal(
+        assert.equal(
           opt_thenInput.getParent(),
           block,
           'Input THEN still connected after connecting parent',
         );
       }
       if (opt_elseInput) {
-        chai.assert.equal(
+        assert.equal(
           opt_elseInput.getParent(),
           block,
           'Input ELSE still connected after connecting parent',
@@ -118,16 +119,16 @@ suite('Logic ternary', function () {
     ) {
       block.getInput('THEN').connection.connect(thenInput.outputConnection);
       eventUtils.TEST_ONLY.fireNow(); // Force synchronous onchange() call.
-      chai.assert.equal(thenInput.getParent(), block, 'THEN is connected');
+      assert.equal(thenInput.getParent(), block, 'THEN is connected');
       if (opt_parent) {
-        chai.assert.equal(
+        assert.equal(
           block.getParent(),
           opt_parent,
           'Still connected to parent after connecting THEN',
         );
       }
       if (opt_elseInput) {
-        chai.assert.equal(
+        assert.equal(
           opt_elseInput.getParent(),
           block,
           'Input ELSE still connected after connecting THEN',
@@ -142,16 +143,16 @@ suite('Logic ternary', function () {
     ) {
       block.getInput('ELSE').connection.connect(elseInput.outputConnection);
       eventUtils.TEST_ONLY.fireNow(); // Force synchronous onchange() call.
-      chai.assert.equal(elseInput.getParent(), block, 'ELSE is connected');
+      assert.equal(elseInput.getParent(), block, 'ELSE is connected');
       if (opt_parent) {
-        chai.assert.equal(
+        assert.equal(
           block.getParent(),
           opt_parent,
           'Still connected to parent after connecting ELSE',
         );
       }
       if (opt_thenInput) {
-        chai.assert.equal(
+        assert.equal(
           opt_thenInput.getParent(),
           block,
           'Input THEN still connected after connecting ELSE',
@@ -232,7 +233,7 @@ suite('Logic ternary', function () {
 
         // Adding mismatching number.
         connectThenInputAndCheckConnections(this.block, number, string);
-        chai.assert.equal(
+        assert.equal(
           this.block.getRootBlock(),
           this.block,
           'Disconnected from parent',
@@ -250,7 +251,7 @@ suite('Logic ternary', function () {
 
         // Adding mismatching number.
         connectElseInputAndCheckConnections(this.block, number, string);
-        chai.assert.equal(
+        assert.equal(
           this.block.getRootBlock(),
           this.block,
           'Disconnected from parent',
@@ -302,7 +303,7 @@ suite('Logic ternary', function () {
           null,
           string,
         );
-        chai.assert.equal(
+        assert.equal(
           number.getRootBlock(),
           number,
           'Input THEN disconnected',
@@ -316,7 +317,7 @@ suite('Logic ternary', function () {
 
         const parent = this.workspace.newBlock('text_trim');
         connectParentAndCheckConnections(this.block, parent, 'TEXT', string);
-        chai.assert.equal(
+        assert.equal(
           number.getRootBlock(),
           number,
           'Input ELSE disconnected',

--- a/tests/mocha/blocks/loops_test.js
+++ b/tests/mocha/blocks/loops_test.js
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import {assert} from '../../../node_modules/chai/chai.js';
 import * as Blockly from '../../../build/src/core/blockly.js';
 import {
   sharedTestSetup,
@@ -27,7 +28,7 @@ suite('Loops', function () {
         this.workspace,
       );
       this.clock.runAll();
-      chai.assert.isFalse(
+      assert.isFalse(
         breakBlock.isEnabled(),
         'Expected the break block to be disabled',
       );
@@ -46,7 +47,7 @@ suite('Loops', function () {
         .getInput('DO')
         .connection.connect(breakBlock.previousConnection);
       this.clock.runAll();
-      chai.assert.isTrue(
+      assert.isTrue(
         breakBlock.isEnabled(),
         'Expected the break block to be enabled',
       );

--- a/tests/mocha/blocks/procedures_test.js
+++ b/tests/mocha/blocks/procedures_test.js
@@ -1342,9 +1342,7 @@ suite('Procedures', function () {
 
     test('returns true if an associated block exists', function () {
       createProcDefBlock(this.workspace, false, [], 'proc name');
-      assert.isTrue(
-        Blockly.Procedures.isNameUsed('proc name', this.workspace),
-      );
+      assert.isTrue(Blockly.Procedures.isNameUsed('proc name', this.workspace));
     });
 
     test('return false if an associated block does not exist', function () {
@@ -1358,9 +1356,7 @@ suite('Procedures', function () {
       this.workspace
         .getProcedureMap()
         .add(new MockProcedureModel().setName('proc name'));
-      assert.isTrue(
-        Blockly.Procedures.isNameUsed('proc name', this.workspace),
-      );
+      assert.isTrue(Blockly.Procedures.isNameUsed('proc name', this.workspace));
     });
 
     test('returns false if an associated procedure model exists', function () {
@@ -1683,10 +1679,7 @@ suite('Procedures', function () {
           defInput.htmlInput_.value = 'proc name 2';
           defInput.onHtmlInputChange_(null);
           assert.equal(this.defBlock.getFieldValue('NAME'), 'proc name 2');
-          assert.equal(
-            this.callBlock.getFieldValue('NAME'),
-            'proc name 2',
-          );
+          assert.equal(this.callBlock.getFieldValue('NAME'), 'proc name 2');
         });
         test('Set Empty', function () {
           const defInput = this.defBlock.getField('NAME');

--- a/tests/mocha/blocks/procedures_test.js
+++ b/tests/mocha/blocks/procedures_test.js
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import {assert} from '../../../node_modules/chai/chai.js';
 import * as Blockly from '../../../build/src/core/blockly.js';
 import {
   assertCallBlockStructure,
@@ -45,7 +46,7 @@ suite('Procedures', function () {
 
       defBlock.setFieldValue('new name', 'NAME');
 
-      chai.assert.equal(
+      assert.equal(
         callBlock.getFieldValue('NAME'),
         'new name',
         'Expected the procedure block to be renamed',
@@ -71,12 +72,12 @@ suite('Procedures', function () {
 
         defBlockB.setFieldValue('procA', 'NAME');
 
-        chai.assert.notEqual(
+        assert.notEqual(
           defBlockB.getFieldValue('NAME'),
           'procA',
           'Expected the procedure def block to have a legal name',
         );
-        chai.assert.notEqual(
+        assert.notEqual(
           callBlockB.getFieldValue('NAME'),
           'procA',
           'Expected the procedure call block to have a legal name',
@@ -112,7 +113,7 @@ suite('Procedures', function () {
         .getWorkspace()
         .getTopBlocks(true)[0]
         .getFieldValue('NAME');
-      chai.assert.notEqual(
+      assert.notEqual(
         newFlyoutParamName,
         origFlyoutParamName,
         'Expected the flyout param to have updated to not conflict',
@@ -133,11 +134,11 @@ suite('Procedures', function () {
         .connection.connect(paramBlock.previousConnection);
       this.clock.runAll();
 
-      chai.assert.isNotNull(
+      assert.isNotNull(
         defBlock.getField('PARAMS'),
         'Expected the params field to exist',
       );
-      chai.assert.isTrue(
+      assert.isTrue(
         defBlock.getFieldValue('PARAMS').includes('param1'),
         'Expected the params field to contain the name of the new param',
       );
@@ -158,11 +159,11 @@ suite('Procedures', function () {
         .connection.connect(paramBlock.previousConnection);
       this.clock.runAll();
 
-      chai.assert.isNotNull(
+      assert.isNotNull(
         callBlock.getInput('ARG0'),
         'Expected the param input to exist',
       );
-      chai.assert.equal(
+      assert.equal(
         callBlock.getFieldValue('ARGNAME0'),
         'param1',
         'Expected the params field to match the name of the new param',
@@ -185,7 +186,7 @@ suite('Procedures', function () {
 
       this.workspace.undo();
 
-      chai.assert.isFalse(
+      assert.isFalse(
         defBlock.getFieldValue('PARAMS').includes('param1'),
         'Expected the params field to not contain the name of the new param',
       );
@@ -211,11 +212,11 @@ suite('Procedures', function () {
         this.workspace.undo();
         this.workspace.undo(/* redo= */ true);
 
-        chai.assert.isNotNull(
+        assert.isNotNull(
           defBlock.getField('PARAMS'),
           'Expected the params field to exist',
         );
-        chai.assert.isTrue(
+        assert.isTrue(
           defBlock.getFieldValue('PARAMS').includes('param1'),
           'Expected the params field to contain the name of the new param',
         );
@@ -241,7 +242,7 @@ suite('Procedures', function () {
       paramBlock.checkAndDelete();
       this.clock.runAll();
 
-      chai.assert.isFalse(
+      assert.isFalse(
         defBlock.getFieldValue('PARAMS').includes('param1'),
         'Expected the params field to not contain the name of the new param',
       );
@@ -265,7 +266,7 @@ suite('Procedures', function () {
       paramBlock.checkAndDelete();
       this.clock.runAll();
 
-      chai.assert.isNull(
+      assert.isNull(
         callBlock.getInput('ARG0'),
         'Expected the param input to not exist',
       );
@@ -289,7 +290,7 @@ suite('Procedures', function () {
 
       this.workspace.undo();
 
-      chai.assert.isTrue(
+      assert.isTrue(
         defBlock.getFieldValue('PARAMS').includes('param1'),
         'Expected the params field to contain the name of the new param',
       );
@@ -317,7 +318,7 @@ suite('Procedures', function () {
         this.workspace.undo();
         this.workspace.undo(/* redo= */ true);
 
-        chai.assert.isFalse(
+        assert.isFalse(
           defBlock.getFieldValue('PARAMS').includes('param1'),
           'Expected the params field to not contain the name of the new param',
         );
@@ -343,11 +344,11 @@ suite('Procedures', function () {
       paramBlock.setFieldValue('new name', 'NAME');
       this.clock.runAll();
 
-      chai.assert.isNotNull(
+      assert.isNotNull(
         defBlock.getField('PARAMS'),
         'Expected the params field to exist',
       );
-      chai.assert.isTrue(
+      assert.isTrue(
         defBlock.getFieldValue('PARAMS').includes('new name'),
         'Expected the params field to contain the new name of the param',
       );
@@ -373,11 +374,11 @@ suite('Procedures', function () {
       paramBlock1.setFieldValue('new name', 'NAME');
       this.clock.runAll();
 
-      chai.assert.isNotNull(
+      assert.isNotNull(
         defBlock.getField('PARAMS'),
         'Expected the params field to exist',
       );
-      chai.assert.isTrue(
+      assert.isTrue(
         defBlock.getFieldValue('PARAMS').includes('new name'),
         'Expected the params field to contain the new name of the param',
       );
@@ -401,11 +402,11 @@ suite('Procedures', function () {
       paramBlock.setFieldValue('new name', 'NAME');
       this.clock.runAll();
 
-      chai.assert.isNotNull(
+      assert.isNotNull(
         callBlock.getInput('ARG0'),
         'Expected the param input to exist',
       );
-      chai.assert.equal(
+      assert.equal(
         callBlock.getFieldValue('ARGNAME0'),
         'new name',
         'Expected the params field to match the name of the new param',
@@ -430,7 +431,7 @@ suite('Procedures', function () {
       paramBlock.setFieldValue('param2', 'NAME');
       this.clock.runAll();
 
-      chai.assert.isNotNull(
+      assert.isNotNull(
         this.workspace.getVariable('param1', ''),
         'Expected the old variable to continue to exist',
       );
@@ -454,11 +455,11 @@ suite('Procedures', function () {
       const variable = this.workspace.getVariable('param1', '');
       this.workspace.renameVariableById(variable.getId(), 'new name');
 
-      chai.assert.isNotNull(
+      assert.isNotNull(
         defBlock.getField('PARAMS'),
         'Expected the params field to exist',
       );
-      chai.assert.isTrue(
+      assert.isTrue(
         defBlock.getFieldValue('PARAMS').includes('new name'),
         'Expected the params field to contain the new name of the param',
       );
@@ -481,7 +482,7 @@ suite('Procedures', function () {
       const variable = this.workspace.getVariable('param1', '');
       this.workspace.renameVariableById(variable.getId(), 'new name');
 
-      chai.assert.equal(
+      assert.equal(
         paramBlock.getFieldValue('NAME'),
         'new name',
         'Expected the params field to contain the new name of the param',
@@ -507,11 +508,11 @@ suite('Procedures', function () {
       const variable = this.workspace.getVariable('param1', '');
       this.workspace.renameVariableById(variable.getId(), 'new name');
 
-      chai.assert.isNotNull(
+      assert.isNotNull(
         callBlock.getInput('ARG0'),
         'Expected the param input to exist',
       );
-      chai.assert.equal(
+      assert.equal(
         callBlock.getFieldValue('ARGNAME0'),
         'new name',
         'Expected the params field to match the name of the new param',
@@ -536,11 +537,11 @@ suite('Procedures', function () {
       const variable = this.workspace.getVariable('param1', '');
       this.workspace.renameVariableById(variable.getId(), 'preCreatedVar');
 
-      chai.assert.isNotNull(
+      assert.isNotNull(
         defBlock.getField('PARAMS'),
         'Expected the params field to exist',
       );
-      chai.assert.isTrue(
+      assert.isTrue(
         defBlock.getFieldValue('PARAMS').includes('preCreatedVar'),
         'Expected the params field to contain the new name of the param',
       );
@@ -563,7 +564,7 @@ suite('Procedures', function () {
       const variable = this.workspace.getVariable('param1', '');
       this.workspace.renameVariableById(variable.getId(), 'preCreatedVar');
 
-      chai.assert.equal(
+      assert.equal(
         paramBlock.getFieldValue('NAME'),
         'preCreatedVar',
         'Expected the params field to contain the new name of the param',
@@ -589,11 +590,11 @@ suite('Procedures', function () {
       const variable = this.workspace.getVariable('param1', '');
       this.workspace.renameVariableById(variable.getId(), 'preCreatedVar');
 
-      chai.assert.isNotNull(
+      assert.isNotNull(
         callBlock.getInput('ARG0'),
         'Expected the param input to exist',
       );
-      chai.assert.equal(
+      assert.equal(
         callBlock.getFieldValue('ARGNAME0'),
         'preCreatedVar',
         'Expected the params field to match the name of the new param',
@@ -631,7 +632,7 @@ suite('Procedures', function () {
       this.workspace.undo();
       this.clock.runAll();
 
-      chai.assert.isTrue(
+      assert.isTrue(
         defBlock.getFieldValue('PARAMS').includes('param1'),
         'Expected the params field to contain the old name of the param',
       );
@@ -662,7 +663,7 @@ suite('Procedures', function () {
       this.workspace.undo();
       this.workspace.undo(/* redo= */ true);
 
-      chai.assert.isTrue(
+      assert.isTrue(
         defBlock.getFieldValue('PARAMS').includes('new'),
         'Expected the params field to contain the new name of the param',
       );
@@ -696,11 +697,11 @@ suite('Procedures', function () {
       paramBlock2.nextConnection.connect(paramBlock1.previousConnection);
       this.clock.runAll();
 
-      chai.assert.isNotNull(
+      assert.isNotNull(
         defBlock.getField('PARAMS'),
         'Expected the params field to exist',
       );
-      chai.assert.isTrue(
+      assert.isTrue(
         defBlock.getFieldValue('PARAMS').includes('param2, param1'),
         'Expected the params field order to match the parameter order',
       );
@@ -733,20 +734,20 @@ suite('Procedures', function () {
       paramBlock2.nextConnection.connect(paramBlock1.previousConnection);
       this.clock.runAll();
 
-      chai.assert.isNotNull(
+      assert.isNotNull(
         callBlock.getInput('ARG0'),
         'Expected the param input to exist',
       );
-      chai.assert.equal(
+      assert.equal(
         callBlock.getFieldValue('ARGNAME0'),
         'param2',
         'Expected the params field to match the name of the second param',
       );
-      chai.assert.isNotNull(
+      assert.isNotNull(
         callBlock.getInput('ARG1'),
         'Expected the param input to exist',
       );
-      chai.assert.equal(
+      assert.equal(
         callBlock.getFieldValue('ARGNAME1'),
         'param1',
         'Expected the params field to match the name of the first param',
@@ -789,12 +790,12 @@ suite('Procedures', function () {
         paramBlock2.nextConnection.connect(paramBlock1.previousConnection);
         this.clock.runAll();
 
-        chai.assert.equal(
+        assert.equal(
           callBlock.getInputTargetBlock('ARG0'),
           block2,
           'Expected the second block to be in the first slot',
         );
-        chai.assert.equal(
+        assert.equal(
           callBlock.getInputTargetBlock('ARG1'),
           block1,
           'Expected the first block to be in the second slot',
@@ -814,7 +815,7 @@ suite('Procedures', function () {
         defBlock.setDisabledReason(true, 'MANUALLY_DISABLED');
         this.clock.runAll();
 
-        chai.assert.isFalse(
+        assert.isFalse(
           callBlock.isEnabled(),
           'Expected the caller block to be disabled',
         );
@@ -831,7 +832,7 @@ suite('Procedures', function () {
         defBlock.setDisabledReason(true, 'test reason');
         this.clock.runAll();
 
-        chai.assert.isFalse(
+        assert.isFalse(
           callBlock.isEnabled(),
           'Expected the caller block to be invalid',
         );
@@ -850,7 +851,7 @@ suite('Procedures', function () {
         defBlock.setDisabledReason(false, 'MANUALLY_DISABLED');
         this.clock.runAll();
 
-        chai.assert.isTrue(
+        assert.isTrue(
           callBlock.isEnabled(),
           'Expected the caller block to be enabled',
         );
@@ -872,7 +873,7 @@ suite('Procedures', function () {
         defBlock.setDisabledReason(false, 'MANUALLY_DISABLED');
         this.clock.runAll();
 
-        chai.assert.isFalse(
+        assert.isFalse(
           callBlock.isEnabled(),
           'Expected the caller block to continue to be disabled',
         );
@@ -887,7 +888,7 @@ suite('Procedures', function () {
         this.workspace,
       );
       this.clock.runAll();
-      chai.assert.isFalse(
+      assert.isFalse(
         ifreturnBlock.isEnabled(),
         'Expected the ifreturn block to be invalid',
       );
@@ -903,7 +904,7 @@ suite('Procedures', function () {
         .getInput('STACK')
         .connection.connect(ifreturnBlock.previousConnection);
       this.clock.runAll();
-      chai.assert.isTrue(
+      assert.isTrue(
         ifreturnBlock.isEnabled(),
         'Expected the ifreturn block to be valid',
       );
@@ -923,11 +924,11 @@ suite('Procedures', function () {
         defBlock.dispose();
         this.clock.runAll();
 
-        chai.assert.isTrue(
+        assert.isTrue(
           callBlock1.disposed,
           'Expected the first caller to be disposed',
         );
-        chai.assert.isTrue(
+        assert.isTrue(
           callBlock2.disposed,
           'Expected the second caller to be disposed',
         );
@@ -1233,7 +1234,7 @@ suite('Procedures', function () {
       const options = [];
       def.customContextMenu(options);
 
-      chai.assert.isTrue(
+      assert.isTrue(
         options[0].text.includes('test name'),
         'Expected the context menu to have an option to create the caller',
       );
@@ -1267,11 +1268,11 @@ suite('Procedures', function () {
       const options = [];
       def.customContextMenu(options);
 
-      chai.assert.isTrue(
+      assert.isTrue(
         options[1].text.includes('testParam1'),
         'Expected the context menu to have an option to create the first param',
       );
-      chai.assert.isTrue(
+      assert.isTrue(
         options[2].text.includes('testParam2'),
         'Expected the context menu to have an option to create the second param',
       );
@@ -1286,13 +1287,13 @@ suite('Procedures', function () {
       returnBlock.setFieldValue('return', 'NAME');
 
       const allProcedures = Blockly.Procedures.allProcedures(this.workspace);
-      chai.assert.lengthOf(allProcedures, 2);
+      assert.lengthOf(allProcedures, 2);
 
-      chai.assert.lengthOf(allProcedures[0], 1);
-      chai.assert.equal(allProcedures[0][0][0], 'no return');
+      assert.lengthOf(allProcedures[0], 1);
+      assert.equal(allProcedures[0][0][0], 'no return');
 
-      chai.assert.lengthOf(allProcedures[1], 1);
-      chai.assert.equal(allProcedures[1][0][0], 'return');
+      assert.lengthOf(allProcedures[1], 1);
+      assert.equal(allProcedures[1][0][0], 'return');
     });
 
     test('Multiple Blocks', function () {
@@ -1305,26 +1306,26 @@ suite('Procedures', function () {
       const _ = this.workspace.newBlock('controls_if');
 
       const allProcedures = Blockly.Procedures.allProcedures(this.workspace);
-      chai.assert.lengthOf(allProcedures, 2);
+      assert.lengthOf(allProcedures, 2);
 
-      chai.assert.lengthOf(allProcedures[0], 1);
-      chai.assert.equal(allProcedures[0][0][0], 'no return');
+      assert.lengthOf(allProcedures[0], 1);
+      assert.equal(allProcedures[0][0][0], 'no return');
 
-      chai.assert.lengthOf(allProcedures[1], 2);
-      chai.assert.equal(allProcedures[1][0][0], 'return');
-      chai.assert.equal(allProcedures[1][1][0], 'return2');
+      assert.lengthOf(allProcedures[1], 2);
+      assert.equal(allProcedures[1][0][0], 'return');
+      assert.equal(allProcedures[1][1][0], 'return2');
     });
 
     test('No Procedures', function () {
       const _ = this.workspace.newBlock('controls_if');
       const allProcedures = Blockly.Procedures.allProcedures(this.workspace);
-      chai.assert.lengthOf(allProcedures, 2);
-      chai.assert.lengthOf(
+      assert.lengthOf(allProcedures, 2);
+      assert.lengthOf(
         allProcedures[0],
         0,
         'No procedures_defnoreturn blocks expected',
       );
-      chai.assert.lengthOf(
+      assert.lengthOf(
         allProcedures[1],
         0,
         'No procedures_defreturn blocks expected',
@@ -1334,21 +1335,21 @@ suite('Procedures', function () {
 
   suite('isNameUsed', function () {
     test('returns false if no blocks or models exists', function () {
-      chai.assert.isFalse(
+      assert.isFalse(
         Blockly.Procedures.isNameUsed('proc name', this.workspace),
       );
     });
 
     test('returns true if an associated block exists', function () {
       createProcDefBlock(this.workspace, false, [], 'proc name');
-      chai.assert.isTrue(
+      assert.isTrue(
         Blockly.Procedures.isNameUsed('proc name', this.workspace),
       );
     });
 
     test('return false if an associated block does not exist', function () {
       createProcDefBlock(this.workspace, false, [], 'proc name');
-      chai.assert.isFalse(
+      assert.isFalse(
         Blockly.Procedures.isNameUsed('other proc name', this.workspace),
       );
     });
@@ -1357,7 +1358,7 @@ suite('Procedures', function () {
       this.workspace
         .getProcedureMap()
         .add(new MockProcedureModel().setName('proc name'));
-      chai.assert.isTrue(
+      assert.isTrue(
         Blockly.Procedures.isNameUsed('proc name', this.workspace),
       );
     });
@@ -1366,7 +1367,7 @@ suite('Procedures', function () {
       this.workspace
         .getProcedureMap()
         .add(new MockProcedureModel().setName('proc name'));
-      chai.assert.isFalse(
+      assert.isFalse(
         Blockly.Procedures.isNameUsed('other proc name', this.workspace),
       );
     });
@@ -1381,20 +1382,20 @@ suite('Procedures', function () {
     ) {
       const allProcedures = Blockly.Procedures.allProcedures(workspace);
       const defNoReturnBlocks = allProcedures[0];
-      chai.assert.lengthOf(
+      assert.lengthOf(
         defNoReturnBlocks,
         noReturnNames.length,
         `Expected the number of no return blocks to be ${noReturnNames.length}`,
       );
       for (let i = 0; i < noReturnNames.length; i++) {
         const expectedName = noReturnNames[i];
-        chai.assert.equal(defNoReturnBlocks[i][0], expectedName);
+        assert.equal(defNoReturnBlocks[i][0], expectedName);
         if (hasCallers) {
           const callers = Blockly.Procedures.getCallers(
             expectedName,
             workspace,
           );
-          chai.assert.lengthOf(
+          assert.lengthOf(
             callers,
             1,
             `Expected there to be one caller of the ${expectedName} block`,
@@ -1402,20 +1403,20 @@ suite('Procedures', function () {
         }
       }
       const defReturnBlocks = allProcedures[1];
-      chai.assert.lengthOf(
+      assert.lengthOf(
         defReturnBlocks,
         returnNames.length,
         `Expected the number of return blocks to be ${returnNames.length}`,
       );
       for (let i = 0; i < returnNames.length; i++) {
         const expectedName = returnNames[i];
-        chai.assert.equal(defReturnBlocks[i][0], expectedName);
+        assert.equal(defReturnBlocks[i][0], expectedName);
         if (hasCallers) {
           const callers = Blockly.Procedures.getCallers(
             expectedName,
             workspace,
           );
-          chai.assert.lengthOf(
+          assert.lengthOf(
             callers,
             1,
             `Expected there to be one caller of the ${expectedName} block`,
@@ -1429,7 +1430,7 @@ suite('Procedures', function () {
         expectedCount *= 2;
       }
       const blocks = workspace.getAllBlocks(false);
-      chai.assert.lengthOf(blocks, expectedCount);
+      assert.lengthOf(blocks, expectedCount);
     }
 
     suite('no name renamed to unnamed', function () {
@@ -1532,7 +1533,7 @@ suite('Procedures', function () {
       // Do not require procedures to be the built-in procedures.
       const defBlock = this.workspace.newBlock('new_proc');
       const def = Blockly.Procedures.getDefinition('test', this.workspace);
-      chai.assert.equal(def, defBlock);
+      assert.equal(def, defBlock);
     });
 
     test('Stacked procedures', function () {
@@ -1542,7 +1543,7 @@ suite('Procedures', function () {
       blockB.name = 'b';
       blockA.nextConnection.connect(blockB.previousConnection);
       const def = Blockly.Procedures.getDefinition('b', this.workspace);
-      chai.assert.equal(def, blockB);
+      assert.equal(def, blockB);
     });
   });
 
@@ -1612,8 +1613,8 @@ suite('Procedures', function () {
             this.defBlock.getFieldValue('NAME') + '2',
             'NAME',
           );
-          chai.assert.equal(this.defBlock.getFieldValue('NAME'), 'proc name2');
-          chai.assert.equal(this.callBlock.getFieldValue('NAME'), 'proc name2');
+          assert.equal(this.defBlock.getFieldValue('NAME'), 'proc name2');
+          assert.equal(this.callBlock.getFieldValue('NAME'), 'proc name2');
         });
         test('Simple, Input', function () {
           const defInput = this.defBlock.getField('NAME');
@@ -1625,8 +1626,8 @@ suite('Procedures', function () {
 
           defInput.htmlInput_.value = 'proc name2';
           defInput.onHtmlInputChange_(null);
-          chai.assert.equal(this.defBlock.getFieldValue('NAME'), 'proc name2');
-          chai.assert.equal(this.callBlock.getFieldValue('NAME'), 'proc name2');
+          assert.equal(this.defBlock.getFieldValue('NAME'), 'proc name2');
+          assert.equal(this.callBlock.getFieldValue('NAME'), 'proc name2');
         });
         test('lower -> CAPS', function () {
           const defInput = this.defBlock.getField('NAME');
@@ -1638,8 +1639,8 @@ suite('Procedures', function () {
 
           defInput.htmlInput_.value = 'PROC NAME';
           defInput.onHtmlInputChange_(null);
-          chai.assert.equal(this.defBlock.getFieldValue('NAME'), 'PROC NAME');
-          chai.assert.equal(this.callBlock.getFieldValue('NAME'), 'PROC NAME');
+          assert.equal(this.defBlock.getFieldValue('NAME'), 'PROC NAME');
+          assert.equal(this.callBlock.getFieldValue('NAME'), 'PROC NAME');
         });
         test('CAPS -> lower', function () {
           this.defBlock.setFieldValue('PROC NAME', 'NAME');
@@ -1653,8 +1654,8 @@ suite('Procedures', function () {
 
           defInput.htmlInput_.value = 'proc name';
           defInput.onHtmlInputChange_(null);
-          chai.assert.equal(this.defBlock.getFieldValue('NAME'), 'proc name');
-          chai.assert.equal(this.callBlock.getFieldValue('NAME'), 'proc name');
+          assert.equal(this.defBlock.getFieldValue('NAME'), 'proc name');
+          assert.equal(this.callBlock.getFieldValue('NAME'), 'proc name');
         });
         test('Whitespace', function () {
           const defInput = this.defBlock.getField('NAME');
@@ -1666,8 +1667,8 @@ suite('Procedures', function () {
 
           defInput.htmlInput_.value = 'proc name ';
           defInput.onHtmlInputChange_(null);
-          chai.assert.equal(this.defBlock.getFieldValue('NAME'), 'proc name');
-          chai.assert.equal(this.callBlock.getFieldValue('NAME'), 'proc name');
+          assert.equal(this.defBlock.getFieldValue('NAME'), 'proc name');
+          assert.equal(this.callBlock.getFieldValue('NAME'), 'proc name');
         });
         test('Whitespace then Text', function () {
           const defInput = this.defBlock.getField('NAME');
@@ -1681,8 +1682,8 @@ suite('Procedures', function () {
           defInput.onHtmlInputChange_(null);
           defInput.htmlInput_.value = 'proc name 2';
           defInput.onHtmlInputChange_(null);
-          chai.assert.equal(this.defBlock.getFieldValue('NAME'), 'proc name 2');
-          chai.assert.equal(
+          assert.equal(this.defBlock.getFieldValue('NAME'), 'proc name 2');
+          assert.equal(
             this.callBlock.getFieldValue('NAME'),
             'proc name 2',
           );
@@ -1697,11 +1698,11 @@ suite('Procedures', function () {
 
           defInput.htmlInput_.value = '';
           defInput.onHtmlInputChange_(null);
-          chai.assert.equal(
+          assert.equal(
             this.defBlock.getFieldValue('NAME'),
             Blockly.Msg['UNNAMED_KEY'],
           );
-          chai.assert.equal(
+          assert.equal(
             this.callBlock.getFieldValue('NAME'),
             Blockly.Msg['UNNAMED_KEY'],
           );
@@ -1718,11 +1719,11 @@ suite('Procedures', function () {
           defInput.onHtmlInputChange_(null);
           const newDefBlock = this.workspace.newBlock(testSuite.defType);
           newDefBlock.setFieldValue('new name', 'NAME');
-          chai.assert.equal(
+          assert.equal(
             this.defBlock.getFieldValue('NAME'),
             Blockly.Msg['UNNAMED_KEY'],
           );
-          chai.assert.equal(
+          assert.equal(
             this.callBlock.getFieldValue('NAME'),
             Blockly.Msg['UNNAMED_KEY'],
           );
@@ -1754,8 +1755,8 @@ suite('Procedures', function () {
             'proc name',
             this.workspace,
           );
-          chai.assert.equal(callers.length, 1);
-          chai.assert.equal(callers[0], this.callBlock);
+          assert.equal(callers.length, 1);
+          assert.equal(callers[0], this.callBlock);
         });
         test('Multiple Callers', function () {
           const caller2 = this.workspace.newBlock(testSuite.callType);
@@ -1767,10 +1768,10 @@ suite('Procedures', function () {
             'proc name',
             this.workspace,
           );
-          chai.assert.equal(callers.length, 3);
-          chai.assert.equal(callers[0], this.callBlock);
-          chai.assert.equal(callers[1], caller2);
-          chai.assert.equal(callers[2], caller3);
+          assert.equal(callers.length, 3);
+          assert.equal(callers[0], this.callBlock);
+          assert.equal(callers[1], caller2);
+          assert.equal(callers[2], caller3);
         });
         test('Multiple Procedures', function () {
           const def2 = this.workspace.newBlock(testSuite.defType);
@@ -1782,8 +1783,8 @@ suite('Procedures', function () {
             'proc name',
             this.workspace,
           );
-          chai.assert.equal(callers.length, 1);
-          chai.assert.equal(callers[0], this.callBlock);
+          assert.equal(callers.length, 1);
+          assert.equal(callers[0], this.callBlock);
         });
         // This can occur if you:
         //  1) Create an uppercase definition and call block.
@@ -1799,8 +1800,8 @@ suite('Procedures', function () {
             'proc name',
             this.workspace,
           );
-          chai.assert.equal(callers.length, 1);
-          chai.assert.equal(callers[0], this.callBlock);
+          assert.equal(callers.length, 1);
+          assert.equal(callers[0], this.callBlock);
         });
         test('Multiple Workspaces', function () {
           const workspace = new Blockly.Workspace();
@@ -1814,12 +1815,12 @@ suite('Procedures', function () {
               'proc name',
               this.workspace,
             );
-            chai.assert.equal(callers.length, 1);
-            chai.assert.equal(callers[0], this.callBlock);
+            assert.equal(callers.length, 1);
+            assert.equal(callers[0], this.callBlock);
 
             callers = Blockly.Procedures.getCallers('proc name', workspace);
-            chai.assert.equal(callers.length, 1);
-            chai.assert.equal(callers[0], caller2);
+            assert.equal(callers.length, 1);
+            assert.equal(callers[0], caller2);
           } finally {
             workspaceTeardown.call(this, workspace);
           }
@@ -1851,7 +1852,7 @@ suite('Procedures', function () {
             'proc name',
             this.workspace,
           );
-          chai.assert.equal(def, this.defBlock);
+          assert.equal(def, this.defBlock);
         });
         test('Multiple Procedures', function () {
           const def2 = this.workspace.newBlock(testSuite.defType);
@@ -1863,7 +1864,7 @@ suite('Procedures', function () {
             'proc name',
             this.workspace,
           );
-          chai.assert.equal(def, this.defBlock);
+          assert.equal(def, this.defBlock);
         });
         test('Multiple Workspaces', function () {
           const workspace = new Blockly.Workspace();
@@ -1877,10 +1878,10 @@ suite('Procedures', function () {
               'proc name',
               this.workspace,
             );
-            chai.assert.equal(def, this.defBlock);
+            assert.equal(def, this.defBlock);
 
             def = Blockly.Procedures.getDefinition('proc name', workspace);
-            chai.assert.equal(def, def2);
+            assert.equal(def, def2);
           } finally {
             workspaceTeardown.call(this, workspace);
           }
@@ -1925,11 +1926,11 @@ suite('Procedures', function () {
             if (testSuite.defType === 'procedures_defreturn') {
               test('Has Statements', function () {
                 setStatementValue(this.workspace, this.defBlock, true);
-                chai.assert.isTrue(this.defBlock.hasStatements_);
+                assert.isTrue(this.defBlock.hasStatements_);
               });
               test('Has No Statements', function () {
                 setStatementValue(this.workspace, this.defBlock, false);
-                chai.assert.isFalse(this.defBlock.hasStatements_);
+                assert.isFalse(this.defBlock.hasStatements_);
               });
               test('Saving Statements', function () {
                 const blockXml = Blockly.utils.xml.textToDom(
@@ -1944,14 +1945,14 @@ suite('Procedures', function () {
                   this.workspace,
                 );
                 setStatementValue(this.workspace, defBlock, false);
-                chai.assert.isNull(defBlock.getInput('STACK'));
+                assert.isNull(defBlock.getInput('STACK'));
                 setStatementValue(this.workspace, defBlock, true);
-                chai.assert.isNotNull(defBlock.getInput('STACK'));
+                assert.isNotNull(defBlock.getInput('STACK'));
                 const statementBlocks = defBlock.getChildren();
-                chai.assert.equal(statementBlocks.length, 1);
+                assert.equal(statementBlocks.length, 1);
                 const block = statementBlocks[0];
-                chai.assert.equal(block.type, 'procedures_ifreturn');
-                chai.assert.equal(block.id, 'test');
+                assert.equal(block.type, 'procedures_ifreturn');
+                assert.equal(block.id, 'test');
               });
             }
           });
@@ -1976,21 +1977,21 @@ suite('Procedures', function () {
               this.clock.runAll();
             }
             function assertArgs(argArray) {
-              chai.assert.equal(
+              assert.equal(
                 this.defBlock.getVars().length,
                 argArray.length,
                 'Expected the def to have the right number of arguments',
               );
               for (let i = 0; i < argArray.length; i++) {
-                chai.assert.equal(this.defBlock.getVars()[i], argArray[i]);
+                assert.equal(this.defBlock.getVars()[i], argArray[i]);
               }
-              chai.assert.equal(
+              assert.equal(
                 this.callBlock.getVars().length,
                 argArray.length,
                 'Expected the call to have the right number of arguments',
               );
               for (let i = 0; i < argArray.length; i++) {
-                chai.assert.equal(this.callBlock.getVars()[i], argArray[i]);
+                assert.equal(this.callBlock.getVars()[i], argArray[i]);
               }
             }
             test('Simple Add Arg', async function () {
@@ -2062,7 +2063,7 @@ suite('Procedures', function () {
                 const statementInput = mutatorWorkspace
                   .getTopBlocks()[0]
                   .getInput('STATEMENT_INPUT');
-                chai.assert.isNotNull(statementInput);
+                assert.isNotNull(statementInput);
               });
               test('Has Statements', function () {
                 this.defBlock.hasStatements_ = true;
@@ -2076,7 +2077,7 @@ suite('Procedures', function () {
                   .getTopBlocks()[0]
                   .getField('STATEMENTS')
                   .getValueBoolean();
-                chai.assert.isTrue(statementValue);
+                assert.isTrue(statementValue);
               });
               test('No Has Statements', function () {
                 this.defBlock.hasStatements_ = false;
@@ -2090,7 +2091,7 @@ suite('Procedures', function () {
                   .getTopBlocks()[0]
                   .getField('STATEMENTS')
                   .getValueBoolean();
-                chai.assert.isFalse(statementValue);
+                assert.isFalse(statementValue);
               });
             } else {
               test('Has no Statement Input', function () {
@@ -2103,7 +2104,7 @@ suite('Procedures', function () {
                 const statementInput = mutatorWorkspace
                   .getTopBlocks()[0]
                   .getInput('STATEMENT_INPUT');
-                chai.assert.isNull(statementInput);
+                assert.isNull(statementInput);
               });
             }
           });

--- a/tests/mocha/blocks/variables_test.js
+++ b/tests/mocha/blocks/variables_test.js
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import {assert} from '../../../node_modules/chai/chai.js';
 import {
   sharedTestSetup,
   sharedTestTeardown,
@@ -64,7 +65,7 @@ suite('Variables', function () {
       createTestVarBlock(this.workspace, '3');
 
       const result = Blockly.Variables.allUsedVarModels(this.workspace);
-      chai.assert.equal(
+      assert.equal(
         result.length,
         3,
         'Expected three variables in the list of used variables',
@@ -75,12 +76,12 @@ suite('Variables', function () {
       createTestVarBlock(this.workspace, '2');
 
       const result = Blockly.Variables.allUsedVarModels(this.workspace);
-      chai.assert.equal(
+      assert.equal(
         result.length,
         1,
         'Expected one variable in the list of used variables',
       );
-      chai.assert.equal(
+      assert.equal(
         result[0].getId(),
         '2',
         'Expected variable with ID 2 in the list of used variables',
@@ -94,12 +95,12 @@ suite('Variables', function () {
       const result = Blockly.Variables.allUsedVarModels(this.workspace);
       // Using the same variable multiple times should not change the number of
       // elements in the list.
-      chai.assert.equal(
+      assert.equal(
         result.length,
         1,
         'Expected one variable in the list of used variables',
       );
-      chai.assert.equal(
+      assert.equal(
         result[0].getId(),
         '2',
         'Expected variable with ID 2 in the list of used variables',
@@ -108,7 +109,7 @@ suite('Variables', function () {
 
     test('All unused', function () {
       const result = Blockly.Variables.allUsedVarModels(this.workspace);
-      chai.assert.equal(
+      assert.equal(
         result.length,
         0,
         'Expected no variables in the list of used variables',
@@ -125,9 +126,9 @@ suite('Variables', function () {
       const result2 = Blockly.Variables.getVariable(this.workspace, 'id2');
       const result3 = Blockly.Variables.getVariable(this.workspace, 'id3');
 
-      chai.assert.equal(var1, result1);
-      chai.assert.equal(var2, result2);
-      chai.assert.equal(var3, result3);
+      assert.equal(var1, result1);
+      assert.equal(var2, result2);
+      assert.equal(var3, result3);
     });
 
     test('By name and type', function () {
@@ -154,9 +155,9 @@ suite('Variables', function () {
       );
 
       // Searching by name + type is correct.
-      chai.assert.equal(var1, result1);
-      chai.assert.equal(var2, result2);
-      chai.assert.equal(var3, result3);
+      assert.equal(var1, result1);
+      assert.equal(var2, result2);
+      assert.equal(var3, result3);
     });
 
     test('Bad ID with name and type fallback', function () {
@@ -183,9 +184,9 @@ suite('Variables', function () {
       );
 
       // Searching by ID failed, but falling back onto name + type is correct.
-      chai.assert.equal(var1, result1);
-      chai.assert.equal(var2, result2);
-      chai.assert.equal(var3, result3);
+      assert.equal(var1, result1);
+      assert.equal(var2, result2);
+      assert.equal(var3, result3);
     });
   });
 
@@ -214,7 +215,7 @@ suite('Variables', function () {
           this.workspace,
         );
 
-        chai.assert.equal(
+        assert.equal(
           'test name',
           nameUsedWithConflictingParam('x', 'y', this.workspace),
           'Expected the name of the procedure with the conflicting ' +
@@ -248,7 +249,7 @@ suite('Variables', function () {
             this.workspace,
           );
 
-          chai.assert.isNull(
+          assert.isNull(
             nameUsedWithConflictingParam('x', 'y', this.workspace),
             'Expected there to be no conflict',
           );
@@ -270,7 +271,7 @@ suite('Variables', function () {
               ),
           );
 
-        chai.assert.equal(
+        assert.equal(
           'test name',
           nameUsedWithConflictingParam('x', 'y', this.workspace),
           'Expected the name of the procedure with the conflicting ' +
@@ -299,7 +300,7 @@ suite('Variables', function () {
                 ),
             );
 
-          chai.assert.isNull(
+          assert.isNull(
             nameUsedWithConflictingParam('x', 'y', this.workspace),
             'Expected there to be no conflict',
           );

--- a/tests/mocha/clipboard_test.js
+++ b/tests/mocha/clipboard_test.js
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import {assert} from '../../node_modules/chai/chai.js';
 import {
   sharedTestSetup,
   sharedTestTeardown,
@@ -30,7 +31,7 @@ suite('Clipboard', function () {
     Blockly.clipboard.registry.register('test-paster', paster);
 
     Blockly.clipboard.paste({paster: 'test-paster'}, this.workspace);
-    chai.assert.isTrue(paster.paste.calledOnce);
+    assert.isTrue(paster.paste.calledOnce);
 
     Blockly.clipboard.registry.unregister('test-paster');
   });
@@ -73,7 +74,7 @@ suite('Clipboard', function () {
         const data = block.toCopyData();
 
         const newBlock = Blockly.clipboard.paste(data, this.workspace);
-        chai.assert.deepEqual(
+        assert.deepEqual(
           newBlock.getRelativeToSurfaceXY(),
           new Blockly.utils.Coordinate(66, 69),
         );
@@ -105,7 +106,7 @@ suite('Clipboard', function () {
         const data = this.workspace.getBlockById('sourceBlockId').toCopyData();
 
         const newBlock = Blockly.clipboard.paste(data, this.workspace);
-        chai.assert.deepEqual(
+        assert.deepEqual(
           newBlock.getRelativeToSurfaceXY(),
           new Blockly.utils.Coordinate(94, 125),
         );
@@ -126,7 +127,7 @@ suite('Clipboard', function () {
       const data = comment.toCopyData();
 
       const newComment = Blockly.clipboard.paste(data, this.workspace);
-      chai.assert.deepEqual(
+      assert.deepEqual(
         newComment.getRelativeToSurfaceXY(),
         new Blockly.utils.Coordinate(60, 60),
       );

--- a/tests/mocha/comment_deserialization_test.js
+++ b/tests/mocha/comment_deserialization_test.js
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import {assert} from '../../node_modules/chai/chai.js';
 import {
   sharedTestSetup,
   sharedTestTeardown,
@@ -60,23 +61,23 @@ suite('Comment Deserialization', function () {
       icon.setBubbleVisible(true);
       // Check comment bubble size.
       const bubbleSize = icon.getBubbleSize();
-      chai.assert.isNotNaN(bubbleSize.width);
-      chai.assert.isNotNaN(bubbleSize.height);
-      chai.assert.equal(icon.getText(), text);
+      assert.isNotNaN(bubbleSize.width);
+      assert.isNotNaN(bubbleSize.height);
+      assert.equal(icon.getText(), text);
     }
     test('Trashcan', function () {
       // Create block.
       this.block = createBlock(this.workspace);
       // Delete block.
       this.block.checkAndDelete();
-      chai.assert.equal(this.workspace.getAllBlocks().length, 0);
+      assert.equal(this.workspace.getAllBlocks().length, 0);
       // Open trashcan.
       simulateClick(this.workspace.trashcan.svgGroup);
       // Place from trashcan.
       simulateClick(
         this.workspace.trashcan.flyout.svgGroup_.querySelector('.blocklyPath'),
       );
-      chai.assert.equal(this.workspace.getAllBlocks().length, 1);
+      assert.equal(this.workspace.getAllBlocks().length, 1);
       // Check comment.
       assertComment(this.workspace, 'test text');
     });
@@ -85,10 +86,10 @@ suite('Comment Deserialization', function () {
       this.block = createBlock(this.workspace);
       // Delete block.
       this.block.checkAndDelete();
-      chai.assert.equal(this.workspace.getAllBlocks().length, 0);
+      assert.equal(this.workspace.getAllBlocks().length, 0);
       // Undo.
       this.workspace.undo(false);
-      chai.assert.equal(this.workspace.getAllBlocks().length, 1);
+      assert.equal(this.workspace.getAllBlocks().length, 1);
       // Check comment.
       assertComment(this.workspace, 'test text');
     });
@@ -98,11 +99,11 @@ suite('Comment Deserialization', function () {
       // Undo & undo.
       this.workspace.undo(false);
       this.workspace.undo(false);
-      chai.assert.equal(this.workspace.getAllBlocks().length, 0);
+      assert.equal(this.workspace.getAllBlocks().length, 0);
       // Redo & redo.
       this.workspace.undo(true);
       this.workspace.undo(true);
-      chai.assert.equal(this.workspace.getAllBlocks().length, 1);
+      assert.equal(this.workspace.getAllBlocks().length, 1);
       // Check comment.
       assertComment(this.workspace, 'test text');
     });
@@ -113,7 +114,7 @@ suite('Comment Deserialization', function () {
       simulateClick(
         toolbox.getFlyout().svgGroup_.querySelector('.blocklyPath'),
       );
-      chai.assert.equal(this.workspace.getAllBlocks().length, 1);
+      assert.equal(this.workspace.getAllBlocks().length, 1);
       // Check comment.
       assertComment(this.workspace, 'test toolbox text');
     });

--- a/tests/mocha/comment_test.js
+++ b/tests/mocha/comment_test.js
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import {assert} from '../../node_modules/chai/chai.js';
 import {assertEventFired} from './test_helpers/events.js';
 import * as eventUtils from '../../build/src/core/events/utils.js';
 import {
@@ -40,16 +41,16 @@ suite('Comments', function () {
     });
 
     function assertEditable(comment) {
-      chai.assert.isNotOk(comment.textBubble);
-      chai.assert.isOk(comment.textInputBubble);
+      assert.isNotOk(comment.textBubble);
+      assert.isOk(comment.textInputBubble);
     }
     function assertNotEditable(comment) {
-      chai.assert.isNotOk(comment.textInputBubble);
-      chai.assert.isOk(comment.textBubble);
+      assert.isNotOk(comment.textInputBubble);
+      assert.isOk(comment.textBubble);
     }
     test('Editable', async function () {
       await this.comment.setBubbleVisible(true);
-      chai.assert.isTrue(this.comment.bubbleIsVisible());
+      assert.isTrue(this.comment.bubbleIsVisible());
       assertEditable(this.comment);
       assertEventFired(
         this.eventsFireStub,
@@ -64,7 +65,7 @@ suite('Comments', function () {
 
       await this.comment.setBubbleVisible(true);
 
-      chai.assert.isTrue(this.comment.bubbleIsVisible());
+      assert.isTrue(this.comment.bubbleIsVisible());
       assertNotEditable(this.comment);
       assertEventFired(
         this.eventsFireStub,
@@ -80,7 +81,7 @@ suite('Comments', function () {
 
       await this.comment.updateEditable();
 
-      chai.assert.isTrue(this.comment.bubbleIsVisible());
+      assert.isTrue(this.comment.bubbleIsVisible());
       assertNotEditable(this.comment);
       assertEventFired(
         this.eventsFireStub,
@@ -98,7 +99,7 @@ suite('Comments', function () {
       editableStub.returns(true);
 
       await this.comment.updateEditable();
-      chai.assert.isTrue(this.comment.bubbleIsVisible());
+      assert.isTrue(this.comment.bubbleIsVisible());
       assertEditable(this.comment);
       assertEventFired(
         this.eventsFireStub,
@@ -115,8 +116,8 @@ suite('Comments', function () {
     });
     function assertBubbleSize(comment, height, width) {
       const size = comment.getBubbleSize();
-      chai.assert.equal(size.height, height);
-      chai.assert.equal(size.width, width);
+      assert.equal(size.height, height);
+      assert.equal(size.width, width);
     }
     function assertBubbleSizeDefault(comment) {
       assertBubbleSize(comment, 80, 160);

--- a/tests/mocha/comment_view_test.js
+++ b/tests/mocha/comment_view_test.js
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import {assert} from '../../node_modules/chai/chai.js';
 import {
   sharedTestSetup,
   sharedTestTeardown,
@@ -28,11 +29,11 @@ suite('Workspace comment', function () {
 
         this.commentView.setText('test');
 
-        chai.assert.isTrue(
+        assert.isTrue(
           spy.calledOnce,
           'Expected the spy to be called once',
         );
-        chai.assert.isTrue(
+        assert.isTrue(
           spy.calledWith('', 'test'),
           'Expected the spy to be called with the given args',
         );
@@ -50,15 +51,15 @@ suite('Workspace comment', function () {
 
         this.commentView.setText('test');
 
-        chai.assert.isTrue(
+        assert.isTrue(
           fake1.calledOnce,
           'Expected the first listener to be called',
         );
-        chai.assert.isTrue(
+        assert.isTrue(
           fake2.calledOnce,
           'Expected the second listener to be called',
         );
-        chai.assert.isTrue(
+        assert.isTrue(
           fake3.calledOnce,
           'Expected the third listener to be called',
         );
@@ -74,11 +75,11 @@ suite('Workspace comment', function () {
 
         this.commentView.setSize(newSize);
 
-        chai.assert.isTrue(
+        assert.isTrue(
           spy.calledOnce,
           'Expected the spy to be called once',
         );
-        chai.assert.isTrue(
+        assert.isTrue(
           spy.calledWith(originalSize, newSize),
           'Expected the spy to be called with the given args',
         );
@@ -97,15 +98,15 @@ suite('Workspace comment', function () {
 
         this.commentView.setSize(newSize);
 
-        chai.assert.isTrue(
+        assert.isTrue(
           fake1.calledOnce,
           'Expected the first listener to be called',
         );
-        chai.assert.isTrue(
+        assert.isTrue(
           fake2.calledOnce,
           'Expected the second listener to be called',
         );
-        chai.assert.isTrue(
+        assert.isTrue(
           fake3.calledOnce,
           'Expected the third listener to be called',
         );
@@ -119,11 +120,11 @@ suite('Workspace comment', function () {
 
         this.commentView.setCollapsed(true);
 
-        chai.assert.isTrue(
+        assert.isTrue(
           spy.calledOnce,
           'Expected the spy to be called once',
         );
-        chai.assert.isTrue(
+        assert.isTrue(
           spy.calledWith(true),
           'Expected the spy to be called with the given args',
         );
@@ -141,15 +142,15 @@ suite('Workspace comment', function () {
 
         this.commentView.setCollapsed(true);
 
-        chai.assert.isTrue(
+        assert.isTrue(
           fake1.calledOnce,
           'Expected the first listener to be called',
         );
-        chai.assert.isTrue(
+        assert.isTrue(
           fake2.calledOnce,
           'Expected the second listener to be called',
         );
-        chai.assert.isTrue(
+        assert.isTrue(
           fake3.calledOnce,
           'Expected the third listener to be called',
         );
@@ -163,7 +164,7 @@ suite('Workspace comment', function () {
 
         this.commentView.dispose();
 
-        chai.assert.isTrue(
+        assert.isTrue(
           spy.calledOnce,
           'Expected the spy to be called once',
         );
@@ -181,15 +182,15 @@ suite('Workspace comment', function () {
 
         this.commentView.dispose();
 
-        chai.assert.isTrue(
+        assert.isTrue(
           fake1.calledOnce,
           'Expected the first listener to be called',
         );
-        chai.assert.isTrue(
+        assert.isTrue(
           fake2.calledOnce,
           'Expected the second listener to be called',
         );
-        chai.assert.isTrue(
+        assert.isTrue(
           fake3.calledOnce,
           'Expected the third listener to be called',
         );

--- a/tests/mocha/comment_view_test.js
+++ b/tests/mocha/comment_view_test.js
@@ -29,10 +29,7 @@ suite('Workspace comment', function () {
 
         this.commentView.setText('test');
 
-        assert.isTrue(
-          spy.calledOnce,
-          'Expected the spy to be called once',
-        );
+        assert.isTrue(spy.calledOnce, 'Expected the spy to be called once');
         assert.isTrue(
           spy.calledWith('', 'test'),
           'Expected the spy to be called with the given args',
@@ -75,10 +72,7 @@ suite('Workspace comment', function () {
 
         this.commentView.setSize(newSize);
 
-        assert.isTrue(
-          spy.calledOnce,
-          'Expected the spy to be called once',
-        );
+        assert.isTrue(spy.calledOnce, 'Expected the spy to be called once');
         assert.isTrue(
           spy.calledWith(originalSize, newSize),
           'Expected the spy to be called with the given args',
@@ -120,10 +114,7 @@ suite('Workspace comment', function () {
 
         this.commentView.setCollapsed(true);
 
-        assert.isTrue(
-          spy.calledOnce,
-          'Expected the spy to be called once',
-        );
+        assert.isTrue(spy.calledOnce, 'Expected the spy to be called once');
         assert.isTrue(
           spy.calledWith(true),
           'Expected the spy to be called with the given args',
@@ -164,10 +155,7 @@ suite('Workspace comment', function () {
 
         this.commentView.dispose();
 
-        assert.isTrue(
-          spy.calledOnce,
-          'Expected the spy to be called once',
-        );
+        assert.isTrue(spy.calledOnce, 'Expected the spy to be called once');
       });
 
       test('dispose listeners can remove themselves without skipping others', function () {

--- a/tests/mocha/connection_checker_test.js
+++ b/tests/mocha/connection_checker_test.js
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import {assert} from '../../node_modules/chai/chai.js';
 import {ConnectionType} from '../../build/src/core/connection_type.js';
 import {
   sharedTestSetup,
@@ -22,9 +23,9 @@ suite('Connection checker', function () {
   });
   suite('Safety checks', function () {
     function assertReasonHelper(checker, one, two, reason) {
-      chai.assert.equal(checker.canConnectWithReason(one, two), reason);
+      assert.equal(checker.canConnectWithReason(one, two), reason);
       // Order should not matter.
-      chai.assert.equal(checker.canConnectWithReason(two, one), reason);
+      assert.equal(checker.canConnectWithReason(two, one), reason);
     }
 
     test('Target Null', function () {
@@ -452,9 +453,9 @@ suite('Connection checker', function () {
       this.con2 = new Blockly.Connection({}, ConnectionType.NEXT_STATEMENT);
     });
     function assertCheckTypes(checker, one, two) {
-      chai.assert.isTrue(checker.doTypeChecks(one, two));
+      assert.isTrue(checker.doTypeChecks(one, two));
       // Order should not matter.
-      chai.assert.isTrue(checker.doTypeChecks(one, two));
+      assert.isTrue(checker.doTypeChecks(one, two));
     }
     test('No Types', function () {
       assertCheckTypes(this.checker, this.con1, this.con2);
@@ -481,7 +482,7 @@ suite('Connection checker', function () {
     test('No Compatible Types', function () {
       this.con1.setCheck('type1');
       this.con2.setCheck('type2');
-      chai.assert.isFalse(this.checker.doTypeChecks(this.con1, this.con2));
+      assert.isFalse(this.checker.doTypeChecks(this.con1, this.con2));
     });
   });
   suite('Dragging Checks', function () {
@@ -509,7 +510,7 @@ suite('Connection checker', function () {
 
       test('Connect a stack', function () {
         // block C is not connected to block A; both are movable.
-        chai.assert.isTrue(
+        assert.isTrue(
           this.checker.doDragChecks(
             this.blockC.nextConnection,
             this.blockA.previousConnection,
@@ -543,7 +544,7 @@ suite('Connection checker', function () {
         // Try to connect blockC into the input connection of blockA, replacing blockB.
         // This is allowed because shadow blocks can always be replaced, even though
         // they are unmovable.
-        chai.assert.isTrue(
+        assert.isTrue(
           this.checker.doDragChecks(
             this.blockC.previousConnection,
             this.blockA.nextConnection,
@@ -556,7 +557,7 @@ suite('Connection checker', function () {
       test('Do not splice into unmovable stack', function () {
         // Try to connect blockC above blockB. It shouldn't work because B is not movable
         // and is already connected to A's nextConnection.
-        chai.assert.isFalse(
+        assert.isFalse(
           this.checker.doDragChecks(
             this.blockC.previousConnection,
             this.blockA.nextConnection,
@@ -569,7 +570,7 @@ suite('Connection checker', function () {
       test('Connect to bottom of unmovable stack', function () {
         // Try to connect blockC below blockB.
         // This is allowed even though B is not movable because it is on B's nextConnection.
-        chai.assert.isTrue(
+        assert.isTrue(
           this.checker.doDragChecks(
             this.blockC.previousConnection,
             this.blockB.nextConnection,
@@ -585,7 +586,7 @@ suite('Connection checker', function () {
 
         // Try to connect blockC above blockB.
         // This is allowed because we're not splicing into a stack.
-        chai.assert.isTrue(
+        assert.isTrue(
           this.checker.doDragChecks(
             this.blockC.nextConnection,
             this.blockB.previousConnection,
@@ -620,7 +621,7 @@ suite('Connection checker', function () {
         // Try to connect C's output to A's input. Should fail because
         // A is already connected to B, which is unmovable.
         const inputConnection = this.blockA.inputList[0].connection;
-        chai.assert.isFalse(
+        assert.isFalse(
           this.checker.doDragChecks(
             this.blockC.outputConnection,
             inputConnection,
@@ -635,7 +636,7 @@ suite('Connection checker', function () {
         this.blockC.setMovable(false);
         // Try to connect A's output to C's input. This is allowed.
         const inputConnection = this.blockC.inputList[0].connection;
-        chai.assert.isTrue(
+        assert.isTrue(
           this.checker.doDragChecks(
             this.blockA.outputConnection,
             inputConnection,
@@ -651,7 +652,7 @@ suite('Connection checker', function () {
 
         // Try to connect C's input to B's output. Allowed because B is now unconnected.
         const inputConnection = this.blockC.inputList[0].connection;
-        chai.assert.isTrue(
+        assert.isTrue(
           this.checker.doDragChecks(
             inputConnection,
             this.blockB.outputConnection,

--- a/tests/mocha/connection_db_test.js
+++ b/tests/mocha/connection_db_test.js
@@ -69,12 +69,7 @@ suite('Connection Database', function () {
     assert.sameOrderedMembers(this.database.connections, [y1, y2, y4]);
 
     this.database.addConnection(y3a, 3);
-    assert.sameOrderedMembers(this.database.connections, [
-      y1,
-      y2,
-      y3a,
-      y4,
-    ]);
+    assert.sameOrderedMembers(this.database.connections, [y1, y2, y3a, y4]);
 
     this.database.addConnection(y3b, 3);
     assert.sameOrderedMembers(this.database.connections, [
@@ -119,12 +114,7 @@ suite('Connection Database', function () {
     ]);
 
     this.database.removeConnection(y4, 4);
-    assert.sameOrderedMembers(this.database.connections, [
-      y1,
-      y3a,
-      y3b,
-      y3c,
-    ]);
+    assert.sameOrderedMembers(this.database.connections, [y1, y3a, y3b, y3c]);
 
     this.database.removeConnection(y1, 1);
     assert.sameOrderedMembers(this.database.connections, [y3a, y3b, y3c]);
@@ -182,10 +172,7 @@ suite('Connection Database', function () {
         new Blockly.ConnectionDB(),
       );
       const neighbors = this.database.getNeighbours(checkConnection, 4);
-      assert.sameMembers(
-        neighbors,
-        this.database.connections.slice(5, 10),
-      );
+      assert.sameMembers(neighbors, this.database.connections.slice(5, 10));
     });
     test('Out of Range X', function () {
       this.createSimpleTestConnections();

--- a/tests/mocha/connection_db_test.js
+++ b/tests/mocha/connection_db_test.js
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import {assert} from '../../node_modules/chai/chai.js';
 import {ConnectionType} from '../../build/src/core/connection_type.js';
 import {
   sharedTestSetup,
@@ -18,7 +19,7 @@ suite('Connection Database', function () {
     this.assertOrder = function () {
       const length = this.database.connections.length;
       for (let i = 1; i < length; i++) {
-        chai.assert.isAtMost(
+        assert.isAtMost(
           this.database.connections[i - 1].y,
           this.database.connections[i].y,
         );
@@ -59,16 +60,16 @@ suite('Connection Database', function () {
     const y3b = {y: 3};
 
     this.database.addConnection(y2, 2);
-    chai.assert.sameOrderedMembers(this.database.connections, [y2]);
+    assert.sameOrderedMembers(this.database.connections, [y2]);
 
     this.database.addConnection(y4, 4);
-    chai.assert.sameOrderedMembers(this.database.connections, [y2, y4]);
+    assert.sameOrderedMembers(this.database.connections, [y2, y4]);
 
     this.database.addConnection(y1, 1);
-    chai.assert.sameOrderedMembers(this.database.connections, [y1, y2, y4]);
+    assert.sameOrderedMembers(this.database.connections, [y1, y2, y4]);
 
     this.database.addConnection(y3a, 3);
-    chai.assert.sameOrderedMembers(this.database.connections, [
+    assert.sameOrderedMembers(this.database.connections, [
       y1,
       y2,
       y3a,
@@ -76,7 +77,7 @@ suite('Connection Database', function () {
     ]);
 
     this.database.addConnection(y3b, 3);
-    chai.assert.sameOrderedMembers(this.database.connections, [
+    assert.sameOrderedMembers(this.database.connections, [
       y1,
       y2,
       y3b,
@@ -99,7 +100,7 @@ suite('Connection Database', function () {
     this.database.addConnection(y3b, 3);
     this.database.addConnection(y3a, 3);
 
-    chai.assert.sameOrderedMembers(this.database.connections, [
+    assert.sameOrderedMembers(this.database.connections, [
       y1,
       y2,
       y3a,
@@ -109,7 +110,7 @@ suite('Connection Database', function () {
     ]);
 
     this.database.removeConnection(y2, 2);
-    chai.assert.sameOrderedMembers(this.database.connections, [
+    assert.sameOrderedMembers(this.database.connections, [
       y1,
       y3a,
       y3b,
@@ -118,7 +119,7 @@ suite('Connection Database', function () {
     ]);
 
     this.database.removeConnection(y4, 4);
-    chai.assert.sameOrderedMembers(this.database.connections, [
+    assert.sameOrderedMembers(this.database.connections, [
       y1,
       y3a,
       y3b,
@@ -126,16 +127,16 @@ suite('Connection Database', function () {
     ]);
 
     this.database.removeConnection(y1, 1);
-    chai.assert.sameOrderedMembers(this.database.connections, [y3a, y3b, y3c]);
+    assert.sameOrderedMembers(this.database.connections, [y3a, y3b, y3c]);
 
     this.database.removeConnection(y3a, 3);
-    chai.assert.sameOrderedMembers(this.database.connections, [y3b, y3c]);
+    assert.sameOrderedMembers(this.database.connections, [y3b, y3c]);
 
     this.database.removeConnection(y3c, 3);
-    chai.assert.sameOrderedMembers(this.database.connections, [y3b]);
+    assert.sameOrderedMembers(this.database.connections, [y3b]);
 
     this.database.removeConnection(y3b, 3);
-    chai.assert.isEmpty(this.database.connections);
+    assert.isEmpty(this.database.connections);
   });
   suite('Get Neighbors', function () {
     test('Empty Database', function () {
@@ -145,7 +146,7 @@ suite('Connection Database', function () {
         ConnectionType.NEXT_STATEMENT,
         new Blockly.ConnectionDB(),
       );
-      chai.assert.isEmpty(this.database.getNeighbours(connection), 100);
+      assert.isEmpty(this.database.getNeighbours(connection), 100);
     });
     test('Block At Top', function () {
       this.createSimpleTestConnections();
@@ -157,7 +158,7 @@ suite('Connection Database', function () {
         new Blockly.ConnectionDB(),
       );
       const neighbors = this.database.getNeighbours(checkConnection, 4);
-      chai.assert.sameMembers(neighbors, this.database.connections.slice(0, 5));
+      assert.sameMembers(neighbors, this.database.connections.slice(0, 5));
     });
     test('Block In Middle', function () {
       this.createSimpleTestConnections();
@@ -169,7 +170,7 @@ suite('Connection Database', function () {
         new Blockly.ConnectionDB(),
       );
       const neighbors = this.database.getNeighbours(checkConnection, 2);
-      chai.assert.sameMembers(neighbors, this.database.connections.slice(2, 7));
+      assert.sameMembers(neighbors, this.database.connections.slice(2, 7));
     });
     test('Block At End', function () {
       this.createSimpleTestConnections();
@@ -181,7 +182,7 @@ suite('Connection Database', function () {
         new Blockly.ConnectionDB(),
       );
       const neighbors = this.database.getNeighbours(checkConnection, 4);
-      chai.assert.sameMembers(
+      assert.sameMembers(
         neighbors,
         this.database.connections.slice(5, 10),
       );
@@ -196,7 +197,7 @@ suite('Connection Database', function () {
         new Blockly.ConnectionDB(),
       );
       const neighbors = this.database.getNeighbours(checkConnection, 4);
-      chai.assert.isEmpty(neighbors);
+      assert.isEmpty(neighbors);
     });
     test('Out of Range Y', function () {
       this.createSimpleTestConnections();
@@ -208,7 +209,7 @@ suite('Connection Database', function () {
         new Blockly.ConnectionDB(),
       );
       const neighbors = this.database.getNeighbours(checkConnection, 4);
-      chai.assert.isEmpty(neighbors);
+      assert.isEmpty(neighbors);
     });
     test('Out of Range Diagonal', function () {
       this.createSimpleTestConnections();
@@ -220,7 +221,7 @@ suite('Connection Database', function () {
         new Blockly.ConnectionDB(),
       );
       const neighbors = this.database.getNeighbours(checkConnection, 2);
-      chai.assert.isEmpty(neighbors);
+      assert.isEmpty(neighbors);
     });
   });
   suite('Ordering', function () {
@@ -300,7 +301,7 @@ suite('Connection Database', function () {
         ConnectionType.NEXT_STATEMENT,
         new Blockly.ConnectionDB(),
       );
-      chai.assert.isNull(
+      assert.isNull(
         this.database.searchForClosest(checkConnection, 100, {x: 0, y: 0})
           .connection,
       );
@@ -319,7 +320,7 @@ suite('Connection Database', function () {
         ConnectionType.NEXT_STATEMENT,
         new Blockly.ConnectionDB(),
       );
-      chai.assert.isNull(
+      assert.isNull(
         this.database.searchForClosest(checkConnection, 50, {x: 0, y: 0})
           .connection,
       );
@@ -334,7 +335,7 @@ suite('Connection Database', function () {
         x: 0,
         y: 0,
       }).connection;
-      chai.assert.equal(last, closest);
+      assert.equal(last, closest);
     });
     test('Many in Range', function () {
       this.createSimpleTestConnections();
@@ -346,7 +347,7 @@ suite('Connection Database', function () {
         x: 0,
         y: 0,
       }).connection;
-      chai.assert.equal(last, closest);
+      assert.equal(last, closest);
     });
     test('No Y-Coord Priority', function () {
       const connection1 = this.createConnection(
@@ -368,7 +369,7 @@ suite('Connection Database', function () {
         x: 0,
         y: 0,
       }).connection;
-      chai.assert.equal(connection2, closest);
+      assert.equal(connection2, closest);
     });
   });
 });

--- a/tests/mocha/connection_test.js
+++ b/tests/mocha/connection_test.js
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import {assert} from '../../node_modules/chai/chai.js';
 import {
   createGenUidStubWithReturns,
   sharedTestSetup,
@@ -39,19 +40,19 @@ suite('Connection', function () {
 
   suite('Set Shadow', function () {
     function assertBlockMatches(block, isShadow, opt_id) {
-      chai.assert.equal(
+      assert.equal(
         block.isShadow(),
         isShadow,
         `expected block ${block.id} to ${isShadow ? '' : 'not'} be a shadow`,
       );
       if (opt_id) {
-        chai.assert.equal(block.id, opt_id);
+        assert.equal(block.id, opt_id);
       }
     }
 
     function assertInputHasBlock(parent, inputName, isShadow, opt_name) {
       const block = parent.getInputTargetBlock(inputName);
-      chai.assert.exists(
+      assert.exists(
         block,
         `expected block ${opt_name || ''} to be attached to ${inputName}`,
       );
@@ -60,7 +61,7 @@ suite('Connection', function () {
 
     function assertNextHasBlock(parent, isShadow, opt_name) {
       const block = parent.getNextBlock();
-      chai.assert.exists(
+      assert.exists(
         block,
         `expected block ${opt_name || ''} to be attached to next connection`,
       );
@@ -69,7 +70,7 @@ suite('Connection', function () {
 
     function assertInputNotHasBlock(parent, inputName) {
       const block = parent.getInputTargetBlock(inputName);
-      chai.assert.notExists(
+      assert.notExists(
         block,
         `expected block ${
           block && block.id
@@ -79,7 +80,7 @@ suite('Connection', function () {
 
     function assertNextNotHasBlock(parent) {
       const block = parent.getNextBlock();
-      chai.assert.notExists(
+      assert.notExists(
         block,
         `expected block ${
           block && block.id
@@ -92,8 +93,8 @@ suite('Connection', function () {
         addNextBlocks: true,
       });
       const actualXml = Blockly.Xml.domToText(Blockly.Xml.blockToDom(block));
-      chai.assert.deepEqual(actualJso, jso);
-      chai.assert.equal(actualXml, xmlText);
+      assert.deepEqual(actualJso, jso);
+      assert.equal(actualXml, xmlText);
     }
 
     const testSuites = [
@@ -1382,7 +1383,7 @@ suite('Connection', function () {
           suite('Invalid', function () {
             test('Attach to output', function () {
               const block = this.workspace.newBlock('row_block');
-              chai.assert.throws(() =>
+              assert.throws(() =>
                 block.outputConnection.setShadowDom(
                   Blockly.utils.xml.textToDom('<block type="row_block">'),
                 ),
@@ -1391,7 +1392,7 @@ suite('Connection', function () {
 
             test('Attach to previous', function () {
               const block = this.workspace.newBlock('stack_block');
-              chai.assert.throws(() =>
+              assert.throws(() =>
                 block.previousConnection.setShadowDom(
                   Blockly.utils.xml.textToDom('<block type="stack_block">'),
                 ),
@@ -1400,7 +1401,7 @@ suite('Connection', function () {
 
             test('Missing output', function () {
               const block = this.workspace.newBlock('row_block');
-              chai.assert.throws(() =>
+              assert.throws(() =>
                 block.outputConnection.setShadowDom(
                   Blockly.utils.xml.textToDom('<block type="stack_block">'),
                 ),
@@ -1409,7 +1410,7 @@ suite('Connection', function () {
 
             test('Missing previous', function () {
               const block = this.workspace.newBlock('stack_block');
-              chai.assert.throws(() =>
+              assert.throws(() =>
                 block.previousConnection.setShadowDom(
                   Blockly.utils.xml.textToDom('<block type="row_block">'),
                 ),
@@ -1418,7 +1419,7 @@ suite('Connection', function () {
 
             test('Invalid connection checks, output', function () {
               const block = this.workspace.newBlock('logic_operation');
-              chai.assert.throws(() =>
+              assert.throws(() =>
                 block
                   .getInput('A')
                   .connection.setShadowDom(
@@ -1437,7 +1438,7 @@ suite('Connection', function () {
                 },
               ]);
               const block = this.workspace.newBlock('stack_checks_block');
-              chai.assert.throws(() =>
+              assert.throws(() =>
                 block.nextConnection.setShadowDom(
                   Blockly.utils.xml.textToDom(
                     '<block type="stack_checks_block">',
@@ -2751,14 +2752,14 @@ suite('Connection', function () {
           suite('Invalid', function () {
             test('Attach to output', function () {
               const block = this.workspace.newBlock('row_block');
-              chai.assert.throws(() =>
+              assert.throws(() =>
                 block.outputConnection.setShadowState({'type': 'row_block'}),
               );
             });
 
             test('Attach to previous', function () {
               const block = this.workspace.newBlock('stack_block');
-              chai.assert.throws(() =>
+              assert.throws(() =>
                 block.previousConnection.setShadowState({
                   'type': 'stack_block',
                 }),
@@ -2767,21 +2768,21 @@ suite('Connection', function () {
 
             test('Missing output', function () {
               const block = this.workspace.newBlock('row_block');
-              chai.assert.throws(() =>
+              assert.throws(() =>
                 block.outputConnection.setShadowState({'type': 'stack_block'}),
               );
             });
 
             test('Missing previous', function () {
               const block = this.workspace.newBlock('stack_block');
-              chai.assert.throws(() =>
+              assert.throws(() =>
                 block.previousConnection.setShadowState({'type': 'row_block'}),
               );
             });
 
             test('Invalid connection checks, output', function () {
               const block = this.workspace.newBlock('logic_operation');
-              chai.assert.throws(() =>
+              assert.throws(() =>
                 block
                   .getInput('A')
                   .connection.setShadowState({'type': 'math_number'}),
@@ -2798,7 +2799,7 @@ suite('Connection', function () {
                 },
               ]);
               const block = this.workspace.newBlock('stack_checks_block');
-              chai.assert.throws(() =>
+              assert.throws(() =>
                 block.nextConnection.setShadowState({
                   'type': 'stack_checks_block',
                 }),
@@ -2984,7 +2985,7 @@ suite('Connection', function () {
 
       // Used to make sure we don't get stray shadow blocks or anything.
       this.assertBlockCount = function (count) {
-        chai.assert.equal(this.workspace.getAllBlocks().length, count);
+        assert.equal(this.workspace.getAllBlocks().length, count);
       };
     });
 
@@ -2997,7 +2998,7 @@ suite('Connection', function () {
         oldParent.getInput('INPUT').connection.connect(child.outputConnection);
         newParent.getInput('INPUT').connection.connect(child.outputConnection);
 
-        chai.assert.isFalse(
+        assert.isFalse(
           oldParent.getInput('INPUT').connection.isConnected(),
         );
         this.assertBlockCount(3);
@@ -3011,7 +3012,7 @@ suite('Connection', function () {
         oldParent.getInput('NAME').connection.connect(child.previousConnection);
         newParent.getInput('NAME').connection.connect(child.previousConnection);
 
-        chai.assert.isFalse(
+        assert.isFalse(
           oldParent.getInput('NAME').connection.isConnected(),
         );
         this.assertBlockCount(3);
@@ -3025,7 +3026,7 @@ suite('Connection', function () {
         oldParent.nextConnection.connect(child.previousConnection);
         newParent.nextConnection.connect(child.previousConnection);
 
-        chai.assert.isFalse(oldParent.nextConnection.isConnected());
+        assert.isFalse(oldParent.nextConnection.isConnected());
         this.assertBlockCount(3);
       });
     });
@@ -3036,11 +3037,11 @@ suite('Connection', function () {
         const child = this.workspace.newBlock('row_block');
         const xml = Blockly.utils.xml.textToDom('<shadow type="row_block"/>');
         newParent.getInput('INPUT').connection.setShadowDom(xml);
-        chai.assert.isTrue(newParent.getInputTargetBlock('INPUT').isShadow());
+        assert.isTrue(newParent.getInputTargetBlock('INPUT').isShadow());
 
         newParent.getInput('INPUT').connection.connect(child.outputConnection);
 
-        chai.assert.isFalse(newParent.getInputTargetBlock('INPUT').isShadow());
+        assert.isFalse(newParent.getInputTargetBlock('INPUT').isShadow());
         this.assertBlockCount(2);
       });
 
@@ -3049,11 +3050,11 @@ suite('Connection', function () {
         const child = this.workspace.newBlock('stack_block');
         const xml = Blockly.utils.xml.textToDom('<shadow type="stack_block"/>');
         newParent.getInput('NAME').connection.setShadowDom(xml);
-        chai.assert.isTrue(newParent.getInputTargetBlock('NAME').isShadow());
+        assert.isTrue(newParent.getInputTargetBlock('NAME').isShadow());
 
         newParent.getInput('NAME').connection.connect(child.previousConnection);
 
-        chai.assert.isFalse(newParent.getInputTargetBlock('NAME').isShadow());
+        assert.isFalse(newParent.getInputTargetBlock('NAME').isShadow());
         this.assertBlockCount(2);
       });
 
@@ -3062,11 +3063,11 @@ suite('Connection', function () {
         const child = this.workspace.newBlock('stack_block');
         const xml = Blockly.utils.xml.textToDom('<shadow type="stack_block"/>');
         newParent.nextConnection.setShadowDom(xml);
-        chai.assert.isTrue(newParent.getNextBlock().isShadow());
+        assert.isTrue(newParent.getNextBlock().isShadow());
 
         newParent.nextConnection.connect(child.previousConnection);
 
-        chai.assert.isFalse(newParent.getNextBlock().isShadow());
+        assert.isFalse(newParent.getNextBlock().isShadow());
         this.assertBlockCount(2);
       });
     });
@@ -3083,8 +3084,8 @@ suite('Connection', function () {
         newParent.getInput('INPUT').connection.disconnect();
 
         const target = newParent.getInputTargetBlock('INPUT');
-        chai.assert.isTrue(target.isShadow());
-        chai.assert.equal(target.getFieldValue('FIELD'), 'new');
+        assert.isTrue(target.isShadow());
+        assert.equal(target.getFieldValue('FIELD'), 'new');
         this.assertBlockCount(3);
       });
 
@@ -3099,8 +3100,8 @@ suite('Connection', function () {
         newParent.getInput('NAME').connection.disconnect();
 
         const target = newParent.getInputTargetBlock('NAME');
-        chai.assert.isTrue(target.isShadow());
-        chai.assert.equal(target.getFieldValue('FIELD'), 'new');
+        assert.isTrue(target.isShadow());
+        assert.equal(target.getFieldValue('FIELD'), 'new');
         this.assertBlockCount(3);
       });
 
@@ -3115,8 +3116,8 @@ suite('Connection', function () {
         newParent.nextConnection.disconnect();
 
         const target = newParent.getNextBlock();
-        chai.assert.isTrue(target.isShadow());
-        chai.assert.equal(target.getFieldValue('FIELD'), 'new');
+        assert.isTrue(target.isShadow());
+        assert.equal(target.getFieldValue('FIELD'), 'new');
         this.assertBlockCount(3);
       });
     });
@@ -3136,11 +3137,11 @@ suite('Connection', function () {
               .getInput('INPUT')
               .connection.connect(newChild.outputConnection);
 
-            chai.assert.isTrue(
+            assert.isTrue(
               parent.getInput('INPUT').connection.isConnected(),
             );
-            chai.assert.equal(parent.getInputTargetBlock('INPUT'), newChild);
-            chai.assert.isFalse(oldChild.outputConnection.isConnected());
+            assert.equal(parent.getInputTargetBlock('INPUT'), newChild);
+            assert.isFalse(oldChild.outputConnection.isConnected());
           });
 
           test('All statements', function () {
@@ -3155,11 +3156,11 @@ suite('Connection', function () {
               .getInput('INPUT')
               .connection.connect(newChild.outputConnection);
 
-            chai.assert.isTrue(
+            assert.isTrue(
               parent.getInput('INPUT').connection.isConnected(),
             );
-            chai.assert.equal(parent.getInputTargetBlock('INPUT'), newChild);
-            chai.assert.isFalse(oldChild.outputConnection.isConnected());
+            assert.equal(parent.getInputTargetBlock('INPUT'), newChild);
+            assert.isFalse(oldChild.outputConnection.isConnected());
           });
 
           test('Bad checks', function () {
@@ -3174,11 +3175,11 @@ suite('Connection', function () {
               .getInput('INPUT')
               .connection.connect(newChild.outputConnection);
 
-            chai.assert.isTrue(
+            assert.isTrue(
               parent.getInput('INPUT').connection.isConnected(),
             );
-            chai.assert.equal(parent.getInputTargetBlock('INPUT'), newChild);
-            chai.assert.isFalse(oldChild.outputConnection.isConnected());
+            assert.equal(parent.getInputTargetBlock('INPUT'), newChild);
+            assert.isFalse(oldChild.outputConnection.isConnected());
           });
 
           test('Through different types', function () {
@@ -3198,11 +3199,11 @@ suite('Connection', function () {
               .getInput('INPUT')
               .connection.connect(newChild.outputConnection);
 
-            chai.assert.isTrue(
+            assert.isTrue(
               parent.getInput('INPUT').connection.isConnected(),
             );
-            chai.assert.equal(parent.getInputTargetBlock('INPUT'), newChild);
-            chai.assert.isFalse(oldChild.outputConnection.isConnected());
+            assert.equal(parent.getInputTargetBlock('INPUT'), newChild);
+            assert.isFalse(oldChild.outputConnection.isConnected());
           });
         });
 
@@ -3223,11 +3224,11 @@ suite('Connection', function () {
                 .getInput('INPUT')
                 .connection.connect(newChild.outputConnection);
 
-              chai.assert.isTrue(
+              assert.isTrue(
                 parent.getInput('INPUT').connection.isConnected(),
               );
-              chai.assert.equal(parent.getInputTargetBlock('INPUT'), newChild);
-              chai.assert.isFalse(oldChild.outputConnection.isConnected());
+              assert.equal(parent.getInputTargetBlock('INPUT'), newChild);
+              assert.isFalse(oldChild.outputConnection.isConnected());
             });
 
             test('Child blocks', function () {
@@ -3253,11 +3254,11 @@ suite('Connection', function () {
                 .getInput('INPUT')
                 .connection.connect(newChild.outputConnection);
 
-              chai.assert.isTrue(
+              assert.isTrue(
                 parent.getInput('INPUT').connection.isConnected(),
               );
-              chai.assert.equal(parent.getInputTargetBlock('INPUT'), newChild);
-              chai.assert.isFalse(oldChild.outputConnection.isConnected());
+              assert.equal(parent.getInputTargetBlock('INPUT'), newChild);
+              assert.isFalse(oldChild.outputConnection.isConnected());
             });
 
             test('Spots filled', function () {
@@ -3279,11 +3280,11 @@ suite('Connection', function () {
                 .getInput('INPUT')
                 .connection.connect(newChild.outputConnection);
 
-              chai.assert.isTrue(
+              assert.isTrue(
                 parent.getInput('INPUT').connection.isConnected(),
               );
-              chai.assert.equal(parent.getInputTargetBlock('INPUT'), newChild);
-              chai.assert.isFalse(oldChild.outputConnection.isConnected());
+              assert.equal(parent.getInputTargetBlock('INPUT'), newChild);
+              assert.isFalse(oldChild.outputConnection.isConnected());
             });
           });
 
@@ -3317,11 +3318,11 @@ suite('Connection', function () {
                 .getInput('INPUT')
                 .connection.connect(newChild.outputConnection);
 
-              chai.assert.isTrue(
+              assert.isTrue(
                 parent.getInput('INPUT').connection.isConnected(),
               );
-              chai.assert.equal(parent.getInputTargetBlock('INPUT'), newChild);
-              chai.assert.isFalse(oldChild.outputConnection.isConnected());
+              assert.equal(parent.getInputTargetBlock('INPUT'), newChild);
+              assert.isFalse(oldChild.outputConnection.isConnected());
             });
 
             test('Child blocks', function () {
@@ -3361,11 +3362,11 @@ suite('Connection', function () {
                 .getInput('INPUT')
                 .connection.connect(newChild.outputConnection);
 
-              chai.assert.isTrue(
+              assert.isTrue(
                 parent.getInput('INPUT').connection.isConnected(),
               );
-              chai.assert.equal(parent.getInputTargetBlock('INPUT'), newChild);
-              chai.assert.isFalse(oldChild.outputConnection.isConnected());
+              assert.equal(parent.getInputTargetBlock('INPUT'), newChild);
+              assert.isFalse(oldChild.outputConnection.isConnected());
             });
 
             test('Spots filled', function () {
@@ -3394,11 +3395,11 @@ suite('Connection', function () {
                 .getInput('INPUT')
                 .connection.connect(newChild.outputConnection);
 
-              chai.assert.isTrue(
+              assert.isTrue(
                 parent.getInput('INPUT').connection.isConnected(),
               );
-              chai.assert.equal(parent.getInputTargetBlock('INPUT'), newChild);
-              chai.assert.isFalse(oldChild.outputConnection.isConnected());
+              assert.equal(parent.getInputTargetBlock('INPUT'), newChild);
+              assert.isFalse(oldChild.outputConnection.isConnected());
             });
           });
         });
@@ -3417,14 +3418,14 @@ suite('Connection', function () {
               .getInput('INPUT')
               .connection.connect(newChild.outputConnection);
 
-            chai.assert.isTrue(
+            assert.isTrue(
               parent.getInput('INPUT').connection.isConnected(),
             );
-            chai.assert.equal(parent.getInputTargetBlock('INPUT'), newChild);
-            chai.assert.isTrue(
+            assert.equal(parent.getInputTargetBlock('INPUT'), newChild);
+            assert.isTrue(
               newChild.getInput('INPUT').connection.isConnected(),
             );
-            chai.assert.equal(newChild.getInputTargetBlock('INPUT'), oldChild);
+            assert.equal(newChild.getInputTargetBlock('INPUT'), oldChild);
           });
 
           test('Shadows', function () {
@@ -3447,14 +3448,14 @@ suite('Connection', function () {
               .getInput('INPUT')
               .connection.connect(newChild.outputConnection);
 
-            chai.assert.isTrue(
+            assert.isTrue(
               parent.getInput('INPUT').connection.isConnected(),
             );
-            chai.assert.equal(parent.getInputTargetBlock('INPUT'), newChild);
-            chai.assert.isTrue(
+            assert.equal(parent.getInputTargetBlock('INPUT'), newChild);
+            assert.isTrue(
               newChild.getInput('INPUT').connection.isConnected(),
             );
-            chai.assert.equal(newChild.getInputTargetBlock('INPUT'), oldChild);
+            assert.equal(newChild.getInputTargetBlock('INPUT'), oldChild);
           });
         });
       });
@@ -3473,12 +3474,12 @@ suite('Connection', function () {
               .getInput('NAME')
               .connection.connect(newChild.previousConnection);
 
-            chai.assert.isTrue(
+            assert.isTrue(
               parent.getInput('NAME').connection.isConnected(),
             );
-            chai.assert.equal(parent.getInputTargetBlock('NAME'), newChild);
-            chai.assert.isTrue(newChild.nextConnection.isConnected());
-            chai.assert.equal(newChild.getNextBlock(), oldChild);
+            assert.equal(parent.getInputTargetBlock('NAME'), newChild);
+            assert.isTrue(newChild.nextConnection.isConnected());
+            assert.equal(newChild.getNextBlock(), oldChild);
             this.assertBlockCount(3);
           });
 
@@ -3496,12 +3497,12 @@ suite('Connection', function () {
               .getInput('NAME')
               .connection.connect(newChild1.previousConnection);
 
-            chai.assert.isTrue(
+            assert.isTrue(
               parent.getInput('NAME').connection.isConnected(),
             );
-            chai.assert.equal(parent.getInputTargetBlock('NAME'), newChild1);
-            chai.assert.isTrue(newChild2.nextConnection.isConnected());
-            chai.assert.equal(newChild2.getNextBlock(), oldChild);
+            assert.equal(parent.getInputTargetBlock('NAME'), newChild1);
+            assert.isTrue(newChild2.nextConnection.isConnected());
+            assert.equal(newChild2.getNextBlock(), oldChild);
             this.assertBlockCount(4);
           });
 
@@ -3521,12 +3522,12 @@ suite('Connection', function () {
               .getInput('NAME')
               .connection.connect(newChild.previousConnection);
 
-            chai.assert.isTrue(
+            assert.isTrue(
               parent.getInput('NAME').connection.isConnected(),
             );
-            chai.assert.equal(parent.getInputTargetBlock('NAME'), newChild);
-            chai.assert.isFalse(newChild.nextConnection.isConnected());
-            chai.assert.isTrue(spy.calledOnce);
+            assert.equal(parent.getInputTargetBlock('NAME'), newChild);
+            assert.isFalse(newChild.nextConnection.isConnected());
+            assert.isTrue(spy.calledOnce);
             this.assertBlockCount(3);
           });
 
@@ -3546,11 +3547,11 @@ suite('Connection', function () {
               .getInput('NAME')
               .connection.connect(newChild.previousConnection);
 
-            chai.assert.isTrue(
+            assert.isTrue(
               parent.getInput('NAME').connection.isConnected(),
             );
-            chai.assert.equal(parent.getInputTargetBlock('NAME'), newChild);
-            chai.assert.isTrue(spy.calledOnce);
+            assert.equal(parent.getInputTargetBlock('NAME'), newChild);
+            assert.isTrue(spy.calledOnce);
             this.assertBlockCount(3);
           });
         });
@@ -3572,12 +3573,12 @@ suite('Connection', function () {
               .getInput('NAME')
               .connection.connect(newChild.previousConnection);
 
-            chai.assert.isTrue(
+            assert.isTrue(
               parent.getInput('NAME').connection.isConnected(),
             );
-            chai.assert.equal(parent.getInputTargetBlock('NAME'), newChild);
-            chai.assert.isTrue(newChild.nextConnection.isConnected());
-            chai.assert.equal(newChild.getNextBlock(), oldChild);
+            assert.equal(parent.getInputTargetBlock('NAME'), newChild);
+            assert.isTrue(newChild.nextConnection.isConnected());
+            assert.equal(newChild.getNextBlock(), oldChild);
             this.assertBlockCount(3);
           });
 
@@ -3599,12 +3600,12 @@ suite('Connection', function () {
               .getInput('NAME')
               .connection.connect(newChild1.previousConnection);
 
-            chai.assert.isTrue(
+            assert.isTrue(
               parent.getInput('NAME').connection.isConnected(),
             );
-            chai.assert.equal(parent.getInputTargetBlock('NAME'), newChild1);
-            chai.assert.isTrue(newChild2.nextConnection.isConnected());
-            chai.assert.equal(newChild2.getNextBlock(), oldChild);
+            assert.equal(parent.getInputTargetBlock('NAME'), newChild1);
+            assert.isTrue(newChild2.nextConnection.isConnected());
+            assert.equal(newChild2.getNextBlock(), oldChild);
             this.assertBlockCount(4);
           });
 
@@ -3628,13 +3629,13 @@ suite('Connection', function () {
               .getInput('NAME')
               .connection.connect(newChild.previousConnection);
 
-            chai.assert.isTrue(
+            assert.isTrue(
               parent.getInput('NAME').connection.isConnected(),
             );
-            chai.assert.equal(parent.getInputTargetBlock('NAME'), newChild);
-            chai.assert.isTrue(newChild.nextConnection.isConnected());
-            chai.assert.isTrue(newChild.getNextBlock().isShadow());
-            chai.assert.isTrue(spy.calledOnce);
+            assert.equal(parent.getInputTargetBlock('NAME'), newChild);
+            assert.isTrue(newChild.nextConnection.isConnected());
+            assert.isTrue(newChild.getNextBlock().isShadow());
+            assert.isTrue(spy.calledOnce);
             this.assertBlockCount(4);
           });
         });
@@ -3650,10 +3651,10 @@ suite('Connection', function () {
 
             parent.nextConnection.connect(newChild.previousConnection);
 
-            chai.assert.isTrue(parent.nextConnection.isConnected());
-            chai.assert.equal(parent.getNextBlock(), newChild);
-            chai.assert.isTrue(newChild.nextConnection.isConnected());
-            chai.assert.equal(newChild.getNextBlock(), oldChild);
+            assert.isTrue(parent.nextConnection.isConnected());
+            assert.equal(parent.getNextBlock(), newChild);
+            assert.isTrue(newChild.nextConnection.isConnected());
+            assert.equal(newChild.getNextBlock(), oldChild);
             this.assertBlockCount(3);
           });
 
@@ -3667,10 +3668,10 @@ suite('Connection', function () {
 
             parent.nextConnection.connect(newChild1.previousConnection);
 
-            chai.assert.isTrue(parent.nextConnection.isConnected());
-            chai.assert.equal(parent.getNextBlock(), newChild1);
-            chai.assert.isTrue(newChild2.nextConnection.isConnected());
-            chai.assert.equal(newChild2.getNextBlock(), oldChild);
+            assert.isTrue(parent.nextConnection.isConnected());
+            assert.equal(parent.getNextBlock(), newChild1);
+            assert.isTrue(newChild2.nextConnection.isConnected());
+            assert.equal(newChild2.getNextBlock(), oldChild);
             this.assertBlockCount(4);
           });
 
@@ -3686,10 +3687,10 @@ suite('Connection', function () {
 
             parent.nextConnection.connect(newChild.previousConnection);
 
-            chai.assert.isTrue(parent.nextConnection.isConnected());
-            chai.assert.equal(parent.getNextBlock(), newChild);
-            chai.assert.isFalse(newChild.nextConnection.isConnected());
-            chai.assert.isTrue(spy.calledOnce);
+            assert.isTrue(parent.nextConnection.isConnected());
+            assert.equal(parent.getNextBlock(), newChild);
+            assert.isFalse(newChild.nextConnection.isConnected());
+            assert.isTrue(spy.calledOnce);
             this.assertBlockCount(3);
           });
 
@@ -3705,9 +3706,9 @@ suite('Connection', function () {
 
             parent.nextConnection.connect(newChild.previousConnection);
 
-            chai.assert.isTrue(parent.nextConnection.isConnected());
-            chai.assert.equal(parent.getNextBlock(), newChild);
-            chai.assert.isTrue(spy.calledOnce);
+            assert.isTrue(parent.nextConnection.isConnected());
+            assert.equal(parent.getNextBlock(), newChild);
+            assert.isTrue(spy.calledOnce);
             this.assertBlockCount(3);
           });
         });
@@ -3725,10 +3726,10 @@ suite('Connection', function () {
 
             parent.nextConnection.connect(newChild.previousConnection);
 
-            chai.assert.isTrue(parent.nextConnection.isConnected());
-            chai.assert.equal(parent.getNextBlock(), newChild);
-            chai.assert.isTrue(newChild.nextConnection.isConnected());
-            chai.assert.equal(newChild.getNextBlock(), oldChild);
+            assert.isTrue(parent.nextConnection.isConnected());
+            assert.equal(parent.getNextBlock(), newChild);
+            assert.isTrue(newChild.nextConnection.isConnected());
+            assert.equal(newChild.getNextBlock(), oldChild);
             this.assertBlockCount(3);
           });
 
@@ -3746,10 +3747,10 @@ suite('Connection', function () {
 
             parent.nextConnection.connect(newChild1.previousConnection);
 
-            chai.assert.isTrue(parent.nextConnection.isConnected());
-            chai.assert.equal(parent.getNextBlock(), newChild1);
-            chai.assert.isTrue(newChild2.nextConnection.isConnected());
-            chai.assert.equal(newChild2.getNextBlock(), oldChild);
+            assert.isTrue(parent.nextConnection.isConnected());
+            assert.equal(parent.getNextBlock(), newChild1);
+            assert.isTrue(newChild2.nextConnection.isConnected());
+            assert.equal(newChild2.getNextBlock(), oldChild);
             this.assertBlockCount(4);
           });
 
@@ -3769,11 +3770,11 @@ suite('Connection', function () {
 
             parent.nextConnection.connect(newChild.previousConnection);
 
-            chai.assert.isTrue(parent.nextConnection.isConnected());
-            chai.assert.equal(parent.getNextBlock(), newChild);
-            chai.assert.isTrue(newChild.nextConnection.isConnected());
-            chai.assert.isTrue(newChild.getNextBlock().isShadow());
-            chai.assert.isTrue(spy.calledOnce);
+            assert.isTrue(parent.nextConnection.isConnected());
+            assert.equal(parent.getNextBlock(), newChild);
+            assert.isTrue(newChild.nextConnection.isConnected());
+            assert.isTrue(newChild.getNextBlock().isShadow());
+            assert.isTrue(spy.calledOnce);
             this.assertBlockCount(4);
           });
         });

--- a/tests/mocha/connection_test.js
+++ b/tests/mocha/connection_test.js
@@ -2998,9 +2998,7 @@ suite('Connection', function () {
         oldParent.getInput('INPUT').connection.connect(child.outputConnection);
         newParent.getInput('INPUT').connection.connect(child.outputConnection);
 
-        assert.isFalse(
-          oldParent.getInput('INPUT').connection.isConnected(),
-        );
+        assert.isFalse(oldParent.getInput('INPUT').connection.isConnected());
         this.assertBlockCount(3);
       });
 
@@ -3012,9 +3010,7 @@ suite('Connection', function () {
         oldParent.getInput('NAME').connection.connect(child.previousConnection);
         newParent.getInput('NAME').connection.connect(child.previousConnection);
 
-        assert.isFalse(
-          oldParent.getInput('NAME').connection.isConnected(),
-        );
+        assert.isFalse(oldParent.getInput('NAME').connection.isConnected());
         this.assertBlockCount(3);
       });
 
@@ -3137,9 +3133,7 @@ suite('Connection', function () {
               .getInput('INPUT')
               .connection.connect(newChild.outputConnection);
 
-            assert.isTrue(
-              parent.getInput('INPUT').connection.isConnected(),
-            );
+            assert.isTrue(parent.getInput('INPUT').connection.isConnected());
             assert.equal(parent.getInputTargetBlock('INPUT'), newChild);
             assert.isFalse(oldChild.outputConnection.isConnected());
           });
@@ -3156,9 +3150,7 @@ suite('Connection', function () {
               .getInput('INPUT')
               .connection.connect(newChild.outputConnection);
 
-            assert.isTrue(
-              parent.getInput('INPUT').connection.isConnected(),
-            );
+            assert.isTrue(parent.getInput('INPUT').connection.isConnected());
             assert.equal(parent.getInputTargetBlock('INPUT'), newChild);
             assert.isFalse(oldChild.outputConnection.isConnected());
           });
@@ -3175,9 +3167,7 @@ suite('Connection', function () {
               .getInput('INPUT')
               .connection.connect(newChild.outputConnection);
 
-            assert.isTrue(
-              parent.getInput('INPUT').connection.isConnected(),
-            );
+            assert.isTrue(parent.getInput('INPUT').connection.isConnected());
             assert.equal(parent.getInputTargetBlock('INPUT'), newChild);
             assert.isFalse(oldChild.outputConnection.isConnected());
           });
@@ -3199,9 +3189,7 @@ suite('Connection', function () {
               .getInput('INPUT')
               .connection.connect(newChild.outputConnection);
 
-            assert.isTrue(
-              parent.getInput('INPUT').connection.isConnected(),
-            );
+            assert.isTrue(parent.getInput('INPUT').connection.isConnected());
             assert.equal(parent.getInputTargetBlock('INPUT'), newChild);
             assert.isFalse(oldChild.outputConnection.isConnected());
           });
@@ -3224,9 +3212,7 @@ suite('Connection', function () {
                 .getInput('INPUT')
                 .connection.connect(newChild.outputConnection);
 
-              assert.isTrue(
-                parent.getInput('INPUT').connection.isConnected(),
-              );
+              assert.isTrue(parent.getInput('INPUT').connection.isConnected());
               assert.equal(parent.getInputTargetBlock('INPUT'), newChild);
               assert.isFalse(oldChild.outputConnection.isConnected());
             });
@@ -3254,9 +3240,7 @@ suite('Connection', function () {
                 .getInput('INPUT')
                 .connection.connect(newChild.outputConnection);
 
-              assert.isTrue(
-                parent.getInput('INPUT').connection.isConnected(),
-              );
+              assert.isTrue(parent.getInput('INPUT').connection.isConnected());
               assert.equal(parent.getInputTargetBlock('INPUT'), newChild);
               assert.isFalse(oldChild.outputConnection.isConnected());
             });
@@ -3280,9 +3264,7 @@ suite('Connection', function () {
                 .getInput('INPUT')
                 .connection.connect(newChild.outputConnection);
 
-              assert.isTrue(
-                parent.getInput('INPUT').connection.isConnected(),
-              );
+              assert.isTrue(parent.getInput('INPUT').connection.isConnected());
               assert.equal(parent.getInputTargetBlock('INPUT'), newChild);
               assert.isFalse(oldChild.outputConnection.isConnected());
             });
@@ -3318,9 +3300,7 @@ suite('Connection', function () {
                 .getInput('INPUT')
                 .connection.connect(newChild.outputConnection);
 
-              assert.isTrue(
-                parent.getInput('INPUT').connection.isConnected(),
-              );
+              assert.isTrue(parent.getInput('INPUT').connection.isConnected());
               assert.equal(parent.getInputTargetBlock('INPUT'), newChild);
               assert.isFalse(oldChild.outputConnection.isConnected());
             });
@@ -3362,9 +3342,7 @@ suite('Connection', function () {
                 .getInput('INPUT')
                 .connection.connect(newChild.outputConnection);
 
-              assert.isTrue(
-                parent.getInput('INPUT').connection.isConnected(),
-              );
+              assert.isTrue(parent.getInput('INPUT').connection.isConnected());
               assert.equal(parent.getInputTargetBlock('INPUT'), newChild);
               assert.isFalse(oldChild.outputConnection.isConnected());
             });
@@ -3395,9 +3373,7 @@ suite('Connection', function () {
                 .getInput('INPUT')
                 .connection.connect(newChild.outputConnection);
 
-              assert.isTrue(
-                parent.getInput('INPUT').connection.isConnected(),
-              );
+              assert.isTrue(parent.getInput('INPUT').connection.isConnected());
               assert.equal(parent.getInputTargetBlock('INPUT'), newChild);
               assert.isFalse(oldChild.outputConnection.isConnected());
             });
@@ -3418,13 +3394,9 @@ suite('Connection', function () {
               .getInput('INPUT')
               .connection.connect(newChild.outputConnection);
 
-            assert.isTrue(
-              parent.getInput('INPUT').connection.isConnected(),
-            );
+            assert.isTrue(parent.getInput('INPUT').connection.isConnected());
             assert.equal(parent.getInputTargetBlock('INPUT'), newChild);
-            assert.isTrue(
-              newChild.getInput('INPUT').connection.isConnected(),
-            );
+            assert.isTrue(newChild.getInput('INPUT').connection.isConnected());
             assert.equal(newChild.getInputTargetBlock('INPUT'), oldChild);
           });
 
@@ -3448,13 +3420,9 @@ suite('Connection', function () {
               .getInput('INPUT')
               .connection.connect(newChild.outputConnection);
 
-            assert.isTrue(
-              parent.getInput('INPUT').connection.isConnected(),
-            );
+            assert.isTrue(parent.getInput('INPUT').connection.isConnected());
             assert.equal(parent.getInputTargetBlock('INPUT'), newChild);
-            assert.isTrue(
-              newChild.getInput('INPUT').connection.isConnected(),
-            );
+            assert.isTrue(newChild.getInput('INPUT').connection.isConnected());
             assert.equal(newChild.getInputTargetBlock('INPUT'), oldChild);
           });
         });
@@ -3474,9 +3442,7 @@ suite('Connection', function () {
               .getInput('NAME')
               .connection.connect(newChild.previousConnection);
 
-            assert.isTrue(
-              parent.getInput('NAME').connection.isConnected(),
-            );
+            assert.isTrue(parent.getInput('NAME').connection.isConnected());
             assert.equal(parent.getInputTargetBlock('NAME'), newChild);
             assert.isTrue(newChild.nextConnection.isConnected());
             assert.equal(newChild.getNextBlock(), oldChild);
@@ -3497,9 +3463,7 @@ suite('Connection', function () {
               .getInput('NAME')
               .connection.connect(newChild1.previousConnection);
 
-            assert.isTrue(
-              parent.getInput('NAME').connection.isConnected(),
-            );
+            assert.isTrue(parent.getInput('NAME').connection.isConnected());
             assert.equal(parent.getInputTargetBlock('NAME'), newChild1);
             assert.isTrue(newChild2.nextConnection.isConnected());
             assert.equal(newChild2.getNextBlock(), oldChild);
@@ -3522,9 +3486,7 @@ suite('Connection', function () {
               .getInput('NAME')
               .connection.connect(newChild.previousConnection);
 
-            assert.isTrue(
-              parent.getInput('NAME').connection.isConnected(),
-            );
+            assert.isTrue(parent.getInput('NAME').connection.isConnected());
             assert.equal(parent.getInputTargetBlock('NAME'), newChild);
             assert.isFalse(newChild.nextConnection.isConnected());
             assert.isTrue(spy.calledOnce);
@@ -3547,9 +3509,7 @@ suite('Connection', function () {
               .getInput('NAME')
               .connection.connect(newChild.previousConnection);
 
-            assert.isTrue(
-              parent.getInput('NAME').connection.isConnected(),
-            );
+            assert.isTrue(parent.getInput('NAME').connection.isConnected());
             assert.equal(parent.getInputTargetBlock('NAME'), newChild);
             assert.isTrue(spy.calledOnce);
             this.assertBlockCount(3);
@@ -3573,9 +3533,7 @@ suite('Connection', function () {
               .getInput('NAME')
               .connection.connect(newChild.previousConnection);
 
-            assert.isTrue(
-              parent.getInput('NAME').connection.isConnected(),
-            );
+            assert.isTrue(parent.getInput('NAME').connection.isConnected());
             assert.equal(parent.getInputTargetBlock('NAME'), newChild);
             assert.isTrue(newChild.nextConnection.isConnected());
             assert.equal(newChild.getNextBlock(), oldChild);
@@ -3600,9 +3558,7 @@ suite('Connection', function () {
               .getInput('NAME')
               .connection.connect(newChild1.previousConnection);
 
-            assert.isTrue(
-              parent.getInput('NAME').connection.isConnected(),
-            );
+            assert.isTrue(parent.getInput('NAME').connection.isConnected());
             assert.equal(parent.getInputTargetBlock('NAME'), newChild1);
             assert.isTrue(newChild2.nextConnection.isConnected());
             assert.equal(newChild2.getNextBlock(), oldChild);
@@ -3629,9 +3585,7 @@ suite('Connection', function () {
               .getInput('NAME')
               .connection.connect(newChild.previousConnection);
 
-            assert.isTrue(
-              parent.getInput('NAME').connection.isConnected(),
-            );
+            assert.isTrue(parent.getInput('NAME').connection.isConnected());
             assert.equal(parent.getInputTargetBlock('NAME'), newChild);
             assert.isTrue(newChild.nextConnection.isConnected());
             assert.isTrue(newChild.getNextBlock().isShadow());

--- a/tests/mocha/contextmenu_items_test.js
+++ b/tests/mocha/contextmenu_items_test.js
@@ -309,17 +309,11 @@ suite('Context Menu Items', function () {
 
       test('Enabled when blocks to delete', function () {
         this.workspace.newBlock('text');
-        assert.equal(
-          this.deleteOption.preconditionFn(this.scope),
-          'enabled',
-        );
+        assert.equal(this.deleteOption.preconditionFn(this.scope), 'enabled');
       });
 
       test('Disabled when no blocks to delete', function () {
-        assert.equal(
-          this.deleteOption.preconditionFn(this.scope),
-          'disabled',
-        );
+        assert.equal(this.deleteOption.preconditionFn(this.scope), 'disabled');
       });
 
       test('Deletes all blocks after confirming', function () {
@@ -375,10 +369,7 @@ suite('Context Menu Items', function () {
 
       test('Has correct label for single block', function () {
         this.workspace.newBlock('text');
-        assert.equal(
-          this.deleteOption.displayText(this.scope),
-          'Delete Block',
-        );
+        assert.equal(this.deleteOption.displayText(this.scope), 'Delete Block');
       });
     });
   });
@@ -412,10 +403,7 @@ suite('Context Menu Items', function () {
 
       test('Hidden when in flyout', function () {
         this.block.isInFlyout = true;
-        assert.equal(
-          this.duplicateOption.preconditionFn(this.scope),
-          'hidden',
-        );
+        assert.equal(this.duplicateOption.preconditionFn(this.scope), 'hidden');
       });
 
       test('the block is duplicated', function () {
@@ -438,10 +426,7 @@ suite('Context Menu Items', function () {
       });
 
       test('Enabled for normal block', function () {
-        assert.equal(
-          this.commentOption.preconditionFn(this.scope),
-          'enabled',
-        );
+        assert.equal(this.commentOption.preconditionFn(this.scope), 'enabled');
       });
 
       test('Hidden for collapsed block', function () {
@@ -450,10 +435,7 @@ suite('Context Menu Items', function () {
         this.block.render();
         this.block.setCollapsed(true);
 
-        assert.equal(
-          this.commentOption.preconditionFn(this.scope),
-          'hidden',
-        );
+        assert.equal(this.commentOption.preconditionFn(this.scope), 'hidden');
       });
 
       test('Creates comment if one did not exist', function () {
@@ -479,10 +461,7 @@ suite('Context Menu Items', function () {
       });
 
       test('Has correct label for add comment', function () {
-        assert.equal(
-          this.commentOption.displayText(this.scope),
-          'Add Comment',
-        );
+        assert.equal(this.commentOption.displayText(this.scope), 'Add Comment');
       });
 
       test('Has correct label for remove comment', function () {
@@ -502,10 +481,7 @@ suite('Context Menu Items', function () {
       test('Enabled when inputs to inline', function () {
         this.block.appendValueInput('test1');
         this.block.appendValueInput('test2');
-        assert.equal(
-          this.inlineOption.preconditionFn(this.scope),
-          'enabled',
-        );
+        assert.equal(this.inlineOption.preconditionFn(this.scope), 'enabled');
       });
     });
   });

--- a/tests/mocha/contextmenu_items_test.js
+++ b/tests/mocha/contextmenu_items_test.js
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import {assert} from '../../node_modules/chai/chai.js';
 import {
   sharedTestSetup,
   sharedTestTeardown,
@@ -39,7 +40,7 @@ suite('Context Menu Items', function () {
 
       test('Disabled when nothing to undo', function () {
         const precondition = this.undoOption.preconditionFn(this.scope);
-        chai.assert.equal(
+        assert.equal(
           precondition,
           'disabled',
           'Should be disabled when there is nothing to undo',
@@ -50,7 +51,7 @@ suite('Context Menu Items', function () {
         // Create a new block, which should be undoable.
         this.workspace.newBlock('text');
         const precondition = this.undoOption.preconditionFn(this.scope);
-        chai.assert.equal(
+        assert.equal(
           precondition,
           'enabled',
           'Should be enabled when there are actions to undo',
@@ -59,9 +60,9 @@ suite('Context Menu Items', function () {
 
       test('Undoes adding a new block', function () {
         this.workspace.newBlock('text');
-        chai.assert.equal(this.workspace.getTopBlocks(false).length, 1);
+        assert.equal(this.workspace.getTopBlocks(false).length, 1);
         this.undoOption.callback(this.scope);
-        chai.assert.equal(
+        assert.equal(
           this.workspace.getTopBlocks(false).length,
           0,
           'Should be no blocks after undo',
@@ -69,7 +70,7 @@ suite('Context Menu Items', function () {
       });
 
       test('Has correct label', function () {
-        chai.assert.equal(this.undoOption.displayText(), 'Undo');
+        assert.equal(this.undoOption.displayText(), 'Undo');
       });
     });
 
@@ -82,7 +83,7 @@ suite('Context Menu Items', function () {
         // Create a new block. There should be something to undo, but not redo.
         this.workspace.newBlock('text');
         const precondition = this.redoOption.preconditionFn(this.scope);
-        chai.assert.equal(
+        assert.equal(
           precondition,
           'disabled',
           'Should be disabled when there is nothing to redo',
@@ -94,7 +95,7 @@ suite('Context Menu Items', function () {
         this.workspace.newBlock('text');
         this.workspace.undo(false);
         const precondition = this.redoOption.preconditionFn(this.scope);
-        chai.assert.equal(
+        assert.equal(
           precondition,
           'enabled',
           'Should be enabled when there are actions to redo',
@@ -105,9 +106,9 @@ suite('Context Menu Items', function () {
         // Add a new block, then undo it, then redo it.
         this.workspace.newBlock('text');
         this.workspace.undo(false);
-        chai.assert.equal(this.workspace.getTopBlocks(false).length, 0);
+        assert.equal(this.workspace.getTopBlocks(false).length, 0);
         this.redoOption.callback(this.scope);
-        chai.assert.equal(
+        assert.equal(
           this.workspace.getTopBlocks(false).length,
           1,
           'Should be 1 block after redo',
@@ -115,7 +116,7 @@ suite('Context Menu Items', function () {
       });
 
       test('Has correct label', function () {
-        chai.assert.equal(this.redoOption.displayText(), 'Redo');
+        assert.equal(this.redoOption.displayText(), 'Redo');
       });
     });
 
@@ -128,7 +129,7 @@ suite('Context Menu Items', function () {
       test('Enabled when multiple blocks', function () {
         this.workspace.newBlock('text');
         this.workspace.newBlock('text');
-        chai.assert.equal(
+        assert.equal(
           this.cleanupOption.preconditionFn(this.scope),
           'enabled',
           'Should be enabled if there are multiple blocks',
@@ -136,7 +137,7 @@ suite('Context Menu Items', function () {
       });
 
       test('Disabled when no blocks', function () {
-        chai.assert.equal(
+        assert.equal(
           this.cleanupOption.preconditionFn(this.scope),
           'disabled',
           'Should be disabled if there are no blocks',
@@ -145,7 +146,7 @@ suite('Context Menu Items', function () {
 
       test('Hidden when not movable', function () {
         sinon.stub(this.workspace, 'isMovable').returns(false);
-        chai.assert.equal(
+        assert.equal(
           this.cleanupOption.preconditionFn(this.scope),
           'hidden',
           'Should be hidden if the workspace is not movable',
@@ -158,7 +159,7 @@ suite('Context Menu Items', function () {
       });
 
       test('Has correct label', function () {
-        chai.assert.equal(this.cleanupOption.displayText(), 'Clean up Blocks');
+        assert.equal(this.cleanupOption.displayText(), 'Clean up Blocks');
       });
     });
 
@@ -171,7 +172,7 @@ suite('Context Menu Items', function () {
         this.workspace.newBlock('text');
         const block2 = this.workspace.newBlock('text');
         block2.setCollapsed(true);
-        chai.assert.equal(
+        assert.equal(
           this.collapseOption.preconditionFn(this.scope),
           'enabled',
           'Should be enabled when any blocks are expanded',
@@ -180,7 +181,7 @@ suite('Context Menu Items', function () {
 
       test('Disabled when all blocks collapsed', function () {
         this.workspace.newBlock('text').setCollapsed(true);
-        chai.assert.equal(
+        assert.equal(
           this.collapseOption.preconditionFn(this.scope),
           'disabled',
           'Should be disabled when no blocks are expanded',
@@ -194,7 +195,7 @@ suite('Context Menu Items', function () {
         this.scope.workspace = workspaceWithOptions;
 
         try {
-          chai.assert.equal(
+          assert.equal(
             this.collapseOption.preconditionFn(this.scope),
             'hidden',
             'Should be hidden if collapse is disabled in options',
@@ -216,18 +217,18 @@ suite('Context Menu Items', function () {
         this.collapseOption.callback(this.scope);
         this.clock.runAll();
 
-        chai.assert.isTrue(
+        assert.isTrue(
           block1.isCollapsed(),
           'Previously collapsed block should still be collapsed',
         );
-        chai.assert.isTrue(
+        assert.isTrue(
           block2.isCollapsed(),
           'Previously expanded block should now be collapsed',
         );
       });
 
       test('Has correct label', function () {
-        chai.assert.equal(this.collapseOption.displayText(), 'Collapse Blocks');
+        assert.equal(this.collapseOption.displayText(), 'Collapse Blocks');
       });
     });
 
@@ -241,7 +242,7 @@ suite('Context Menu Items', function () {
         const block2 = this.workspace.newBlock('text');
         block2.setCollapsed(true);
 
-        chai.assert.equal(
+        assert.equal(
           this.expandOption.preconditionFn(this.scope),
           'enabled',
           'Should be enabled when any blocks are collapsed',
@@ -250,7 +251,7 @@ suite('Context Menu Items', function () {
 
       test('Disabled when no collapsed blocks', function () {
         this.workspace.newBlock('text');
-        chai.assert.equal(
+        assert.equal(
           this.expandOption.preconditionFn(this.scope),
           'disabled',
           'Should be disabled when no blocks are collapsed',
@@ -264,7 +265,7 @@ suite('Context Menu Items', function () {
         this.scope.workspace = workspaceWithOptions;
 
         try {
-          chai.assert.equal(
+          assert.equal(
             this.expandOption.preconditionFn(this.scope),
             'hidden',
             'Should be hidden if collapse is disabled in options',
@@ -286,18 +287,18 @@ suite('Context Menu Items', function () {
         this.expandOption.callback(this.scope);
         this.clock.runAll();
 
-        chai.assert.isFalse(
+        assert.isFalse(
           block1.isCollapsed(),
           'Previously expanded block should still be expanded',
         );
-        chai.assert.isFalse(
+        assert.isFalse(
           block2.isCollapsed(),
           'Previously collapsed block should now be expanded',
         );
       });
 
       test('Has correct label', function () {
-        chai.assert.equal(this.expandOption.displayText(), 'Expand Blocks');
+        assert.equal(this.expandOption.displayText(), 'Expand Blocks');
       });
     });
 
@@ -308,14 +309,14 @@ suite('Context Menu Items', function () {
 
       test('Enabled when blocks to delete', function () {
         this.workspace.newBlock('text');
-        chai.assert.equal(
+        assert.equal(
           this.deleteOption.preconditionFn(this.scope),
           'enabled',
         );
       });
 
       test('Disabled when no blocks to delete', function () {
-        chai.assert.equal(
+        assert.equal(
           this.deleteOption.preconditionFn(this.scope),
           'disabled',
         );
@@ -332,7 +333,7 @@ suite('Context Menu Items', function () {
         this.deleteOption.callback(this.scope);
         this.clock.runAll();
         sinon.assert.calledOnce(confirmStub);
-        chai.assert.equal(this.workspace.getTopBlocks(false).length, 0);
+        assert.equal(this.workspace.getTopBlocks(false).length, 0);
       });
 
       test('Does not delete blocks if not confirmed', function () {
@@ -346,7 +347,7 @@ suite('Context Menu Items', function () {
         this.deleteOption.callback(this.scope);
         this.clock.runAll();
         sinon.assert.calledOnce(confirmStub);
-        chai.assert.equal(this.workspace.getTopBlocks(false).length, 2);
+        assert.equal(this.workspace.getTopBlocks(false).length, 2);
       });
 
       test('No dialog for single block', function () {
@@ -359,14 +360,14 @@ suite('Context Menu Items', function () {
         this.clock.runAll();
 
         sinon.assert.notCalled(confirmStub);
-        chai.assert.equal(this.workspace.getTopBlocks(false).length, 0);
+        assert.equal(this.workspace.getTopBlocks(false).length, 0);
       });
 
       test('Has correct label for multiple blocks', function () {
         this.workspace.newBlock('text');
         this.workspace.newBlock('text');
 
-        chai.assert.equal(
+        assert.equal(
           this.deleteOption.displayText(this.scope),
           'Delete 2 Blocks',
         );
@@ -374,7 +375,7 @@ suite('Context Menu Items', function () {
 
       test('Has correct label for single block', function () {
         this.workspace.newBlock('text');
-        chai.assert.equal(
+        assert.equal(
           this.deleteOption.displayText(this.scope),
           'Delete Block',
         );
@@ -395,7 +396,7 @@ suite('Context Menu Items', function () {
 
       test('Enabled when block is duplicatable', function () {
         // Block is duplicatable by default
-        chai.assert.equal(
+        assert.equal(
           this.duplicateOption.preconditionFn(this.scope),
           'enabled',
         );
@@ -403,7 +404,7 @@ suite('Context Menu Items', function () {
 
       test('Disabled when block is not dupicatable', function () {
         sinon.stub(this.block, 'isDuplicatable').returns(false);
-        chai.assert.equal(
+        assert.equal(
           this.duplicateOption.preconditionFn(this.scope),
           'disabled',
         );
@@ -411,7 +412,7 @@ suite('Context Menu Items', function () {
 
       test('Hidden when in flyout', function () {
         this.block.isInFlyout = true;
-        chai.assert.equal(
+        assert.equal(
           this.duplicateOption.preconditionFn(this.scope),
           'hidden',
         );
@@ -419,7 +420,7 @@ suite('Context Menu Items', function () {
 
       test('the block is duplicated', function () {
         this.duplicateOption.callback(this.scope);
-        chai.assert.equal(
+        assert.equal(
           this.workspace.getTopBlocks(false).length,
           2,
           'Expected a second block',
@@ -427,7 +428,7 @@ suite('Context Menu Items', function () {
       });
 
       test('Has correct label', function () {
-        chai.assert.equal(this.duplicateOption.displayText(), 'Duplicate');
+        assert.equal(this.duplicateOption.displayText(), 'Duplicate');
       });
     });
 
@@ -437,7 +438,7 @@ suite('Context Menu Items', function () {
       });
 
       test('Enabled for normal block', function () {
-        chai.assert.equal(
+        assert.equal(
           this.commentOption.preconditionFn(this.scope),
           'enabled',
         );
@@ -449,20 +450,20 @@ suite('Context Menu Items', function () {
         this.block.render();
         this.block.setCollapsed(true);
 
-        chai.assert.equal(
+        assert.equal(
           this.commentOption.preconditionFn(this.scope),
           'hidden',
         );
       });
 
       test('Creates comment if one did not exist', function () {
-        chai.assert.isUndefined(
+        assert.isUndefined(
           this.block.getIcon(Blockly.icons.CommentIcon.TYPE),
           'New block should not have a comment',
         );
         this.commentOption.callback(this.scope);
-        chai.assert.exists(this.block.getIcon(Blockly.icons.CommentIcon.TYPE));
-        chai.assert.isEmpty(
+        assert.exists(this.block.getIcon(Blockly.icons.CommentIcon.TYPE));
+        assert.isEmpty(
           this.block.getCommentText(),
           'Block should have empty comment text',
         );
@@ -471,14 +472,14 @@ suite('Context Menu Items', function () {
       test('Removes comment if block had one', function () {
         this.block.setCommentText('Test comment');
         this.commentOption.callback(this.scope);
-        chai.assert.isNull(
+        assert.isNull(
           this.block.getCommentText(),
           'Block should not have comment after removal',
         );
       });
 
       test('Has correct label for add comment', function () {
-        chai.assert.equal(
+        assert.equal(
           this.commentOption.displayText(this.scope),
           'Add Comment',
         );
@@ -486,7 +487,7 @@ suite('Context Menu Items', function () {
 
       test('Has correct label for remove comment', function () {
         this.block.setCommentText('Test comment');
-        chai.assert.equal(
+        assert.equal(
           this.commentOption.displayText(this.scope),
           'Remove Comment',
         );
@@ -501,7 +502,7 @@ suite('Context Menu Items', function () {
       test('Enabled when inputs to inline', function () {
         this.block.appendValueInput('test1');
         this.block.appendValueInput('test2');
-        chai.assert.equal(
+        assert.equal(
           this.inlineOption.preconditionFn(this.scope),
           'enabled',
         );

--- a/tests/mocha/contextmenu_test.js
+++ b/tests/mocha/contextmenu_test.js
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import {assert} from '../../node_modules/chai/chai.js';
 import {
   sharedTestSetup,
   sharedTestTeardown,
@@ -42,9 +43,9 @@ suite('Context Menu', function () {
       const callback = callbackFactory(this.forLoopBlock, xmlBlock);
       const getVarBlock = callback();
 
-      chai.assert.equal(getVarBlock.type, 'variables_get');
-      chai.assert.equal(getVarBlock.workspace, this.forLoopBlock.workspace);
-      chai.assert.equal(
+      assert.equal(getVarBlock.type, 'variables_get');
+      assert.equal(getVarBlock.workspace, this.forLoopBlock.workspace);
+      assert.equal(
         getVarBlock.getField('VAR').getVariable().getId(),
         this.forLoopBlock.getField('VAR').getVariable().getId(),
       );
@@ -59,9 +60,9 @@ suite('Context Menu', function () {
       const callback = callbackFactory(this.forLoopBlock, jsonState);
       const getVarBlock = callback();
 
-      chai.assert.equal(getVarBlock.type, 'variables_get');
-      chai.assert.equal(getVarBlock.workspace, this.forLoopBlock.workspace);
-      chai.assert.equal(
+      assert.equal(getVarBlock.type, 'variables_get');
+      assert.equal(getVarBlock.workspace, this.forLoopBlock.workspace);
+      assert.equal(
         getVarBlock.getField('VAR').getVariable().getId(),
         this.forLoopBlock.getField('VAR').getVariable().getId(),
       );

--- a/tests/mocha/cursor_test.js
+++ b/tests/mocha/cursor_test.js
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import {assert} from '../../node_modules/chai/chai.js';
 import {
   sharedTestSetup,
   sharedTestTeardown,
@@ -90,7 +91,7 @@ suite('Cursor', function () {
     this.cursor.setCurNode(prevNode);
     this.cursor.next();
     const curNode = this.cursor.getCurNode();
-    chai.assert.equal(curNode.getLocation(), this.blocks.B.previousConnection);
+    assert.equal(curNode.getLocation(), this.blocks.B.previousConnection);
   });
   test('Next - From last block in a stack go to next connection', function () {
     const prevNode = ASTNode.createConnectionNode(
@@ -99,7 +100,7 @@ suite('Cursor', function () {
     this.cursor.setCurNode(prevNode);
     this.cursor.next();
     const curNode = this.cursor.getCurNode();
-    chai.assert.equal(curNode.getLocation(), this.blocks.B.nextConnection);
+    assert.equal(curNode.getLocation(), this.blocks.B.nextConnection);
   });
 
   test('In - From output connection', function () {
@@ -110,7 +111,7 @@ suite('Cursor', function () {
     this.cursor.setCurNode(outputNode);
     this.cursor.in();
     const curNode = this.cursor.getCurNode();
-    chai.assert.equal(
+    assert.equal(
       curNode.getLocation(),
       fieldBlock.inputList[0].fieldRow[0],
     );
@@ -122,7 +123,7 @@ suite('Cursor', function () {
     this.cursor.setCurNode(prevConnectionNode);
     this.cursor.prev();
     const curNode = this.cursor.getCurNode();
-    chai.assert.equal(curNode.getLocation(), this.blocks.A.previousConnection);
+    assert.equal(curNode.getLocation(), this.blocks.A.previousConnection);
   });
 
   test('Out - From field skip over block node', function () {
@@ -131,6 +132,6 @@ suite('Cursor', function () {
     this.cursor.setCurNode(fieldNode);
     this.cursor.out();
     const curNode = this.cursor.getCurNode();
-    chai.assert.equal(curNode.getLocation(), this.blocks.E.outputConnection);
+    assert.equal(curNode.getLocation(), this.blocks.E.outputConnection);
   });
 });

--- a/tests/mocha/cursor_test.js
+++ b/tests/mocha/cursor_test.js
@@ -111,10 +111,7 @@ suite('Cursor', function () {
     this.cursor.setCurNode(outputNode);
     this.cursor.in();
     const curNode = this.cursor.getCurNode();
-    assert.equal(
-      curNode.getLocation(),
-      fieldBlock.inputList[0].fieldRow[0],
-    );
+    assert.equal(curNode.getLocation(), fieldBlock.inputList[0].fieldRow[0]);
   });
 
   test('Prev - From previous connection skip over next connection', function () {

--- a/tests/mocha/dropdowndiv_test.js
+++ b/tests/mocha/dropdowndiv_test.js
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import {assert} from '../../node_modules/chai/chai.js';
 import {
   sharedTestSetup,
   sharedTestTeardown,
@@ -51,10 +52,10 @@ suite('DropDownDiv', function () {
         -10,
       );
       // "Above" in value actually means below in render.
-      chai.assert.isAtLeast(metrics.initialY, 0);
-      chai.assert.isAbove(metrics.finalY, 0);
-      chai.assert.isTrue(metrics.arrowVisible);
-      chai.assert.isTrue(metrics.arrowAtTop);
+      assert.isAtLeast(metrics.initialY, 0);
+      assert.isAbove(metrics.finalY, 0);
+      assert.isTrue(metrics.arrowVisible);
+      assert.isTrue(metrics.arrowAtTop);
     });
     test('Above, in Bounds', function () {
       const metrics = Blockly.DropDownDiv.TEST_ONLY.getPositionMetrics(
@@ -64,10 +65,10 @@ suite('DropDownDiv', function () {
         90,
       );
       // "Below" in value actually means above in render.
-      chai.assert.isAtMost(metrics.initialY, 100);
-      chai.assert.isBelow(metrics.finalY, 100);
-      chai.assert.isTrue(metrics.arrowVisible);
-      chai.assert.isFalse(metrics.arrowAtTop);
+      assert.isAtMost(metrics.initialY, 100);
+      assert.isBelow(metrics.finalY, 100);
+      assert.isTrue(metrics.arrowVisible);
+      assert.isFalse(metrics.arrowAtTop);
     });
     test('Below, out of Bounds', function () {
       const metrics = Blockly.DropDownDiv.TEST_ONLY.getPositionMetrics(
@@ -77,10 +78,10 @@ suite('DropDownDiv', function () {
         50,
       );
       // "Above" in value actually means below in render.
-      chai.assert.isAtLeast(metrics.initialY, 60);
-      chai.assert.isAbove(metrics.finalY, 60);
-      chai.assert.isTrue(metrics.arrowVisible);
-      chai.assert.isTrue(metrics.arrowAtTop);
+      assert.isAtLeast(metrics.initialY, 60);
+      assert.isAbove(metrics.finalY, 60);
+      assert.isTrue(metrics.arrowVisible);
+      assert.isTrue(metrics.arrowAtTop);
     });
     test('Above, in Bounds', function () {
       const metrics = Blockly.DropDownDiv.TEST_ONLY.getPositionMetrics(
@@ -90,10 +91,10 @@ suite('DropDownDiv', function () {
         90,
       );
       // "Below" in value actually means above in render.
-      chai.assert.isAtMost(metrics.initialY, 100);
-      chai.assert.isBelow(metrics.finalY, 100);
-      chai.assert.isTrue(metrics.arrowVisible);
-      chai.assert.isFalse(metrics.arrowAtTop);
+      assert.isAtMost(metrics.initialY, 100);
+      assert.isBelow(metrics.finalY, 100);
+      assert.isTrue(metrics.arrowVisible);
+      assert.isFalse(metrics.arrowAtTop);
     });
     test('No Solution, Render At Top', function () {
       this.clientHeightStub.get(function () {
@@ -106,10 +107,10 @@ suite('DropDownDiv', function () {
         50,
       );
       // "Above" in value actually means below in render.
-      chai.assert.equal(metrics.initialY, 0);
-      chai.assert.equal(metrics.finalY, 0);
-      chai.assert.isFalse(metrics.arrowVisible);
-      chai.assert.isNotOk(metrics.arrowAtTop);
+      assert.equal(metrics.initialY, 0);
+      assert.equal(metrics.finalY, 0);
+      assert.isFalse(metrics.arrowVisible);
+      assert.isNotOk(metrics.arrowAtTop);
     });
   });
 });

--- a/tests/mocha/event_block_change_test.js
+++ b/tests/mocha/event_block_change_test.js
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import {assert} from '../../node_modules/chai/chai.js';
 import {
   sharedTestSetup,
   sharedTestTeardown,
@@ -45,7 +46,7 @@ suite('Block Change Event', function () {
             '<mutation hasInput="true"/>',
           );
           blockChange.run(false);
-          chai.assert.isFalse(block.hasInput);
+          assert.isFalse(block.hasInput);
         });
 
         test('Redo', function () {
@@ -58,7 +59,7 @@ suite('Block Change Event', function () {
             '<mutation hasInput="true"/>',
           );
           blockChange.run(true);
-          chai.assert.isTrue(block.hasInput);
+          assert.isTrue(block.hasInput);
         });
       });
 
@@ -74,7 +75,7 @@ suite('Block Change Event', function () {
             '{"hasInput":true}',
           );
           blockChange.run(false);
-          chai.assert.isFalse(block.hasInput);
+          assert.isFalse(block.hasInput);
         });
 
         test('Redo', function () {
@@ -87,7 +88,7 @@ suite('Block Change Event', function () {
             '{"hasInput":true}',
           );
           blockChange.run(true);
-          chai.assert.isTrue(block.hasInput);
+          assert.isTrue(block.hasInput);
         });
       });
     });
@@ -119,7 +120,7 @@ suite('Block Change Event', function () {
       const json = origEvent.toJson();
       const newEvent = new Blockly.Events.fromJson(json, this.workspace);
 
-      chai.assert.deepEqual(newEvent, origEvent);
+      assert.deepEqual(newEvent, origEvent);
     });
   });
 });

--- a/tests/mocha/event_block_create_test.js
+++ b/tests/mocha/event_block_create_test.js
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import {assert} from '../../node_modules/chai/chai.js';
 import {assertEventFired} from './test_helpers/events.js';
 import * as eventUtils from '../../build/src/core/events/utils.js';
 import {
@@ -53,7 +54,7 @@ suite('Block Create Event', function () {
     );
     const calls = this.eventsFireStub.getCalls();
     const event = calls[calls.length - 1].args[0];
-    chai.assert.equal(event.xml.tagName, 'shadow');
+    assert.equal(event.xml.tagName, 'shadow');
   });
 
   test('Does not create extra shadow blocks', function () {
@@ -85,7 +86,7 @@ suite('Block Create Event', function () {
     event.run(true);
 
     const blocksAfter = this.workspace.getAllBlocks();
-    chai.assert.deepEqual(
+    assert.deepEqual(
       blocksAfter,
       blocksBefore,
       'No new blocks should be created from an event that only creates shadow blocks',
@@ -102,7 +103,7 @@ suite('Block Create Event', function () {
       delete origEvent.xml; // xml fails deep equals for some reason.
       delete newEvent.xml; // xml fails deep equals for some reason.
 
-      chai.assert.deepEqual(newEvent, origEvent);
+      assert.deepEqual(newEvent, origEvent);
     });
   });
 });

--- a/tests/mocha/event_block_delete_test.js
+++ b/tests/mocha/event_block_delete_test.js
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import {assert} from '../../node_modules/chai/chai.js';
 import {defineRowBlock} from './test_helpers/block_definitions.js';
 import {
   sharedTestSetup,
@@ -34,7 +35,7 @@ suite('Block Delete Event', function () {
       testBlock.dispose();
       this.clock.runAll();
 
-      chai.assert.isFalse(spy.called);
+      assert.isFalse(spy.called);
     });
   });
 
@@ -48,7 +49,7 @@ suite('Block Delete Event', function () {
       delete origEvent.oldXml; // xml fails deep equals for some reason.
       delete newEvent.oldXml; // xml fails deep equals for some reason.
 
-      chai.assert.deepEqual(newEvent, origEvent);
+      assert.deepEqual(newEvent, origEvent);
     });
   });
 });

--- a/tests/mocha/event_block_drag_test.js
+++ b/tests/mocha/event_block_drag_test.js
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import {assert} from '../../node_modules/chai/chai.js';
 import {defineRowBlock} from './test_helpers/block_definitions.js';
 import {
   sharedTestSetup,
@@ -29,7 +30,7 @@ suite('Block Drag Event', function () {
       const json = origEvent.toJson();
       const newEvent = new Blockly.Events.fromJson(json, this.workspace);
 
-      chai.assert.deepEqual(newEvent, origEvent);
+      assert.deepEqual(newEvent, origEvent);
     });
   });
 });

--- a/tests/mocha/event_block_field_intermediate_change_test.js
+++ b/tests/mocha/event_block_field_intermediate_change_test.js
@@ -48,10 +48,7 @@ suite('Field Intermediate Change Event', function () {
       );
       origEvent.run(true);
 
-      assert.deepEqual(
-        block.getField(origEvent.name).getValue(),
-        'new value',
-      );
+      assert.deepEqual(block.getField(origEvent.name).getValue(), 'new value');
     });
 
     test("running backward changes the block's value to old value", function () {
@@ -64,10 +61,7 @@ suite('Field Intermediate Change Event', function () {
       );
       origEvent.run(false);
 
-      assert.deepEqual(
-        block.getField(origEvent.name).getValue(),
-        'old value',
-      );
+      assert.deepEqual(block.getField(origEvent.name).getValue(), 'old value');
     });
   });
 });

--- a/tests/mocha/event_block_field_intermediate_change_test.js
+++ b/tests/mocha/event_block_field_intermediate_change_test.js
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import {assert} from '../../node_modules/chai/chai.js';
 import {
   sharedTestSetup,
   sharedTestTeardown,
@@ -32,7 +33,7 @@ suite('Field Intermediate Change Event', function () {
       const json = origEvent.toJson();
       const newEvent = new Blockly.Events.fromJson(json, this.workspace);
 
-      chai.assert.deepEqual(newEvent, origEvent);
+      assert.deepEqual(newEvent, origEvent);
     });
   });
 
@@ -47,7 +48,7 @@ suite('Field Intermediate Change Event', function () {
       );
       origEvent.run(true);
 
-      chai.assert.deepEqual(
+      assert.deepEqual(
         block.getField(origEvent.name).getValue(),
         'new value',
       );
@@ -63,7 +64,7 @@ suite('Field Intermediate Change Event', function () {
       );
       origEvent.run(false);
 
-      chai.assert.deepEqual(
+      assert.deepEqual(
         block.getField(origEvent.name).getValue(),
         'old value',
       );

--- a/tests/mocha/event_block_move_test.js
+++ b/tests/mocha/event_block_move_test.js
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import {assert} from '../../node_modules/chai/chai.js';
 import {defineRowBlock} from './test_helpers/block_definitions.js';
 import {
   sharedTestSetup,
@@ -32,7 +33,7 @@ suite('Block Move Event', function () {
       const json = origEvent.toJson();
       const newEvent = new Blockly.Events.fromJson(json, this.workspace);
 
-      chai.assert.deepEqual(newEvent, origEvent);
+      assert.deepEqual(newEvent, origEvent);
     });
   });
 });

--- a/tests/mocha/event_bubble_open_test.js
+++ b/tests/mocha/event_bubble_open_test.js
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import {assert} from '../../node_modules/chai/chai.js';
 import {defineMutatorBlocks} from './test_helpers/block_definitions.js';
 import {
   sharedTestSetup,
@@ -35,7 +36,7 @@ suite('Bubble Open Event', function () {
       const json = origEvent.toJson();
       const newEvent = new Blockly.Events.fromJson(json, this.workspace);
 
-      chai.assert.deepEqual(newEvent, origEvent);
+      assert.deepEqual(newEvent, origEvent);
     });
   });
 });

--- a/tests/mocha/event_click_test.js
+++ b/tests/mocha/event_click_test.js
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import {assert} from '../../node_modules/chai/chai.js';
 import {defineRowBlock} from './test_helpers/block_definitions.js';
 import {
   sharedTestSetup,
@@ -33,7 +34,7 @@ suite('Click Event', function () {
       const json = origEvent.toJson();
       const newEvent = new Blockly.Events.fromJson(json, this.workspace);
 
-      chai.assert.deepEqual(newEvent, origEvent);
+      assert.deepEqual(newEvent, origEvent);
     });
   });
 });

--- a/tests/mocha/event_comment_change_test.js
+++ b/tests/mocha/event_comment_change_test.js
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import {assert} from '../../node_modules/chai/chai.js';
 import {
   sharedTestSetup,
   sharedTestTeardown,
@@ -32,7 +33,7 @@ suite('Comment Change Event', function () {
       const json = origEvent.toJson();
       const newEvent = new Blockly.Events.fromJson(json, this.workspace);
 
-      chai.assert.deepEqual(newEvent, origEvent);
+      assert.deepEqual(newEvent, origEvent);
     });
   });
 });

--- a/tests/mocha/event_comment_collapse_test.js
+++ b/tests/mocha/event_comment_collapse_test.js
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import {assert} from '../../node_modules/chai/chai.js';
 import {
   sharedTestSetup,
   sharedTestTeardown,
@@ -27,7 +28,7 @@ suite('Comment Collapse Event', function () {
       const json = origEvent.toJson();
       const newEvent = new Blockly.Events.fromJson(json, this.workspace);
 
-      chai.assert.deepEqual(newEvent, origEvent);
+      assert.deepEqual(newEvent, origEvent);
     });
   });
 });

--- a/tests/mocha/event_comment_create_test.js
+++ b/tests/mocha/event_comment_create_test.js
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import {assert} from '../../node_modules/chai/chai.js';
 import {
   sharedTestSetup,
   sharedTestTeardown,
@@ -31,7 +32,7 @@ suite('Comment Create Event', function () {
       delete origEvent.xml; // xml fails deep equals for some reason.
       delete newEvent.xml; // xml fails deep equals for some reason.
 
-      chai.assert.deepEqual(newEvent, origEvent);
+      assert.deepEqual(newEvent, origEvent);
     });
   });
 });

--- a/tests/mocha/event_comment_delete_test.js
+++ b/tests/mocha/event_comment_delete_test.js
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import {assert} from '../../node_modules/chai/chai.js';
 import {
   sharedTestSetup,
   sharedTestTeardown,
@@ -31,7 +32,7 @@ suite('Comment Delete Event', function () {
       delete origEvent.xml; // xml fails deep equals for some reason.
       delete newEvent.xml; // xml fails deep equals for some reason.
 
-      chai.assert.deepEqual(newEvent, origEvent);
+      assert.deepEqual(newEvent, origEvent);
     });
   });
 });

--- a/tests/mocha/event_comment_move_test.js
+++ b/tests/mocha/event_comment_move_test.js
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import {assert} from '../../node_modules/chai/chai.js';
 import {
   sharedTestSetup,
   sharedTestTeardown,
@@ -33,7 +34,7 @@ suite('Comment Move Event', function () {
       delete origEvent.comment_; // Ignore private properties.
       delete newEvent.comment_; // Ignore private properties.
 
-      chai.assert.deepEqual(newEvent, origEvent);
+      assert.deepEqual(newEvent, origEvent);
     });
   });
 });

--- a/tests/mocha/event_marker_move_test.js
+++ b/tests/mocha/event_marker_move_test.js
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import {assert} from '../../node_modules/chai/chai.js';
 import {defineRowBlock} from './test_helpers/block_definitions.js';
 import {
   sharedTestSetup,
@@ -37,7 +38,7 @@ suite('Marker Move Event', function () {
       const json = origEvent.toJson();
       const newEvent = new Blockly.Events.fromJson(json, this.workspace);
 
-      chai.assert.deepEqual(newEvent, origEvent);
+      assert.deepEqual(newEvent, origEvent);
     });
   });
 });

--- a/tests/mocha/event_selected_test.js
+++ b/tests/mocha/event_selected_test.js
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import {assert} from '../../node_modules/chai/chai.js';
 import {defineRowBlock} from './test_helpers/block_definitions.js';
 import {
   sharedTestSetup,
@@ -34,7 +35,7 @@ suite('Selected Event', function () {
       const json = origEvent.toJson();
       const newEvent = new Blockly.Events.fromJson(json, this.workspace);
 
-      chai.assert.deepEqual(newEvent, origEvent);
+      assert.deepEqual(newEvent, origEvent);
     });
   });
 });

--- a/tests/mocha/event_test.js
+++ b/tests/mocha/event_test.js
@@ -917,10 +917,7 @@ suite('Events', function () {
               const json = event.toJson();
               const event2 = Blockly.Events.fromJson(json, this.workspace);
 
-              assert.equal(
-                safeStringify(event2.toJson()),
-                safeStringify(json),
-              );
+              assert.equal(safeStringify(event2.toJson()), safeStringify(json));
             });
           });
         });
@@ -932,10 +929,7 @@ suite('Events', function () {
                 const json = event.toJson();
                 const expectedJson = testCase.getExpectedJson(this);
 
-                assert.equal(
-                  safeStringify(json),
-                  safeStringify(expectedJson),
-                );
+                assert.equal(safeStringify(json), safeStringify(expectedJson));
               });
             }
           });
@@ -1109,13 +1103,9 @@ suite('Events', function () {
       const filteredEvents = eventUtils.filter(events, true);
       assert.equal(filteredEvents.length, 4); // no event should have been removed.
       // test that the order hasn't changed
-      assert.isTrue(
-        filteredEvents[0] instanceof Blockly.Events.BlockCreate,
-      );
+      assert.isTrue(filteredEvents[0] instanceof Blockly.Events.BlockCreate);
       assert.isTrue(filteredEvents[1] instanceof Blockly.Events.BlockMove);
-      assert.isTrue(
-        filteredEvents[2] instanceof Blockly.Events.BlockChange,
-      );
+      assert.isTrue(filteredEvents[2] instanceof Blockly.Events.BlockChange);
       assert.isTrue(filteredEvents[3] instanceof Blockly.Events.Click);
     });
 
@@ -1141,9 +1131,7 @@ suite('Events', function () {
       const filteredEvents = eventUtils.filter(events, true);
       assert.equal(filteredEvents.length, 2); // duplicate moves should have been removed.
       // test that the order hasn't changed
-      assert.isTrue(
-        filteredEvents[0] instanceof Blockly.Events.BlockCreate,
-      );
+      assert.isTrue(filteredEvents[0] instanceof Blockly.Events.BlockCreate);
       assert.isTrue(filteredEvents[1] instanceof Blockly.Events.BlockMove);
       assert.equal(filteredEvents[1].newCoordinate.x, 3);
       assert.equal(filteredEvents[1].newCoordinate.y, 3);
@@ -1158,9 +1146,7 @@ suite('Events', function () {
       const filteredEvents = eventUtils.filter(events, false);
       assert.equal(filteredEvents.length, 2); // duplicate event should have been removed.
       // test that the order hasn't changed
-      assert.isTrue(
-        filteredEvents[0] instanceof Blockly.Events.BlockCreate,
-      );
+      assert.isTrue(filteredEvents[0] instanceof Blockly.Events.BlockCreate);
       assert.isTrue(filteredEvents[1] instanceof Blockly.Events.BlockMove);
       assert.equal(filteredEvents[1].newCoordinate.x, 1);
       assert.equal(filteredEvents[1].newCoordinate.y, 1);
@@ -1223,15 +1209,9 @@ suite('Events', function () {
       const filteredEvents = eventUtils.filter(events, true);
       // click event merged into corresponding *Open event
       assert.equal(filteredEvents.length, 3);
-      assert.isTrue(
-        filteredEvents[0] instanceof Blockly.Events.BubbleOpen,
-      );
-      assert.isTrue(
-        filteredEvents[1] instanceof Blockly.Events.BubbleOpen,
-      );
-      assert.isTrue(
-        filteredEvents[2] instanceof Blockly.Events.BubbleOpen,
-      );
+      assert.isTrue(filteredEvents[0] instanceof Blockly.Events.BubbleOpen);
+      assert.isTrue(filteredEvents[1] instanceof Blockly.Events.BubbleOpen);
+      assert.isTrue(filteredEvents[2] instanceof Blockly.Events.BubbleOpen);
       assert.equal(filteredEvents[0].bubbleType, 'comment');
       assert.equal(filteredEvents[1].bubbleType, 'mutator');
       assert.equal(filteredEvents[2].bubbleType, 'warning');
@@ -1292,9 +1272,7 @@ suite('Events', function () {
       // test that the order hasn't changed
       assert.isTrue(filteredEvents[0] instanceof Blockly.Events.BlockMove);
       assert.isTrue(filteredEvents[1] instanceof Blockly.Events.BlockMove);
-      assert.isTrue(
-        filteredEvents[2] instanceof Blockly.Events.BlockDelete,
-      );
+      assert.isTrue(filteredEvents[2] instanceof Blockly.Events.BlockDelete);
       assert.isTrue(filteredEvents[3] instanceof Blockly.Events.BlockMove);
     });
   });
@@ -1375,11 +1353,7 @@ suite('Events', function () {
       // Expect both events to trigger change listener.
       sinon.assert.calledTwice(this.changeListenerSpy);
       // Both events should be on undo stack
-      assert.equal(
-        this.workspace.undoStack_.length,
-        2,
-        'Undo stack length',
-      );
+      assert.equal(this.workspace.undoStack_.length, 2, 'Undo stack length');
 
       assertNthCallEventArgEquals(
         this.changeListenerSpy,
@@ -1433,11 +1407,7 @@ suite('Events', function () {
       // The first varCreate and move event should have been ignored.
       sinon.assert.callCount(this.changeListenerSpy, 3);
       // Expect two events on undo stack: varCreate and block create.
-      assert.equal(
-        this.workspace.undoStack_.length,
-        2,
-        'Undo stack length',
-      );
+      assert.equal(this.workspace.undoStack_.length, 2, 'Undo stack length');
 
       assertNthCallEventArgEquals(
         this.changeListenerSpy,

--- a/tests/mocha/event_test.js
+++ b/tests/mocha/event_test.js
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import {assert} from '../../node_modules/chai/chai.js';
 import * as Blockly from '../../build/src/core/blockly.js';
 import {ASTNode} from '../../build/src/core/keyboard_nav/ast_node.js';
 import {
@@ -916,7 +917,7 @@ suite('Events', function () {
               const json = event.toJson();
               const event2 = Blockly.Events.fromJson(json, this.workspace);
 
-              chai.assert.equal(
+              assert.equal(
                 safeStringify(event2.toJson()),
                 safeStringify(json),
               );
@@ -931,7 +932,7 @@ suite('Events', function () {
                 const json = event.toJson();
                 const expectedJson = testCase.getExpectedJson(this);
 
-                chai.assert.equal(
+                assert.equal(
                   safeStringify(json),
                   safeStringify(expectedJson),
                 );
@@ -958,10 +959,10 @@ suite('Events', function () {
      */
     function checkVariableValues(container, name, type, id) {
       const variable = container.getVariableById(id);
-      chai.assert.isDefined(variable);
-      chai.assert.equal(name, variable.name);
-      chai.assert.equal(type, variable.type);
-      chai.assert.equal(id, variable.getId());
+      assert.isDefined(variable);
+      assert.equal(name, variable.name);
+      assert.equal(type, variable.type);
+      assert.equal(id, variable.getId());
     }
 
     suite('Constructors', function () {
@@ -1036,29 +1037,29 @@ suite('Events', function () {
         };
         const event = eventUtils.fromJson(json, this.workspace);
         const x = this.workspace.getVariableById('id2');
-        chai.assert.isNull(x);
+        assert.isNull(x);
         event.run(true);
         assertVariableValues(this.workspace, 'name2', 'type2', 'id2');
       });
 
       test('Var delete', function () {
         const event = new Blockly.Events.VarDelete(this.variable);
-        chai.assert.isNotNull(this.workspace.getVariableById('id1'));
+        assert.isNotNull(this.workspace.getVariableById('id1'));
         event.run(true);
-        chai.assert.isNull(this.workspace.getVariableById('id1'));
+        assert.isNull(this.workspace.getVariableById('id1'));
       });
 
       test('Var rename', function () {
         const event = new Blockly.Events.VarRename(this.variable, 'name2');
         event.run(true);
-        chai.assert.isNull(this.workspace.getVariable('name1'));
+        assert.isNull(this.workspace.getVariable('name1'));
         checkVariableValues(this.workspace, 'name2', 'type1', 'id1');
       });
     });
     suite('Run Backward', function () {
       test('Var create', function () {
         const event = new Blockly.Events.VarCreate(this.variable);
-        chai.assert.isNotNull(this.workspace.getVariableById('id1'));
+        assert.isNotNull(this.workspace.getVariableById('id1'));
         event.run(false);
       });
 
@@ -1070,7 +1071,7 @@ suite('Events', function () {
           varName: 'name2',
         };
         const event = eventUtils.fromJson(json, this.workspace);
-        chai.assert.isNull(this.workspace.getVariableById('id2'));
+        assert.isNull(this.workspace.getVariableById('id2'));
         event.run(false);
         assertVariableValues(this.workspace, 'name2', 'type2', 'id2');
       });
@@ -1078,7 +1079,7 @@ suite('Events', function () {
       test('Var rename', function () {
         const event = new Blockly.Events.VarRename(this.variable, 'name2');
         event.run(false);
-        chai.assert.isNull(this.workspace.getVariable('name2'));
+        assert.isNull(this.workspace.getVariable('name2'));
         checkVariableValues(this.workspace, 'name1', 'type1', 'id1');
       });
     });
@@ -1106,16 +1107,16 @@ suite('Events', function () {
         new Blockly.Events.Click(block),
       ];
       const filteredEvents = eventUtils.filter(events, true);
-      chai.assert.equal(filteredEvents.length, 4); // no event should have been removed.
+      assert.equal(filteredEvents.length, 4); // no event should have been removed.
       // test that the order hasn't changed
-      chai.assert.isTrue(
+      assert.isTrue(
         filteredEvents[0] instanceof Blockly.Events.BlockCreate,
       );
-      chai.assert.isTrue(filteredEvents[1] instanceof Blockly.Events.BlockMove);
-      chai.assert.isTrue(
+      assert.isTrue(filteredEvents[1] instanceof Blockly.Events.BlockMove);
+      assert.isTrue(
         filteredEvents[2] instanceof Blockly.Events.BlockChange,
       );
-      chai.assert.isTrue(filteredEvents[3] instanceof Blockly.Events.Click);
+      assert.isTrue(filteredEvents[3] instanceof Blockly.Events.Click);
     });
 
     test('Different blocks no removed', function () {
@@ -1128,7 +1129,7 @@ suite('Events', function () {
         new Blockly.Events.BlockMove(block2),
       ];
       const filteredEvents = eventUtils.filter(events, true);
-      chai.assert.equal(filteredEvents.length, 4); // no event should have been removed.
+      assert.equal(filteredEvents.length, 4); // no event should have been removed.
     });
 
     test('Forward', function () {
@@ -1138,14 +1139,14 @@ suite('Events', function () {
       addMoveEvent(events, block, 2, 2);
       addMoveEvent(events, block, 3, 3);
       const filteredEvents = eventUtils.filter(events, true);
-      chai.assert.equal(filteredEvents.length, 2); // duplicate moves should have been removed.
+      assert.equal(filteredEvents.length, 2); // duplicate moves should have been removed.
       // test that the order hasn't changed
-      chai.assert.isTrue(
+      assert.isTrue(
         filteredEvents[0] instanceof Blockly.Events.BlockCreate,
       );
-      chai.assert.isTrue(filteredEvents[1] instanceof Blockly.Events.BlockMove);
-      chai.assert.equal(filteredEvents[1].newCoordinate.x, 3);
-      chai.assert.equal(filteredEvents[1].newCoordinate.y, 3);
+      assert.isTrue(filteredEvents[1] instanceof Blockly.Events.BlockMove);
+      assert.equal(filteredEvents[1].newCoordinate.x, 3);
+      assert.equal(filteredEvents[1].newCoordinate.y, 3);
     });
 
     test('Backward', function () {
@@ -1155,14 +1156,14 @@ suite('Events', function () {
       addMoveEvent(events, block, 2, 2);
       addMoveEvent(events, block, 3, 3);
       const filteredEvents = eventUtils.filter(events, false);
-      chai.assert.equal(filteredEvents.length, 2); // duplicate event should have been removed.
+      assert.equal(filteredEvents.length, 2); // duplicate event should have been removed.
       // test that the order hasn't changed
-      chai.assert.isTrue(
+      assert.isTrue(
         filteredEvents[0] instanceof Blockly.Events.BlockCreate,
       );
-      chai.assert.isTrue(filteredEvents[1] instanceof Blockly.Events.BlockMove);
-      chai.assert.equal(filteredEvents[1].newCoordinate.x, 1);
-      chai.assert.equal(filteredEvents[1].newCoordinate.y, 1);
+      assert.isTrue(filteredEvents[1] instanceof Blockly.Events.BlockMove);
+      assert.equal(filteredEvents[1].newCoordinate.x, 1);
+      assert.equal(filteredEvents[1].newCoordinate.y, 1);
     });
 
     test('Merge block move events', function () {
@@ -1171,9 +1172,9 @@ suite('Events', function () {
       addMoveEvent(events, block, 0, 0);
       addMoveEvent(events, block, 1, 1);
       const filteredEvents = eventUtils.filter(events, true);
-      chai.assert.equal(filteredEvents.length, 1); // second move event merged into first
-      chai.assert.equal(filteredEvents[0].newCoordinate.x, 1);
-      chai.assert.equal(filteredEvents[0].newCoordinate.y, 1);
+      assert.equal(filteredEvents.length, 1); // second move event merged into first
+      assert.equal(filteredEvents[0].newCoordinate.x, 1);
+      assert.equal(filteredEvents[0].newCoordinate.y, 1);
     });
 
     test('Merge block change events', function () {
@@ -1189,9 +1190,9 @@ suite('Events', function () {
         ),
       ];
       const filteredEvents = eventUtils.filter(events, true);
-      chai.assert.equal(filteredEvents.length, 1); // second change event merged into first
-      chai.assert.equal(filteredEvents[0].oldValue, 'item');
-      chai.assert.equal(filteredEvents[0].newValue, 'item2');
+      assert.equal(filteredEvents.length, 1); // second change event merged into first
+      assert.equal(filteredEvents[0].oldValue, 'item');
+      assert.equal(filteredEvents[0].newValue, 'item2');
     });
 
     test('Merge viewport change events', function () {
@@ -1200,11 +1201,11 @@ suite('Events', function () {
         new Blockly.Events.ViewportChange(5, 6, 7, this.workspace, 8),
       ];
       const filteredEvents = eventUtils.filter(events, true);
-      chai.assert.equal(filteredEvents.length, 1); // second change event merged into first
-      chai.assert.equal(filteredEvents[0].viewTop, 5);
-      chai.assert.equal(filteredEvents[0].viewLeft, 6);
-      chai.assert.equal(filteredEvents[0].scale, 7);
-      chai.assert.equal(filteredEvents[0].oldScale, 8);
+      assert.equal(filteredEvents.length, 1); // second change event merged into first
+      assert.equal(filteredEvents[0].viewTop, 5);
+      assert.equal(filteredEvents[0].viewLeft, 6);
+      assert.equal(filteredEvents[0].scale, 7);
+      assert.equal(filteredEvents[0].oldScale, 8);
     });
 
     test('Merge ui events', function () {
@@ -1221,19 +1222,19 @@ suite('Events', function () {
       ];
       const filteredEvents = eventUtils.filter(events, true);
       // click event merged into corresponding *Open event
-      chai.assert.equal(filteredEvents.length, 3);
-      chai.assert.isTrue(
+      assert.equal(filteredEvents.length, 3);
+      assert.isTrue(
         filteredEvents[0] instanceof Blockly.Events.BubbleOpen,
       );
-      chai.assert.isTrue(
+      assert.isTrue(
         filteredEvents[1] instanceof Blockly.Events.BubbleOpen,
       );
-      chai.assert.isTrue(
+      assert.isTrue(
         filteredEvents[2] instanceof Blockly.Events.BubbleOpen,
       );
-      chai.assert.equal(filteredEvents[0].bubbleType, 'comment');
-      chai.assert.equal(filteredEvents[1].bubbleType, 'mutator');
-      chai.assert.equal(filteredEvents[2].bubbleType, 'warning');
+      assert.equal(filteredEvents[0].bubbleType, 'comment');
+      assert.equal(filteredEvents[1].bubbleType, 'mutator');
+      assert.equal(filteredEvents[2].bubbleType, 'warning');
     });
 
     test('Colliding events not dropped', function () {
@@ -1246,9 +1247,9 @@ suite('Events', function () {
       ];
       const filteredEvents = eventUtils.filter(events, true);
       // click and stackclick should both exist
-      chai.assert.equal(filteredEvents.length, 2);
-      chai.assert.isTrue(filteredEvents[0] instanceof Blockly.Events.Click);
-      chai.assert.equal(filteredEvents[1].isStart, true);
+      assert.equal(filteredEvents.length, 2);
+      assert.isTrue(filteredEvents[0] instanceof Blockly.Events.Click);
+      assert.equal(filteredEvents[1].isStart, true);
     });
 
     test('Merging null operations dropped', function () {
@@ -1267,7 +1268,7 @@ suite('Events', function () {
       const filteredEvents = eventUtils.filter(events, true);
       // The two events should be merged, but because nothing has changed
       // they will be filtered out.
-      chai.assert.equal(filteredEvents.length, 0);
+      assert.equal(filteredEvents.length, 0);
     });
 
     test('Move events different blocks not merged', function () {
@@ -1287,14 +1288,14 @@ suite('Events', function () {
 
       const filteredEvents = eventUtils.filter(events, true);
       // Nothing should have merged.
-      chai.assert.equal(filteredEvents.length, 4);
+      assert.equal(filteredEvents.length, 4);
       // test that the order hasn't changed
-      chai.assert.isTrue(filteredEvents[0] instanceof Blockly.Events.BlockMove);
-      chai.assert.isTrue(filteredEvents[1] instanceof Blockly.Events.BlockMove);
-      chai.assert.isTrue(
+      assert.isTrue(filteredEvents[0] instanceof Blockly.Events.BlockMove);
+      assert.isTrue(filteredEvents[1] instanceof Blockly.Events.BlockMove);
+      assert.isTrue(
         filteredEvents[2] instanceof Blockly.Events.BlockDelete,
       );
-      chai.assert.isTrue(filteredEvents[3] instanceof Blockly.Events.BlockMove);
+      assert.isTrue(filteredEvents[3] instanceof Blockly.Events.BlockMove);
     });
   });
 
@@ -1344,7 +1345,7 @@ suite('Events', function () {
         );
 
         // Expect the workspace to not have a variable with ID 'test_block_id'.
-        chai.assert.isNull(this.workspace.getVariableById(TEST_BLOCK_ID));
+        assert.isNull(this.workspace.getVariableById(TEST_BLOCK_ID));
       } finally {
         workspaceTeardown.call(this, workspaceSvg);
       }
@@ -1374,7 +1375,7 @@ suite('Events', function () {
       // Expect both events to trigger change listener.
       sinon.assert.calledTwice(this.changeListenerSpy);
       // Both events should be on undo stack
-      chai.assert.equal(
+      assert.equal(
         this.workspace.undoStack_.length,
         2,
         'Undo stack length',
@@ -1398,7 +1399,7 @@ suite('Events', function () {
       );
 
       // Expect the workspace to have a variable with ID 'test_var_id'.
-      chai.assert.isNotNull(this.workspace.getVariableById(TEST_VAR_ID));
+      assert.isNotNull(this.workspace.getVariableById(TEST_VAR_ID));
     });
 
     test('New block new var xml', function () {
@@ -1432,7 +1433,7 @@ suite('Events', function () {
       // The first varCreate and move event should have been ignored.
       sinon.assert.callCount(this.changeListenerSpy, 3);
       // Expect two events on undo stack: varCreate and block create.
-      chai.assert.equal(
+      assert.equal(
         this.workspace.undoStack_.length,
         2,
         'Undo stack length',
@@ -1466,7 +1467,7 @@ suite('Events', function () {
       );
 
       // Expect the workspace to have a variable with ID 'test_var_id'.
-      chai.assert.isNotNull(this.workspace.getVariableById(TEST_VAR_ID));
+      assert.isNotNull(this.workspace.getVariableById(TEST_VAR_ID));
     });
   });
   suite('Disable orphans', function () {
@@ -1487,7 +1488,7 @@ suite('Events', function () {
       // Fire all events
       this.clock.runAll();
 
-      chai.assert.isFalse(
+      assert.isFalse(
         block.isEnabled(),
         'Expected orphan block to be disabled after creation',
       );
@@ -1503,7 +1504,7 @@ suite('Events', function () {
       // Fire all events
       this.clock.runAll();
 
-      chai.assert.isTrue(
+      assert.isTrue(
         functionBlock.isEnabled(),
         'Expected top-level procedure block to be enabled',
       );
@@ -1527,7 +1528,7 @@ suite('Events', function () {
       // Fire all events
       this.clock.runAll();
 
-      chai.assert.isFalse(
+      assert.isFalse(
         block.isEnabled(),
         'Expected disconnected block to be disabled',
       );
@@ -1548,7 +1549,7 @@ suite('Events', function () {
       // Fire all events
       this.clock.runAll();
 
-      chai.assert.isTrue(
+      assert.isTrue(
         block.isEnabled(),
         'Expected block to be enabled after connecting to parent',
       );
@@ -1575,7 +1576,7 @@ suite('Events', function () {
       const disabledEvents = this.workspace.getUndoStack().filter(function (e) {
         return e.element === 'disabled';
       });
-      chai.assert.isEmpty(
+      assert.isEmpty(
         disabledEvents,
         'Undo stack should not contain any disabled events',
       );

--- a/tests/mocha/event_theme_change_test.js
+++ b/tests/mocha/event_theme_change_test.js
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import {assert} from '../../node_modules/chai/chai.js';
 import {
   sharedTestSetup,
   sharedTestTeardown,
@@ -29,7 +30,7 @@ suite('Theme Change Event', function () {
       const json = origEvent.toJson();
       const newEvent = new Blockly.Events.fromJson(json, this.workspace);
 
-      chai.assert.deepEqual(newEvent, origEvent);
+      assert.deepEqual(newEvent, origEvent);
     });
   });
 });

--- a/tests/mocha/event_toolbox_item_select_test.js
+++ b/tests/mocha/event_toolbox_item_select_test.js
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import {assert} from '../../node_modules/chai/chai.js';
 import {
   sharedTestSetup,
   sharedTestTeardown,
@@ -57,7 +58,7 @@ suite('Toolbox Item Select Event', function () {
       const json = origEvent.toJson();
       const newEvent = new Blockly.Events.fromJson(json, this.workspace);
 
-      chai.assert.deepEqual(newEvent, origEvent);
+      assert.deepEqual(newEvent, origEvent);
     });
   });
 });

--- a/tests/mocha/event_trashcan_open_test.js
+++ b/tests/mocha/event_trashcan_open_test.js
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import {assert} from '../../node_modules/chai/chai.js';
 import {
   sharedTestSetup,
   sharedTestTeardown,
@@ -29,7 +30,7 @@ suite('Trashcan Open Event', function () {
       const json = origEvent.toJson();
       const newEvent = new Blockly.Events.fromJson(json, this.workspace);
 
-      chai.assert.deepEqual(newEvent, origEvent);
+      assert.deepEqual(newEvent, origEvent);
     });
   });
 });

--- a/tests/mocha/event_var_create_test.js
+++ b/tests/mocha/event_var_create_test.js
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import {assert} from '../../node_modules/chai/chai.js';
 import {
   sharedTestSetup,
   sharedTestTeardown,
@@ -32,7 +33,7 @@ suite('Var Create Event', function () {
       const json = origEvent.toJson();
       const newEvent = new Blockly.Events.fromJson(json, this.workspace);
 
-      chai.assert.deepEqual(newEvent, origEvent);
+      assert.deepEqual(newEvent, origEvent);
     });
 
     test('typed variable events round-trip through JSON', function () {
@@ -47,7 +48,7 @@ suite('Var Create Event', function () {
       const json = origEvent.toJson();
       const newEvent = new Blockly.Events.fromJson(json, this.workspace);
 
-      chai.assert.deepEqual(newEvent, origEvent);
+      assert.deepEqual(newEvent, origEvent);
     });
   });
 });

--- a/tests/mocha/event_var_delete_test.js
+++ b/tests/mocha/event_var_delete_test.js
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import {assert} from '../../node_modules/chai/chai.js';
 import {
   sharedTestSetup,
   sharedTestTeardown,
@@ -32,7 +33,7 @@ suite('Var Delete Event', function () {
       const json = origEvent.toJson();
       const newEvent = new Blockly.Events.fromJson(json, this.workspace);
 
-      chai.assert.deepEqual(newEvent, origEvent);
+      assert.deepEqual(newEvent, origEvent);
     });
 
     test('typed variable events round-trip through JSON', function () {
@@ -47,7 +48,7 @@ suite('Var Delete Event', function () {
       const json = origEvent.toJson();
       const newEvent = new Blockly.Events.fromJson(json, this.workspace);
 
-      chai.assert.deepEqual(newEvent, origEvent);
+      assert.deepEqual(newEvent, origEvent);
     });
   });
 });

--- a/tests/mocha/event_var_rename_test.js
+++ b/tests/mocha/event_var_rename_test.js
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import {assert} from '../../node_modules/chai/chai.js';
 import {
   sharedTestSetup,
   sharedTestTeardown,
@@ -32,7 +33,7 @@ suite('Var Rename Event', function () {
       const json = origEvent.toJson();
       const newEvent = new Blockly.Events.fromJson(json, this.workspace);
 
-      chai.assert.deepEqual(newEvent, origEvent);
+      assert.deepEqual(newEvent, origEvent);
     });
   });
 });

--- a/tests/mocha/event_viewport_test.js
+++ b/tests/mocha/event_viewport_test.js
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import {assert} from '../../node_modules/chai/chai.js';
 import {
   sharedTestSetup,
   sharedTestTeardown,
@@ -32,7 +33,7 @@ suite('Viewport Change Event', function () {
       const json = origEvent.toJson();
       const newEvent = new Blockly.Events.fromJson(json, this.workspace);
 
-      chai.assert.deepEqual(newEvent, origEvent);
+      assert.deepEqual(newEvent, origEvent);
     });
   });
 });

--- a/tests/mocha/extensions_test.js
+++ b/tests/mocha/extensions_test.js
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import {assert} from '../../node_modules/chai/chai.js';
 import {
   sharedTestSetup,
   sharedTestTeardown,
@@ -27,7 +28,7 @@ suite('Extensions', function () {
     this.extensionsCleanup_.push('extensions_test_before');
     this.extensionsCleanup_.push('extensions_test_after');
 
-    chai.assert.isUndefined(
+    assert.isUndefined(
       Blockly.Extensions.TEST_ONLY.allExtensions['extensions_test_before'],
     );
     const beforeCallback = sinon.spy();
@@ -42,18 +43,18 @@ suite('Extensions', function () {
       },
     ]);
 
-    chai.assert.isUndefined(
+    assert.isUndefined(
       Blockly.Extensions.TEST_ONLY.allExtensions['extensions_test_after'],
     );
     const afterCallback = sinon.spy();
     // Extension defined after the block type (but before instantiation).
     Blockly.Extensions.register('extensions_test_after', afterCallback);
 
-    chai.assert.typeOf(
+    assert.typeOf(
       Blockly.Extensions.TEST_ONLY.allExtensions['extensions_test_before'],
       'function',
     );
-    chai.assert.typeOf(
+    assert.typeOf(
       Blockly.Extensions.TEST_ONLY.allExtensions['extensions_test_after'],
       'function',
     );
@@ -98,27 +99,27 @@ suite('Extensions', function () {
     );
 
     // Tooltip is dynamic after extension initialization.
-    chai.assert.typeOf(block.tooltip, 'function');
-    chai.assert.equal(block.tooltip(), defaultTooltip);
+    assert.typeOf(block.tooltip, 'function');
+    assert.equal(block.tooltip(), defaultTooltip);
 
     // Tooltip is normal before connected to parent.
     const parent = new Blockly.Block(this.workspace, 'test_parent');
-    chai.assert.equal(parent.tooltip, parentTooltip);
-    chai.assert.notExists(parent.inputsInline);
+    assert.equal(parent.tooltip, parentTooltip);
+    assert.notExists(parent.inputsInline);
 
     // Tooltip is normal when parent is not inline.
     parent.getInput('INPUT').connection.connect(block.outputConnection);
-    chai.assert.equal(block.getParent(), parent);
-    chai.assert.equal(block.tooltip(), defaultTooltip);
+    assert.equal(block.getParent(), parent);
+    assert.equal(block.tooltip(), defaultTooltip);
 
     // Tooltip is parent's when parent is inline.
     parent.setInputsInline(true);
-    chai.assert.equal(block.tooltip(), parentTooltip);
+    assert.equal(block.tooltip(), parentTooltip);
 
     // Tooltip revert when disconnected.
     parent.getInput('INPUT').connection.disconnect();
-    chai.assert.notExists(block.getParent());
-    chai.assert.equal(block.tooltip(), defaultTooltip);
+    assert.notExists(block.getParent());
+    assert.equal(block.tooltip(), defaultTooltip);
   });
 
   suite('Mixin', function () {
@@ -132,13 +133,13 @@ suite('Extensions', function () {
         },
       };
 
-      chai.assert.isUndefined(
+      assert.isUndefined(
         Blockly.Extensions.TEST_ONLY.allExtensions['mixin_test'],
       );
       // Extension defined before the block type is defined.
       Blockly.Extensions.registerMixin('mixin_test', testMixin);
 
-      chai.assert.typeOf(
+      assert.typeOf(
         Blockly.Extensions.TEST_ONLY.allExtensions['mixin_test'],
         'function',
       );
@@ -153,8 +154,8 @@ suite('Extensions', function () {
 
       const block = new Blockly.Block(this.workspace, 'test_block_mixin');
 
-      chai.assert.equal(testMixin.field, block.field);
-      chai.assert.equal(testMixin.method, block.method);
+      assert.equal(testMixin.field, block.field);
+      assert.equal(testMixin.method, block.method);
     });
 
     suite('Mutator', function () {
@@ -190,10 +191,10 @@ suite('Extensions', function () {
         const block = new Blockly.Block(this.workspace, 'mutator_test_block');
 
         // Make sure all of the functions were installed correctly.
-        chai.assert.equal(block.domToMutation(), 'domToMutationFn');
-        chai.assert.equal(block.mutationToDom(), 'mutationToDomFn');
-        chai.assert.equal(block.compose(), 'composeFn');
-        chai.assert.equal(block.decompose(), 'decomposeFn');
+        assert.equal(block.domToMutation(), 'domToMutationFn');
+        assert.equal(block.mutationToDom(), 'mutationToDomFn');
+        assert.equal(block.compose(), 'composeFn');
+        assert.equal(block.decompose(), 'decomposeFn');
       });
 
       test('With helper function', function () {
@@ -210,7 +211,7 @@ suite('Extensions', function () {
         // Events code calls mutationToDom and expects it to give back a
         // meaningful value.
         Blockly.Events.disable();
-        chai.assert.isUndefined(
+        assert.isUndefined(
           Blockly.Extensions.TEST_ONLY.allExtensions['extensions_test'],
         );
         const helperFunctionSpy = sinon.spy();
@@ -246,7 +247,7 @@ suite('Extensions', function () {
         // Events code calls mutationToDom and expects it to give back a
         // meaningful value.
         Blockly.Events.disable();
-        chai.assert.isUndefined(
+        assert.isUndefined(
           Blockly.Extensions.TEST_ONLY.allExtensions['mutator_test'],
         );
         Blockly.Extensions.registerMutator('mutator_test', {
@@ -261,10 +262,10 @@ suite('Extensions', function () {
         const block = new Blockly.Block(this.workspace, 'mutator_test_block');
 
         // Make sure all of the functions were installed correctly.
-        chai.assert.equal(block.domToMutation(), 'domToMutationFn');
-        chai.assert.equal(block.mutationToDom(), 'mutationToDomFn');
-        chai.assert.isUndefined(block['compose']);
-        chai.assert.isUndefined(block['decompose']);
+        assert.equal(block.domToMutation(), 'domToMutationFn');
+        assert.equal(block.mutationToDom(), 'mutationToDomFn');
+        assert.isUndefined(block['compose']);
+        assert.isUndefined(block['decompose']);
       });
     });
   });
@@ -279,11 +280,11 @@ suite('Extensions', function () {
         },
       ]);
 
-      chai.assert.isUndefined(
+      assert.isUndefined(
         Blockly.Extensions.TEST_ONLY.allExtensions['missing_extension'],
       );
       const workspace = this.workspace;
-      chai.assert.throws(function () {
+      assert.throws(function () {
         const _ = new Blockly.Block(workspace, 'missing_extension_block');
       });
     });
@@ -295,7 +296,7 @@ suite('Extensions', function () {
         inputList: 'bad inputList', // Defined in constructor
       };
 
-      chai.assert.isUndefined(
+      assert.isUndefined(
         Blockly.Extensions.TEST_ONLY.allExtensions['mixin_bad_inputList'],
       );
       // Extension defined before the block type is defined.
@@ -303,7 +304,7 @@ suite('Extensions', function () {
         'mixin_bad_inputList',
         TEST_MIXIN_BAD_INPUTLIST,
       );
-      chai.assert.typeOf(
+      assert.typeOf(
         Blockly.Extensions.TEST_ONLY.allExtensions['mixin_bad_inputList'],
         'function',
       );
@@ -317,7 +318,7 @@ suite('Extensions', function () {
       ]);
 
       const workspace = this.workspace;
-      chai.assert.throws(function () {
+      assert.throws(function () {
         const _ = new Blockly.Block(workspace, 'test_block_bad_inputList');
       }, /inputList/);
     });
@@ -329,7 +330,7 @@ suite('Extensions', function () {
         colour_: 'bad colour_', // Defined on prototype
       };
 
-      chai.assert.isUndefined(
+      assert.isUndefined(
         Blockly.Extensions.TEST_ONLY.allExtensions['mixin_bad_colour_'],
       );
       // Extension defined before the block type is defined.
@@ -337,7 +338,7 @@ suite('Extensions', function () {
         'mixin_bad_colour_',
         TEST_MIXIN_BAD_COLOUR,
       );
-      chai.assert.typeOf(
+      assert.typeOf(
         Blockly.Extensions.TEST_ONLY.allExtensions['mixin_bad_colour_'],
         'function',
       );
@@ -351,7 +352,7 @@ suite('Extensions', function () {
       ]);
 
       const workspace = this.workspace;
-      chai.assert.throws(function () {
+      assert.throws(function () {
         const _ = new Blockly.Block(workspace, 'test_block_bad_colour');
       }, /colour_/);
     });
@@ -370,7 +371,7 @@ suite('Extensions', function () {
       // Events code calls mutationToDom and expects it to give back a
       // meaningful value.
       Blockly.Events.disable();
-      chai.assert.isUndefined(
+      assert.isUndefined(
         Blockly.Extensions.TEST_ONLY.allExtensions['mutator_test'],
       );
       Blockly.Extensions.registerMutator('mutator_test', {
@@ -383,11 +384,11 @@ suite('Extensions', function () {
       });
 
       const workspace = this.workspace;
-      chai.assert.throws(function () {
+      assert.throws(function () {
         const _ = new Blockly.Block(workspace, 'mutator_test_block');
       });
       // Should have failed on apply, not on register.
-      chai.assert.isNotNull(
+      assert.isNotNull(
         Blockly.Extensions.TEST_ONLY.allExtensions['mutator_test'],
       );
     });
@@ -406,7 +407,7 @@ suite('Extensions', function () {
       // Events code calls mutationToDom and expects it to give back a
       // meaningful value.
       Blockly.Events.disable();
-      chai.assert.isUndefined(
+      assert.isUndefined(
         Blockly.Extensions.TEST_ONLY.allExtensions['mutator_test'],
       );
       Blockly.Extensions.registerMixin('mutator_test', {
@@ -419,11 +420,11 @@ suite('Extensions', function () {
       });
 
       const workspace = this.workspace;
-      chai.assert.throws(function () {
+      assert.throws(function () {
         const _ = new Blockly.Block(workspace, 'mutator_test_block');
       });
       // Should have failed on apply, not on register.
-      chai.assert.isNotNull(
+      assert.isNotNull(
         Blockly.Extensions.TEST_ONLY.allExtensions['mutator_test'],
       );
     });
@@ -442,7 +443,7 @@ suite('Extensions', function () {
       // Events code calls mutationToDom and expects it to give back a
       // meaningful value.
       Blockly.Events.disable();
-      chai.assert.isUndefined(
+      assert.isUndefined(
         Blockly.Extensions.TEST_ONLY.allExtensions['extensions_test'],
       );
       Blockly.Extensions.register('extensions_test', function () {
@@ -450,11 +451,11 @@ suite('Extensions', function () {
       });
 
       const workspace = this.workspace;
-      chai.assert.throws(function () {
+      assert.throws(function () {
         const _ = new Blockly.Block(workspace, 'mutator_test_block');
       });
       // Should have failed on apply, not on register.
-      chai.assert.isNotNull(
+      assert.isNotNull(
         Blockly.Extensions.TEST_ONLY.allExtensions['extensions_test'],
       );
     });
@@ -462,30 +463,30 @@ suite('Extensions', function () {
     suite('register', function () {
       test('Just a string', function () {
         this.extensionsCleanup_.push('extension_just_a_string');
-        chai.assert.isUndefined(
+        assert.isUndefined(
           Blockly.Extensions.TEST_ONLY.allExtensions['extension_just_a_string'],
         );
-        chai.assert.throws(function () {
+        assert.throws(function () {
           Blockly.Extensions.register('extension_just_a_string', null);
         });
       });
 
       test('Null', function () {
         this.extensionsCleanup_.push('extension_is_null');
-        chai.assert.isUndefined(
+        assert.isUndefined(
           Blockly.Extensions.TEST_ONLY.allExtensions['extension_is_null'],
         );
-        chai.assert.throws(function () {
+        assert.throws(function () {
           Blockly.Extensions.register('extension_is_null', null);
         });
       });
 
       test('Undefined', function () {
         this.extensionsCleanup_.push('extension_is_undefined');
-        chai.assert.isUndefined(
+        assert.isUndefined(
           Blockly.Extensions.TEST_ONLY.allExtensions['extension_is_undefined'],
         );
-        chai.assert.throws(function () {
+        assert.throws(function () {
           Blockly.Extensions.register('extension_is_undefined', null);
         });
       });
@@ -494,7 +495,7 @@ suite('Extensions', function () {
     suite('registerMutator', function () {
       test('No domToMutation', function () {
         this.extensionsCleanup_.push('mutator_test');
-        chai.assert.throws(function () {
+        assert.throws(function () {
           Blockly.Extensions.registerMutator('mutator_test', {
             mutationToDom: function () {
               return 'mutationToDomFn';
@@ -511,7 +512,7 @@ suite('Extensions', function () {
 
       test('No mutationToDom', function () {
         this.extensionsCleanup_.push('mutator_test');
-        chai.assert.throws(function () {
+        assert.throws(function () {
           Blockly.Extensions.registerMutator('mutator_test', {
             domToMutation: function () {
               return 'domToMutationFn';
@@ -528,7 +529,7 @@ suite('Extensions', function () {
 
       test('No saveExtraState', function () {
         this.extensionsCleanup_.push('mutator_test');
-        chai.assert.throws(function () {
+        assert.throws(function () {
           Blockly.Extensions.registerMutator('mutator_test', {
             loadExtraState: function () {
               return 'loadExtraState';
@@ -545,7 +546,7 @@ suite('Extensions', function () {
 
       test('No loadExtraState', function () {
         this.extensionsCleanup_.push('mutator_test');
-        chai.assert.throws(function () {
+        assert.throws(function () {
           Blockly.Extensions.registerMutator('mutator_test', {
             saveExtraState: function () {
               return 'saveExtraState';
@@ -562,7 +563,7 @@ suite('Extensions', function () {
 
       test('No serialization hooks', function () {
         this.extensionsCleanup_.push('mutator_test');
-        chai.assert.throws(function () {
+        assert.throws(function () {
           Blockly.Extensions.registerMutator('mutator_test', {
             compose: function () {
               return 'composeFn';
@@ -576,7 +577,7 @@ suite('Extensions', function () {
 
       test('Has decompose but no compose', function () {
         this.extensionsCleanup_.push('mutator_test');
-        chai.assert.throws(function () {
+        assert.throws(function () {
           Blockly.Extensions.registerMutator('mutator_test', {
             domToMutation: function () {
               return 'domToMutationFn';
@@ -593,7 +594,7 @@ suite('Extensions', function () {
 
       test('Has compose but no decompose', function () {
         this.extensionsCleanup_.push('mutator_test');
-        chai.assert.throws(function () {
+        assert.throws(function () {
           Blockly.Extensions.registerMutator('mutator_test', {
             domToMutation: function () {
               return 'domToMutationFn';

--- a/tests/mocha/field_checkbox_test.js
+++ b/tests/mocha/field_checkbox_test.js
@@ -265,10 +265,7 @@ suite('Checkbox Fields', function () {
         });
         assertCharacter(field, '\u2661');
         field.setCheckCharacter(null);
-        assert(
-          field.textContent_.nodeValue,
-          Blockly.FieldCheckbox.CHECK_CHAR,
-        );
+        assert(field.textContent_.nodeValue, Blockly.FieldCheckbox.CHECK_CHAR);
       });
     });
   });

--- a/tests/mocha/field_checkbox_test.js
+++ b/tests/mocha/field_checkbox_test.js
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import {assert} from '../../node_modules/chai/chai.js';
 import * as Blockly from '../../build/src/core/blockly.js';
 import {
   assertFieldValue,
@@ -223,7 +224,7 @@ suite('Checkbox Fields', function () {
         };
         field.initView();
         field.render_();
-        chai.assert(field.textContent_.nodeValue, char);
+        assert(field.textContent_.nodeValue, char);
       }
       test('Constant', function () {
         const checkChar = Blockly.FieldCheckbox.CHECK_CHAR;
@@ -251,7 +252,7 @@ suite('Checkbox Fields', function () {
         assertCharacter(field, Blockly.FieldCheckbox.CHECK_CHAR);
         field.setCheckCharacter('\u2661');
         // Don't call assertCharacter b/c we don't want to re-initialize.
-        chai.assert.equal(field.textContent_.nodeValue, '\u2661');
+        assert.equal(field.textContent_.nodeValue, '\u2661');
       });
       test('setCheckCharacter Before Init', function () {
         const field = new Blockly.FieldCheckbox();
@@ -264,7 +265,7 @@ suite('Checkbox Fields', function () {
         });
         assertCharacter(field, '\u2661');
         field.setCheckCharacter(null);
-        chai.assert(
+        assert(
           field.textContent_.nodeValue,
           Blockly.FieldCheckbox.CHECK_CHAR,
         );
@@ -282,7 +283,7 @@ suite('Checkbox Fields', function () {
         const field = new Blockly.FieldCheckbox(value);
         block.getInput('INPUT').appendField(field, 'CHECK');
         const jso = Blockly.serialization.blocks.save(block);
-        chai.assert.deepEqual(jso['fields'], {'CHECK': value});
+        assert.deepEqual(jso['fields'], {'CHECK': value});
       };
     });
 

--- a/tests/mocha/field_colour_test.js
+++ b/tests/mocha/field_colour_test.js
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import {assert} from '../../node_modules/chai/chai.js';
 import * as Blockly from '../../build/src/core/blockly.js';
 import {
   assertFieldValue,
@@ -253,8 +254,8 @@ suite('Colour Fields', function () {
         let index = 0;
         let node = field.picker.firstChild.firstChild;
         while (node) {
-          chai.assert.equal(node.getAttribute('title'), titles[index]);
-          chai.assert.equal(
+          assert.equal(node.getAttribute('title'), titles[index]);
+          assert.equal(
             Blockly.utils.colour.parse(node.style.backgroundColor),
             colours[index],
           );
@@ -331,7 +332,7 @@ suite('Colour Fields', function () {
     suite('Columns', function () {
       function assertColumns(field, columns) {
         field.dropdownCreate();
-        chai.assert.equal(field.picker.firstChild.children.length, columns);
+        assert.equal(field.picker.firstChild.children.length, columns);
       }
       test('Constants', function () {
         const columns = Blockly.FieldColour.COLUMNS;
@@ -375,7 +376,7 @@ suite('Colour Fields', function () {
         const field = new Blockly.FieldColour(value);
         block.getInput('INPUT').appendField(field, 'COLOUR');
         const jso = Blockly.serialization.blocks.save(block);
-        chai.assert.deepEqual(jso['fields'], {'COLOUR': value});
+        assert.deepEqual(jso['fields'], {'COLOUR': value});
       };
     });
 

--- a/tests/mocha/field_dropdown_test.js
+++ b/tests/mocha/field_dropdown_test.js
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import {assert} from '../../node_modules/chai/chai.js';
 import * as Blockly from '../../build/src/core/blockly.js';
 import {
   assertFieldValue,
@@ -252,7 +253,7 @@ suite('Dropdown Fields', function () {
         field.setValue(value);
         block.getInput('INPUT').appendField(field, 'DROPDOWN');
         const jso = Blockly.serialization.blocks.save(block);
-        chai.assert.deepEqual(jso['fields'], {'DROPDOWN': value});
+        assert.deepEqual(jso['fields'], {'DROPDOWN': value});
       };
     });
 

--- a/tests/mocha/field_image_test.js
+++ b/tests/mocha/field_image_test.js
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import {assert} from '../../node_modules/chai/chai.js';
 import * as Blockly from '../../build/src/core/blockly.js';
 import {
   assertFieldValue,
@@ -134,23 +135,23 @@ suite('Image Fields', function () {
       });
       test('JS Constructor', function () {
         const field = new Blockly.FieldImage('src', 10, 10, null, this.onClick);
-        chai.assert.equal(field.clickHandler, this.onClick);
+        assert.equal(field.clickHandler, this.onClick);
       });
       test('setOnClickHandler', function () {
         const field = new Blockly.FieldImage('src', 10, 10);
         field.setOnClickHandler(this.onClick);
-        chai.assert.equal(field.clickHandler, this.onClick);
+        assert.equal(field.clickHandler, this.onClick);
       });
       test('Remove Click Handler', function () {
         const field = new Blockly.FieldImage('src', 10, 10, null, this.onClick);
         field.setOnClickHandler(null);
-        chai.assert.isNull(field.clickHandler);
+        assert.isNull(field.clickHandler);
       });
     });
     suite('Alt', function () {
       test('JS Constructor', function () {
         const field = new Blockly.FieldImage('src', 10, 10, 'alt');
-        chai.assert.equal(field.getText(), 'alt');
+        assert.equal(field.getText(), 'alt');
       });
       test('JSON Definition', function () {
         const field = Blockly.FieldImage.fromJson({
@@ -159,7 +160,7 @@ suite('Image Fields', function () {
           height: 10,
           alt: 'alt',
         });
-        chai.assert.equal(field.getText(), 'alt');
+        assert.equal(field.getText(), 'alt');
       });
       suite('SetAlt', function () {
         setup(function () {
@@ -182,31 +183,31 @@ suite('Image Fields', function () {
         const field = new Blockly.FieldImage('src', 10, 10, null, null, null, {
           alt: 'alt',
         });
-        chai.assert.equal(field.getText(), 'alt');
+        assert.equal(field.getText(), 'alt');
       });
       test('JS Configuration - Ignore', function () {
         const field = new Blockly.FieldImage('src', 10, 10, 'alt', null, null, {
           alt: 'configAlt',
         });
-        chai.assert.equal(field.getText(), 'configAlt');
+        assert.equal(field.getText(), 'configAlt');
       });
       test("JS Configuration - Ignore - ''", function () {
         const field = new Blockly.FieldImage('src', 10, 10, '', null, null, {
           alt: 'configAlt',
         });
-        chai.assert.equal(field.getText(), 'configAlt');
+        assert.equal(field.getText(), 'configAlt');
       });
       test("JS Configuration - Ignore - Config ''", function () {
         const field = new Blockly.FieldImage('src', 10, 10, 'alt', null, null, {
           alt: '',
         });
-        chai.assert.equal(field.getText(), '');
+        assert.equal(field.getText(), '');
       });
     });
     suite('Flip RTL', function () {
       test('JS Constructor', function () {
         const field = new Blockly.FieldImage('src', 10, 10, null, null, true);
-        chai.assert.isTrue(field.getFlipRtl());
+        assert.isTrue(field.getFlipRtl());
       });
       test('JSON Definition', function () {
         const field = Blockly.FieldImage.fromJson({
@@ -215,25 +216,25 @@ suite('Image Fields', function () {
           height: 10,
           flipRtl: true,
         });
-        chai.assert.isTrue(field.getFlipRtl());
+        assert.isTrue(field.getFlipRtl());
       });
       test('JS Configuration - Simple', function () {
         const field = new Blockly.FieldImage('src', 10, 10, null, null, null, {
           flipRtl: true,
         });
-        chai.assert.isTrue(field.getFlipRtl());
+        assert.isTrue(field.getFlipRtl());
       });
       test('JS Configuration - Ignore - True', function () {
         const field = new Blockly.FieldImage('src', 10, 10, null, null, true, {
           flipRtl: false,
         });
-        chai.assert.isFalse(field.getFlipRtl());
+        assert.isFalse(field.getFlipRtl());
       });
       test('JS Configuration - Ignore - False', function () {
         const field = new Blockly.FieldImage('src', 10, 10, null, null, false, {
           flipRtl: true,
         });
-        chai.assert.isTrue(field.getFlipRtl());
+        assert.isTrue(field.getFlipRtl());
       });
     });
   });

--- a/tests/mocha/field_label_serializable_test.js
+++ b/tests/mocha/field_label_serializable_test.js
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import {assert} from '../../node_modules/chai/chai.js';
 import * as Blockly from '../../build/src/core/blockly.js';
 import {
   assertFieldValue,
@@ -137,7 +138,7 @@ suite('Label Serializable Fields', function () {
         FIELD_TEXT_BASELINE_Y: 13,
       };
       labelField.initView();
-      chai.assert.isTrue(
+      assert.isTrue(
         Blockly.utils.dom.hasClass(labelField.textElement_, cssClass),
       );
     }
@@ -151,7 +152,7 @@ suite('Label Serializable Fields', function () {
         FIELD_TEXT_BASELINE_Y: 13,
       };
       labelField.initView();
-      chai.assert.isFalse(
+      assert.isFalse(
         Blockly.utils.dom.hasClass(labelField.textElement_, cssClass),
       );
     }
@@ -204,7 +205,7 @@ suite('Label Serializable Fields', function () {
         field.initView();
         field.setClass('testClass');
         // Don't call assertHasClass b/c we don't want to re-initialize.
-        chai.assert.isTrue(
+        assert.isTrue(
           Blockly.utils.dom.hasClass(field.textElement_, 'testClass'),
         );
       });
@@ -219,7 +220,7 @@ suite('Label Serializable Fields', function () {
         });
         assertHasClass(field, 'testClass');
         field.setClass(null);
-        chai.assert.isFalse(
+        assert.isFalse(
           Blockly.utils.dom.hasClass(field.textElement_, 'testClass'),
         );
       });
@@ -236,7 +237,7 @@ suite('Label Serializable Fields', function () {
         const field = new Blockly.FieldLabelSerializable(value);
         block.getInput('INPUT').appendField(field, 'LABEL');
         const jso = Blockly.serialization.blocks.save(block);
-        chai.assert.deepEqual(jso['fields'], {'LABEL': value});
+        assert.deepEqual(jso['fields'], {'LABEL': value});
       };
     });
 

--- a/tests/mocha/field_label_test.js
+++ b/tests/mocha/field_label_test.js
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import {assert} from '../../node_modules/chai/chai.js';
 import * as Blockly from '../../build/src/core/blockly.js';
 import {
   assertFieldValue,
@@ -133,7 +134,7 @@ suite('Label Fields', function () {
         FIELD_TEXT_BASELINE_Y: 13,
       };
       labelField.initView();
-      chai.assert.isTrue(
+      assert.isTrue(
         Blockly.utils.dom.hasClass(labelField.textElement_, cssClass),
       );
     }
@@ -147,7 +148,7 @@ suite('Label Fields', function () {
         FIELD_TEXT_BASELINE_Y: 13,
       };
       labelField.initView();
-      chai.assert.isFalse(
+      assert.isFalse(
         Blockly.utils.dom.hasClass(labelField.textElement_, cssClass),
       );
     }
@@ -201,7 +202,7 @@ suite('Label Fields', function () {
         field.initView();
         field.setClass('testClass');
         // Don't call assertHasClass b/c we don't want to re-initialize.
-        chai.assert.isTrue(
+        assert.isTrue(
           Blockly.utils.dom.hasClass(field.textElement_, 'testClass'),
         );
       });
@@ -216,7 +217,7 @@ suite('Label Fields', function () {
         });
         assertHasClass(field, 'testClass');
         field.setClass(null);
-        chai.assert.isFalse(
+        assert.isFalse(
           Blockly.utils.dom.hasClass(field.textElement_, 'testClass'),
         );
       });

--- a/tests/mocha/field_number_test.js
+++ b/tests/mocha/field_number_test.js
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import {assert} from '../../node_modules/chai/chai.js';
 import * as Blockly from '../../build/src/core/blockly.js';
 import {
   assertFieldValue,
@@ -87,9 +88,9 @@ suite('Number Fields', function () {
     expectedValue,
   ) {
     assertFieldValue(field, expectedValue);
-    chai.assert.equal(field.getMin(), expectedMin, 'Min');
-    chai.assert.equal(field.getMax(), expectedMax, 'Max');
-    chai.assert.equal(field.getPrecision(), expectedPrecision, 'Precision');
+    assert.equal(field.getMin(), expectedMin, 'Min');
+    assert.equal(field.getMax(), expectedMax, 'Max');
+    assert.equal(field.getPrecision(), expectedPrecision, 'Precision');
   }
   /**
    * Asserts that the field property values are set to default.
@@ -190,7 +191,7 @@ suite('Number Fields', function () {
         });
         test('Null', function () {
           const field = Blockly.FieldNumber.fromJson({precision: null});
-          chai.assert.equal(field.getPrecision(), 0);
+          assert.equal(field.getPrecision(), 0);
         });
       });
       const setValueBoundsTestFn = function (testCase) {
@@ -226,7 +227,7 @@ suite('Number Fields', function () {
         runTestCases(testCases, setValueBoundsTestFn);
         test('Null', function () {
           const field = Blockly.FieldNumber.fromJson({min: null});
-          chai.assert.equal(field.getMin(), -Infinity);
+          assert.equal(field.getMin(), -Infinity);
         });
       });
       suite('Max', function () {
@@ -253,7 +254,7 @@ suite('Number Fields', function () {
         runTestCases(testCases, setValueBoundsTestFn);
         test('Null', function () {
           const field = Blockly.FieldNumber.fromJson({max: null});
-          chai.assert.equal(field.getMax(), Infinity);
+          assert.equal(field.getMax(), Infinity);
         });
       });
     });
@@ -473,7 +474,7 @@ suite('Number Fields', function () {
         const field = new Blockly.FieldNumber(value);
         block.getInput('INPUT').appendField(field, 'NUMBER');
         const jso = Blockly.serialization.blocks.save(block);
-        chai.assert.deepEqual(jso['fields'], {'NUMBER': value});
+        assert.deepEqual(jso['fields'], {'NUMBER': value});
       };
     });
 

--- a/tests/mocha/field_registry_test.js
+++ b/tests/mocha/field_registry_test.js
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import {assert} from '../../node_modules/chai/chai.js';
 import * as Blockly from '../../build/src/core/blockly.js';
 import {createDeprecationWarningStub} from './test_helpers/warnings.js';
 import {
@@ -37,20 +38,20 @@ suite('Field Registry', function () {
       Blockly.fieldRegistry.register('field_custom_test', CustomFieldType);
     });
     test('fromJson as Key', function () {
-      chai.assert.throws(function () {
+      assert.throws(function () {
         Blockly.fieldRegistry.register(CustomFieldType.fromJson, '');
       }, 'Invalid name');
     });
     test('No fromJson', function () {
       class IncorrectField {}
-      chai.assert.throws(function () {
+      assert.throws(function () {
         Blockly.fieldRegistry.register('field_custom_test', IncorrectField);
       }, 'must have a fromJson function');
     });
     test('fromJson not a function', function () {
       const fromJson = CustomFieldType.fromJson;
       CustomFieldType.fromJson = true;
-      chai.assert.throws(function () {
+      assert.throws(function () {
         Blockly.fieldRegistry.register('field_custom_test', CustomFieldType);
       }, 'must have a fromJson function');
       CustomFieldType.fromJson = fromJson;
@@ -67,8 +68,8 @@ suite('Field Registry', function () {
 
       const field = Blockly.fieldRegistry.fromJson(json);
 
-      chai.assert.isNotNull(field);
-      chai.assert.equal(field.getValue(), 'ok');
+      assert.isNotNull(field);
+      assert.equal(field.getValue(), 'ok');
     });
     test('Not Registered', function () {
       const json = {
@@ -78,8 +79,8 @@ suite('Field Registry', function () {
 
       const spy = sinon.stub(console, 'warn');
       const field = Blockly.fieldRegistry.fromJson(json);
-      chai.assert.isNull(field);
-      chai.assert.isTrue(spy.called);
+      assert.isNull(field);
+      assert.isTrue(spy.called);
       spy.restore();
     });
     test('Case Different', function () {
@@ -92,8 +93,8 @@ suite('Field Registry', function () {
 
       const field = Blockly.fieldRegistry.fromJson(json);
 
-      chai.assert.isNotNull(field);
-      chai.assert.equal(field.getValue(), 'ok');
+      assert.isNotNull(field);
+      assert.equal(field.getValue(), 'ok');
     });
     test('Did not override fromJson', function () {
       // This class will have a fromJson method, so it can be registered
@@ -107,7 +108,7 @@ suite('Field Registry', function () {
         value: 'ok',
       };
 
-      chai.assert.throws(function () {
+      assert.throws(function () {
         Blockly.fieldRegistry.fromJson(json);
       }, 'Attempted to instantiate a field from the registry');
     });

--- a/tests/mocha/field_test.js
+++ b/tests/mocha/field_test.js
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import {assert} from '../../node_modules/chai/chai.js';
 import * as Blockly from '../../build/src/core/blockly.js';
 import {
   addBlockTypeToCleanup,
@@ -65,26 +66,26 @@ suite('Abstract Fields', function () {
       // An old default field should be serialized.
       const field = new FieldDefault();
       const stub = sinon.stub(console, 'warn');
-      chai.assert.isTrue(field.isSerializable());
+      assert.isTrue(field.isSerializable());
       sinon.assert.calledOnce(stub);
       stub.restore();
     });
     test('Editable False, Serializable Default(false)', function () {
       // An old non-editable field should not be serialized.
       const field = new FieldFalseDefault();
-      chai.assert.isFalse(field.isSerializable());
+      assert.isFalse(field.isSerializable());
     });
     /* Test Other Cases */
     test('Editable Default(true), Serializable True', function () {
       // A field that is both editable and serializable should be serialized.
       const field = new FieldDefaultTrue();
-      chai.assert.isTrue(field.isSerializable());
+      assert.isTrue(field.isSerializable());
     });
     test('Editable False, Serializable True', function () {
       // A field that is not editable, but overrides serializable to true
       // should be serialized (e.g. field_label_serializable)
       const field = new FieldFalseTrue();
-      chai.assert.isTrue(field.isSerializable());
+      assert.isTrue(field.isSerializable());
     });
   });
 
@@ -193,19 +194,19 @@ suite('Abstract Fields', function () {
         test('No implementations', function () {
           const field = new DefaultSerializationField('test value');
           const value = field.saveState();
-          chai.assert.equal(value, 'test value');
+          assert.equal(value, 'test value');
         });
 
         test('Xml implementations', function () {
           const field = new CustomXmlField('test value');
           const value = field.saveState();
-          chai.assert.equal(value, '<field name="">custom value</field>');
+          assert.equal(value, '<field name="">custom value</field>');
         });
 
         test('Xml super implementation', function () {
           const field = new CustomXmlCallSuperField('test value');
           const value = field.saveState();
-          chai.assert.equal(
+          assert.equal(
             value,
             '<field name="" attribute="custom value">test value</field>',
           );
@@ -214,13 +215,13 @@ suite('Abstract Fields', function () {
         test('JSO implementations', function () {
           const field = new CustomJsoField('test value');
           const value = field.saveState();
-          chai.assert.equal(value, 'custom value');
+          assert.equal(value, 'custom value');
         });
 
         test('JSO super implementations', function () {
           const field = new CustomJsoCallSuperField('test value');
           const value = field.saveState();
-          chai.assert.deepEqual(value, {
+          assert.deepEqual(value, {
             default: 'test value',
             val: 'custom value',
           });
@@ -229,7 +230,7 @@ suite('Abstract Fields', function () {
         test('Xml and JSO implementations', function () {
           const field = new CustomXmlAndJsoField('test value');
           const value = field.saveState();
-          chai.assert.equal(value, 'custom value');
+          assert.equal(value, 'custom value');
         });
       });
 
@@ -238,7 +239,7 @@ suite('Abstract Fields', function () {
           const field = new DefaultSerializationField('test value');
           const element = document.createElement('field');
           const value = Blockly.Xml.domToText(field.toXml(element));
-          chai.assert.equal(
+          assert.equal(
             value,
             '<field xmlns="http://www.w3.org/1999/xhtml">test value</field>',
           );
@@ -248,7 +249,7 @@ suite('Abstract Fields', function () {
           const field = new CustomXmlField('test value');
           const element = document.createElement('field');
           const value = Blockly.Xml.domToText(field.toXml(element));
-          chai.assert.equal(
+          assert.equal(
             value,
             '<field xmlns="http://www.w3.org/1999/xhtml">custom value</field>',
           );
@@ -258,7 +259,7 @@ suite('Abstract Fields', function () {
           const field = new CustomXmlCallSuperField('test value');
           const element = document.createElement('field');
           const value = Blockly.Xml.domToText(field.toXml(element));
-          chai.assert.equal(
+          assert.equal(
             value,
             '<field xmlns="http://www.w3.org/1999/xhtml" ' +
               'attribute="custom value">test value</field>',
@@ -269,7 +270,7 @@ suite('Abstract Fields', function () {
           const field = new CustomXmlAndJsoField('test value');
           const element = document.createElement('field');
           const value = Blockly.Xml.domToText(field.toXml(element));
-          chai.assert.equal(
+          assert.equal(
             value,
             '<field xmlns="http://www.w3.org/1999/xhtml">custom value</field>',
           );
@@ -282,13 +283,13 @@ suite('Abstract Fields', function () {
         test('No implementations', function () {
           const field = new DefaultSerializationField('');
           field.loadState('test value');
-          chai.assert.equal(field.getValue(), 'test value');
+          assert.equal(field.getValue(), 'test value');
         });
 
         test('Xml implementations', function () {
           const field = new CustomXmlField('');
           field.loadState('<field name="">custom value</field>');
-          chai.assert.equal(field.someProperty, 'custom value');
+          assert.equal(field.someProperty, 'custom value');
         });
 
         test('Xml super implementation', function () {
@@ -296,27 +297,27 @@ suite('Abstract Fields', function () {
           field.loadState(
             '<field attribute="custom value" name="">test value</field>',
           );
-          chai.assert.equal(field.getValue(), 'test value');
-          chai.assert.equal(field.someProperty, 'custom value');
+          assert.equal(field.getValue(), 'test value');
+          assert.equal(field.someProperty, 'custom value');
         });
 
         test('JSO implementations', function () {
           const field = new CustomJsoField('');
           field.loadState('custom value');
-          chai.assert.equal(field.someProperty, 'custom value');
+          assert.equal(field.someProperty, 'custom value');
         });
 
         test('JSO super implementations', function () {
           const field = new CustomJsoCallSuperField('');
           field.loadState({default: 'test value', val: 'custom value'});
-          chai.assert.equal(field.getValue(), 'test value');
-          chai.assert.equal(field.someProperty, 'custom value');
+          assert.equal(field.getValue(), 'test value');
+          assert.equal(field.someProperty, 'custom value');
         });
 
         test('Xml and JSO implementations', function () {
           const field = new CustomXmlAndJsoField('');
           field.loadState('custom value');
-          chai.assert.equal(field.someProperty, 'custom value');
+          assert.equal(field.someProperty, 'custom value');
         });
       });
 
@@ -326,7 +327,7 @@ suite('Abstract Fields', function () {
           field.fromXml(
             Blockly.utils.xml.textToDom('<field name="">test value</field>'),
           );
-          chai.assert.equal(field.getValue(), 'test value');
+          assert.equal(field.getValue(), 'test value');
         });
 
         test('Xml implementations', function () {
@@ -334,7 +335,7 @@ suite('Abstract Fields', function () {
           field.fromXml(
             Blockly.utils.xml.textToDom('<field name="">custom value</field>'),
           );
-          chai.assert.equal(field.someProperty, 'custom value');
+          assert.equal(field.someProperty, 'custom value');
         });
 
         test('Xml super implementation', function () {
@@ -344,8 +345,8 @@ suite('Abstract Fields', function () {
               '<field attribute="custom value" name="">test value</field>',
             ),
           );
-          chai.assert.equal(field.getValue(), 'test value');
-          chai.assert.equal(field.someProperty, 'custom value');
+          assert.equal(field.getValue(), 'test value');
+          assert.equal(field.someProperty, 'custom value');
         });
 
         test('XML andd JSO implementations', function () {
@@ -353,7 +354,7 @@ suite('Abstract Fields', function () {
           field.fromXml(
             Blockly.utils.xml.textToDom('<field name="">custom value</field>'),
           );
-          chai.assert.equal(field.someProperty, 'custom value');
+          assert.equal(field.someProperty, 'custom value');
         });
       });
     });
@@ -572,7 +573,7 @@ suite('Abstract Fields', function () {
       stubClassValidatorWithReturn(this.field, undefined);
       addSpies(this.field);
       this.field.setValue('value');
-      chai.assert.equal(this.field.getValue(), 'value');
+      assert.equal(this.field.getValue(), 'value');
       sinon.assert.notCalled(this.field.doValueInvalid_);
       sinon.assert.calledOnce(this.field.doValueUpdate_);
     });
@@ -603,7 +604,7 @@ suite('Abstract Fields', function () {
       setLocalValidatorWithReturn(this.field, undefined);
       addSpies(this.field);
       this.field.setValue('value');
-      chai.assert.equal(this.field.getValue(), 'value');
+      assert.equal(this.field.getValue(), 'value');
       sinon.assert.notCalled(this.field.doValueInvalid_);
       sinon.assert.calledOnce(this.field.doValueUpdate_);
     });
@@ -626,7 +627,7 @@ suite('Abstract Fields', function () {
         const field = new Blockly.Field('value', null, {
           tooltip: 'test tooltip',
         });
-        chai.assert.equal(field.tooltip_, 'test tooltip');
+        assert.equal(field.tooltip_, 'test tooltip');
       });
       test('JS Constructor - Dynamic', function () {
         const returnTooltip = function () {
@@ -635,13 +636,13 @@ suite('Abstract Fields', function () {
         const field = new Blockly.Field('value', null, {
           tooltip: returnTooltip,
         });
-        chai.assert.equal(field.tooltip_, returnTooltip);
+        assert.equal(field.tooltip_, returnTooltip);
       });
       test('JSON Definition', function () {
         const field = CustomField.fromJson({
           tooltip: 'test tooltip',
         });
-        chai.assert.equal(field.tooltip_, 'test tooltip');
+        assert.equal(field.tooltip_, 'test tooltip');
       });
       suite('W/ Msg References', function () {
         setup(function () {
@@ -652,13 +653,13 @@ suite('Abstract Fields', function () {
           const field = new Blockly.Field('value', null, {
             tooltip: '%{BKY_TOOLTIP}',
           });
-          chai.assert.equal(field.tooltip_, 'test tooltip');
+          assert.equal(field.tooltip_, 'test tooltip');
         });
         test('JSON Definition', function () {
           const field = CustomField.fromJson({
             tooltip: '%{BKY_TOOLTIP}',
           });
-          chai.assert.equal(field.tooltip_, 'test tooltip');
+          assert.equal(field.tooltip_, 'test tooltip');
         });
       });
       suite('setTooltip', function () {
@@ -687,7 +688,7 @@ suite('Abstract Fields', function () {
             this.workspace,
           );
           const field = block.getField('TOOLTIP');
-          chai.assert.equal(field.getClickTarget_().tooltip, 'tooltip');
+          assert.equal(field.getClickTarget_().tooltip, 'tooltip');
         });
         test('After Append', function () {
           addBlockTypeToCleanup(this.sharedCleanup, 'tooltip');
@@ -707,7 +708,7 @@ suite('Abstract Fields', function () {
             this.workspace,
           );
           const field = block.getField('TOOLTIP');
-          chai.assert.equal(field.getClickTarget_().tooltip, 'tooltip');
+          assert.equal(field.getClickTarget_().tooltip, 'tooltip');
         });
         test('After Block Creation', function () {
           addBlockTypeToCleanup(this.sharedCleanup, 'tooltip');
@@ -727,7 +728,7 @@ suite('Abstract Fields', function () {
           );
           const field = block.getField('TOOLTIP');
           field.setTooltip('tooltip');
-          chai.assert.equal(field.getClickTarget_().tooltip, 'tooltip');
+          assert.equal(field.getClickTarget_().tooltip, 'tooltip');
         });
         test('Dynamic Function', function () {
           addBlockTypeToCleanup(this.sharedCleanup, 'tooltip');
@@ -751,7 +752,7 @@ suite('Abstract Fields', function () {
             this.workspace,
           );
           const field = block.getField('TOOLTIP');
-          chai.assert.equal(field.getClickTarget_().tooltip, block.tooltipFunc);
+          assert.equal(field.getClickTarget_().tooltip, block.tooltipFunc);
         });
         test('Element', function () {
           addBlockTypeToCleanup(this.sharedCleanup, 'tooltip');
@@ -774,7 +775,7 @@ suite('Abstract Fields', function () {
             this.workspace,
           );
           const field = block.getField('TOOLTIP');
-          chai.assert.equal(field.getClickTarget_().tooltip, block.element);
+          assert.equal(field.getClickTarget_().tooltip, block.element);
         });
         test('Null', function () {
           addBlockTypeToCleanup(this.sharedCleanup, 'tooltip');
@@ -794,7 +795,7 @@ suite('Abstract Fields', function () {
             this.workspace,
           );
           const field = block.getField('TOOLTIP');
-          chai.assert.equal(field.getClickTarget_().tooltip, block);
+          assert.equal(field.getClickTarget_().tooltip, block);
         });
         test('Undefined', function () {
           addBlockTypeToCleanup(this.sharedCleanup, 'tooltip');
@@ -813,7 +814,7 @@ suite('Abstract Fields', function () {
             this.workspace,
           );
           const field = block.getField('TOOLTIP');
-          chai.assert.equal(field.getClickTarget_().tooltip, block);
+          assert.equal(field.getClickTarget_().tooltip, block);
         });
       });
     });

--- a/tests/mocha/field_textinput_test.js
+++ b/tests/mocha/field_textinput_test.js
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import {assert} from '../../node_modules/chai/chai.js';
 import * as Blockly from '../../build/src/core/blockly.js';
 import {
   assertFieldValue,
@@ -228,7 +229,7 @@ suite('Text Input Fields', function () {
         this.assertSpellcheck = function (field, value) {
           this.prepField(field);
           field.showEditor_();
-          chai.assert.equal(
+          assert.equal(
             field.htmlInput_.getAttribute('spellcheck'),
             value.toString(),
           );
@@ -266,7 +267,7 @@ suite('Text Input Fields', function () {
         this.prepField(field);
         field.showEditor_();
         field.setSpellcheck(false);
-        chai.assert.equal(field.htmlInput_.getAttribute('spellcheck'), 'false');
+        assert.equal(field.htmlInput_.getAttribute('spellcheck'), 'false');
       });
     });
   });
@@ -281,7 +282,7 @@ suite('Text Input Fields', function () {
         const field = new Blockly.FieldTextInput(value);
         block.getInput('INPUT').appendField(field, 'TEXT');
         const jso = Blockly.serialization.blocks.save(block);
-        chai.assert.deepEqual(jso['fields'], {'TEXT': value});
+        assert.deepEqual(jso['fields'], {'TEXT': value});
       };
     });
 

--- a/tests/mocha/field_variable_test.js
+++ b/tests/mocha/field_variable_test.js
@@ -204,15 +204,9 @@ suite('Variable Fields', function () {
       for (let i = 0, option; (option = expectedVarOptions[i]); i++) {
         assert.deepEqual(dropdownOptions[i], option);
       }
-      assert.include(
-        dropdownOptions[dropdownOptions.length - 2][0],
-        'Rename',
-      );
+      assert.include(dropdownOptions[dropdownOptions.length - 2][0], 'Rename');
 
-      assert.include(
-        dropdownOptions[dropdownOptions.length - 1][0],
-        'Delete',
-      );
+      assert.include(dropdownOptions[dropdownOptions.length - 1][0], 'Delete');
     };
     test('Contains variables created before field', function () {
       this.workspace.createVariable('name1', '', 'id1');

--- a/tests/mocha/field_variable_test.js
+++ b/tests/mocha/field_variable_test.js
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import {assert} from '../../node_modules/chai/chai.js';
 import * as Blockly from '../../build/src/core/blockly.js';
 import {
   assertFieldValue,
@@ -135,8 +136,8 @@ suite('Variable Fields', function () {
   suite('initModel', function () {
     test('No Value Before InitModel', function () {
       const fieldVariable = new Blockly.FieldVariable('name1');
-      chai.assert.equal(fieldVariable.getText(), '');
-      chai.assert.isNull(fieldVariable.getValue());
+      assert.equal(fieldVariable.getText(), '');
+      assert.isNull(fieldVariable.getValue());
     });
   });
 
@@ -199,16 +200,16 @@ suite('Variable Fields', function () {
       const dropdownOptions =
         Blockly.FieldVariable.dropdownCreate.call(fieldVariable);
       // Expect variable options, a rename option, and a delete option.
-      chai.assert.lengthOf(dropdownOptions, expectedVarOptions.length + 2);
+      assert.lengthOf(dropdownOptions, expectedVarOptions.length + 2);
       for (let i = 0, option; (option = expectedVarOptions[i]); i++) {
-        chai.assert.deepEqual(dropdownOptions[i], option);
+        assert.deepEqual(dropdownOptions[i], option);
       }
-      chai.assert.include(
+      assert.include(
         dropdownOptions[dropdownOptions.length - 2][0],
         'Rename',
       );
 
-      chai.assert.include(
+      assert.include(
         dropdownOptions[dropdownOptions.length - 1][0],
         'Delete',
       );
@@ -311,8 +312,8 @@ suite('Variable Fields', function () {
           ['Type1'],
           'Type1',
         );
-        chai.assert.deepEqual(field.variableTypes, ['Type1']);
-        chai.assert.equal(field.defaultType, 'Type1');
+        assert.deepEqual(field.variableTypes, ['Type1']);
+        assert.equal(field.defaultType, 'Type1');
       });
       test('JSON Definition', function () {
         const field = Blockly.FieldVariable.fromJson({
@@ -320,8 +321,8 @@ suite('Variable Fields', function () {
           variableTypes: ['Type1'],
           defaultType: 'Type1',
         });
-        chai.assert.deepEqual(field.variableTypes, ['Type1']);
-        chai.assert.equal(field.defaultType, 'Type1');
+        assert.deepEqual(field.variableTypes, ['Type1']);
+        assert.equal(field.defaultType, 'Type1');
       });
       test('JS Configuration - Simple', function () {
         const field = new Blockly.FieldVariable(
@@ -334,8 +335,8 @@ suite('Variable Fields', function () {
             defaultType: 'Type1',
           },
         );
-        chai.assert.deepEqual(field.variableTypes, ['Type1']);
-        chai.assert.equal(field.defaultType, 'Type1');
+        assert.deepEqual(field.variableTypes, ['Type1']);
+        assert.equal(field.defaultType, 'Type1');
       });
       test('JS Configuration - Ignore', function () {
         const field = new Blockly.FieldVariable(
@@ -348,8 +349,8 @@ suite('Variable Fields', function () {
             defaultType: 'Type1',
           },
         );
-        chai.assert.deepEqual(field.variableTypes, ['Type1']);
-        chai.assert.equal(field.defaultType, 'Type1');
+        assert.deepEqual(field.variableTypes, ['Type1']);
+        assert.equal(field.defaultType, 'Type1');
       });
     });
   });
@@ -363,7 +364,7 @@ suite('Variable Fields', function () {
       // will be returned (regardless of what types are available on the workspace).
       const fieldVariable = new Blockly.FieldVariable('name1');
       const resultTypes = fieldVariable.getVariableTypes();
-      chai.assert.deepEqual(resultTypes, ['']);
+      assert.deepEqual(resultTypes, ['']);
     });
     test('variableTypes is explicit', function () {
       // Expect that since variableTypes is defined, it will be the return
@@ -375,8 +376,8 @@ suite('Variable Fields', function () {
         'type1',
       );
       const resultTypes = fieldVariable.getVariableTypes();
-      chai.assert.deepEqual(resultTypes, ['type1', 'type2']);
-      chai.assert.equal(
+      assert.deepEqual(resultTypes, ['type1', 'type2']);
+      assert.equal(
         fieldVariable.defaultType,
         'type1',
         'Default type was wrong',
@@ -394,7 +395,7 @@ suite('Variable Fields', function () {
 
       const resultTypes = fieldVariable.getVariableTypes();
       // The empty string is always one of the options.
-      chai.assert.deepEqual(resultTypes, ['type1', 'type2', '']);
+      assert.deepEqual(resultTypes, ['type1', 'type2', '']);
     });
     test('variableTypes is the empty list', function () {
       const fieldVariable = new Blockly.FieldVariable('name1');
@@ -403,7 +404,7 @@ suite('Variable Fields', function () {
       fieldVariable.setSourceBlock(mockBlock);
       fieldVariable.variableTypes = [];
 
-      chai.assert.throws(function () {
+      assert.throws(function () {
         fieldVariable.getVariableTypes();
       });
     });
@@ -411,7 +412,7 @@ suite('Variable Fields', function () {
   suite('Default types', function () {
     test('Default type exists', function () {
       const fieldVariable = new Blockly.FieldVariable(null, null, ['b'], 'b');
-      chai.assert.equal(
+      assert.equal(
         fieldVariable.defaultType,
         'b',
         'The variable field\'s default type should be "b"',
@@ -419,25 +420,25 @@ suite('Variable Fields', function () {
     });
     test('No default type', function () {
       const fieldVariable = new Blockly.FieldVariable(null);
-      chai.assert.equal(
+      assert.equal(
         fieldVariable.defaultType,
         '',
         "The variable field's default type should be the empty string",
       );
-      chai.assert.isNull(
+      assert.isNull(
         fieldVariable.variableTypes,
         "The variable field's allowed types should be null",
       );
     });
     test('Default type mismatch', function () {
       // Invalid default type when creating a variable field.
-      chai.assert.throws(function () {
+      assert.throws(function () {
         new Blockly.FieldVariable(null, null, ['a'], 'b');
       });
     });
     test('Default type mismatch with empty array', function () {
       // Invalid default type when creating a variable field.
-      chai.assert.throws(function () {
+      assert.throws(function () {
         new Blockly.FieldVariable(null, null, ['a']);
       });
     });
@@ -466,14 +467,14 @@ suite('Variable Fields', function () {
     });
     test('Rename & Keep Old ID', function () {
       this.workspace.renameVariableById('id1', 'name2');
-      chai.assert.equal(this.variableField.getText(), 'name2');
-      chai.assert.equal(this.variableField.getValue(), 'id1');
+      assert.equal(this.variableField.getText(), 'name2');
+      assert.equal(this.variableField.getValue(), 'id1');
     });
     test('Rename & Get New ID', function () {
       this.workspace.createVariable('name2', null, 'id2');
       this.workspace.renameVariableById('id1', 'name2');
-      chai.assert.equal(this.variableField.getText(), 'name2');
-      chai.assert.equal(this.variableField.getValue(), 'id2');
+      assert.equal(this.variableField.getText(), 'name2');
+      assert.equal(this.variableField.getValue(), 'id2');
     });
   });
 
@@ -494,7 +495,7 @@ suite('Variable Fields', function () {
         const field = new Blockly.FieldVariable('x');
         block.getInput('INPUT').appendField(field, 'VAR');
         const jso = Blockly.serialization.blocks.save(block);
-        chai.assert.deepEqual(jso['fields'], {
+        assert.deepEqual(jso['fields'], {
           'VAR': {'id': 'id2', 'name': 'x', 'type': ''},
         });
       });
@@ -509,7 +510,7 @@ suite('Variable Fields', function () {
         );
         block.getInput('INPUT').appendField(field, 'VAR');
         const jso = Blockly.serialization.blocks.save(block);
-        chai.assert.deepEqual(jso['fields'], {
+        assert.deepEqual(jso['fields'], {
           'VAR': {'id': 'id2', 'name': 'x', 'type': 'String'},
         });
       });
@@ -523,9 +524,9 @@ suite('Variable Fields', function () {
         const jso = Blockly.serialization.blocks.save(block, {
           doFullSerialization: false,
         });
-        chai.assert.deepEqual(jso['fields'], {'VAR': {'id': 'id2'}});
-        chai.assert.isUndefined(jso['fields']['VAR']['name']);
-        chai.assert.isUndefined(jso['fields']['VAR']['type']);
+        assert.deepEqual(jso['fields'], {'VAR': {'id': 'id2'}});
+        assert.isUndefined(jso['fields']['VAR']['name']);
+        assert.isUndefined(jso['fields']['VAR']['type']);
       });
 
       test('Typed', function () {
@@ -540,9 +541,9 @@ suite('Variable Fields', function () {
         const jso = Blockly.serialization.blocks.save(block, {
           doFullSerialization: false,
         });
-        chai.assert.deepEqual(jso['fields'], {'VAR': {'id': 'id2'}});
-        chai.assert.isUndefined(jso['fields']['VAR']['name']);
-        chai.assert.isUndefined(jso['fields']['VAR']['type']);
+        assert.deepEqual(jso['fields'], {'VAR': {'id': 'id2'}});
+        assert.isUndefined(jso['fields']['VAR']['name']);
+        assert.isUndefined(jso['fields']['VAR']['type']);
       });
     });
   });
@@ -572,9 +573,9 @@ suite('Variable Fields', function () {
         this.workspace,
       );
       const variable = block.getField('VAR').getVariable();
-      chai.assert.equal(variable.name, 'test');
-      chai.assert.equal(variable.type, '');
-      chai.assert.equal(variable.getId(), 'id1');
+      assert.equal(variable.name, 'test');
+      assert.equal(variable.type, '');
+      assert.equal(variable.getId(), 'id1');
     });
 
     test('Name, untyped', function () {
@@ -590,9 +591,9 @@ suite('Variable Fields', function () {
         this.workspace,
       );
       const variable = block.getField('VAR').getVariable();
-      chai.assert.equal(variable.name, 'test');
-      chai.assert.equal(variable.type, '');
-      chai.assert.equal(variable.getId(), 'id2');
+      assert.equal(variable.name, 'test');
+      assert.equal(variable.type, '');
+      assert.equal(variable.getId(), 'id2');
     });
 
     test('Name, typed', function () {
@@ -609,9 +610,9 @@ suite('Variable Fields', function () {
         this.workspace,
       );
       const variable = block.getField('VAR').getVariable();
-      chai.assert.equal(variable.name, 'test');
-      chai.assert.equal(variable.type, 'string');
-      chai.assert.equal(variable.getId(), 'id2');
+      assert.equal(variable.name, 'test');
+      assert.equal(variable.type, 'string');
+      assert.equal(variable.getId(), 'id2');
     });
   });
 });

--- a/tests/mocha/flyout_test.js
+++ b/tests/mocha/flyout_test.js
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import {assert} from '../../node_modules/chai/chai.js';
 import {
   sharedTestSetup,
   sharedTestTeardown,
@@ -59,7 +60,7 @@ suite('Flyout', function () {
             this.flyout.targetWorkspace.getMetricsManager();
         });
         test('y is always 0', function () {
-          chai.assert.equal(
+          assert.equal(
             this.flyout.getY(),
             0,
             'y coordinate in vertical flyout should be 0',
@@ -72,7 +73,7 @@ suite('Flyout', function () {
           this.flyout.targetWorkspace.toolboxPosition =
             Blockly.utils.toolbox.Position.RIGHT;
           this.flyout.toolboxPosition_ = Blockly.utils.toolbox.Position.RIGHT;
-          chai.assert.equal(
+          assert.equal(
             this.flyout.getX(),
             100,
             'x should be right of workspace',
@@ -82,7 +83,7 @@ suite('Flyout', function () {
           this.flyout.targetWorkspace.toolboxPosition =
             Blockly.utils.toolbox.Position.LEFT;
           this.flyout.toolboxPosition_ = Blockly.utils.toolbox.Position.LEFT;
-          chai.assert.equal(
+          assert.equal(
             this.flyout.getX(),
             0,
             'x should be 0 if the flyout is on the left',
@@ -110,7 +111,7 @@ suite('Flyout', function () {
           this.flyout.targetWorkspace.toolboxPosition =
             Blockly.utils.toolbox.Position.LEFT;
           this.flyout.toolboxPosition_ = Blockly.utils.toolbox.Position.LEFT;
-          chai.assert.equal(
+          assert.equal(
             this.flyout.getX(),
             20,
             'x should be aligned with toolbox',
@@ -128,7 +129,7 @@ suite('Flyout', function () {
           this.flyout.targetWorkspace.toolboxPosition =
             Blockly.utils.toolbox.Position.RIGHT;
           this.flyout.toolboxPosition_ = Blockly.utils.toolbox.Position.RIGHT;
-          chai.assert.equal(
+          assert.equal(
             this.flyout.getX(),
             90,
             'x + width should be aligned with toolbox',
@@ -150,7 +151,7 @@ suite('Flyout', function () {
           this.flyout.targetWorkspace.toolboxPosition =
             Blockly.utils.toolbox.Position.RIGHT;
           this.flyout.toolboxPosition_ = Blockly.utils.toolbox.Position.LEFT;
-          chai.assert.equal(
+          assert.equal(
             this.flyout.getX(),
             0,
             'x should be aligned with left edge',
@@ -169,7 +170,7 @@ suite('Flyout', function () {
           this.flyout.targetWorkspace.toolboxPosition =
             Blockly.utils.toolbox.Position.LEFT;
           this.flyout.toolboxPosition_ = Blockly.utils.toolbox.Position.RIGHT;
-          chai.assert.equal(
+          assert.equal(
             this.flyout.getX(),
             90,
             'x + width should be aligned with right edge',
@@ -195,7 +196,7 @@ suite('Flyout', function () {
             this.flyout.targetWorkspace.getMetricsManager();
         });
         test('x is always 0', function () {
-          chai.assert.equal(
+          assert.equal(
             this.flyout.getX(),
             0,
             'x coordinate in horizontal flyout should be 0',
@@ -205,7 +206,7 @@ suite('Flyout', function () {
           this.flyout.targetWorkspace.toolboxPosition =
             Blockly.utils.toolbox.Position.TOP;
           this.flyout.toolboxPosition_ = Blockly.utils.toolbox.Position.TOP;
-          chai.assert.equal(
+          assert.equal(
             this.flyout.getY(),
             0,
             'y should be 0 if flyout is at the top',
@@ -218,7 +219,7 @@ suite('Flyout', function () {
           sinon.stub(this.targetMetricsManager, 'getViewMetrics').returns({
             height: 50,
           });
-          chai.assert.equal(
+          assert.equal(
             this.flyout.getY(),
             50,
             'y should be below the workspace',
@@ -247,7 +248,7 @@ suite('Flyout', function () {
           this.flyout.targetWorkspace.toolboxPosition =
             Blockly.utils.toolbox.Position.TOP;
           this.flyout.toolboxPosition_ = Blockly.utils.toolbox.Position.TOP;
-          chai.assert.equal(
+          assert.equal(
             this.flyout.getY(),
             20,
             'y should be aligned with toolbox',
@@ -265,7 +266,7 @@ suite('Flyout', function () {
           this.flyout.targetWorkspace.toolboxPosition =
             Blockly.utils.toolbox.Position.BOTTOM;
           this.flyout.toolboxPosition_ = Blockly.utils.toolbox.Position.BOTTOM;
-          chai.assert.equal(
+          assert.equal(
             this.flyout.getY(),
             70,
             'y + height should be aligned with toolbox',
@@ -284,7 +285,7 @@ suite('Flyout', function () {
           this.flyout.targetWorkspace.toolboxPosition =
             Blockly.utils.toolbox.Position.BOTTOM;
           this.flyout.toolboxPosition_ = Blockly.utils.toolbox.Position.TOP;
-          chai.assert.equal(
+          assert.equal(
             this.flyout.getY(),
             0,
             'y should be aligned with top',
@@ -302,7 +303,7 @@ suite('Flyout', function () {
           });
           this.flyout.setVisible(true);
           this.flyout.height_ = 20;
-          chai.assert.equal(
+          assert.equal(
             this.flyout.getY(),
             40,
             'y + height should be aligned with bottom',
@@ -324,26 +325,26 @@ suite('Flyout', function () {
       const gaps = flyoutInfo.gaps;
 
       const expectedGaps = [20, 24, 24];
-      chai.assert.deepEqual(gaps, expectedGaps);
+      assert.deepEqual(gaps, expectedGaps);
 
-      chai.assert.equal(contents.length, 3, 'Contents');
+      assert.equal(contents.length, 3, 'Contents');
 
-      chai.assert.equal(contents[0].type, 'block', 'Contents');
+      assert.equal(contents[0].type, 'block', 'Contents');
       const block = contents[0]['block'];
-      chai.assert.instanceOf(block, Blockly.BlockSvg);
-      chai.assert.equal(block.getFieldValue('OP'), 'NEQ');
+      assert.instanceOf(block, Blockly.BlockSvg);
+      assert.equal(block.getFieldValue('OP'), 'NEQ');
       const childA = block.getInputTargetBlock('A');
       const childB = block.getInputTargetBlock('B');
-      chai.assert.isTrue(childA.isShadow());
-      chai.assert.isFalse(childB.isShadow());
-      chai.assert.equal(childA.getFieldValue('NUM'), 1);
-      chai.assert.equal(childB.getFieldValue('NUM'), 2);
+      assert.isTrue(childA.isShadow());
+      assert.isFalse(childB.isShadow());
+      assert.equal(childA.getFieldValue('NUM'), 1);
+      assert.equal(childB.getFieldValue('NUM'), 2);
 
-      chai.assert.equal(contents[1].type, 'button', 'Contents');
-      chai.assert.instanceOf(contents[1]['button'], Blockly.FlyoutButton);
+      assert.equal(contents[1].type, 'button', 'Contents');
+      assert.instanceOf(contents[1]['button'], Blockly.FlyoutButton);
 
-      chai.assert.equal(contents[2].type, 'button', 'Contents');
-      chai.assert.instanceOf(contents[2]['button'], Blockly.FlyoutButton);
+      assert.equal(contents[2].type, 'button', 'Contents');
+      assert.instanceOf(contents[2]['button'], Blockly.FlyoutButton);
     }
 
     suite('Direct show', function () {
@@ -391,7 +392,7 @@ suite('Flyout', function () {
       });
 
       test('No category available', function () {
-        chai.assert.throws(
+        assert.throws(
           function () {
             this.flyout.show('someString');
           }.bind(this),
@@ -431,7 +432,7 @@ suite('Flyout', function () {
 
         this.assertDisabled = function (disabled) {
           const block = this.flyout.getWorkspace().getTopBlocks(false)[0];
-          chai.assert.equal(!block.isEnabled(), disabled);
+          assert.equal(!block.isEnabled(), disabled);
         };
       });
 
@@ -630,7 +631,7 @@ suite('Flyout', function () {
         ],
       });
       const block = this.flyout.workspace_.getAllBlocks()[0];
-      chai.assert.equal(block.getFieldValue('NUM'), 321);
+      assert.equal(block.getFieldValue('NUM'), 321);
     });
 
     test('Recycling enabled', function () {
@@ -660,7 +661,7 @@ suite('Flyout', function () {
         ],
       });
       const block = this.flyout.workspace_.getAllBlocks()[0];
-      chai.assert.equal(block.getFieldValue('NUM'), 123);
+      assert.equal(block.getFieldValue('NUM'), 123);
     });
   });
 });

--- a/tests/mocha/flyout_test.js
+++ b/tests/mocha/flyout_test.js
@@ -285,11 +285,7 @@ suite('Flyout', function () {
           this.flyout.targetWorkspace.toolboxPosition =
             Blockly.utils.toolbox.Position.BOTTOM;
           this.flyout.toolboxPosition_ = Blockly.utils.toolbox.Position.TOP;
-          assert.equal(
-            this.flyout.getY(),
-            0,
-            'y should be aligned with top',
-          );
+          assert.equal(this.flyout.getY(), 0, 'y should be aligned with top');
         });
         test('trashcan on bottom covers bottom of workspace', function () {
           this.flyout.targetWorkspace.toolboxPosition =

--- a/tests/mocha/generator_test.js
+++ b/tests/mocha/generator_test.js
@@ -40,10 +40,7 @@ suite('Generator', function () {
     });
 
     test('One line', function () {
-      assert.equal(
-        this.generator.prefixLines('Hello\n', '12'),
-        '12Hello\n',
-      );
+      assert.equal(this.generator.prefixLines('Hello\n', '12'), '12Hello\n');
     });
 
     test('Two lines', function () {

--- a/tests/mocha/generator_test.js
+++ b/tests/mocha/generator_test.js
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import {assert} from '../../node_modules/chai/chai.js';
 import * as Blockly from '../../build/src/core/blockly.js';
 import {DartGenerator} from '../../build/src/generators/dart/dart_generator.js';
 import {JavascriptGenerator} from '../../build/src/generators/javascript/javascript_generator.js';
@@ -31,22 +32,22 @@ suite('Generator', function () {
     });
 
     test('Nothing', function () {
-      chai.assert.equal(this.generator.prefixLines('', ''), '');
+      assert.equal(this.generator.prefixLines('', ''), '');
     });
 
     test('One word', function () {
-      chai.assert.equal(this.generator.prefixLines('Hello', '@'), '@Hello');
+      assert.equal(this.generator.prefixLines('Hello', '@'), '@Hello');
     });
 
     test('One line', function () {
-      chai.assert.equal(
+      assert.equal(
         this.generator.prefixLines('Hello\n', '12'),
         '12Hello\n',
       );
     });
 
     test('Two lines', function () {
-      chai.assert.equal(
+      assert.equal(
         this.generator.prefixLines('Hello\nWorld\n', '***'),
         '***Hello\n***World\n',
       );
@@ -97,7 +98,7 @@ suite('Generator', function () {
         const code = generator.blockToCode(rowBlock, opt_thisOnly);
         delete generator.forBlock['stack_block'];
         delete generator.forBlock['row_block'];
-        chai.assert.equal(code, expectedCode, opt_message);
+        assert.equal(code, expectedCode, opt_message);
       };
     });
 
@@ -187,7 +188,7 @@ suite('Generator', function () {
           blockA.nextConnection.connect(blockC.previousConnection);
 
           const code = generator.blockToCode(blockA, opt_thisOnly);
-          chai.assert.equal(code, expectedCode, opt_message);
+          assert.equal(code, expectedCode, opt_message);
         };
       });
 
@@ -214,7 +215,7 @@ suite('Generator', function () {
         this.generator = new TestGenerator();
       });
       test('No nameDB_ initialized', function () {
-        chai.assert.throws(() => {
+        assert.throws(() => {
           this.generator.getVariableName('foo');
         });
       });
@@ -222,13 +223,13 @@ suite('Generator', function () {
       test('Get variable name', function () {
         this.generator.init();
 
-        chai.assert.equal(this.generator.getVariableName('foo'), 'foo');
+        assert.equal(this.generator.getVariableName('foo'), 'foo');
       });
 
       test('Get procedure name', function () {
         this.generator.init();
 
-        chai.assert.equal(this.generator.getProcedureName('foo'), 'foo');
+        assert.equal(this.generator.getProcedureName('foo'), 'foo');
       });
     });
   });

--- a/tests/mocha/gesture_test.js
+++ b/tests/mocha/gesture_test.js
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import {assert} from '../../node_modules/chai/chai.js';
 import {assertEventFired, assertEventNotFired} from './test_helpers/events.js';
 import {defineBasicBlockWithField} from './test_helpers/block_definitions.js';
 import {dispatchPointerEvent} from './test_helpers/user_input.js';
@@ -17,7 +18,7 @@ suite('Gesture', function () {
   function testGestureIsFieldClick(block, isFieldClick, eventsFireStub) {
     const field = block.getField('NAME');
     const eventTarget = field.getClickTarget_();
-    chai.assert.exists(
+    assert.exists(
       eventTarget,
       'Precondition: missing click target for field',
     );
@@ -29,14 +30,14 @@ suite('Gesture', function () {
     // Gestures triggered on flyouts are stored on targetWorkspace.
     const gestureWorkspace = fieldWorkspace.targetWorkspace || fieldWorkspace;
     const gesture = gestureWorkspace.currentGesture_;
-    chai.assert.exists(gesture, 'Gesture exists after pointerdown.');
+    assert.exists(gesture, 'Gesture exists after pointerdown.');
     const isFieldClickSpy = sinon.spy(gesture, 'isFieldClick');
 
     dispatchPointerEvent(eventTarget, 'pointerup');
     dispatchPointerEvent(eventTarget, 'click');
 
     sinon.assert.called(isFieldClickSpy);
-    chai.assert.isTrue(isFieldClickSpy.alwaysReturned(isFieldClick));
+    assert.isTrue(isFieldClickSpy.alwaysReturned(isFieldClick));
 
     assertEventFired(
       eventsFireStub,
@@ -67,8 +68,8 @@ suite('Gesture', function () {
   test('Constructor', function () {
     const e = {id: 'dummy_test_event'};
     const gesture = new Blockly.Gesture(e, this.workspace);
-    chai.assert.equal(gesture.mostRecentEvent, e);
-    chai.assert.equal(gesture.creatorWorkspace, this.workspace);
+    assert.equal(gesture.mostRecentEvent, e);
+    assert.equal(gesture.creatorWorkspace, this.workspace);
   });
 
   test('Field click - Click in workspace', function () {
@@ -81,7 +82,7 @@ suite('Gesture', function () {
 
   test('Field click - Auto close flyout', function () {
     const flyout = this.workspace.getFlyout(true);
-    chai.assert.exists(flyout, 'Precondition: missing flyout');
+    assert.exists(flyout, 'Precondition: missing flyout');
     flyout.autoClose = true;
 
     const block = getTopFlyoutBlock(flyout);
@@ -90,7 +91,7 @@ suite('Gesture', function () {
 
   test('Field click - Always open flyout', function () {
     const flyout = this.workspace.getFlyout(true);
-    chai.assert.exists(flyout, 'Precondition: missing flyout');
+    assert.exists(flyout, 'Precondition: missing flyout');
     flyout.autoClose = false;
 
     const block = getTopFlyoutBlock(flyout);

--- a/tests/mocha/gesture_test.js
+++ b/tests/mocha/gesture_test.js
@@ -18,10 +18,7 @@ suite('Gesture', function () {
   function testGestureIsFieldClick(block, isFieldClick, eventsFireStub) {
     const field = block.getField('NAME');
     const eventTarget = field.getClickTarget_();
-    assert.exists(
-      eventTarget,
-      'Precondition: missing click target for field',
-    );
+    assert.exists(eventTarget, 'Precondition: missing click target for field');
 
     eventsFireStub.resetHistory();
     dispatchPointerEvent(eventTarget, 'pointerdown');

--- a/tests/mocha/icon_test.js
+++ b/tests/mocha/icon_test.js
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import {assert} from '../../node_modules/chai/chai.js';
 import {
   sharedTestSetup,
   sharedTestTeardown,
@@ -62,7 +63,7 @@ suite('Icon', function () {
 
         block.addIcon(icon);
 
-        chai.assert.isFalse(
+        assert.isFalse(
           initViewSpy.called,
           'Expected initView to not be called',
         );
@@ -79,7 +80,7 @@ suite('Icon', function () {
           const initViewSpy = sinon.spy(icon, 'initView');
 
           block.addIcon(icon);
-          chai.assert.isTrue(
+          assert.isTrue(
             initViewSpy.calledOnce,
             'Expected initView to be called',
           );
@@ -96,7 +97,7 @@ suite('Icon', function () {
 
         block.addIcon(icon);
 
-        chai.assert.isFalse(
+        assert.isFalse(
           applyColourSpy.called,
           'Expected applyColour to not be called',
         );
@@ -112,7 +113,7 @@ suite('Icon', function () {
           const applyColourSpy = sinon.spy(icon, 'applyColour');
 
           block.addIcon(icon);
-          chai.assert.isTrue(
+          assert.isTrue(
             applyColourSpy.calledOnce,
             'Expected applyColour to be called',
           );
@@ -128,7 +129,7 @@ suite('Icon', function () {
         block.addIcon(icon);
         applyColourSpy.resetHistory();
         block.setColour('#cccccc');
-        chai.assert.isTrue(
+        assert.isTrue(
           applyColourSpy.calledOnce,
           'Expected applyColour to be called',
         );
@@ -143,7 +144,7 @@ suite('Icon', function () {
         block.addIcon(icon);
         applyColourSpy.resetHistory();
         block.setStyle('logic_block');
-        chai.assert.isTrue(
+        assert.isTrue(
           applyColourSpy.calledOnce,
           'Expected applyColour to be called',
         );
@@ -158,7 +159,7 @@ suite('Icon', function () {
         block.addIcon(icon);
         applyColourSpy.resetHistory();
         block.setDisabledReason(true, 'test reason');
-        chai.assert.isTrue(
+        assert.isTrue(
           applyColourSpy.calledOnce,
           'Expected applyColour to be called',
         );
@@ -173,7 +174,7 @@ suite('Icon', function () {
         block.addIcon(icon);
         applyColourSpy.resetHistory();
         block.setShadow(true);
-        chai.assert.isTrue(
+        assert.isTrue(
           applyColourSpy.calledOnce,
           'Expected applyColour to be called',
         );
@@ -189,7 +190,7 @@ suite('Icon', function () {
 
         block.addIcon(icon);
 
-        chai.assert.isFalse(
+        assert.isFalse(
           updateEditableSpy.called,
           'Expected updateEditable to not be called',
         );
@@ -205,7 +206,7 @@ suite('Icon', function () {
           const updateEditableSpy = sinon.spy(icon, 'updateEditable');
 
           block.addIcon(icon);
-          chai.assert.isTrue(
+          assert.isTrue(
             updateEditableSpy.calledOnce,
             'Expected updateEditable to be called',
           );
@@ -221,7 +222,7 @@ suite('Icon', function () {
         block.addIcon(icon);
         updateEditableSpy.resetHistory();
         block.setEditable(false);
-        chai.assert.isTrue(
+        assert.isTrue(
           updateEditableSpy.calledOnce,
           'Expected updateEditable to be called',
         );
@@ -237,7 +238,7 @@ suite('Icon', function () {
         block.setEditable(false);
         updateEditableSpy.resetHistory();
         block.setEditable(true);
-        chai.assert.isTrue(
+        assert.isTrue(
           updateEditableSpy.calledOnce,
           'Expected updateEditable to be called',
         );
@@ -255,7 +256,7 @@ suite('Icon', function () {
         block.setCollapsed(true);
         block.setCollapsed(false);
 
-        chai.assert.isFalse(
+        assert.isFalse(
           updateCollapsedSpy.called,
           'Expected updateCollapsed to not be called',
         );
@@ -272,7 +273,7 @@ suite('Icon', function () {
         block.setCollapsed(true);
         this.clock.runAll();
 
-        chai.assert.isTrue(
+        assert.isTrue(
           updateCollapsedSpy.called,
           'Expected updateCollapsed to be called',
         );
@@ -289,7 +290,7 @@ suite('Icon', function () {
         block.setCollapsed(false);
         this.clock.runAll();
 
-        chai.assert.isTrue(
+        assert.isTrue(
           updateCollapsedSpy.called,
           'Expected updateCollapsed to be called',
         );
@@ -302,7 +303,7 @@ suite('Icon', function () {
       const block = createHeadlessBlock(createHeadlessWorkspace());
       block.addIcon(new MockSerializableIcon());
       const json = Blockly.serialization.blocks.save(block);
-      chai.assert.deepNestedInclude(
+      assert.deepNestedInclude(
         json,
         {'icons': {'serializable icon': 'some state'}},
         'Expected the JSON to include the saved state of the ' +
@@ -314,7 +315,7 @@ suite('Icon', function () {
       const block = createHeadlessBlock(createHeadlessWorkspace());
       block.addIcon(new MockNonSerializableIcon());
       const json = Blockly.serialization.blocks.save(block);
-      chai.assert.notProperty(
+      assert.notProperty(
         json,
         'icons',
         'Expected the JSON to not include any saved state for icons',
@@ -337,7 +338,7 @@ suite('Icon', function () {
         },
       };
       const block = Blockly.serialization.blocks.append(json, workspace);
-      chai.assert.equal(
+      assert.equal(
         block.getIcon('serializable icon').state,
         'some state',
         'Expected the icon to have been properly instantiated and ' +
@@ -355,7 +356,7 @@ suite('Icon', function () {
           'serializable icon': 'some state',
         },
       };
-      chai.assert.throws(
+      assert.throws(
         () => {
           Blockly.serialization.blocks.append(json, workspace);
         },

--- a/tests/mocha/index.html
+++ b/tests/mocha/index.html
@@ -21,7 +21,6 @@
     <!-- Load mocha et al. before Blockly and the test modules so that
          we can safely import the test modules that make calls
          to (e.g.)  suite() at the top level. -->
-    <script src="../../node_modules/chai/chai.js"></script>
     <script src="../../node_modules/mocha/mocha.js"></script>
     <script src="../../node_modules/sinon/pkg/sinon.js"></script>
     <script>

--- a/tests/mocha/input_test.js
+++ b/tests/mocha/input_test.js
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import {assert} from '../../node_modules/chai/chai.js';
 import {
   sharedTestSetup,
   sharedTestTeardown,
@@ -41,13 +42,13 @@ suite('Inputs', function () {
     suite('Index Bounds', function () {
       test('< 0', function () {
         const field = new Blockly.FieldLabel('field');
-        chai.assert.throws(function () {
+        assert.throws(function () {
           this.dummy.insertFieldAt(-1, field);
         });
       });
       test('> length', function () {
         const field = new Blockly.FieldLabel('field');
-        chai.assert.throws(function () {
+        assert.throws(function () {
           this.dummy.insertFieldAt(1, field);
         });
       });
@@ -57,37 +58,37 @@ suite('Inputs', function () {
       test('Field', function () {
         const field = new Blockly.FieldLabel('field');
         this.dummy.insertFieldAt(0, field);
-        chai.assert.equal(this.dummy.fieldRow[0], field);
+        assert.equal(this.dummy.fieldRow[0], field);
       });
       test('String', function () {
         this.dummy.insertFieldAt(0, 'field');
-        chai.assert.instanceOf(this.dummy.fieldRow[0], Blockly.FieldLabel);
+        assert.instanceOf(this.dummy.fieldRow[0], Blockly.FieldLabel);
       });
       test('String w/ field_label overwritten', function () {
         Blockly.fieldRegistry.unregister('field_label');
         Blockly.fieldRegistry.register('field_label', Blockly.FieldNumber);
 
         this.dummy.insertFieldAt(0, '1');
-        chai.assert.instanceOf(this.dummy.fieldRow[0], Blockly.FieldNumber);
+        assert.instanceOf(this.dummy.fieldRow[0], Blockly.FieldNumber);
 
         Blockly.fieldRegistry.unregister('field_label');
         Blockly.fieldRegistry.register('field_label', Blockly.FieldLabel);
       });
       test('Empty String', function () {
         this.dummy.insertFieldAt(0, '');
-        chai.assert.isEmpty(this.dummy.fieldRow);
+        assert.isEmpty(this.dummy.fieldRow);
       });
       test('Empty String W/ Name', function () {
         this.dummy.insertFieldAt(0, '', 'NAME');
-        chai.assert.instanceOf(this.dummy.fieldRow[0], Blockly.FieldLabel);
+        assert.instanceOf(this.dummy.fieldRow[0], Blockly.FieldLabel);
       });
       test('Null', function () {
         this.dummy.insertFieldAt(0, null);
-        chai.assert.isEmpty(this.dummy.fieldRow);
+        assert.isEmpty(this.dummy.fieldRow);
       });
       test('Undefined', function () {
         this.dummy.insertFieldAt(0, undefined);
-        chai.assert.isEmpty(this.dummy.fieldRow);
+        assert.isEmpty(this.dummy.fieldRow);
       });
     });
     suite('Prefixes and Suffixes', function () {
@@ -97,7 +98,7 @@ suite('Inputs', function () {
         field.prefixField = prefix;
 
         this.dummy.appendField(field);
-        chai.assert.deepEqual(this.dummy.fieldRow, [prefix, field]);
+        assert.deepEqual(this.dummy.fieldRow, [prefix, field]);
       });
       test('Suffix', function () {
         const field = new Blockly.FieldLabel('field');
@@ -105,7 +106,7 @@ suite('Inputs', function () {
         field.suffixField = suffix;
 
         this.dummy.appendField(field);
-        chai.assert.deepEqual(this.dummy.fieldRow, [field, suffix]);
+        assert.deepEqual(this.dummy.fieldRow, [field, suffix]);
       });
       test('Prefix and Suffix', function () {
         const field = new Blockly.FieldLabel('field');
@@ -115,7 +116,7 @@ suite('Inputs', function () {
         field.suffixField = suffix;
 
         this.dummy.appendField(field);
-        chai.assert.deepEqual(this.dummy.fieldRow, [prefix, field, suffix]);
+        assert.deepEqual(this.dummy.fieldRow, [prefix, field, suffix]);
       });
       test('Dropdown - Prefix', function () {
         const field = new Blockly.FieldDropdown([
@@ -124,7 +125,7 @@ suite('Inputs', function () {
         ]);
 
         this.dummy.appendField(field);
-        chai.assert.equal(this.dummy.fieldRow.length, 2);
+        assert.equal(this.dummy.fieldRow.length, 2);
       });
       test('Dropdown - Suffix', function () {
         const field = new Blockly.FieldDropdown([
@@ -133,7 +134,7 @@ suite('Inputs', function () {
         ]);
 
         this.dummy.appendField(field);
-        chai.assert.equal(this.dummy.fieldRow.length, 2);
+        assert.equal(this.dummy.fieldRow.length, 2);
       });
       test('Dropdown - Prefix and Suffix', function () {
         const field = new Blockly.FieldDropdown([
@@ -142,7 +143,7 @@ suite('Inputs', function () {
         ]);
 
         this.dummy.appendField(field);
-        chai.assert.equal(this.dummy.fieldRow.length, 3);
+        assert.equal(this.dummy.fieldRow.length, 3);
       });
     });
     suite('Field Initialization', function () {
@@ -153,7 +154,7 @@ suite('Inputs', function () {
 
         this.dummy.insertFieldAt(0, field);
         sinon.assert.calledOnce(setBlockSpy);
-        chai.assert.equal(setBlockSpy.getCall(0).args[0], this.block);
+        assert.equal(setBlockSpy.getCall(0).args[0], this.block);
         sinon.assert.calledOnce(initSpy);
         sinon.assert.calledOnce(this.renderStub);
 
@@ -171,7 +172,7 @@ suite('Inputs', function () {
 
         this.dummy.insertFieldAt(0, field);
         sinon.assert.calledOnce(setBlockSpy);
-        chai.assert.equal(setBlockSpy.getCall(0).args[0], this.block);
+        assert.equal(setBlockSpy.getCall(0).args[0], this.block);
         sinon.assert.calledOnce(initModelSpy);
         sinon.assert.notCalled(this.renderStub);
 
@@ -182,7 +183,7 @@ suite('Inputs', function () {
   });
   suite('Remove Field', function () {
     test('Field Not Found', function () {
-      chai.assert.throws(function () {
+      assert.throws(function () {
         this.dummy.removeField('FIELD');
       });
     });
@@ -222,28 +223,28 @@ suite('Inputs', function () {
       this.dummy.appendField(this.b, 'B');
       this.dummy.appendField(this.c, 'C');
 
-      chai.assert.deepEqual(this.dummy.fieldRow, [this.a, this.b, this.c]);
+      assert.deepEqual(this.dummy.fieldRow, [this.a, this.b, this.c]);
     });
     test('Append B, C; Insert A at Start', function () {
       this.dummy.appendField(this.b, 'B');
       this.dummy.appendField(this.c, 'C');
       this.dummy.insertFieldAt(0, this.a, 'A');
 
-      chai.assert.deepEqual(this.dummy.fieldRow, [this.a, this.b, this.c]);
+      assert.deepEqual(this.dummy.fieldRow, [this.a, this.b, this.c]);
     });
     test('Append A, C; Insert B Between', function () {
       this.dummy.appendField(this.a, 'A');
       this.dummy.appendField(this.c, 'C');
       this.dummy.insertFieldAt(1, this.b, 'B');
 
-      chai.assert.deepEqual(this.dummy.fieldRow, [this.a, this.b, this.c]);
+      assert.deepEqual(this.dummy.fieldRow, [this.a, this.b, this.c]);
     });
     test('Append A, B; Insert C at End', function () {
       this.dummy.appendField(this.a, 'A');
       this.dummy.appendField(this.b, 'B');
       this.dummy.insertFieldAt(2, this.c, 'C');
 
-      chai.assert.deepEqual(this.dummy.fieldRow, [this.a, this.b, this.c]);
+      assert.deepEqual(this.dummy.fieldRow, [this.a, this.b, this.c]);
     });
     test('Append A, B, C; Remove A, B, C', function () {
       this.dummy.appendField(this.a, 'A');
@@ -254,7 +255,7 @@ suite('Inputs', function () {
       this.dummy.removeField('B');
       this.dummy.removeField('C');
 
-      chai.assert.isEmpty(this.dummy.fieldRow);
+      assert.isEmpty(this.dummy.fieldRow);
     });
     test('Append A, B, C; Remove A', function () {
       this.dummy.appendField(this.a, 'A');
@@ -263,7 +264,7 @@ suite('Inputs', function () {
 
       this.dummy.removeField('A');
 
-      chai.assert.deepEqual(this.dummy.fieldRow, [this.b, this.c]);
+      assert.deepEqual(this.dummy.fieldRow, [this.b, this.c]);
     });
     test('Append A, B, C; Remove B', function () {
       this.dummy.appendField(this.a, 'A');
@@ -272,7 +273,7 @@ suite('Inputs', function () {
 
       this.dummy.removeField('B');
 
-      chai.assert.deepEqual(this.dummy.fieldRow, [this.a, this.c]);
+      assert.deepEqual(this.dummy.fieldRow, [this.a, this.c]);
     });
     test('Append A, B, C; Remove C', function () {
       this.dummy.appendField(this.a, 'A');
@@ -281,7 +282,7 @@ suite('Inputs', function () {
 
       this.dummy.removeField('C');
 
-      chai.assert.deepEqual(this.dummy.fieldRow, [this.a, this.b]);
+      assert.deepEqual(this.dummy.fieldRow, [this.a, this.b]);
     });
     test('Append A, B; Remove A; Append C', function () {
       this.dummy.appendField(this.a, 'A');
@@ -289,7 +290,7 @@ suite('Inputs', function () {
       this.dummy.removeField('A');
       this.dummy.appendField(this.c, 'C');
 
-      chai.assert.deepEqual(this.dummy.fieldRow, [this.b, this.c]);
+      assert.deepEqual(this.dummy.fieldRow, [this.b, this.c]);
     });
   });
 });

--- a/tests/mocha/insertion_marker_manager_test.js
+++ b/tests/mocha/insertion_marker_manager_test.js
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import {assert} from '../../node_modules/chai/chai.js';
 import {
   sharedTestSetup,
   sharedTestTeardown,
@@ -47,7 +48,7 @@ suite('Insertion marker manager', function () {
       };
       const manager = createBlocksAndManager(this.workspace, state);
       const markers = manager.getInsertionMarkers();
-      chai.assert.equal(markers.length, 1);
+      assert.equal(markers.length, 1);
     });
 
     test('Two stack blocks create two markers', function () {
@@ -69,7 +70,7 @@ suite('Insertion marker manager', function () {
       };
       const manager = createBlocksAndManager(this.workspace, state);
       const markers = manager.getInsertionMarkers();
-      chai.assert.equal(markers.length, 2);
+      assert.equal(markers.length, 2);
     });
 
     test('Three stack blocks create two markers', function () {
@@ -97,7 +98,7 @@ suite('Insertion marker manager', function () {
       };
       const manager = createBlocksAndManager(this.workspace, state);
       const markers = manager.getInsertionMarkers();
-      chai.assert.equal(markers.length, 2);
+      assert.equal(markers.length, 2);
     });
 
     test('One value block creates one marker', function () {
@@ -113,7 +114,7 @@ suite('Insertion marker manager', function () {
       };
       const manager = createBlocksAndManager(this.workspace, state);
       const markers = manager.getInsertionMarkers();
-      chai.assert.equal(markers.length, 1);
+      assert.equal(markers.length, 1);
     });
 
     test('Two value blocks create one marker', function () {
@@ -137,7 +138,7 @@ suite('Insertion marker manager', function () {
       };
       const manager = createBlocksAndManager(this.workspace, state);
       const markers = manager.getInsertionMarkers();
-      chai.assert.equal(markers.length, 1);
+      assert.equal(markers.length, 1);
     });
 
     test('One row to stack block creates one marker', function () {
@@ -153,7 +154,7 @@ suite('Insertion marker manager', function () {
       };
       const manager = createBlocksAndManager(this.workspace, state);
       const markers = manager.getInsertionMarkers();
-      chai.assert.equal(markers.length, 1);
+      assert.equal(markers.length, 1);
     });
 
     test('Row to stack block with child creates two markers', function () {
@@ -175,7 +176,7 @@ suite('Insertion marker manager', function () {
       };
       const manager = createBlocksAndManager(this.workspace, state);
       const markers = manager.getInsertionMarkers();
-      chai.assert.equal(markers.length, 2);
+      assert.equal(markers.length, 2);
     });
 
     suite('children being set as insertion markers', function () {
@@ -225,7 +226,7 @@ suite('Insertion marker manager', function () {
         };
         const manager = createBlocksAndManager(this.workspace, state);
         const markers = manager.getInsertionMarkers();
-        chai.assert.isTrue(
+        assert.isTrue(
           markers[0].getChildren()[0].isInsertionMarker(),
           'Expected the shadow block to be an insertion maker',
         );
@@ -244,7 +245,7 @@ suite('Insertion marker manager', function () {
         };
         const manager = createBlocksAndManager(this.workspace, state);
         const markers = manager.getInsertionMarkers();
-        chai.assert.isTrue(
+        assert.isTrue(
           markers[0].getChildren()[0].isInsertionMarker(),
           'Expected the shadow block to be an insertion maker',
         );
@@ -285,7 +286,7 @@ suite('Insertion marker manager', function () {
         id: 'fakeDragTarget',
       };
       this.manager.update(this.dxy, fakeDragTarget);
-      chai.assert.isTrue(this.manager.wouldDeleteBlock);
+      assert.isTrue(this.manager.wouldDeleteBlock);
     });
 
     test('Over delete area and rejected would not delete', function () {
@@ -300,7 +301,7 @@ suite('Insertion marker manager', function () {
         id: 'fakeDragTarget',
       };
       this.manager.update(this.dxy, fakeDragTarget);
-      chai.assert.isFalse(this.manager.wouldDeleteBlock);
+      assert.isFalse(this.manager.wouldDeleteBlock);
     });
 
     test('Drag target is not a delete area would not delete', function () {
@@ -315,12 +316,12 @@ suite('Insertion marker manager', function () {
         id: 'fakeDragTarget',
       };
       this.manager.update(this.dxy, fakeDragTarget);
-      chai.assert.isFalse(this.manager.wouldDeleteBlock);
+      assert.isFalse(this.manager.wouldDeleteBlock);
     });
 
     test('Not over drag target would not delete', function () {
       this.manager.update(this.dxy, null);
-      chai.assert.isFalse(this.manager.wouldDeleteBlock);
+      assert.isFalse(this.manager.wouldDeleteBlock);
     });
   });
 
@@ -352,35 +353,35 @@ suite('Insertion marker manager', function () {
 
     test('No other blocks nearby would not connect', function () {
       this.manager.update(new Blockly.utils.Coordinate(0, 0), null);
-      chai.assert.isFalse(this.manager.wouldConnectBlock());
+      assert.isFalse(this.manager.wouldConnectBlock());
     });
 
     test('Near other block and above would connect before', function () {
       this.manager.update(new Blockly.utils.Coordinate(200, 190), null);
-      chai.assert.isTrue(this.manager.wouldConnectBlock());
+      assert.isTrue(this.manager.wouldConnectBlock());
       const markers = this.manager.getInsertionMarkers();
-      chai.assert.equal(markers.length, 1);
+      assert.equal(markers.length, 1);
       const marker = markers[0];
-      chai.assert.isTrue(marker.nextConnection.isConnected());
+      assert.isTrue(marker.nextConnection.isConnected());
     });
 
     test('Near other block and below would connect after', function () {
       this.manager.update(new Blockly.utils.Coordinate(200, 210), null);
-      chai.assert.isTrue(this.manager.wouldConnectBlock());
+      assert.isTrue(this.manager.wouldConnectBlock());
       const markers = this.manager.getInsertionMarkers();
-      chai.assert.equal(markers.length, 1);
+      assert.equal(markers.length, 1);
       const marker = markers[0];
-      chai.assert.isTrue(marker.previousConnection.isConnected());
+      assert.isTrue(marker.previousConnection.isConnected());
     });
 
     test('Near other block and left would connect', function () {
       this.manager.update(new Blockly.utils.Coordinate(190, 200), null);
-      chai.assert.isTrue(this.manager.wouldConnectBlock());
+      assert.isTrue(this.manager.wouldConnectBlock());
     });
 
     test('Near other block and right would connect', function () {
       this.manager.update(new Blockly.utils.Coordinate(210, 200), null);
-      chai.assert.isTrue(this.manager.wouldConnectBlock());
+      assert.isTrue(this.manager.wouldConnectBlock());
     });
   });
 
@@ -412,31 +413,31 @@ suite('Insertion marker manager', function () {
 
     test('No other blocks nearby would not connect', function () {
       this.manager.update(new Blockly.utils.Coordinate(0, 0), null);
-      chai.assert.isFalse(this.manager.wouldConnectBlock());
+      assert.isFalse(this.manager.wouldConnectBlock());
     });
 
     test('Near other block and above would connect', function () {
       this.manager.update(new Blockly.utils.Coordinate(200, 190), null);
-      chai.assert.isTrue(this.manager.wouldConnectBlock());
+      assert.isTrue(this.manager.wouldConnectBlock());
     });
 
     test('Near other block and below would connect', function () {
       this.manager.update(new Blockly.utils.Coordinate(200, 210), null);
-      chai.assert.isTrue(this.manager.wouldConnectBlock());
+      assert.isTrue(this.manager.wouldConnectBlock());
     });
 
     test('Near other block and left would connect before', function () {
       this.manager.update(new Blockly.utils.Coordinate(190, 200), null);
-      chai.assert.isTrue(this.manager.wouldConnectBlock());
+      assert.isTrue(this.manager.wouldConnectBlock());
       const markers = this.manager.getInsertionMarkers();
-      chai.assert.isTrue(markers[0].getInput('INPUT').connection.isConnected());
+      assert.isTrue(markers[0].getInput('INPUT').connection.isConnected());
     });
 
     test('Near other block and right would connect after', function () {
       this.manager.update(new Blockly.utils.Coordinate(210, 200), null);
-      chai.assert.isTrue(this.manager.wouldConnectBlock());
+      assert.isTrue(this.manager.wouldConnectBlock());
       const markers = this.manager.getInsertionMarkers();
-      chai.assert.isTrue(markers[0].outputConnection.isConnected());
+      assert.isTrue(markers[0].outputConnection.isConnected());
     });
   });
 });

--- a/tests/mocha/insertion_marker_test.js
+++ b/tests/mocha/insertion_marker_test.js
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import {assert} from '../../node_modules/chai/chai.js';
 import {
   sharedTestSetup,
   sharedTestTeardown,
@@ -77,7 +78,7 @@ suite('InsertionMarkers', function () {
         const block = this.workspace.getBlockById('insertion');
         block.isInsertionMarker_ = true;
         const code = javascriptGenerator.workspaceToCode(this.workspace);
-        chai.assert.equal(code, expectedCode);
+        assert.equal(code, expectedCode);
       };
     });
     teardown(function () {
@@ -227,7 +228,7 @@ suite('InsertionMarkers', function () {
         let xml = Blockly.Xml.workspaceToDom(this.workspace);
         Blockly.Xml.domToWorkspace(xml, this.workspace);
         xml = Blockly.Xml.domToText(xml);
-        chai.assert.equal(xml, expectXml);
+        assert.equal(xml, expectXml);
       };
     });
     test('Marker Surrounds', function () {

--- a/tests/mocha/jso_deserialization_test.js
+++ b/tests/mocha/jso_deserialization_test.js
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import {assert} from '../../node_modules/chai/chai.js';
 import {
   sharedTestSetup,
   sharedTestTeardown,
@@ -39,10 +40,10 @@ suite('JSO Deserialization', function () {
           ],
         },
       };
-      chai.assert.throws(() => {
+      assert.throws(() => {
         Blockly.serialization.workspaces.load(state, this.workspace);
       });
-      chai.assert.isTrue(
+      assert.isTrue(
         Blockly.Events.isEnabled(),
         'Expected events to be enabled',
       );
@@ -121,7 +122,7 @@ suite('JSO Deserialization', function () {
         Blockly.serialization.workspaces.load(state, this.workspace);
         const calls = this.eventsFireStub.getCalls();
         const group = calls[0].args[0].group;
-        chai.assert.isTrue(calls.every((call) => call.args[0].group == group));
+        assert.isTrue(calls.every((call) => call.args[0].group == group));
       });
     });
 
@@ -217,7 +218,7 @@ suite('JSO Deserialization', function () {
         Blockly.serialization.workspaces.load(state, this.workspace);
         const calls = this.eventsFireStub.getCalls();
         const group = calls[0].args[0].group;
-        chai.assert.isTrue(calls.every((call) => call.args[0].group == group));
+        assert.isTrue(calls.every((call) => call.args[0].group == group));
       });
 
       test('Var with block', function () {
@@ -252,7 +253,7 @@ suite('JSO Deserialization', function () {
           }
           return acc;
         }, 0);
-        chai.assert.equal(count, 1);
+        assert.equal(count, 1);
         assertEventFired(
           this.eventsFireStub,
           Blockly.Events.VarCreate,
@@ -363,7 +364,7 @@ suite('JSO Deserialization', function () {
           Blockly.serialization.workspaces.load(state, this.workspace);
           const calls = this.eventsFireStub.getCalls();
           const group = calls[0].args[0].group;
-          chai.assert.isTrue(
+          assert.isTrue(
             calls.every((call) => call.args[0].group == group),
           );
         });
@@ -467,7 +468,7 @@ suite('JSO Deserialization', function () {
   suite('Exceptions', function () {
     setup(function () {
       this.assertThrows = function (state, error) {
-        chai.assert.throws(() => {
+        assert.throws(() => {
           Blockly.serialization.workspaces.load(state, this.workspace);
         }, error);
       };
@@ -748,7 +749,7 @@ suite('JSO Deserialization', function () {
     Blockly.serialization.registry.register('blocks', blocksSerializer);
     Blockly.serialization.registry.register('variables', variablesSerializer);
 
-    chai.assert.deepEqual(calls, [
+    assert.deepEqual(calls, [
       'third-clear',
       'second-clear',
       'first-clear',
@@ -786,7 +787,7 @@ suite('JSO Deserialization', function () {
 
       delete Blockly.Blocks['test_block'];
 
-      chai.assert.equal(block.someProperty, 'some value');
+      assert.equal(block.someProperty, 'some value');
     });
   });
 
@@ -816,7 +817,7 @@ suite('JSO Deserialization', function () {
 
       this.procedureSerializer.load(state, this.workspace);
 
-      chai.assert.isTrue(
+      assert.isTrue(
         spy.calledOnce,
         'Expected the loadState method to be called',
       );
@@ -841,7 +842,7 @@ suite('JSO Deserialization', function () {
 
       this.procedureSerializer.load(state, this.workspace);
 
-      chai.assert.isTrue(
+      assert.isTrue(
         spy.calledTwice,
         'Expected the loadState method to be called once for each parameter',
       );

--- a/tests/mocha/jso_deserialization_test.js
+++ b/tests/mocha/jso_deserialization_test.js
@@ -364,9 +364,7 @@ suite('JSO Deserialization', function () {
           Blockly.serialization.workspaces.load(state, this.workspace);
           const calls = this.eventsFireStub.getCalls();
           const group = calls[0].args[0].group;
-          assert.isTrue(
-            calls.every((call) => call.args[0].group == group),
-          );
+          assert.isTrue(calls.every((call) => call.args[0].group == group));
         });
 
         test('With children', function () {

--- a/tests/mocha/jso_serialization_test.js
+++ b/tests/mocha/jso_serialization_test.js
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import {assert} from '../../node_modules/chai/chai.js';
 import * as Blockly from '../../build/src/core/blockly.js';
 import {
   createGenUidStubWithReturns,
@@ -41,7 +42,7 @@ suite('JSO Serialization', function () {
   });
 
   function assertProperty(obj, property, value) {
-    chai.assert.deepEqual(obj[property], value);
+    assert.deepEqual(obj[property], value);
   }
 
   function assertNoProperty(obj, property) {
@@ -53,7 +54,7 @@ suite('JSO Serialization', function () {
       const block = this.workspace.newBlock('row_block');
       block.setInsertionMarker(true);
       const jso = Blockly.serialization.blocks.save(block);
-      chai.assert.isNull(jso);
+      assert.isNull(jso);
     });
 
     test('Basic', function () {
@@ -384,7 +385,7 @@ suite('JSO Serialization', function () {
     suite('Connected blocks', function () {
       setup(function () {
         this.assertInput = function (jso, name, value) {
-          chai.assert.deepInclude(jso['inputs'][name], value);
+          assert.deepInclude(jso['inputs'][name], value);
         };
 
         this.createBlockWithChild = function (blockType, inputName) {
@@ -467,7 +468,7 @@ suite('JSO Serialization', function () {
           const jso = Blockly.serialization.blocks.save(block, {
             addInputBlocks: false,
           });
-          chai.assert.isUndefined(jso['inputs']);
+          assert.isUndefined(jso['inputs']);
         };
 
         this.assertNoShadow = function (blockType, inputName) {
@@ -475,7 +476,7 @@ suite('JSO Serialization', function () {
           const jso = Blockly.serialization.blocks.save(block, {
             addInputBlocks: false,
           });
-          chai.assert.isUndefined(jso['inputs']);
+          assert.isUndefined(jso['inputs']);
         };
 
         this.assertNoOverwrittenShadow = function (blockType, inputName) {
@@ -486,7 +487,7 @@ suite('JSO Serialization', function () {
           const jso = Blockly.serialization.blocks.save(block, {
             addInputBlocks: false,
           });
-          chai.assert.isUndefined(jso['inputs']);
+          assert.isUndefined(jso['inputs']);
         };
       });
 
@@ -662,7 +663,7 @@ suite('JSO Serialization', function () {
           test('Child', function () {
             const block = this.createNextWithChild();
             const jso = Blockly.serialization.blocks.save(block);
-            chai.assert.deepInclude(jso['next'], {
+            assert.deepInclude(jso['next'], {
               'block': {'type': 'stack_block', 'id': 'id2'},
             });
           });
@@ -670,7 +671,7 @@ suite('JSO Serialization', function () {
           test('Shadow', function () {
             const block = this.createNextWithShadow();
             const jso = Blockly.serialization.blocks.save(block);
-            chai.assert.deepInclude(jso['next'], {
+            assert.deepInclude(jso['next'], {
               'shadow': {'type': 'stack_block', 'id': 'test'},
             });
           });
@@ -678,7 +679,7 @@ suite('JSO Serialization', function () {
           test('Overwritten shadow', function () {
             const block = this.createNextWithShadowAndChild();
             const jso = Blockly.serialization.blocks.save(block);
-            chai.assert.deepInclude(jso['next'], {
+            assert.deepInclude(jso['next'], {
               'block': {
                 'type': 'stack_block',
                 'id': 'id2',
@@ -699,7 +700,7 @@ suite('JSO Serialization', function () {
               .getInput('NAME')
               .connection.connect(grandChildBlock.previousConnection);
             const jso = Blockly.serialization.blocks.save(block);
-            chai.assert.deepInclude(jso['next'], {
+            assert.deepInclude(jso['next'], {
               'block': {
                 'type': 'statement_block',
                 'id': 'id2',
@@ -722,7 +723,7 @@ suite('JSO Serialization', function () {
             const jso = Blockly.serialization.blocks.save(block, {
               addNextBlocks: false,
             });
-            chai.assert.isUndefined(jso['next']);
+            assert.isUndefined(jso['next']);
           });
 
           test('Shadow', function () {
@@ -730,7 +731,7 @@ suite('JSO Serialization', function () {
             const jso = Blockly.serialization.blocks.save(block, {
               addNextBlocks: false,
             });
-            chai.assert.isUndefined(jso['next']);
+            assert.isUndefined(jso['next']);
           });
 
           test('Overwritten shadow', function () {
@@ -738,7 +739,7 @@ suite('JSO Serialization', function () {
             const jso = Blockly.serialization.blocks.save(block, {
               addNextBlocks: false,
             });
-            chai.assert.isUndefined(jso['next']);
+            assert.isUndefined(jso['next']);
           });
         });
       });
@@ -749,7 +750,7 @@ suite('JSO Serialization', function () {
         test('Single block', function () {
           const block = this.workspace.newBlock('variables_get');
           const jso = Blockly.serialization.blocks.save(block);
-          chai.assert.deepEqual(jso['fields']['VAR'], {
+          assert.deepEqual(jso['fields']['VAR'], {
             'id': 'id2',
             'name': 'item',
             'type': '',
@@ -763,7 +764,7 @@ suite('JSO Serialization', function () {
             .getInput('INPUT')
             .connection.connect(childBlock.outputConnection);
           const jso = Blockly.serialization.blocks.save(block);
-          chai.assert.deepEqual(
+          assert.deepEqual(
             jso['inputs']['INPUT']['block']['fields']['VAR'],
             {'id': 'id4', 'name': 'item', 'type': ''},
           );
@@ -774,7 +775,7 @@ suite('JSO Serialization', function () {
           const childBlock = this.workspace.newBlock('variables_set');
           block.nextConnection.connect(childBlock.previousConnection);
           const jso = Blockly.serialization.blocks.save(block);
-          chai.assert.deepEqual(jso['next']['block']['fields']['VAR'], {
+          assert.deepEqual(jso['next']['block']['fields']['VAR'], {
             'id': 'id4',
             'name': 'item',
             'type': '',
@@ -788,9 +789,9 @@ suite('JSO Serialization', function () {
           const jso = Blockly.serialization.blocks.save(block, {
             doFullSerialization: false,
           });
-          chai.assert.deepEqual(jso['fields']['VAR'], {'id': 'id2'});
-          chai.assert.isUndefined(jso['fields']['VAR']['name']);
-          chai.assert.isUndefined(jso['fields']['VAR']['type']);
+          assert.deepEqual(jso['fields']['VAR'], {'id': 'id2'});
+          assert.isUndefined(jso['fields']['VAR']['name']);
+          assert.isUndefined(jso['fields']['VAR']['type']);
         });
 
         test('Input block', function () {
@@ -802,14 +803,14 @@ suite('JSO Serialization', function () {
           const jso = Blockly.serialization.blocks.save(block, {
             doFullSerialization: false,
           });
-          chai.assert.deepEqual(
+          assert.deepEqual(
             jso['inputs']['INPUT']['block']['fields']['VAR'],
             {'id': 'id4'},
           );
-          chai.assert.isUndefined(
+          assert.isUndefined(
             jso['inputs']['INPUT']['block']['fields']['VAR']['name'],
           );
-          chai.assert.isUndefined(
+          assert.isUndefined(
             jso['inputs']['INPUT']['block']['fields']['VAR']['type'],
           );
         });
@@ -821,13 +822,13 @@ suite('JSO Serialization', function () {
           const jso = Blockly.serialization.blocks.save(block, {
             doFullSerialization: false,
           });
-          chai.assert.deepEqual(jso['next']['block']['fields']['VAR'], {
+          assert.deepEqual(jso['next']['block']['fields']['VAR'], {
             'id': 'id4',
           });
-          chai.assert.isUndefined(
+          assert.isUndefined(
             jso['next']['block']['fields']['VAR']['name'],
           );
-          chai.assert.isUndefined(
+          assert.isUndefined(
             jso['next']['block']['fields']['VAR']['type'],
           );
         });
@@ -877,7 +878,7 @@ suite('JSO Serialization', function () {
 
       this.serializer.save(this.workspace);
 
-      chai.assert.isTrue(
+      assert.isTrue(
         spy.calledOnce,
         'Expected the saveState method to be called on the procedure model',
       );
@@ -895,11 +896,11 @@ suite('JSO Serialization', function () {
 
       this.serializer.save(this.workspace);
 
-      chai.assert.isTrue(
+      assert.isTrue(
         spy1.calledOnce,
         'Expected the saveState method to be called on the first parameter model',
       );
-      chai.assert.isTrue(
+      assert.isTrue(
         spy2.calledOnce,
         'Expected the saveState method to be called on the first parameter model',
       );

--- a/tests/mocha/jso_serialization_test.js
+++ b/tests/mocha/jso_serialization_test.js
@@ -764,10 +764,11 @@ suite('JSO Serialization', function () {
             .getInput('INPUT')
             .connection.connect(childBlock.outputConnection);
           const jso = Blockly.serialization.blocks.save(block);
-          assert.deepEqual(
-            jso['inputs']['INPUT']['block']['fields']['VAR'],
-            {'id': 'id4', 'name': 'item', 'type': ''},
-          );
+          assert.deepEqual(jso['inputs']['INPUT']['block']['fields']['VAR'], {
+            'id': 'id4',
+            'name': 'item',
+            'type': '',
+          });
         });
 
         test('Next block', function () {
@@ -803,10 +804,9 @@ suite('JSO Serialization', function () {
           const jso = Blockly.serialization.blocks.save(block, {
             doFullSerialization: false,
           });
-          assert.deepEqual(
-            jso['inputs']['INPUT']['block']['fields']['VAR'],
-            {'id': 'id4'},
-          );
+          assert.deepEqual(jso['inputs']['INPUT']['block']['fields']['VAR'], {
+            'id': 'id4',
+          });
           assert.isUndefined(
             jso['inputs']['INPUT']['block']['fields']['VAR']['name'],
           );
@@ -825,12 +825,8 @@ suite('JSO Serialization', function () {
           assert.deepEqual(jso['next']['block']['fields']['VAR'], {
             'id': 'id4',
           });
-          assert.isUndefined(
-            jso['next']['block']['fields']['VAR']['name'],
-          );
-          assert.isUndefined(
-            jso['next']['block']['fields']['VAR']['type'],
-          );
+          assert.isUndefined(jso['next']['block']['fields']['VAR']['name']);
+          assert.isUndefined(jso['next']['block']['fields']['VAR']['type']);
         });
       });
     });

--- a/tests/mocha/json_test.js
+++ b/tests/mocha/json_test.js
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import {assert} from '../../node_modules/chai/chai.js';
 import {
   addMessageToCleanup,
   sharedTestSetup,
@@ -35,16 +36,16 @@ suite('JSON Block Definitions', function () {
         block = new Blockly.Block(this.workspace_, BLOCK_TYPE);
       });
 
-      chai.assert.isNotNull(block);
-      chai.assert.equal(BLOCK_TYPE, block.type);
+      assert.isNotNull(block);
+      assert.equal(BLOCK_TYPE, block.type);
     });
 
     test('Null or undefined type id', function () {
       const BLOCK_TYPE1 = 'test_json_before_bad_blocks';
       const BLOCK_TYPE2 = 'test_json_after_bad_blocks';
 
-      chai.assert.isUndefined(Blockly.Blocks[BLOCK_TYPE1]);
-      chai.assert.isUndefined(Blockly.Blocks[BLOCK_TYPE2]);
+      assert.isUndefined(Blockly.Blocks[BLOCK_TYPE1]);
+      assert.isUndefined(Blockly.Blocks[BLOCK_TYPE2]);
       const blockTypeCount = Object.keys(Blockly.Blocks).length;
 
       assertWarnings(() => {
@@ -55,23 +56,23 @@ suite('JSON Block Definitions', function () {
           {'type': BLOCK_TYPE2},
         ]);
       }, [/missing a type attribute/, /missing a type attribute/]);
-      chai.assert.isNotNull(
+      assert.isNotNull(
         Blockly.Blocks[BLOCK_TYPE1],
         'Block before bad blocks should be defined.',
       );
-      chai.assert.isNotNull(
+      assert.isNotNull(
         Blockly.Blocks[BLOCK_TYPE2],
         'Block after bad blocks should be defined.',
       );
-      chai.assert.equal(Object.keys(Blockly.Blocks).length, blockTypeCount + 2);
+      assert.equal(Object.keys(Blockly.Blocks).length, blockTypeCount + 2);
     });
 
     test('Null item', function () {
       const BLOCK_TYPE1 = 'test_block_before_null';
       const BLOCK_TYPE2 = 'test_block_after_null';
 
-      chai.assert.isUndefined(Blockly.Blocks[BLOCK_TYPE1]);
-      chai.assert.isUndefined(Blockly.Blocks[BLOCK_TYPE2]);
+      assert.isUndefined(Blockly.Blocks[BLOCK_TYPE1]);
+      assert.isUndefined(Blockly.Blocks[BLOCK_TYPE2]);
       const blockTypeCount = Object.keys(Blockly.Blocks).length;
 
       assertWarnings(() => {
@@ -87,23 +88,23 @@ suite('JSON Block Definitions', function () {
           },
         ]);
       }, /is null/);
-      chai.assert.isNotNull(
+      assert.isNotNull(
         Blockly.Blocks[BLOCK_TYPE1],
         'Block before null in array should be defined.',
       );
-      chai.assert.isNotNull(
+      assert.isNotNull(
         Blockly.Blocks[BLOCK_TYPE2],
         'Block after null in array should be defined.',
       );
-      chai.assert.equal(Object.keys(Blockly.Blocks).length, blockTypeCount + 2);
+      assert.equal(Object.keys(Blockly.Blocks).length, blockTypeCount + 2);
     });
 
     test('Undefined item', function () {
       const BLOCK_TYPE1 = 'test_block_before_undefined';
       const BLOCK_TYPE2 = 'test_block_after_undefined';
 
-      chai.assert.isUndefined(Blockly.Blocks[BLOCK_TYPE1]);
-      chai.assert.isUndefined(Blockly.Blocks[BLOCK_TYPE2]);
+      assert.isUndefined(Blockly.Blocks[BLOCK_TYPE1]);
+      assert.isUndefined(Blockly.Blocks[BLOCK_TYPE2]);
       const blockTypeCount = Object.keys(Blockly.Blocks).length;
       assertWarnings(() => {
         Blockly.defineBlocksWithJsonArray([
@@ -118,15 +119,15 @@ suite('JSON Block Definitions', function () {
           },
         ]);
       }, /is undefined/);
-      chai.assert.isNotNull(
+      assert.isNotNull(
         Blockly.Blocks[BLOCK_TYPE1],
         'Block before undefined in array should be defined.',
       );
-      chai.assert.isNotNull(
+      assert.isNotNull(
         Blockly.Blocks[BLOCK_TYPE2],
         'Block after undefined in array should be defined.',
       );
-      chai.assert.equal(Object.keys(Blockly.Blocks).length, blockTypeCount + 2);
+      assert.equal(Object.keys(Blockly.Blocks).length, blockTypeCount + 2);
     });
 
     test('message0 creates input', function () {
@@ -140,11 +141,11 @@ suite('JSON Block Definitions', function () {
       ]);
 
       const block = new Blockly.Block(this.workspace_, BLOCK_TYPE);
-      chai.assert.equal(block.inputList.length, 1);
-      chai.assert.equal(block.inputList[0].fieldRow.length, 1);
+      assert.equal(block.inputList.length, 1);
+      assert.equal(block.inputList[0].fieldRow.length, 1);
       const textField = block.inputList[0].fieldRow[0];
-      chai.assert.equal(Blockly.FieldLabel, textField.constructor);
-      chai.assert.equal(MESSAGE0, textField.getText());
+      assert.equal(Blockly.FieldLabel, textField.constructor);
+      assert.equal(MESSAGE0, textField.getText());
     });
 
     test('message1 and message0 creates two inputs', function () {
@@ -161,17 +162,17 @@ suite('JSON Block Definitions', function () {
       ]);
 
       const block = new Blockly.Block(this.workspace_, BLOCK_TYPE);
-      chai.assert.equal(block.inputList.length, 2);
+      assert.equal(block.inputList.length, 2);
 
-      chai.assert.equal(block.inputList[0].fieldRow.length, 1);
+      assert.equal(block.inputList[0].fieldRow.length, 1);
       const firstTextField = block.inputList[0].fieldRow[0];
-      chai.assert.equal(Blockly.FieldLabel, firstTextField.constructor);
-      chai.assert.equal(MESSAGE0, firstTextField.getText());
+      assert.equal(Blockly.FieldLabel, firstTextField.constructor);
+      assert.equal(MESSAGE0, firstTextField.getText());
 
-      chai.assert.equal(block.inputList[1].fieldRow.length, 1);
+      assert.equal(block.inputList[1].fieldRow.length, 1);
       const secondTextField = block.inputList[1].fieldRow[0];
-      chai.assert.equal(Blockly.FieldLabel, secondTextField.constructor);
-      chai.assert.equal(MESSAGE1, secondTextField.getText());
+      assert.equal(Blockly.FieldLabel, secondTextField.constructor);
+      assert.equal(MESSAGE1, secondTextField.getText());
     });
 
     test('Message string is dereferenced', function () {
@@ -189,11 +190,11 @@ suite('JSON Block Definitions', function () {
       ]);
 
       const block = new Blockly.Block(this.workspace_, BLOCK_TYPE);
-      chai.assert.equal(block.inputList.length, 1);
-      chai.assert.equal(block.inputList[0].fieldRow.length, 1);
+      assert.equal(block.inputList.length, 1);
+      assert.equal(block.inputList[0].fieldRow.length, 1);
       const textField = block.inputList[0].fieldRow[0];
-      chai.assert.equal(Blockly.FieldLabel, textField.constructor);
-      chai.assert.equal(MESSAGE, textField.getText());
+      assert.equal(Blockly.FieldLabel, textField.constructor);
+      assert.equal(MESSAGE, textField.getText());
     });
 
     test('Dropdown', function () {
@@ -221,18 +222,18 @@ suite('JSON Block Definitions', function () {
       ]);
 
       const block = new Blockly.Block(this.workspace_, BLOCK_TYPE);
-      chai.assert.equal(block.inputList.length, 1);
-      chai.assert.equal(block.inputList[0].fieldRow.length, 1);
+      assert.equal(block.inputList.length, 1);
+      assert.equal(block.inputList[0].fieldRow.length, 1);
       const dropdown = block.inputList[0].fieldRow[0];
-      chai.assert.equal(dropdown, block.getField(FIELD_NAME));
-      chai.assert.equal(Blockly.FieldDropdown, dropdown.constructor);
-      chai.assert.equal(VALUE0, dropdown.getValue());
+      assert.equal(dropdown, block.getField(FIELD_NAME));
+      assert.equal(Blockly.FieldDropdown, dropdown.constructor);
+      assert.equal(VALUE0, dropdown.getValue());
 
       const options = dropdown.getOptions();
-      chai.assert.equal(LABEL0, options[0][0]);
-      chai.assert.equal(VALUE0, options[0][1]);
-      chai.assert.equal(LABEL1, options[1][0]);
-      chai.assert.equal(VALUE1, options[1][1]);
+      assert.equal(LABEL0, options[0][0]);
+      assert.equal(VALUE0, options[0][1]);
+      assert.equal(LABEL1, options[1][0]);
+      assert.equal(VALUE1, options[1][1]);
     });
 
     test('Dropdown with images', function () {
@@ -281,34 +282,34 @@ suite('JSON Block Definitions', function () {
       ]);
 
       const block = new Blockly.Block(this.workspace_, BLOCK_TYPE);
-      chai.assert.equal(block.inputList.length, 1);
-      chai.assert.equal(block.inputList[0].fieldRow.length, 1);
+      assert.equal(block.inputList.length, 1);
+      assert.equal(block.inputList[0].fieldRow.length, 1);
       const dropdown = block.inputList[0].fieldRow[0];
-      chai.assert.equal(dropdown, block.getField(FIELD_NAME));
-      chai.assert.equal(Blockly.FieldDropdown, dropdown.constructor);
-      chai.assert.equal(VALUE0, dropdown.getValue());
+      assert.equal(dropdown, block.getField(FIELD_NAME));
+      assert.equal(Blockly.FieldDropdown, dropdown.constructor);
+      assert.equal(VALUE0, dropdown.getValue());
 
       function assertImageEquals(actualImage, expectedImage) {
-        chai.assert.equal(actualImage.width, expectedImage.width);
-        chai.assert.equal(actualImage.height, expectedImage.height);
-        chai.assert.equal(actualImage.src, expectedImage.src);
+        assert.equal(actualImage.width, expectedImage.width);
+        assert.equal(actualImage.height, expectedImage.height);
+        assert.equal(actualImage.src, expectedImage.src);
       }
 
       const options = dropdown.getOptions();
       const image0 = options[0][0];
       assertImageEquals(IMAGE0, image0);
-      chai.assert.equal(IMAGE0.alt, image0.alt);
-      chai.assert.equal(options[0][1], VALUE0);
+      assert.equal(IMAGE0.alt, image0.alt);
+      assert.equal(options[0][1], VALUE0);
 
       const image1 = options[1][0];
       assertImageEquals(IMAGE1, image1);
-      chai.assert.equal(image1.alt, IMAGE1_ALT_TEXT); // Via Msg reference
-      chai.assert.equal(VALUE1, options[1][1]);
+      assert.equal(image1.alt, IMAGE1_ALT_TEXT); // Via Msg reference
+      assert.equal(VALUE1, options[1][1]);
 
       const image2 = options[2][0];
       assertImageEquals(IMAGE1, image1);
-      chai.assert.notExists(image2.alt); // No alt specified.
-      chai.assert.equal(VALUE2, options[2][1]);
+      assert.notExists(image2.alt); // No alt specified.
+      assert.equal(VALUE2, options[2][1]);
     });
   });
 });

--- a/tests/mocha/layering_test.js
+++ b/tests/mocha/layering_test.js
@@ -3,6 +3,7 @@
  * Copyright 2023 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
+import {assert} from '../../node_modules/chai/chai.js';
 import {
   sharedTestSetup,
   sharedTestTeardown,
@@ -35,7 +36,7 @@ suite('Layering', function () {
       const layerCount = this.layerManager.layers.size;
       this.layerManager.append(elem2, 999);
 
-      chai.assert.equal(
+      assert.equal(
         this.layerManager.layers.size,
         layerCount,
         'Expected the element to be appended to the existing layer',
@@ -54,7 +55,7 @@ suite('Layering', function () {
 
       const layer1000 = this.layerManager.layers.get(1000);
       const layer1010 = this.layerManager.layers.get(1010);
-      chai.assert.equal(
+      assert.equal(
         layer1000.nextSibling,
         layer1010,
         'Expected layer 1000 to be direclty before layer 1010',
@@ -70,7 +71,7 @@ suite('Layering', function () {
 
       const layer1010 = this.layerManager.layers.get(1010);
       const layer1000 = this.layerManager.layers.get(1000);
-      chai.assert.equal(
+      assert.equal(
         layer1000.nextSibling,
         layer1010,
         'Expected layer 1000 to be direclty before layer 1010',
@@ -84,7 +85,7 @@ suite('Layering', function () {
 
       this.layerManager.moveToDragLayer(elem);
 
-      chai.assert.equal(
+      assert.equal(
         this.layerManager.dragLayer.firstChild,
         elem.getSvgRoot(),
         'Expected the element to be the first element in the drag layer.',

--- a/tests/mocha/metrics_test.js
+++ b/tests/mocha/metrics_test.js
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import {assert} from '../../node_modules/chai/chai.js';
 import {
   sharedTestSetup,
   sharedTestTeardown,
@@ -13,10 +14,10 @@ suite('Metrics', function () {
   const SCROLL_X = 10;
   const SCROLL_Y = 10;
   function assertDimensionsMatch(toCheck, left, top, width, height) {
-    chai.assert.equal(top, toCheck.top, 'Top did not match.');
-    chai.assert.equal(left, toCheck.left, 'Left did not match.');
-    chai.assert.equal(width, toCheck.width, 'Width did not match.');
-    chai.assert.equal(height, toCheck.height, 'Height did not match.');
+    assert.equal(top, toCheck.top, 'Top did not match.');
+    assert.equal(left, toCheck.left, 'Left did not match.');
+    assert.equal(width, toCheck.width, 'Width did not match.');
+    assert.equal(height, toCheck.height, 'Height did not match.');
   }
 
   // Make a mock workspace object with two properties:

--- a/tests/mocha/mutator_test.js
+++ b/tests/mocha/mutator_test.js
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import {assert} from '../../node_modules/chai/chai.js';
 import {
   sharedTestSetup,
   sharedTestTeardown,
@@ -51,7 +52,7 @@ suite('Mutator', function () {
       mutatorWorkspace
         .getBlockById('check_block')
         .setFieldValue('TRUE', 'CHECK');
-      chai.assert.isTrue(
+      assert.isTrue(
         this.eventsFireStub
           .getCalls()
           .some(

--- a/tests/mocha/names_test.js
+++ b/tests/mocha/names_test.js
@@ -27,57 +27,21 @@ suite('Names', function () {
       'my_9lives',
       'SafeName number start.',
     );
-    assert.equal(
-      varDB.safeName('lives9'),
-      'lives9',
-      'SafeName number end.',
-    );
-    assert.equal(
-      varDB.safeName('!@#$'),
-      '____',
-      'SafeName special chars.',
-    );
+    assert.equal(varDB.safeName('lives9'), 'lives9', 'SafeName number end.');
+    assert.equal(varDB.safeName('!@#$'), '____', 'SafeName special chars.');
     assert.equal(varDB.safeName('door'), 'door', 'SafeName reserved.');
   });
 
   test('Get name', function () {
     const varDB = new Blockly.Names('window,door');
-    assert.equal(
-      varDB.getName('Foo.bar', 'var'),
-      'Foo_bar',
-      'Name add #1.',
-    );
-    assert.equal(
-      varDB.getName('Foo.bar', 'var'),
-      'Foo_bar',
-      'Name get #1.',
-    );
-    assert.equal(
-      varDB.getName('Foo bar', 'var'),
-      'Foo_bar2',
-      'Name add #2.',
-    );
-    assert.equal(
-      varDB.getName('foo BAR', 'var'),
-      'Foo_bar2',
-      'Name get #2.',
-    );
+    assert.equal(varDB.getName('Foo.bar', 'var'), 'Foo_bar', 'Name add #1.');
+    assert.equal(varDB.getName('Foo.bar', 'var'), 'Foo_bar', 'Name get #1.');
+    assert.equal(varDB.getName('Foo bar', 'var'), 'Foo_bar2', 'Name add #2.');
+    assert.equal(varDB.getName('foo BAR', 'var'), 'Foo_bar2', 'Name get #2.');
     assert.equal(varDB.getName('door', 'var'), 'door2', 'Name add #3.');
-    assert.equal(
-      varDB.getName('Foo.bar', 'proc'),
-      'Foo_bar3',
-      'Name add #4.',
-    );
-    assert.equal(
-      varDB.getName('Foo.bar', 'var'),
-      'Foo_bar',
-      'Name get #1b.',
-    );
-    assert.equal(
-      varDB.getName('Foo.bar', 'proc'),
-      'Foo_bar3',
-      'Name get #4.',
-    );
+    assert.equal(varDB.getName('Foo.bar', 'proc'), 'Foo_bar3', 'Name add #4.');
+    assert.equal(varDB.getName('Foo.bar', 'var'), 'Foo_bar', 'Name get #1b.');
+    assert.equal(varDB.getName('Foo.bar', 'proc'), 'Foo_bar3', 'Name get #4.');
 
     assert.equal(
       String(varDB.getUserNames('var')),

--- a/tests/mocha/names_test.js
+++ b/tests/mocha/names_test.js
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import {assert} from '../../node_modules/chai/chai.js';
 import {
   sharedTestSetup,
   sharedTestTeardown,
@@ -19,71 +20,71 @@ suite('Names', function () {
 
   test('Safe name', function () {
     const varDB = new Blockly.Names('window,door');
-    chai.assert.equal(varDB.safeName(''), 'unnamed', 'SafeName empty.');
-    chai.assert.equal(varDB.safeName('foobar'), 'foobar', 'SafeName ok.');
-    chai.assert.equal(
+    assert.equal(varDB.safeName(''), 'unnamed', 'SafeName empty.');
+    assert.equal(varDB.safeName('foobar'), 'foobar', 'SafeName ok.');
+    assert.equal(
       varDB.safeName('9lives'),
       'my_9lives',
       'SafeName number start.',
     );
-    chai.assert.equal(
+    assert.equal(
       varDB.safeName('lives9'),
       'lives9',
       'SafeName number end.',
     );
-    chai.assert.equal(
+    assert.equal(
       varDB.safeName('!@#$'),
       '____',
       'SafeName special chars.',
     );
-    chai.assert.equal(varDB.safeName('door'), 'door', 'SafeName reserved.');
+    assert.equal(varDB.safeName('door'), 'door', 'SafeName reserved.');
   });
 
   test('Get name', function () {
     const varDB = new Blockly.Names('window,door');
-    chai.assert.equal(
+    assert.equal(
       varDB.getName('Foo.bar', 'var'),
       'Foo_bar',
       'Name add #1.',
     );
-    chai.assert.equal(
+    assert.equal(
       varDB.getName('Foo.bar', 'var'),
       'Foo_bar',
       'Name get #1.',
     );
-    chai.assert.equal(
+    assert.equal(
       varDB.getName('Foo bar', 'var'),
       'Foo_bar2',
       'Name add #2.',
     );
-    chai.assert.equal(
+    assert.equal(
       varDB.getName('foo BAR', 'var'),
       'Foo_bar2',
       'Name get #2.',
     );
-    chai.assert.equal(varDB.getName('door', 'var'), 'door2', 'Name add #3.');
-    chai.assert.equal(
+    assert.equal(varDB.getName('door', 'var'), 'door2', 'Name add #3.');
+    assert.equal(
       varDB.getName('Foo.bar', 'proc'),
       'Foo_bar3',
       'Name add #4.',
     );
-    chai.assert.equal(
+    assert.equal(
       varDB.getName('Foo.bar', 'var'),
       'Foo_bar',
       'Name get #1b.',
     );
-    chai.assert.equal(
+    assert.equal(
       varDB.getName('Foo.bar', 'proc'),
       'Foo_bar3',
       'Name get #4.',
     );
 
-    chai.assert.equal(
+    assert.equal(
       String(varDB.getUserNames('var')),
       'foo.bar,foo bar,door',
       'Get var names.',
     );
-    chai.assert.equal(
+    assert.equal(
       String(varDB.getUserNames('proc')),
       'foo.bar',
       'Get proc names.',
@@ -92,23 +93,23 @@ suite('Names', function () {
 
   test('Get distinct name', function () {
     const varDB = new Blockly.Names('window,door');
-    chai.assert.equal(
+    assert.equal(
       varDB.getDistinctName('Foo.bar', 'var'),
       'Foo_bar',
       'Name distinct #1.',
     );
-    chai.assert.equal(
+    assert.equal(
       varDB.getDistinctName('Foo.bar', 'var'),
       'Foo_bar2',
       'Name distinct #2.',
     );
-    chai.assert.equal(
+    assert.equal(
       varDB.getDistinctName('Foo.bar', 'proc'),
       'Foo_bar3',
       'Name distinct #3.',
     );
     varDB.reset();
-    chai.assert.equal(
+    assert.equal(
       varDB.getDistinctName('Foo.bar', 'var'),
       'Foo_bar',
       'Name distinct #4.',
@@ -116,15 +117,15 @@ suite('Names', function () {
   });
 
   test('name equals', function () {
-    chai.assert.isTrue(
+    assert.isTrue(
       Blockly.Names.equals('Foo.bar', 'Foo.bar'),
       'Name equals #1.',
     );
-    chai.assert.isFalse(
+    assert.isFalse(
       Blockly.Names.equals('Foo.bar', 'Foo_bar'),
       'Name equals #2.',
     );
-    chai.assert.isTrue(
+    assert.isTrue(
       Blockly.Names.equals('Foo.bar', 'FOO.BAR'),
       'Name equals #3.',
     );

--- a/tests/mocha/old_workspace_comment_test.js
+++ b/tests/mocha/old_workspace_comment_test.js
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import {assert} from '../../node_modules/chai/chai.js';
 import {
   sharedTestSetup,
   sharedTestTeardown,
@@ -21,7 +22,7 @@ suite.skip('Workspace comment', function () {
 
   suite('getTopComments(ordered=true)', function () {
     test('No comments', function () {
-      chai.assert.equal(this.workspace.getTopComments(true).length, 0);
+      assert.equal(this.workspace.getTopComments(true).length, 0);
     });
 
     test('One comment', function () {
@@ -32,13 +33,13 @@ suite.skip('Workspace comment', function () {
         0,
         'comment id',
       );
-      chai.assert.equal(this.workspace.getTopComments(true).length, 1);
-      chai.assert.equal(this.workspace.commentDB.get('comment id'), comment);
+      assert.equal(this.workspace.getTopComments(true).length, 1);
+      assert.equal(this.workspace.commentDB.get('comment id'), comment);
     });
 
     test('After clear empty workspace', function () {
       this.workspace.clear();
-      chai.assert.equal(this.workspace.getTopComments(true).length, 0);
+      assert.equal(this.workspace.getTopComments(true).length, 0);
     });
 
     test('After clear non-empty workspace', function () {
@@ -50,8 +51,8 @@ suite.skip('Workspace comment', function () {
         'comment id',
       );
       this.workspace.clear();
-      chai.assert.equal(this.workspace.getTopComments(true).length, 0);
-      chai.assert.isFalse(this.workspace.commentDB.has('comment id'));
+      assert.equal(this.workspace.getTopComments(true).length, 0);
+      assert.isFalse(this.workspace.commentDB.has('comment id'));
     });
 
     test('After dispose', function () {
@@ -63,14 +64,14 @@ suite.skip('Workspace comment', function () {
         'comment id',
       );
       comment.dispose();
-      chai.assert.equal(this.workspace.getTopComments(true).length, 0);
-      chai.assert.isFalse(this.workspace.commentDB.has('comment id'));
+      assert.equal(this.workspace.getTopComments(true).length, 0);
+      assert.isFalse(this.workspace.commentDB.has('comment id'));
     });
   });
 
   suite('getTopComments(ordered=false)', function () {
     test('No comments', function () {
-      chai.assert.equal(this.workspace.getTopComments(false).length, 0);
+      assert.equal(this.workspace.getTopComments(false).length, 0);
     });
 
     test('One comment', function () {
@@ -81,13 +82,13 @@ suite.skip('Workspace comment', function () {
         0,
         'comment id',
       );
-      chai.assert.equal(this.workspace.getTopComments(false).length, 1);
-      chai.assert.equal(this.workspace.commentDB.get('comment id'), comment);
+      assert.equal(this.workspace.getTopComments(false).length, 1);
+      assert.equal(this.workspace.commentDB.get('comment id'), comment);
     });
 
     test('After clear empty workspace', function () {
       this.workspace.clear();
-      chai.assert.equal(this.workspace.getTopComments(false).length, 0);
+      assert.equal(this.workspace.getTopComments(false).length, 0);
     });
 
     test('After clear non-empty workspace', function () {
@@ -99,8 +100,8 @@ suite.skip('Workspace comment', function () {
         'comment id',
       );
       this.workspace.clear();
-      chai.assert.equal(this.workspace.getTopComments(false).length, 0);
-      chai.assert.isFalse(this.workspace.commentDB.has('comment id'));
+      assert.equal(this.workspace.getTopComments(false).length, 0);
+      assert.isFalse(this.workspace.commentDB.has('comment id'));
     });
 
     test('After dispose', function () {
@@ -112,8 +113,8 @@ suite.skip('Workspace comment', function () {
         'comment id',
       );
       comment.dispose();
-      chai.assert.equal(this.workspace.getTopComments(false).length, 0);
-      chai.assert.isFalse(this.workspace.commentDB.has('comment id'));
+      assert.equal(this.workspace.getTopComments(false).length, 0);
+      assert.isFalse(this.workspace.commentDB.has('comment id'));
     });
   });
 
@@ -126,15 +127,15 @@ suite.skip('Workspace comment', function () {
         0,
         'comment id',
       );
-      chai.assert.equal(this.workspace.getCommentById(comment.id), comment);
+      assert.equal(this.workspace.getCommentById(comment.id), comment);
     });
 
     test('Null id', function () {
-      chai.assert.isNull(this.workspace.getCommentById(null));
+      assert.isNull(this.workspace.getCommentById(null));
     });
 
     test('Non-existent id', function () {
-      chai.assert.isNull(this.workspace.getCommentById('badId'));
+      assert.isNull(this.workspace.getCommentById('badId'));
     });
 
     test('After dispose', function () {
@@ -146,7 +147,7 @@ suite.skip('Workspace comment', function () {
         'comment id',
       );
       comment.dispose();
-      chai.assert.isNull(this.workspace.getCommentById(comment.id));
+      assert.isNull(this.workspace.getCommentById(comment.id));
     });
   });
 
@@ -177,20 +178,20 @@ suite.skip('Workspace comment', function () {
     });
 
     test('Initial values', function () {
-      chai.assert.equal(this.comment.getWidth(), 20, 'Width');
-      chai.assert.equal(this.comment.getHeight(), 10, 'Height');
+      assert.equal(this.comment.getWidth(), 20, 'Width');
+      assert.equal(this.comment.getHeight(), 10, 'Height');
     });
 
     test('setWidth does not affect height', function () {
       this.comment.setWidth(30);
-      chai.assert.equal(this.comment.getWidth(), 30, 'Width');
-      chai.assert.equal(this.comment.getHeight(), 10, 'Height');
+      assert.equal(this.comment.getWidth(), 30, 'Width');
+      assert.equal(this.comment.getHeight(), 10, 'Height');
     });
 
     test('setHeight does not affect width', function () {
       this.comment.setHeight(30);
-      chai.assert.equal(this.comment.getWidth(), 20, 'Width');
-      chai.assert.equal(this.comment.getHeight(), 30, 'Height');
+      assert.equal(this.comment.getWidth(), 20, 'Width');
+      assert.equal(this.comment.getHeight(), 30, 'Height');
     });
   });
 
@@ -207,15 +208,15 @@ suite.skip('Workspace comment', function () {
 
     test('Initial position', function () {
       const xy = this.comment.getRelativeToSurfaceXY();
-      chai.assert.equal(xy.x, 0, 'Initial X position');
-      chai.assert.equal(xy.y, 0, 'Initial Y position');
+      assert.equal(xy.x, 0, 'Initial X position');
+      assert.equal(xy.y, 0, 'Initial Y position');
     });
 
     test('moveBy', function () {
       this.comment.moveBy(10, 100);
       const xy = this.comment.getRelativeToSurfaceXY();
-      chai.assert.equal(xy.x, 10, 'New X position');
-      chai.assert.equal(xy.y, 100, 'New Y position');
+      assert.equal(xy.x, 10, 'New X position');
+      assert.equal(xy.y, 100, 'New Y position');
     });
   });
 
@@ -235,8 +236,8 @@ suite.skip('Workspace comment', function () {
     });
 
     test('After creation', function () {
-      chai.assert.equal(this.comment.getContent(), 'comment text');
-      chai.assert.equal(
+      assert.equal(this.comment.getContent(), 'comment text');
+      assert.equal(
         this.workspace.undoStack_.length,
         1,
         'Workspace undo stack',
@@ -245,9 +246,9 @@ suite.skip('Workspace comment', function () {
 
     test('Set to same value', function () {
       this.comment.setContent('comment text');
-      chai.assert.equal(this.comment.getContent(), 'comment text');
+      assert.equal(this.comment.getContent(), 'comment text');
       // Setting the text to the old value does not fire an event.
-      chai.assert.equal(
+      assert.equal(
         this.workspace.undoStack_.length,
         1,
         'Workspace undo stack',
@@ -256,8 +257,8 @@ suite.skip('Workspace comment', function () {
 
     test('Set to different value', function () {
       this.comment.setContent('new comment text');
-      chai.assert.equal(this.comment.getContent(), 'new comment text');
-      chai.assert.equal(
+      assert.equal(this.comment.getContent(), 'new comment text');
+      assert.equal(
         this.workspace.undoStack_.length,
         2,
         'Workspace undo stack',

--- a/tests/mocha/old_workspace_comment_test.js
+++ b/tests/mocha/old_workspace_comment_test.js
@@ -237,32 +237,20 @@ suite.skip('Workspace comment', function () {
 
     test('After creation', function () {
       assert.equal(this.comment.getContent(), 'comment text');
-      assert.equal(
-        this.workspace.undoStack_.length,
-        1,
-        'Workspace undo stack',
-      );
+      assert.equal(this.workspace.undoStack_.length, 1, 'Workspace undo stack');
     });
 
     test('Set to same value', function () {
       this.comment.setContent('comment text');
       assert.equal(this.comment.getContent(), 'comment text');
       // Setting the text to the old value does not fire an event.
-      assert.equal(
-        this.workspace.undoStack_.length,
-        1,
-        'Workspace undo stack',
-      );
+      assert.equal(this.workspace.undoStack_.length, 1, 'Workspace undo stack');
     });
 
     test('Set to different value', function () {
       this.comment.setContent('new comment text');
       assert.equal(this.comment.getContent(), 'new comment text');
-      assert.equal(
-        this.workspace.undoStack_.length,
-        2,
-        'Workspace undo stack',
-      );
+      assert.equal(this.workspace.undoStack_.length, 2, 'Workspace undo stack');
     });
   });
 });

--- a/tests/mocha/procedure_map_test.js
+++ b/tests/mocha/procedure_map_test.js
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import {assert} from '../../node_modules/chai/chai.js';
 import {
   sharedTestSetup,
   sharedTestTeardown,
@@ -32,7 +33,7 @@ suite('Procedure Map', function () {
       const spy = sinon.spy(procedureModel, 'startPublishing');
       this.procedureMap.set(procedureModel.getId(), procedureModel);
 
-      chai.assert.isTrue(spy.called, 'Expected the model to start publishing');
+      assert.isTrue(spy.called, 'Expected the model to start publishing');
     });
 
     test('adding a procedure tells it to start publishing', function () {
@@ -40,7 +41,7 @@ suite('Procedure Map', function () {
       const spy = sinon.spy(procedureModel, 'startPublishing');
       this.procedureMap.add(procedureModel);
 
-      chai.assert.isTrue(spy.called, 'Expected the model to start publishing');
+      assert.isTrue(spy.called, 'Expected the model to start publishing');
     });
 
     test('deleting a procedure tells it to stop publishing', function () {
@@ -50,7 +51,7 @@ suite('Procedure Map', function () {
 
       this.procedureMap.delete(procedureModel.getId());
 
-      chai.assert.isTrue(spy.calledOnce, 'Expected the model stop publishing');
+      assert.isTrue(spy.calledOnce, 'Expected the model stop publishing');
     });
   });
 });

--- a/tests/mocha/registry_test.js
+++ b/tests/mocha/registry_test.js
@@ -110,9 +110,7 @@ suite('Registry', function () {
     suite('Does not have', function () {
       test('Type', function () {
         assertWarnings(() => {
-          assert.isNull(
-            Blockly.registry.getClass('bad_type', 'test_name'),
-          );
+          assert.isNull(Blockly.registry.getClass('bad_type', 'test_name'));
         }, /Unable to find/);
       });
 
@@ -152,9 +150,7 @@ suite('Registry', function () {
     suite('Does not have', function () {
       test('Type', function () {
         assertWarnings(() => {
-          assert.isNull(
-            Blockly.registry.getObject('bad_type', 'test_name'),
-          );
+          assert.isNull(Blockly.registry.getObject('bad_type', 'test_name'));
         }, /Unable to find/);
       });
 

--- a/tests/mocha/registry_test.js
+++ b/tests/mocha/registry_test.js
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import {assert} from '../../node_modules/chai/chai.js';
 import {assertWarnings} from './test_helpers/warnings.js';
 import {
   sharedTestSetup,
@@ -33,20 +34,20 @@ suite('Registry', function () {
     });
 
     test('Empty String Key', function () {
-      chai.assert.throws(function () {
+      assert.throws(function () {
         Blockly.registry.register('test', '', TestClass);
       }, 'Invalid name');
     });
 
     test('Class as Key', function () {
-      chai.assert.throws(function () {
+      assert.throws(function () {
         Blockly.registry.register('test', TestClass, '');
       }, 'Invalid name');
     });
 
     test('Overwrite a Key', function () {
       Blockly.registry.register('test', 'test_name', TestClass);
-      chai.assert.throws(function () {
+      assert.throws(function () {
         // Registers a different object under the same name
         Blockly.registry.register('test', 'test_name', {});
       }, 'already registered');
@@ -54,14 +55,14 @@ suite('Registry', function () {
 
     test('Register a Duplicate Item', function () {
       Blockly.registry.register('test', 'test_name', TestClass);
-      chai.assert.doesNotThrow(function () {
+      assert.doesNotThrow(function () {
         // Registering the same object under the same name is allowed
         Blockly.registry.register('test', 'test_name', TestClass);
       }, 'already registered');
     });
 
     test('Null Value', function () {
-      chai.assert.throws(function () {
+      assert.throws(function () {
         Blockly.registry.register('test', 'field_custom_test', null);
       }, 'Can not register a null value');
     });
@@ -73,26 +74,26 @@ suite('Registry', function () {
     });
 
     test('Has', function () {
-      chai.assert.isTrue(Blockly.registry.hasItem('test', 'test_name'));
+      assert.isTrue(Blockly.registry.hasItem('test', 'test_name'));
     });
 
     suite('Does not have', function () {
       test('Type', function () {
-        chai.assert.isFalse(Blockly.registry.hasItem('bad_type', 'test_name'));
+        assert.isFalse(Blockly.registry.hasItem('bad_type', 'test_name'));
       });
 
       test('Name', function () {
-        chai.assert.isFalse(Blockly.registry.hasItem('test', 'bad_name'));
+        assert.isFalse(Blockly.registry.hasItem('test', 'bad_name'));
       });
     });
 
     suite('Case', function () {
       test('Caseless type', function () {
-        chai.assert.isTrue(Blockly.registry.hasItem('TEST', 'test_name'));
+        assert.isTrue(Blockly.registry.hasItem('TEST', 'test_name'));
       });
 
       test('Caseless name', function () {
-        chai.assert.isTrue(Blockly.registry.hasItem('test', 'TEST_NAME'));
+        assert.isTrue(Blockly.registry.hasItem('test', 'TEST_NAME'));
       });
     });
   });
@@ -103,13 +104,13 @@ suite('Registry', function () {
     });
 
     test('Has', function () {
-      chai.assert.isNotNull(Blockly.registry.getClass('test', 'test_name'));
+      assert.isNotNull(Blockly.registry.getClass('test', 'test_name'));
     });
 
     suite('Does not have', function () {
       test('Type', function () {
         assertWarnings(() => {
-          chai.assert.isNull(
+          assert.isNull(
             Blockly.registry.getClass('bad_type', 'test_name'),
           );
         }, /Unable to find/);
@@ -117,12 +118,12 @@ suite('Registry', function () {
 
       test('Name', function () {
         assertWarnings(() => {
-          chai.assert.isNull(Blockly.registry.getClass('test', 'bad_name'));
+          assert.isNull(Blockly.registry.getClass('test', 'bad_name'));
         }, /Unable to find/);
       });
 
       test('Throw if missing', function () {
-        chai.assert.throws(function () {
+        assert.throws(function () {
           Blockly.registry.getClass('test', 'bad_name', true);
         });
       });
@@ -130,11 +131,11 @@ suite('Registry', function () {
 
     suite('Case', function () {
       test('Caseless type', function () {
-        chai.assert.isNotNull(Blockly.registry.getClass('TEST', 'test_name'));
+        assert.isNotNull(Blockly.registry.getClass('TEST', 'test_name'));
       });
 
       test('Caseless name', function () {
-        chai.assert.isNotNull(Blockly.registry.getClass('test', 'TEST_NAME'));
+        assert.isNotNull(Blockly.registry.getClass('test', 'TEST_NAME'));
       });
     });
   });
@@ -145,13 +146,13 @@ suite('Registry', function () {
     });
 
     test('Has', function () {
-      chai.assert.isNotNull(Blockly.registry.getObject('test', 'test_name'));
+      assert.isNotNull(Blockly.registry.getObject('test', 'test_name'));
     });
 
     suite('Does not have', function () {
       test('Type', function () {
         assertWarnings(() => {
-          chai.assert.isNull(
+          assert.isNull(
             Blockly.registry.getObject('bad_type', 'test_name'),
           );
         }, /Unable to find/);
@@ -159,12 +160,12 @@ suite('Registry', function () {
 
       test('Name', function () {
         assertWarnings(() => {
-          chai.assert.isNull(Blockly.registry.getObject('test', 'bad_name'));
+          assert.isNull(Blockly.registry.getObject('test', 'bad_name'));
         }, /Unable to find/);
       });
 
       test('Throw if missing', function () {
-        chai.assert.throws(function () {
+        assert.throws(function () {
           Blockly.registry.getObject('test', 'bad_name', true);
         });
       });
@@ -172,11 +173,11 @@ suite('Registry', function () {
 
     suite('Case', function () {
       test('Caseless type', function () {
-        chai.assert.isNotNull(Blockly.registry.getObject('TEST', 'test_name'));
+        assert.isNotNull(Blockly.registry.getObject('TEST', 'test_name'));
       });
 
       test('Caseless name', function () {
-        chai.assert.isNotNull(Blockly.registry.getObject('test', 'TEST_NAME'));
+        assert.isNotNull(Blockly.registry.getObject('test', 'TEST_NAME'));
       });
     });
   });
@@ -192,27 +193,27 @@ suite('Registry', function () {
     });
 
     test('Has', function () {
-      chai.assert.isNotNull(Blockly.registry.getAllItems('test'));
+      assert.isNotNull(Blockly.registry.getAllItems('test'));
     });
 
     test('Does not have', function () {
       assertWarnings(() => {
-        chai.assert.isNull(Blockly.registry.getAllItems('bad_type'));
+        assert.isNull(Blockly.registry.getAllItems('bad_type'));
       }, /Unable to find/);
     });
 
     test('Throw if missing', function () {
-      chai.assert.throws(function () {
+      assert.throws(function () {
         Blockly.registry.getAllItems('bad_type', false, true);
       });
     });
 
     test('Ignore type case', function () {
-      chai.assert.isNotNull(Blockly.registry.getAllItems('TEST'));
+      assert.isNotNull(Blockly.registry.getAllItems('TEST'));
     });
 
     test('Respect name case', function () {
-      chai.assert.deepEqual(Blockly.registry.getAllItems('test', true), {
+      assert.deepEqual(Blockly.registry.getAllItems('test', true), {
         'test_name': {},
         'casedNAME': {},
       });
@@ -220,7 +221,7 @@ suite('Registry', function () {
 
     test('Respect overwriting name case', function () {
       Blockly.registry.register('test', 'CASEDname', {}, true);
-      chai.assert.deepEqual(Blockly.registry.getAllItems('test', true), {
+      assert.deepEqual(Blockly.registry.getAllItems('test', true), {
         'test_name': {},
         'CASEDname': {},
       });
@@ -251,7 +252,7 @@ suite('Registry', function () {
         'test',
         this.options,
       );
-      chai.assert.instanceOf(new testClass(), TestClass);
+      assert.instanceOf(new testClass(), TestClass);
     });
 
     test('Simple - Plugin class given', function () {
@@ -260,7 +261,7 @@ suite('Registry', function () {
         'test',
         this.options,
       );
-      chai.assert.instanceOf(new testClass(), TestClass);
+      assert.instanceOf(new testClass(), TestClass);
     });
 
     test('No Plugin Name Given', function () {
@@ -269,7 +270,7 @@ suite('Registry', function () {
         'test',
         this.options,
       );
-      chai.assert.instanceOf(new testClass(), this.defaultClass);
+      assert.instanceOf(new testClass(), this.defaultClass);
     });
 
     test('Incorrect Plugin Name', function () {
@@ -278,7 +279,7 @@ suite('Registry', function () {
       assertWarnings(() => {
         testClass = Blockly.registry.getClassFromOptions('test', this.options);
       }, /Unable to find/);
-      chai.assert.isNull(testClass);
+      assert.isNull(testClass);
     });
   });
 });

--- a/tests/mocha/render_management_test.js
+++ b/tests/mocha/render_management_test.js
@@ -121,10 +121,7 @@ suite('Render Management', function () {
       Blockly.renderManagement.triggerQueuedRenders(workspace1);
 
       assert.isTrue(block1.hasRendered, 'Expected block1 to be rendered');
-      assert.isFalse(
-        block2.hasRendered,
-        'Expected block2 to not be rendered',
-      );
+      assert.isFalse(block2.hasRendered, 'Expected block2 to not be rendered');
     });
   });
 });

--- a/tests/mocha/render_management_test.js
+++ b/tests/mocha/render_management_test.js
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import {assert} from '../../node_modules/chai/chai.js';
 import {
   sharedTestSetup,
   sharedTestTeardown,
@@ -43,7 +44,7 @@ suite('Render Management', function () {
     test('the queueRender promise is properly resolved after rendering', function () {
       const block = createMockBlock();
       const promise = Blockly.renderManagement.queueRender(block).then(() => {
-        chai.assert.isTrue(block.hasRendered, 'Expected block to be rendered');
+        assert.isTrue(block.hasRendered, 'Expected block to be rendered');
       });
       this.clock.runAll();
       return promise;
@@ -53,7 +54,7 @@ suite('Render Management', function () {
       const block = createMockBlock();
       Blockly.renderManagement.queueRender(block);
       const promise = Blockly.renderManagement.finishQueuedRenders(() => {
-        chai.assert.isTrue(block.hasRendered, 'Expected block to be rendered');
+        assert.isTrue(block.hasRendered, 'Expected block to be rendered');
       });
       this.clock.runAll();
       return promise;
@@ -92,7 +93,7 @@ suite('Render Management', function () {
 
       Blockly.renderManagement.triggerQueuedRenders();
 
-      chai.assert.isTrue(block.hasRendered, 'Expected block to be rendered');
+      assert.isTrue(block.hasRendered, 'Expected block to be rendered');
     });
 
     test('triggering queued renders rerenders blocks in all workspaces', function () {
@@ -105,8 +106,8 @@ suite('Render Management', function () {
 
       Blockly.renderManagement.triggerQueuedRenders();
 
-      chai.assert.isTrue(block1.hasRendered, 'Expected block1 to be rendered');
-      chai.assert.isTrue(block2.hasRendered, 'Expected block2 to be rendered');
+      assert.isTrue(block1.hasRendered, 'Expected block1 to be rendered');
+      assert.isTrue(block2.hasRendered, 'Expected block2 to be rendered');
     });
 
     test('triggering queued renders in one workspace does not rerender blocks in another workspace', function () {
@@ -119,8 +120,8 @@ suite('Render Management', function () {
 
       Blockly.renderManagement.triggerQueuedRenders(workspace1);
 
-      chai.assert.isTrue(block1.hasRendered, 'Expected block1 to be rendered');
-      chai.assert.isFalse(
+      assert.isTrue(block1.hasRendered, 'Expected block1 to be rendered');
+      assert.isFalse(
         block2.hasRendered,
         'Expected block2 to not be rendered',
       );

--- a/tests/mocha/serializer_test.js
+++ b/tests/mocha/serializer_test.js
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import {assert} from '../../node_modules/chai/chai.js';
 import * as Blockly from '../../build/src/core/blockly.js';
 import {
   TestCase,
@@ -2067,7 +2068,7 @@ const runSerializerTestSuite = (serializer, deserializer, testSuite) => {
         workspaces.load(deserializer(save), this.workspace);
       }
       const newXml = Blockly.Xml.workspaceToDom(this.workspace);
-      chai.assert.equal(Blockly.Xml.domToText(newXml), test.xml);
+      assert.equal(Blockly.Xml.domToText(newXml), test.xml);
     };
   };
 

--- a/tests/mocha/shortcut_registry_test.js
+++ b/tests/mocha/shortcut_registry_test.js
@@ -250,10 +250,7 @@ suite('Keyboard Shortcut Registry Test', function () {
     test('Sets the key map', function () {
       this.registry.setKeyMap({'keyCode': ['test_shortcut']});
       assert.equal(Object.keys(this.registry.getKeyMap()).length, 1);
-      assert.equal(
-        this.registry.getKeyMap()['keyCode'][0],
-        'test_shortcut',
-      );
+      assert.equal(this.registry.getKeyMap()['keyCode'][0], 'test_shortcut');
     });
     test('Gets a copy of the key map', function () {
       this.registry.setKeyMap({'keyCode': ['a']});

--- a/tests/mocha/shortcut_registry_test.js
+++ b/tests/mocha/shortcut_registry_test.js
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import {assert} from '../../node_modules/chai/chai.js';
 import {createKeyDownEvent} from './test_helpers/user_input.js';
 import {
   sharedTestSetup,
@@ -26,7 +27,7 @@ suite('Keyboard Shortcut Registry Test', function () {
       const testShortcut = {'name': 'test_shortcut'};
       this.registry.register(testShortcut, true);
       const shortcut = this.registry.getRegistry()['test_shortcut'];
-      chai.assert.equal(shortcut.name, 'test_shortcut');
+      assert.equal(shortcut.name, 'test_shortcut');
     });
     test('Registers shortcut with same name', function () {
       const registry = this.registry;
@@ -37,7 +38,7 @@ suite('Keyboard Shortcut Registry Test', function () {
       const shouldThrow = function () {
         registry.register(testShortcut);
       };
-      chai.assert.throws(
+      assert.throws(
         shouldThrow,
         Error,
         'Shortcut named "test_shortcut" already exists.',
@@ -56,8 +57,8 @@ suite('Keyboard Shortcut Registry Test', function () {
       const shouldNotThrow = function () {
         registry.register(otherShortcut, true);
       };
-      chai.assert.doesNotThrow(shouldNotThrow);
-      chai.assert.exists(registry.getRegistry()['test_shortcut'].callback);
+      assert.doesNotThrow(shouldNotThrow);
+      assert.exists(registry.getRegistry()['test_shortcut'].callback);
     });
     test('Registering a shortcut with keycodes', function () {
       const shiftA = this.registry.createSerializedKey('65', [
@@ -68,9 +69,9 @@ suite('Keyboard Shortcut Registry Test', function () {
         'keyCodes': ['65', 66, shiftA],
       };
       this.registry.register(testShortcut, true);
-      chai.assert.lengthOf(this.registry.getKeyMap()[shiftA], 1);
-      chai.assert.lengthOf(this.registry.getKeyMap()['65'], 1);
-      chai.assert.lengthOf(this.registry.getKeyMap()['66'], 1);
+      assert.lengthOf(this.registry.getKeyMap()[shiftA], 1);
+      assert.lengthOf(this.registry.getKeyMap()['65'], 1);
+      assert.lengthOf(this.registry.getKeyMap()['66'], 1);
     });
     test('Registering a shortcut with allowCollision', function () {
       const testShortcut = {
@@ -87,7 +88,7 @@ suite('Keyboard Shortcut Registry Test', function () {
       const shouldNotThrow = function () {
         registry.register(duplicateShortcut);
       };
-      chai.assert.doesNotThrow(shouldNotThrow);
+      assert.doesNotThrow(shouldNotThrow);
     });
   });
 
@@ -95,16 +96,16 @@ suite('Keyboard Shortcut Registry Test', function () {
     test('Unregistering a shortcut', function () {
       const testShortcut = {'name': 'test_shortcut'};
       this.registry.register(testShortcut);
-      chai.assert.isOk(this.registry.getRegistry()['test_shortcut']);
+      assert.isOk(this.registry.getRegistry()['test_shortcut']);
       this.registry.unregister('test_shortcut');
-      chai.assert.isUndefined(this.registry.getRegistry()['test_shortcut']);
+      assert.isUndefined(this.registry.getRegistry()['test_shortcut']);
     });
     test('Unregistering a nonexistent shortcut', function () {
       const consoleStub = sinon.stub(console, 'warn');
-      chai.assert.isUndefined(this.registry.getRegistry['test']);
+      assert.isUndefined(this.registry.getRegistry['test']);
 
       const registry = this.registry;
-      chai.assert.isFalse(registry.unregister('test'));
+      assert.isFalse(registry.unregister('test'));
       sinon.assert.calledOnceWithExactly(
         consoleStub,
         'Keyboard shortcut named "test" not found.',
@@ -119,8 +120,8 @@ suite('Keyboard Shortcut Registry Test', function () {
 
       const shortcut = this.registry.getRegistry()['test_shortcut'];
       const keyMappings = this.registry.getKeyMap()['keyCode'];
-      chai.assert.isUndefined(shortcut);
-      chai.assert.isUndefined(keyMappings);
+      assert.isUndefined(shortcut);
+      assert.isUndefined(keyMappings);
     });
     test('Unregistering a shortcut with colliding key mappings', function () {
       const testShortcut = {'name': 'test_shortcut'};
@@ -134,8 +135,8 @@ suite('Keyboard Shortcut Registry Test', function () {
 
       const shortcut = this.registry.getRegistry()['test_shortcut'];
       const keyMappings = this.registry.getKeyMap()['keyCode'];
-      chai.assert.lengthOf(keyMappings, 1);
-      chai.assert.isUndefined(shortcut);
+      assert.lengthOf(keyMappings, 1);
+      assert.isUndefined(shortcut);
     });
   });
 
@@ -147,8 +148,8 @@ suite('Keyboard Shortcut Registry Test', function () {
       this.registry.addKeyMapping('keyCode', 'test_shortcut');
 
       const shortcutNames = this.registry.getKeyMap()['keyCode'];
-      chai.assert.lengthOf(shortcutNames, 1);
-      chai.assert.equal(shortcutNames[0], 'test_shortcut');
+      assert.lengthOf(shortcutNames, 1);
+      assert.equal(shortcutNames[0], 'test_shortcut');
     });
     test('Adds a colliding key mapping - opt_allowCollision=true', function () {
       const testShortcut = {'name': 'test_shortcut'};
@@ -160,9 +161,9 @@ suite('Keyboard Shortcut Registry Test', function () {
       this.registry.addKeyMapping('keyCode', 'test_shortcut', true);
 
       const shortcutNames = this.registry.getKeyMap()['keyCode'];
-      chai.assert.lengthOf(shortcutNames, 2);
-      chai.assert.equal(shortcutNames[0], 'test_shortcut');
-      chai.assert.equal(shortcutNames[1], 'test_shortcut_2');
+      assert.lengthOf(shortcutNames, 2);
+      assert.equal(shortcutNames[0], 'test_shortcut');
+      assert.equal(shortcutNames[1], 'test_shortcut_2');
     });
     test('Adds a colliding key mapping - opt_allowCollision=false', function () {
       const testShortcut = {'name': 'test_shortcut'};
@@ -175,7 +176,7 @@ suite('Keyboard Shortcut Registry Test', function () {
       const shouldThrow = function () {
         registry.addKeyMapping('keyCode', 'test_shortcut');
       };
-      chai.assert.throws(
+      assert.throws(
         shouldThrow,
         Error,
         'Shortcut named "test_shortcut" collides with shortcuts "test_shortcut_2"',
@@ -198,9 +199,9 @@ suite('Keyboard Shortcut Registry Test', function () {
       );
 
       const shortcutNames = this.registry.getKeyMap()['keyCode'];
-      chai.assert.lengthOf(shortcutNames, 1);
-      chai.assert.equal(shortcutNames[0], 'test_shortcut_2');
-      chai.assert.isTrue(isRemoved);
+      assert.lengthOf(shortcutNames, 1);
+      assert.equal(shortcutNames[0], 'test_shortcut_2');
+      assert.isTrue(isRemoved);
     });
     test('Removes last key mapping for a key', function () {
       const testShortcut = {'name': 'test_shortcut'};
@@ -210,7 +211,7 @@ suite('Keyboard Shortcut Registry Test', function () {
       this.registry.removeKeyMapping('keyCode', 'test_shortcut');
 
       const shortcutNames = this.registry.getKeyMap()['keyCode'];
-      chai.assert.isUndefined(shortcutNames);
+      assert.isUndefined(shortcutNames);
     });
     test('Removes a key map that does not exist opt_quiet=false', function () {
       const consoleStub = sinon.stub(console, 'warn');
@@ -223,7 +224,7 @@ suite('Keyboard Shortcut Registry Test', function () {
         'test_shortcut',
       );
 
-      chai.assert.isFalse(isRemoved);
+      assert.isFalse(isRemoved);
       sinon.assert.calledOnceWithExactly(
         consoleStub,
         'No keyboard shortcut named "test_shortcut" registered with key code "keyCode"',
@@ -237,7 +238,7 @@ suite('Keyboard Shortcut Registry Test', function () {
         'test_shortcut',
       );
 
-      chai.assert.isFalse(isRemoved);
+      assert.isFalse(isRemoved);
       sinon.assert.calledOnceWithExactly(
         consoleStub,
         'No keyboard shortcut named "test_shortcut" registered with key code "keyCode"',
@@ -248,8 +249,8 @@ suite('Keyboard Shortcut Registry Test', function () {
   suite('Setters/Getters', function () {
     test('Sets the key map', function () {
       this.registry.setKeyMap({'keyCode': ['test_shortcut']});
-      chai.assert.equal(Object.keys(this.registry.getKeyMap()).length, 1);
-      chai.assert.equal(
+      assert.equal(Object.keys(this.registry.getKeyMap()).length, 1);
+      assert.equal(
         this.registry.getKeyMap()['keyCode'][0],
         'test_shortcut',
       );
@@ -258,14 +259,14 @@ suite('Keyboard Shortcut Registry Test', function () {
       this.registry.setKeyMap({'keyCode': ['a']});
       const keyMapCopy = this.registry.getKeyMap();
       keyMapCopy['keyCode'] = ['b'];
-      chai.assert.equal(this.registry.getKeyMap()['keyCode'][0], 'a');
+      assert.equal(this.registry.getKeyMap()['keyCode'][0], 'a');
     });
     test('Gets a copy of the registry', function () {
       const shortcut = {'name': 'shortcutName'};
       this.registry.register(shortcut);
       const registrycopy = this.registry.getRegistry();
       registrycopy['shortcutName']['name'] = 'shortcutName1';
-      chai.assert.equal(
+      assert.equal(
         this.registry.getRegistry()['shortcutName']['name'],
         'shortcutName',
       );
@@ -273,7 +274,7 @@ suite('Keyboard Shortcut Registry Test', function () {
     test('Gets keyboard shortcuts from a key code', function () {
       this.registry.setKeyMap({'keyCode': ['shortcutName']});
       const shortcutNames = this.registry.getShortcutNamesByKeyCode('keyCode');
-      chai.assert.equal(shortcutNames[0], 'shortcutName');
+      assert.equal(shortcutNames[0], 'shortcutName');
     });
     test('Gets keycodes by shortcut name', function () {
       this.registry.setKeyMap({
@@ -282,9 +283,9 @@ suite('Keyboard Shortcut Registry Test', function () {
       });
       const shortcutNames =
         this.registry.getKeyCodesByShortcutName('shortcutName');
-      chai.assert.lengthOf(shortcutNames, 2);
-      chai.assert.equal(shortcutNames[0], 'keyCode');
-      chai.assert.equal(shortcutNames[1], 'keyCode1');
+      assert.lengthOf(shortcutNames, 2);
+      assert.equal(shortcutNames[0], 'keyCode');
+      assert.equal(shortcutNames[1], 'keyCode1');
     });
   });
 
@@ -314,17 +315,17 @@ suite('Keyboard Shortcut Registry Test', function () {
     });
     test('Execute a shortcut from event', function () {
       const event = createKeyDownEvent(Blockly.utils.KeyCodes.C);
-      chai.assert.isTrue(this.registry.onKeyDown(this.workspace, event));
+      assert.isTrue(this.registry.onKeyDown(this.workspace, event));
       sinon.assert.calledOnce(this.callBackStub);
     });
     test('No shortcut executed from event', function () {
       const event = createKeyDownEvent(Blockly.utils.KeyCodes.D);
-      chai.assert.isFalse(this.registry.onKeyDown(this.workspace, event));
+      assert.isFalse(this.registry.onKeyDown(this.workspace, event));
     });
     test('No precondition available - execute callback', function () {
       delete this.testShortcut['precondition'];
       const event = createKeyDownEvent(Blockly.utils.KeyCodes.C);
-      chai.assert.isTrue(this.registry.onKeyDown(this.workspace, event));
+      assert.isTrue(this.registry.onKeyDown(this.workspace, event));
       sinon.assert.calledOnce(this.callBackStub);
     });
     test('Execute all shortcuts in list', function () {
@@ -344,7 +345,7 @@ suite('Keyboard Shortcut Registry Test', function () {
         Blockly.utils.KeyCodes.C,
         false,
       );
-      chai.assert.isTrue(this.registry.onKeyDown(this.workspace, event));
+      assert.isTrue(this.registry.onKeyDown(this.workspace, event));
       sinon.assert.calledOnce(testShortcut2Stub);
       sinon.assert.calledOnce(this.callBackStub);
     });
@@ -365,7 +366,7 @@ suite('Keyboard Shortcut Registry Test', function () {
         Blockly.utils.KeyCodes.C,
         true,
       );
-      chai.assert.isTrue(this.registry.onKeyDown(this.workspace, event));
+      assert.isTrue(this.registry.onKeyDown(this.workspace, event));
       sinon.assert.calledOnce(testShortcut2Stub);
       sinon.assert.notCalled(this.callBackStub);
     });
@@ -376,7 +377,7 @@ suite('Keyboard Shortcut Registry Test', function () {
       const serializedKey = this.registry.createSerializedKey(
         Blockly.utils.KeyCodes.A,
       );
-      chai.assert.equal(serializedKey, '65');
+      assert.equal(serializedKey, '65');
     });
 
     test('Serialize key code and modifier', function () {
@@ -384,32 +385,32 @@ suite('Keyboard Shortcut Registry Test', function () {
         Blockly.utils.KeyCodes.A,
         [Blockly.utils.KeyCodes.CTRL],
       );
-      chai.assert.equal(serializedKey, 'Control+65');
+      assert.equal(serializedKey, 'Control+65');
     });
     test('Serialize only a modifier', function () {
       const serializedKey = this.registry.createSerializedKey(null, [
         Blockly.utils.KeyCodes.CTRL,
       ]);
-      chai.assert.equal(serializedKey, 'Control');
+      assert.equal(serializedKey, 'Control');
     });
     test('Serialize multiple modifiers', function () {
       const serializedKey = this.registry.createSerializedKey(null, [
         Blockly.utils.KeyCodes.CTRL,
         Blockly.utils.KeyCodes.SHIFT,
       ]);
-      chai.assert.equal(serializedKey, 'Shift+Control');
+      assert.equal(serializedKey, 'Shift+Control');
     });
     test('Order of modifiers should result in same serialized key', function () {
       const serializedKey = this.registry.createSerializedKey(null, [
         Blockly.utils.KeyCodes.CTRL,
         Blockly.utils.KeyCodes.SHIFT,
       ]);
-      chai.assert.equal(serializedKey, 'Shift+Control');
+      assert.equal(serializedKey, 'Shift+Control');
       const serializedKeyNewOrder = this.registry.createSerializedKey(null, [
         Blockly.utils.KeyCodes.SHIFT,
         Blockly.utils.KeyCodes.CTRL,
       ]);
-      chai.assert.equal(serializedKeyNewOrder, 'Shift+Control');
+      assert.equal(serializedKeyNewOrder, 'Shift+Control');
     });
   });
 
@@ -417,19 +418,19 @@ suite('Keyboard Shortcut Registry Test', function () {
     test('Serialize key', function () {
       const mockEvent = createKeyDownEvent(Blockly.utils.KeyCodes.A);
       const serializedKey = this.registry.serializeKeyEvent_(mockEvent);
-      chai.assert.equal(serializedKey, '65');
+      assert.equal(serializedKey, '65');
     });
     test('Serialize key code and modifier', function () {
       const mockEvent = createKeyDownEvent(Blockly.utils.KeyCodes.A, [
         Blockly.utils.KeyCodes.CTRL,
       ]);
       const serializedKey = this.registry.serializeKeyEvent_(mockEvent);
-      chai.assert.equal(serializedKey, 'Control+65');
+      assert.equal(serializedKey, 'Control+65');
     });
     test('Serialize only a modifier', function () {
       const mockEvent = createKeyDownEvent(null, [Blockly.utils.KeyCodes.CTRL]);
       const serializedKey = this.registry.serializeKeyEvent_(mockEvent);
-      chai.assert.equal(serializedKey, 'Control');
+      assert.equal(serializedKey, 'Control');
     });
     test('Serialize multiple modifiers', function () {
       const mockEvent = createKeyDownEvent(null, [
@@ -437,14 +438,14 @@ suite('Keyboard Shortcut Registry Test', function () {
         Blockly.utils.KeyCodes.SHIFT,
       ]);
       const serializedKey = this.registry.serializeKeyEvent_(mockEvent);
-      chai.assert.equal(serializedKey, 'Shift+Control');
+      assert.equal(serializedKey, 'Shift+Control');
     });
     test('Throw error when incorrect modifier', function () {
       const registry = this.registry;
       const shouldThrow = function () {
         registry.createSerializedKey(Blockly.utils.KeyCodes.K, ['s']);
       };
-      chai.assert.throws(shouldThrow, Error, 's is not a valid modifier key.');
+      assert.throws(shouldThrow, Error, 's is not a valid modifier key.');
     });
   });
 

--- a/tests/mocha/test_helpers/code_generation.js
+++ b/tests/mocha/test_helpers/code_generation.js
@@ -5,6 +5,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import {assert} from '../../../node_modules/chai/chai.js';
 import {runTestSuites} from './common.js';
 
 /**
@@ -84,14 +85,14 @@ const createCodeGenerationTestFn_ = (generator) => {
       }
       const assertFunc =
         typeof testCase.expectedCode === 'string'
-          ? chai.assert.equal
-          : chai.assert.match;
+          ? assert.equal
+          : assert.match;
       assertFunc(code, testCase.expectedCode);
       if (
         !testCase.useWorkspaceToCode &&
         testCase.expectedInnerOrder !== undefined
       ) {
-        chai.assert.equal(innerOrder, testCase.expectedInnerOrder);
+        assert.equal(innerOrder, testCase.expectedInnerOrder);
       }
     };
   };

--- a/tests/mocha/test_helpers/code_generation.js
+++ b/tests/mocha/test_helpers/code_generation.js
@@ -84,9 +84,7 @@ const createCodeGenerationTestFn_ = (generator) => {
         }
       }
       const assertFunc =
-        typeof testCase.expectedCode === 'string'
-          ? assert.equal
-          : assert.match;
+        typeof testCase.expectedCode === 'string' ? assert.equal : assert.match;
       assertFunc(code, testCase.expectedCode);
       if (
         !testCase.useWorkspaceToCode &&

--- a/tests/mocha/test_helpers/events.js
+++ b/tests/mocha/test_helpers/events.js
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import {assert} from '../../../node_modules/chai/chai.js';
+
 /**
  * Creates spy for workspace fireChangeListener
  * @param {!Blockly.Workspace} workspace The workspace to spy fireChangeListener
@@ -40,7 +42,7 @@ function assertXmlPropertyEqual_(xmlValue, expectedValue, message) {
   if (expectedValue instanceof Node) {
     expectedValue = Blockly.Xml.domToText(expectedValue);
   }
-  chai.assert.equal(value, expectedValue, message);
+  assert.equal(value, expectedValue, message);
 }
 
 /**
@@ -55,13 +57,13 @@ function assertXmlProperties_(obj, expectedXmlProperties) {
     const value = obj[key];
     const expectedValue = expectedXmlProperties[key];
     if (expectedValue === undefined) {
-      chai.assert.isUndefined(
+      assert.isUndefined(
         value,
         'Expected ' + key + ' property to be undefined',
       );
       return;
     }
-    chai.assert.exists(value, 'Expected ' + key + ' property to exist');
+    assert.exists(value, 'Expected ' + key + ' property to exist');
     assertXmlPropertyEqual_(value, expectedValue, 'Checking property ' + key);
   });
 }
@@ -98,13 +100,13 @@ export function assertEventEquals(
 ) {
   let prependMessage = message ? message + ' ' : '';
   prependMessage += 'Event fired ';
-  chai.assert.equal(event.type, expectedType, prependMessage + 'type');
-  chai.assert.equal(
+  assert.equal(event.type, expectedType, prependMessage + 'type');
+  assert.equal(
     event.workspaceId,
     expectedWorkspaceId,
     prependMessage + 'workspace id',
   );
-  chai.assert.equal(
+  assert.equal(
     event.blockId,
     expectedBlockId,
     prependMessage + 'block id',
@@ -113,20 +115,20 @@ export function assertEventEquals(
     const value = event[key];
     const expectedValue = expectedProperties[key];
     if (expectedValue === undefined) {
-      chai.assert.isUndefined(value, prependMessage + key);
+      assert.isUndefined(value, prependMessage + key);
       return;
     }
-    chai.assert.exists(value, prependMessage + key);
+    assert.exists(value, prependMessage + key);
     if (isXmlProperty_(key)) {
       assertXmlPropertyEqual_(value, expectedValue, prependMessage + key);
     } else {
-      chai.assert.equal(value, expectedValue, prependMessage + key);
+      assert.equal(value, expectedValue, prependMessage + key);
     }
   });
   if (isUiEvent) {
-    chai.assert.isTrue(event.isUiEvent);
+    assert.isTrue(event.isUiEvent);
   } else {
-    chai.assert.isFalse(event.isUiEvent);
+    assert.isFalse(event.isUiEvent);
   }
 }
 

--- a/tests/mocha/test_helpers/events.js
+++ b/tests/mocha/test_helpers/events.js
@@ -106,11 +106,7 @@ export function assertEventEquals(
     expectedWorkspaceId,
     prependMessage + 'workspace id',
   );
-  assert.equal(
-    event.blockId,
-    expectedBlockId,
-    prependMessage + 'block id',
-  );
+  assert.equal(event.blockId, expectedBlockId, prependMessage + 'block id');
   Object.keys(expectedProperties).map((key) => {
     const value = event[key];
     const expectedValue = expectedProperties[key];

--- a/tests/mocha/test_helpers/fields.js
+++ b/tests/mocha/test_helpers/fields.js
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import {assert} from '../../../node_modules/chai/chai.js';
 import {runTestCases, TestCase} from './common.js';
 
 /**
@@ -74,8 +75,8 @@ export function assertFieldValue(
   if (expectedText === undefined) {
     expectedText = String(expectedValue);
   }
-  chai.assert.deepEqual(actualValue, expectedValue);
-  chai.assert.deepEqual(actualText, expectedText);
+  assert.deepEqual(actualValue, expectedValue);
+  assert.deepEqual(actualText, expectedText);
 }
 
 /**
@@ -119,7 +120,7 @@ function runCreationTestsAssertThrows_(testCases, creation) {
    */
   const createTestFn = (testCase) => {
     return function () {
-      chai.assert.throws(function () {
+      assert.throws(function () {
         creation.call(this, testCase);
       }, testCase.errMsgMatcher);
     };
@@ -161,7 +162,7 @@ export function runConstructorSuiteTests(
       });
     } else {
       test('Empty', function () {
-        chai.assert.throws(function () {
+        assert.throws(function () {
           customCreateWithJs
             ? customCreateWithJs.call(this)
             : new TestedField();
@@ -226,7 +227,7 @@ export function runFromJsonSuiteTests(
       });
     } else {
       test('Empty', function () {
-        chai.assert.throws(function () {
+        assert.throws(function () {
           customCreateWithJson
             ? customCreateWithJson.call(this)
             : TestedField.fromJson({});

--- a/tests/mocha/test_helpers/procedures.js
+++ b/tests/mocha/test_helpers/procedures.js
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import {assert} from '../../../node_modules/chai/chai.js';
 import {ConnectionType} from '../../../build/src/core/connection_type.js';
 import {VariableModel} from '../../../build/src/core/variable_model.js';
 
@@ -19,7 +20,7 @@ function assertBlockVarModels(block, varIds) {
   for (let i = 0; i < varIds.length; i++) {
     expectedVarModels.push(block.workspace.getVariableById(varIds[i]));
   }
-  chai.assert.sameDeepOrderedMembers(block.getVarModels(), expectedVarModels);
+  assert.sameDeepOrderedMembers(block.getVarModels(), expectedVarModels);
 }
 
 /**
@@ -29,7 +30,7 @@ function assertBlockVarModels(block, varIds) {
  */
 function assertCallBlockArgsStructure(callBlock, args) {
   // inputList also contains "TOPROW"
-  chai.assert.equal(
+  assert.equal(
     callBlock.inputList.length - 1,
     args.length,
     'call block has the expected number of args',
@@ -38,15 +39,15 @@ function assertCallBlockArgsStructure(callBlock, args) {
   for (let i = 0; i < args.length; i++) {
     const expectedName = args[i];
     const callInput = callBlock.inputList[i + 1];
-    chai.assert.equal(callInput.type, ConnectionType.INPUT_VALUE);
-    chai.assert.equal(callInput.name, 'ARG' + i);
-    chai.assert.equal(
+    assert.equal(callInput.type, ConnectionType.INPUT_VALUE);
+    assert.equal(callInput.name, 'ARG' + i);
+    assert.equal(
       callInput.fieldRow[0].getValue(),
       expectedName,
       'Call block consts did not match expected.',
     );
   }
-  chai.assert.sameOrderedMembers(callBlock.getVars(), args);
+  assert.sameOrderedMembers(callBlock.getVars(), args);
 }
 
 /**
@@ -68,42 +69,42 @@ export function assertDefBlockStructure(
   hasStatements = true,
 ) {
   if (hasStatements) {
-    chai.assert.isNotNull(
+    assert.isNotNull(
       defBlock.getInput('STACK'),
       'Def block should have STACK input',
     );
   } else {
-    chai.assert.isNull(
+    assert.isNull(
       defBlock.getInput('STACK'),
       'Def block should not have STACK input',
     );
   }
   if (hasReturn) {
-    chai.assert.isNotNull(
+    assert.isNotNull(
       defBlock.getInput('RETURN'),
       'Def block should have RETURN input',
     );
   } else {
-    chai.assert.isNull(
+    assert.isNull(
       defBlock.getInput('RETURN'),
       'Def block should not have RETURN input',
     );
   }
   if (args.length) {
-    chai.assert.include(
+    assert.include(
       defBlock.toString(),
       'with',
       'Def block string should include "with"',
     );
   } else {
-    chai.assert.notInclude(
+    assert.notInclude(
       defBlock.toString(),
       'with',
       'Def block string should not include "with"',
     );
   }
 
-  chai.assert.sameOrderedMembers(defBlock.getVars(), args);
+  assert.sameOrderedMembers(defBlock.getVars(), args);
   assertBlockVarModels(defBlock, varIds);
 }
 
@@ -122,15 +123,15 @@ export function assertCallBlockStructure(
   name = undefined,
 ) {
   if (args.length) {
-    chai.assert.include(callBlock.toString(), 'with');
+    assert.include(callBlock.toString(), 'with');
   } else {
-    chai.assert.notInclude(callBlock.toString(), 'with');
+    assert.notInclude(callBlock.toString(), 'with');
   }
 
   assertCallBlockArgsStructure(callBlock, args);
   assertBlockVarModels(callBlock, varIds);
   if (name !== undefined) {
-    chai.assert.equal(callBlock.getFieldValue('NAME'), name);
+    assert.equal(callBlock.getFieldValue('NAME'), name);
   }
 }
 

--- a/tests/mocha/test_helpers/serialization.js
+++ b/tests/mocha/test_helpers/serialization.js
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import {assert} from '../../../node_modules/chai/chai.js';
 import {runTestCases} from './common.js';
 
 /**
@@ -89,7 +90,7 @@ export const runSerializationTestSuite = (testCases) => {
         this.clock.runAll();
         const generatedJson = Blockly.serialization.blocks.save(block);
         const expectedJson = testCase.expectedJson || testCase.json;
-        chai.assert.deepEqual(generatedJson, expectedJson);
+        assert.deepEqual(generatedJson, expectedJson);
       } else {
         const block = Blockly.Xml.domToBlock(
           Blockly.utils.xml.textToDom(testCase.xml),
@@ -100,7 +101,7 @@ export const runSerializationTestSuite = (testCases) => {
           Blockly.Xml.blockToDom(block),
         );
         const expectedXml = testCase.expectedXml || testCase.xml;
-        chai.assert.equal(generatedXml, expectedXml);
+        assert.equal(generatedXml, expectedXml);
       }
     };
   };

--- a/tests/mocha/test_helpers/variables.js
+++ b/tests/mocha/test_helpers/variables.js
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import {assert} from '../../../node_modules/chai/chai.js';
+
 /**
  * Check if a variable with the given values exists.
  * @param {Blockly.Workspace|Blockly.VariableMap} container The workspace  or
@@ -14,8 +16,8 @@
  */
 export function assertVariableValues(container, name, type, id) {
   const variable = container.getVariableById(id);
-  chai.assert.isDefined(variable);
-  chai.assert.equal(variable.name, name);
-  chai.assert.equal(variable.type, type);
-  chai.assert.equal(variable.getId(), id);
+  assert.isDefined(variable);
+  assert.equal(variable.name, name);
+  assert.equal(variable.type, type);
+  assert.equal(variable.getId(), id);
 }

--- a/tests/mocha/test_helpers/warnings.js
+++ b/tests/mocha/test_helpers/warnings.js
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import {assert} from '../../../node_modules/chai/chai.js';
+
 /**
  * Captures the strings sent to console.warn() when calling a function.
  * Copies from core.
@@ -35,9 +37,9 @@ export function assertWarnings(innerFunc, messages) {
     messages = [messages];
   }
   const warnings = captureWarnings(innerFunc);
-  chai.assert.lengthOf(warnings, messages.length);
+  assert.lengthOf(warnings, messages.length);
   messages.forEach((message, i) => {
-    chai.assert.match(warnings[i], message);
+    assert.match(warnings[i], message);
   });
 }
 

--- a/tests/mocha/test_helpers/workspace.js
+++ b/tests/mocha/test_helpers/workspace.js
@@ -454,10 +454,7 @@ export function testAWorkspace() {
     test('At instance limit of 0 after clear', function () {
       this.workspace.clear();
       this.workspace.options.maxInstances['get_var_block'] = 0;
-      assert.equal(
-        this.workspace.remainingCapacityOfType('get_var_block'),
-        0,
-      );
+      assert.equal(this.workspace.remainingCapacityOfType('get_var_block'), 0);
     });
 
     test('At instance limit with multiple block types', function () {
@@ -478,10 +475,7 @@ export function testAWorkspace() {
       this.workspace.newBlock('');
       this.workspace.options.maxInstances['get_var_block'] = 0;
       this.workspace.clear();
-      assert.equal(
-        this.workspace.remainingCapacityOfType('get_var_block'),
-        0,
-      );
+      assert.equal(this.workspace.remainingCapacityOfType('get_var_block'), 0);
     });
 
     test('Over instance limit', function () {
@@ -672,14 +666,8 @@ export function testAWorkspace() {
     });
 
     test('Trivial', function () {
-      assert.equal(
-        this.workspace.getBlockById(this.blockA.id),
-        this.blockA,
-      );
-      assert.equal(
-        this.workspace.getBlockById(this.blockB.id),
-        this.blockB,
-      );
+      assert.equal(this.workspace.getBlockById(this.blockA.id), this.blockA);
+      assert.equal(this.workspace.getBlockById(this.blockB.id), this.blockB);
     });
 
     test('Null id', function () {
@@ -693,10 +681,7 @@ export function testAWorkspace() {
     test('After dispose', function () {
       this.blockA.dispose();
       assert.isNull(this.workspace.getBlockById(this.blockA.id));
-      assert.equal(
-        this.workspace.getBlockById(this.blockB.id),
-        this.blockB,
-      );
+      assert.equal(this.workspace.getBlockById(this.blockB.id), this.blockB);
     });
 
     test('After clear', function () {
@@ -1435,10 +1420,7 @@ export function testAWorkspace() {
           // Check the undoStack only recorded one delete event.
           const undoStack = this.workspace.undoStack_;
           assert.equal(undoStack[undoStack.length - 1].type, 'var_delete');
-          assert.notEqual(
-            undoStack[undoStack.length - 2].type,
-            'var_delete',
-          );
+          assert.notEqual(undoStack[undoStack.length - 2].type, 'var_delete');
 
           // Undo delete
           this.workspace.undo();
@@ -1471,10 +1453,7 @@ export function testAWorkspace() {
           const undoStack = this.workspace.undoStack_;
           assert.equal(undoStack[undoStack.length - 1].type, 'var_delete');
           assert.equal(undoStack[undoStack.length - 2].type, 'delete');
-          assert.notEqual(
-            undoStack[undoStack.length - 3].type,
-            'var_delete',
-          );
+          assert.notEqual(undoStack[undoStack.length - 3].type, 'var_delete');
 
           // Undo delete
           this.workspace.undo();

--- a/tests/mocha/test_helpers/workspace.js
+++ b/tests/mocha/test_helpers/workspace.js
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import {assert} from '../../../node_modules/chai/chai.js';
 import {assertVariableValues} from './variables.js';
 import {assertWarnings} from './warnings.js';
 import * as eventUtils from '../../../build/src/core/events/utils.js';
@@ -37,14 +38,14 @@ export function testAWorkspace() {
 
   function assertBlockVarModelName(workspace, blockIndex, name) {
     const block = workspace.getTopBlocks(false)[blockIndex];
-    chai.assert.exists(block, 'Block at topBlocks[' + blockIndex + ']');
+    assert.exists(block, 'Block at topBlocks[' + blockIndex + ']');
     const varModel = block.getVarModels()[0];
-    chai.assert.exists(
+    assert.exists(
       varModel,
       'VariableModel for block at topBlocks[' + blockIndex + ']',
     );
     const blockVarName = varModel.name;
-    chai.assert.equal(
+    assert.equal(
       blockVarName,
       name,
       'VariableModel name for block at topBlocks[' + blockIndex + ']',
@@ -72,9 +73,9 @@ export function testAWorkspace() {
       this.workspace.newBlock('');
 
       this.workspace.clear();
-      chai.assert.equal(this.workspace.getTopBlocks(false).length, 0);
+      assert.equal(this.workspace.getTopBlocks(false).length, 0);
       const varMapLength = this.workspace.getVariableMap().variableMap.size;
-      chai.assert.equal(varMapLength, 0);
+      assert.equal(varMapLength, 0);
     });
 
     test('No variables', function () {
@@ -82,9 +83,9 @@ export function testAWorkspace() {
       this.workspace.newBlock('');
 
       this.workspace.clear();
-      chai.assert.equal(this.workspace.getTopBlocks(false).length, 0);
+      assert.equal(this.workspace.getTopBlocks(false).length, 0);
       const varMapLength = this.workspace.getVariableMap().variableMap.size;
-      chai.assert.equal(varMapLength, 0);
+      assert.equal(varMapLength, 0);
     });
   });
 
@@ -106,7 +107,7 @@ export function testAWorkspace() {
 
       sinon.assert.notCalled(stub);
       const variable = this.workspace.getVariableById('id2');
-      chai.assert.isNull(variable);
+      assert.isNull(variable);
       assertVariableValues(this.workspace, 'name1', 'type1', 'id1');
       assertBlockVarModelName(this.workspace, 0, 'name1');
     });
@@ -120,7 +121,7 @@ export function testAWorkspace() {
 
       sinon.assert.calledOnce(stub);
       const variable = this.workspace.getVariableById('id1');
-      chai.assert.isNull(variable);
+      assert.isNull(variable);
       assertVariableValues(this.workspace, 'name2', 'type2', 'id2');
       assertBlockVarModelName(this.workspace, 0, 'name2');
     });
@@ -150,7 +151,7 @@ export function testAWorkspace() {
       this.workspace.renameVariableById('id1', 'name2');
       assertVariableValues(this.workspace, 'name2', 'type1', 'id1');
       // Renaming should not have created a new variable.
-      chai.assert.equal(this.workspace.getAllVariables().length, 1);
+      assert.equal(this.workspace.getAllVariables().length, 1);
     });
 
     test('Reference exists rename to name2', function () {
@@ -159,7 +160,7 @@ export function testAWorkspace() {
       this.workspace.renameVariableById('id1', 'name2');
       assertVariableValues(this.workspace, 'name2', 'type1', 'id1');
       // Renaming should not have created a new variable.
-      chai.assert.equal(this.workspace.getAllVariables().length, 1);
+      assert.equal(this.workspace.getAllVariables().length, 1);
       assertBlockVarModelName(this.workspace, 0, 'name2');
     });
 
@@ -169,7 +170,7 @@ export function testAWorkspace() {
       this.workspace.renameVariableById('id1', 'Name1');
       assertVariableValues(this.workspace, 'Name1', 'type1', 'id1');
       // Renaming should not have created a new variable.
-      chai.assert.equal(this.workspace.getAllVariables().length, 1);
+      assert.equal(this.workspace.getAllVariables().length, 1);
       assertBlockVarModelName(this.workspace, 0, 'Name1');
     });
 
@@ -184,9 +185,9 @@ export function testAWorkspace() {
         assertVariableValues(this.workspace, 'name2', 'type1', 'id2');
         // The first variable should have been deleted.
         const variable = this.workspace.getVariableById('id1');
-        chai.assert.isNull(variable);
+        assert.isNull(variable);
         // There should only be one variable left.
-        chai.assert.equal(this.workspace.getAllVariables().length, 1);
+        assert.equal(this.workspace.getAllVariables().length, 1);
 
         // Both blocks should now reference variable with name2.
         assertBlockVarModelName(this.workspace, 0, 'name2');
@@ -218,9 +219,9 @@ export function testAWorkspace() {
         assertVariableValues(this.workspace, 'Name2', 'type1', 'id2');
         // The first variable should have been deleted.
         const variable = this.workspace.getVariableById('id1');
-        chai.assert.isNull(variable);
+        assert.isNull(variable);
         // There should only be one variable left.
-        chai.assert.equal(this.workspace.getAllVariables().length, 1);
+        assert.equal(this.workspace.getAllVariables().length, 1);
 
         // Both blocks should now reference variable with Name2.
         assertBlockVarModelName(this.workspace, 0, 'Name2');
@@ -247,30 +248,30 @@ export function testAWorkspace() {
 
   suite('getTopBlocks(ordered=true)', function () {
     test('Empty workspace', function () {
-      chai.assert.equal(this.workspace.getTopBlocks(true).length, 0);
+      assert.equal(this.workspace.getTopBlocks(true).length, 0);
     });
 
     test('Flat workspace one block', function () {
       this.workspace.newBlock('');
-      chai.assert.equal(this.workspace.getTopBlocks(true).length, 1);
+      assert.equal(this.workspace.getTopBlocks(true).length, 1);
     });
 
     test('Flat workspace one block after dispose', function () {
       const blockA = this.workspace.newBlock('');
       this.workspace.newBlock('');
       blockA.dispose();
-      chai.assert.equal(this.workspace.getTopBlocks(true).length, 1);
+      assert.equal(this.workspace.getTopBlocks(true).length, 1);
     });
 
     test('Flat workspace two blocks', function () {
       this.workspace.newBlock('');
       this.workspace.newBlock('');
-      chai.assert.equal(this.workspace.getTopBlocks(true).length, 2);
+      assert.equal(this.workspace.getTopBlocks(true).length, 2);
     });
 
     test('Clear', function () {
       this.workspace.clear();
-      chai.assert.equal(
+      assert.equal(
         this.workspace.getTopBlocks(true).length,
         0,
         'Clear empty workspace',
@@ -278,72 +279,72 @@ export function testAWorkspace() {
       this.workspace.newBlock('');
       this.workspace.newBlock('');
       this.workspace.clear();
-      chai.assert.equal(this.workspace.getTopBlocks(true).length, 0);
+      assert.equal(this.workspace.getTopBlocks(true).length, 0);
     });
   });
 
   suite('getTopBlocks(ordered=false)', function () {
     test('Empty workspace', function () {
-      chai.assert.equal(this.workspace.getTopBlocks(false).length, 0);
+      assert.equal(this.workspace.getTopBlocks(false).length, 0);
     });
 
     test('Flat workspace one block', function () {
       this.workspace.newBlock('');
-      chai.assert.equal(this.workspace.getTopBlocks(false).length, 1);
+      assert.equal(this.workspace.getTopBlocks(false).length, 1);
     });
 
     test('Flat workspace one block after dispose', function () {
       const blockA = this.workspace.newBlock('');
       this.workspace.newBlock('');
       blockA.dispose();
-      chai.assert.equal(this.workspace.getTopBlocks(false).length, 1);
+      assert.equal(this.workspace.getTopBlocks(false).length, 1);
     });
 
     test('Flat workspace two blocks', function () {
       this.workspace.newBlock('');
       this.workspace.newBlock('');
-      chai.assert.equal(this.workspace.getTopBlocks(false).length, 2);
+      assert.equal(this.workspace.getTopBlocks(false).length, 2);
     });
 
     test('Clear empty workspace', function () {
       this.workspace.clear();
-      chai.assert.equal(this.workspace.getTopBlocks(false).length, 0);
+      assert.equal(this.workspace.getTopBlocks(false).length, 0);
     });
 
     test('Clear non-empty workspace', function () {
       this.workspace.newBlock('');
       this.workspace.newBlock('');
       this.workspace.clear();
-      chai.assert.equal(this.workspace.getTopBlocks(false).length, 0);
+      assert.equal(this.workspace.getTopBlocks(false).length, 0);
     });
   });
 
   suite('getAllBlocks', function () {
     test('Empty workspace', function () {
-      chai.assert.equal(this.workspace.getAllBlocks(true).length, 0);
+      assert.equal(this.workspace.getAllBlocks(true).length, 0);
     });
 
     test('Flat workspace one block', function () {
       this.workspace.newBlock('');
-      chai.assert.equal(this.workspace.getAllBlocks(true).length, 1);
+      assert.equal(this.workspace.getAllBlocks(true).length, 1);
     });
 
     test('Flat workspace one block after dispose', function () {
       const blockA = this.workspace.newBlock('');
       this.workspace.newBlock('');
       blockA.dispose();
-      chai.assert.equal(this.workspace.getAllBlocks(true).length, 1);
+      assert.equal(this.workspace.getAllBlocks(true).length, 1);
     });
 
     test('Flat workspace two blocks', function () {
       this.workspace.newBlock('');
       this.workspace.newBlock('');
-      chai.assert.equal(this.workspace.getAllBlocks(true).length, 2);
+      assert.equal(this.workspace.getAllBlocks(true).length, 2);
     });
 
     test('Clear', function () {
       this.workspace.clear();
-      chai.assert.equal(
+      assert.equal(
         this.workspace.getAllBlocks(true).length,
         0,
         'Clear empty workspace',
@@ -351,7 +352,7 @@ export function testAWorkspace() {
       this.workspace.newBlock('');
       this.workspace.newBlock('');
       this.workspace.clear();
-      chai.assert.equal(this.workspace.getAllBlocks(true).length, 0);
+      assert.equal(this.workspace.getAllBlocks(true).length, 0);
     });
   });
 
@@ -362,35 +363,35 @@ export function testAWorkspace() {
     });
 
     test('No block limit', function () {
-      chai.assert.equal(this.workspace.remainingCapacity(), Infinity);
+      assert.equal(this.workspace.remainingCapacity(), Infinity);
     });
 
     test('Under block limit', function () {
       this.workspace.options.maxBlocks = 3;
-      chai.assert.equal(this.workspace.remainingCapacity(), 1);
+      assert.equal(this.workspace.remainingCapacity(), 1);
       this.workspace.options.maxBlocks = 4;
-      chai.assert.equal(this.workspace.remainingCapacity(), 2);
+      assert.equal(this.workspace.remainingCapacity(), 2);
     });
 
     test('At block limit', function () {
       this.workspace.options.maxBlocks = 2;
-      chai.assert.equal(this.workspace.remainingCapacity(), 0);
+      assert.equal(this.workspace.remainingCapacity(), 0);
     });
 
     test('At block limit of 0 after clear', function () {
       this.workspace.options.maxBlocks = 0;
       this.workspace.clear();
-      chai.assert.equal(this.workspace.remainingCapacity(), 0);
+      assert.equal(this.workspace.remainingCapacity(), 0);
     });
 
     test('Over block limit', function () {
       this.workspace.options.maxBlocks = 1;
-      chai.assert.equal(this.workspace.remainingCapacity(), -1);
+      assert.equal(this.workspace.remainingCapacity(), -1);
     });
 
     test('Over block limit of 0', function () {
       this.workspace.options.maxBlocks = 0;
-      chai.assert.equal(this.workspace.remainingCapacity(), -2);
+      assert.equal(this.workspace.remainingCapacity(), -2);
     });
   });
 
@@ -402,7 +403,7 @@ export function testAWorkspace() {
     });
 
     test('No instance limit', function () {
-      chai.assert.equal(
+      assert.equal(
         this.workspace.remainingCapacityOfType('get_var_block'),
         Infinity,
       );
@@ -410,13 +411,13 @@ export function testAWorkspace() {
 
     test('Under instance limit', function () {
       this.workspace.options.maxInstances['get_var_block'] = 3;
-      chai.assert.equal(
+      assert.equal(
         this.workspace.remainingCapacityOfType('get_var_block'),
         1,
         'With maxInstances limit 3',
       );
       this.workspace.options.maxInstances['get_var_block'] = 4;
-      chai.assert.equal(
+      assert.equal(
         this.workspace.remainingCapacityOfType('get_var_block'),
         2,
         'With maxInstances limit 4',
@@ -428,13 +429,13 @@ export function testAWorkspace() {
       this.workspace.newBlock('');
       this.workspace.newBlock('');
       this.workspace.options.maxInstances['get_var_block'] = 3;
-      chai.assert.equal(
+      assert.equal(
         this.workspace.remainingCapacityOfType('get_var_block'),
         1,
         'With maxInstances limit 3',
       );
       this.workspace.options.maxInstances['get_var_block'] = 4;
-      chai.assert.equal(
+      assert.equal(
         this.workspace.remainingCapacityOfType('get_var_block'),
         2,
         'With maxInstances limit 4',
@@ -443,7 +444,7 @@ export function testAWorkspace() {
 
     test('At instance limit', function () {
       this.workspace.options.maxInstances['get_var_block'] = 2;
-      chai.assert.equal(
+      assert.equal(
         this.workspace.remainingCapacityOfType('get_var_block'),
         0,
         'With maxInstances limit 2',
@@ -453,7 +454,7 @@ export function testAWorkspace() {
     test('At instance limit of 0 after clear', function () {
       this.workspace.clear();
       this.workspace.options.maxInstances['get_var_block'] = 0;
-      chai.assert.equal(
+      assert.equal(
         this.workspace.remainingCapacityOfType('get_var_block'),
         0,
       );
@@ -464,7 +465,7 @@ export function testAWorkspace() {
       this.workspace.newBlock('');
       this.workspace.newBlock('');
       this.workspace.options.maxInstances['get_var_block'] = 2;
-      chai.assert.equal(
+      assert.equal(
         this.workspace.remainingCapacityOfType('get_var_block'),
         0,
         'With maxInstances limit 2',
@@ -477,7 +478,7 @@ export function testAWorkspace() {
       this.workspace.newBlock('');
       this.workspace.options.maxInstances['get_var_block'] = 0;
       this.workspace.clear();
-      chai.assert.equal(
+      assert.equal(
         this.workspace.remainingCapacityOfType('get_var_block'),
         0,
       );
@@ -485,7 +486,7 @@ export function testAWorkspace() {
 
     test('Over instance limit', function () {
       this.workspace.options.maxInstances['get_var_block'] = 1;
-      chai.assert.equal(
+      assert.equal(
         this.workspace.remainingCapacityOfType('get_var_block'),
         -1,
         'With maxInstances limit 1',
@@ -494,7 +495,7 @@ export function testAWorkspace() {
 
     test('Over instance limit of 0', function () {
       this.workspace.options.maxInstances['get_var_block'] = 0;
-      chai.assert.equal(
+      assert.equal(
         this.workspace.remainingCapacityOfType('get_var_block'),
         -2,
         'With maxInstances limit 0',
@@ -506,7 +507,7 @@ export function testAWorkspace() {
       this.workspace.newBlock('');
       this.workspace.newBlock('');
       this.workspace.options.maxInstances['get_var_block'] = 1;
-      chai.assert.equal(
+      assert.equal(
         this.workspace.remainingCapacityOfType('get_var_block'),
         -1,
         'With maxInstances limit 1',
@@ -518,7 +519,7 @@ export function testAWorkspace() {
       this.workspace.newBlock('');
       this.workspace.newBlock('');
       this.workspace.options.maxInstances['get_var_block'] = 0;
-      chai.assert.equal(
+      assert.equal(
         this.workspace.remainingCapacityOfType('get_var_block'),
         -2,
         'With maxInstances limit 0',
@@ -536,26 +537,26 @@ export function testAWorkspace() {
     test('Under block limit and no instance limit', function () {
       this.workspace.options.maxBlocks = 3;
       const typeCountsMap = {'get_var_block': 1};
-      chai.assert.isTrue(this.workspace.isCapacityAvailable(typeCountsMap));
+      assert.isTrue(this.workspace.isCapacityAvailable(typeCountsMap));
     });
 
     test('At block limit and no instance limit', function () {
       this.workspace.options.maxBlocks = 2;
       const typeCountsMap = {'get_var_block': 1};
-      chai.assert.isFalse(this.workspace.isCapacityAvailable(typeCountsMap));
+      assert.isFalse(this.workspace.isCapacityAvailable(typeCountsMap));
     });
 
     test('Over block limit of 0 and no instance limit', function () {
       this.workspace.options.maxBlocks = 0;
       const typeCountsMap = {'get_var_block': 1};
-      chai.assert.isFalse(this.workspace.isCapacityAvailable(typeCountsMap));
+      assert.isFalse(this.workspace.isCapacityAvailable(typeCountsMap));
     });
 
     test('Over block limit but under instance limit', function () {
       this.workspace.options.maxBlocks = 1;
       this.workspace.options.maxInstances['get_var_block'] = 3;
       const typeCountsMap = {'get_var_block': 1};
-      chai.assert.isFalse(
+      assert.isFalse(
         this.workspace.isCapacityAvailable(typeCountsMap),
         'With maxBlocks limit 1 and maxInstances limit 3',
       );
@@ -565,7 +566,7 @@ export function testAWorkspace() {
       this.workspace.options.maxBlocks = 0;
       this.workspace.options.maxInstances['get_var_block'] = 3;
       const typeCountsMap = {'get_var_block': 1};
-      chai.assert.isFalse(
+      assert.isFalse(
         this.workspace.isCapacityAvailable(typeCountsMap),
         'With maxBlocks limit 0 and maxInstances limit 3',
       );
@@ -575,7 +576,7 @@ export function testAWorkspace() {
       this.workspace.options.maxBlocks = 1;
       this.workspace.options.maxInstances['get_var_block'] = 2;
       const typeCountsMap = {'get_var_block': 1};
-      chai.assert.isFalse(
+      assert.isFalse(
         this.workspace.isCapacityAvailable(typeCountsMap),
         'With maxBlocks limit 1 and maxInstances limit 2',
       );
@@ -585,7 +586,7 @@ export function testAWorkspace() {
       this.workspace.options.maxBlocks = 1;
       this.workspace.options.maxInstances['get_var_block'] = 1;
       const typeCountsMap = {'get_var_block': 1};
-      chai.assert.isFalse(
+      assert.isFalse(
         this.workspace.isCapacityAvailable(typeCountsMap),
         'With maxBlocks limit 1 and maxInstances limit 1',
       );
@@ -595,7 +596,7 @@ export function testAWorkspace() {
       this.workspace.options.maxBlocks = 0;
       this.workspace.options.maxInstances['get_var_block'] = 1;
       const typeCountsMap = {'get_var_block': 1};
-      chai.assert.isFalse(
+      assert.isFalse(
         this.workspace.isCapacityAvailable(typeCountsMap),
         'With maxBlocks limit 0 and maxInstances limit 1',
       );
@@ -605,7 +606,7 @@ export function testAWorkspace() {
       this.workspace.options.maxBlocks = 1;
       this.workspace.options.maxInstances['get_var_block'] = 0;
       const typeCountsMap = {'get_var_block': 1};
-      chai.assert.isFalse(
+      assert.isFalse(
         this.workspace.isCapacityAvailable(typeCountsMap),
         'With maxBlocks limit 1 and maxInstances limit 0',
       );
@@ -615,7 +616,7 @@ export function testAWorkspace() {
       this.workspace.options.maxBlocks = 0;
       this.workspace.options.maxInstances['get_var_block'] = 0;
       const typeCountsMap = {'get_var_block': 1};
-      chai.assert.isFalse(this.workspace.isCapacityAvailable(typeCountsMap));
+      assert.isFalse(this.workspace.isCapacityAvailable(typeCountsMap));
     });
   });
 
@@ -631,12 +632,12 @@ export function testAWorkspace() {
     });
 
     test('Trivial', function () {
-      chai.assert.equal(
+      assert.equal(
         Blockly.Workspace.getById(this.workspace.id),
         this.workspace,
         'Find workspace',
       );
-      chai.assert.equal(
+      assert.equal(
         Blockly.Workspace.getById(this.workspaceB.id),
         this.workspaceB,
         'Find workspaceB',
@@ -644,16 +645,16 @@ export function testAWorkspace() {
     });
 
     test('Null id', function () {
-      chai.assert.isNull(Blockly.Workspace.getById(null));
+      assert.isNull(Blockly.Workspace.getById(null));
     });
 
     test('Non-existent id', function () {
-      chai.assert.isNull(Blockly.Workspace.getById('badId'));
+      assert.isNull(Blockly.Workspace.getById('badId'));
     });
 
     test('After dispose', function () {
       this.workspaceB.dispose();
-      chai.assert.isNull(Blockly.Workspace.getById(this.workspaceB.id));
+      assert.isNull(Blockly.Workspace.getById(this.workspaceB.id));
     });
   });
 
@@ -671,28 +672,28 @@ export function testAWorkspace() {
     });
 
     test('Trivial', function () {
-      chai.assert.equal(
+      assert.equal(
         this.workspace.getBlockById(this.blockA.id),
         this.blockA,
       );
-      chai.assert.equal(
+      assert.equal(
         this.workspace.getBlockById(this.blockB.id),
         this.blockB,
       );
     });
 
     test('Null id', function () {
-      chai.assert.isNull(this.workspace.getBlockById(null));
+      assert.isNull(this.workspace.getBlockById(null));
     });
 
     test('Non-existent id', function () {
-      chai.assert.isNull(this.workspace.getBlockById('badId'));
+      assert.isNull(this.workspace.getBlockById('badId'));
     });
 
     test('After dispose', function () {
       this.blockA.dispose();
-      chai.assert.isNull(this.workspace.getBlockById(this.blockA.id));
-      chai.assert.equal(
+      assert.isNull(this.workspace.getBlockById(this.blockA.id));
+      assert.equal(
         this.workspace.getBlockById(this.blockB.id),
         this.blockB,
       );
@@ -700,8 +701,8 @@ export function testAWorkspace() {
 
     test('After clear', function () {
       this.workspace.clear();
-      chai.assert.isNull(this.workspace.getBlockById(this.blockA.id));
-      chai.assert.isNull(this.workspace.getBlockById(this.blockB.id));
+      assert.isNull(this.workspace.getBlockById(this.blockA.id));
+      assert.isNull(this.workspace.getBlockById(this.blockB.id));
     });
   });
 
@@ -716,16 +717,16 @@ export function testAWorkspace() {
       const expectedString =
         '\n' + Blockly.Xml.domToPrettyText(expected) + '\n';
 
-      chai.assert.equal(actual.tagName, expected.tagName);
+      assert.equal(actual.tagName, expected.tagName);
       for (let i = 0, attr; (attr = expected.attributes[i]); i++) {
-        chai.assert.equal(
+        assert.equal(
           actual.getAttribute(attr.name),
           attr.value,
           `expected attribute ${attr.name} on ${actualString} to match ` +
             `${expectedString}`,
         );
       }
-      chai.assert.equal(
+      assert.equal(
         actual.childElementCount,
         expected.childElementCount,
         `expected node ${actualString} to have the same children as node ` +
@@ -1220,7 +1221,7 @@ export function testAWorkspace() {
           '  </block>' +
           '</xml>';
         testUndoDisconnect.call(this, xml, '2');
-        chai.assert.equal(
+        assert.equal(
           this.workspace.getAllBlocks().length,
           2,
           'expected there to only be 2 blocks on the workspace ' +
@@ -1239,7 +1240,7 @@ export function testAWorkspace() {
           '  </block>' +
           '</xml>';
         testUndoDisconnect.call(this, xml, '2');
-        chai.assert.equal(
+        assert.equal(
           this.workspace.getAllBlocks().length,
           2,
           'expected there to only be 2 blocks on the workspace ' +
@@ -1275,11 +1276,11 @@ export function testAWorkspace() {
           this.workspace.undo();
           this.clock.runAll();
           assertVariableValues(this.workspace, 'name1', 'type1', 'id1');
-          chai.assert.isNull(this.workspace.getVariableById('id2'));
+          assert.isNull(this.workspace.getVariableById('id2'));
 
           this.workspace.undo();
-          chai.assert.isNull(this.workspace.getVariableById('id1'));
-          chai.assert.isNull(this.workspace.getVariableById('id2'));
+          assert.isNull(this.workspace.getVariableById('id1'));
+          assert.isNull(this.workspace.getVariableById('id2'));
         });
 
         test('Undo and redo', function () {
@@ -1289,7 +1290,7 @@ export function testAWorkspace() {
           this.workspace.undo();
           this.clock.runAll();
           assertVariableValues(this.workspace, 'name1', 'type1', 'id1');
-          chai.assert.isNull(this.workspace.getVariableById('id2'));
+          assert.isNull(this.workspace.getVariableById('id2'));
 
           this.workspace.undo(true);
 
@@ -1299,13 +1300,13 @@ export function testAWorkspace() {
 
           this.workspace.undo();
           this.workspace.undo();
-          chai.assert.isNull(this.workspace.getVariableById('id1'));
-          chai.assert.isNull(this.workspace.getVariableById('id2'));
+          assert.isNull(this.workspace.getVariableById('id1'));
+          assert.isNull(this.workspace.getVariableById('id2'));
           this.workspace.undo(true);
 
           // Expect that variable 'id1' is recreated
           assertVariableValues(this.workspace, 'name1', 'type1', 'id1');
-          chai.assert.isNull(this.workspace.getVariableById('id2'));
+          assert.isNull(this.workspace.getVariableById('id2'));
         });
       });
 
@@ -1319,7 +1320,7 @@ export function testAWorkspace() {
 
           this.workspace.undo();
           this.clock.runAll();
-          chai.assert.isNull(this.workspace.getVariableById('id1'));
+          assert.isNull(this.workspace.getVariableById('id1'));
           assertVariableValues(this.workspace, 'name2', 'type2', 'id2');
 
           this.workspace.undo();
@@ -1340,7 +1341,7 @@ export function testAWorkspace() {
           this.workspace.undo();
           this.clock.runAll();
           assertBlockVarModelName(this.workspace, 0, 'name2');
-          chai.assert.isNull(this.workspace.getVariableById('id1'));
+          assert.isNull(this.workspace.getVariableById('id1'));
           assertVariableValues(this.workspace, 'name2', 'type2', 'id2');
 
           this.workspace.undo();
@@ -1360,14 +1361,14 @@ export function testAWorkspace() {
 
           this.workspace.undo();
           this.clock.runAll();
-          chai.assert.isNull(this.workspace.getVariableById('id1'));
+          assert.isNull(this.workspace.getVariableById('id1'));
           assertVariableValues(this.workspace, 'name2', 'type2', 'id2');
 
           this.workspace.undo(true);
           this.clock.runAll();
           // Expect that both variables are deleted
-          chai.assert.isNull(this.workspace.getVariableById('id1'));
-          chai.assert.isNull(this.workspace.getVariableById('id2'));
+          assert.isNull(this.workspace.getVariableById('id1'));
+          assert.isNull(this.workspace.getVariableById('id2'));
 
           this.workspace.undo();
           this.clock.runAll();
@@ -1379,7 +1380,7 @@ export function testAWorkspace() {
           this.workspace.undo(true);
           this.clock.runAll();
           // Expect that variable 'id2' is recreated
-          chai.assert.isNull(this.workspace.getVariableById('id1'));
+          assert.isNull(this.workspace.getVariableById('id1'));
           assertVariableValues(this.workspace, 'name2', 'type2', 'id2');
         });
 
@@ -1395,15 +1396,15 @@ export function testAWorkspace() {
           this.workspace.undo();
           this.clock.runAll();
           assertBlockVarModelName(this.workspace, 0, 'name2');
-          chai.assert.isNull(this.workspace.getVariableById('id1'));
+          assert.isNull(this.workspace.getVariableById('id1'));
           assertVariableValues(this.workspace, 'name2', 'type2', 'id2');
 
           this.workspace.undo(true);
           this.clock.runAll();
           // Expect that both variables are deleted
-          chai.assert.equal(this.workspace.getTopBlocks(false).length, 0);
-          chai.assert.isNull(this.workspace.getVariableById('id1'));
-          chai.assert.isNull(this.workspace.getVariableById('id2'));
+          assert.equal(this.workspace.getTopBlocks(false).length, 0);
+          assert.isNull(this.workspace.getVariableById('id1'));
+          assert.isNull(this.workspace.getVariableById('id2'));
 
           this.workspace.undo();
           this.clock.runAll();
@@ -1418,7 +1419,7 @@ export function testAWorkspace() {
           this.clock.runAll();
           // Expect that variable 'id2' is recreated
           assertBlockVarModelName(this.workspace, 0, 'name2');
-          chai.assert.isNull(this.workspace.getVariableById('id1'));
+          assert.isNull(this.workspace.getVariableById('id1'));
           assertVariableValues(this.workspace, 'name2', 'type2', 'id2');
         });
 
@@ -1433,8 +1434,8 @@ export function testAWorkspace() {
 
           // Check the undoStack only recorded one delete event.
           const undoStack = this.workspace.undoStack_;
-          chai.assert.equal(undoStack[undoStack.length - 1].type, 'var_delete');
-          chai.assert.notEqual(
+          assert.equal(undoStack[undoStack.length - 1].type, 'var_delete');
+          assert.notEqual(
             undoStack[undoStack.length - 2].type,
             'var_delete',
           );
@@ -1447,12 +1448,12 @@ export function testAWorkspace() {
           // Redo delete
           this.workspace.undo(true);
           this.clock.runAll();
-          chai.assert.isNull(this.workspace.getVariableById('id1'));
+          assert.isNull(this.workspace.getVariableById('id1'));
 
           // Redo delete, nothing should happen
           this.workspace.undo(true);
           this.clock.runAll();
-          chai.assert.isNull(this.workspace.getVariableById('id1'));
+          assert.isNull(this.workspace.getVariableById('id1'));
         });
 
         test('Delete same variable twice with usages', function () {
@@ -1468,9 +1469,9 @@ export function testAWorkspace() {
 
           // Check the undoStack only recorded one delete event.
           const undoStack = this.workspace.undoStack_;
-          chai.assert.equal(undoStack[undoStack.length - 1].type, 'var_delete');
-          chai.assert.equal(undoStack[undoStack.length - 2].type, 'delete');
-          chai.assert.notEqual(
+          assert.equal(undoStack[undoStack.length - 1].type, 'var_delete');
+          assert.equal(undoStack[undoStack.length - 2].type, 'delete');
+          assert.notEqual(
             undoStack[undoStack.length - 3].type,
             'var_delete',
           );
@@ -1484,14 +1485,14 @@ export function testAWorkspace() {
           // Redo delete
           this.workspace.undo(true);
           this.clock.runAll();
-          chai.assert.equal(this.workspace.getTopBlocks(false).length, 0);
-          chai.assert.isNull(this.workspace.getVariableById('id1'));
+          assert.equal(this.workspace.getTopBlocks(false).length, 0);
+          assert.isNull(this.workspace.getVariableById('id1'));
 
           // Redo delete, nothing should happen
           this.workspace.undo(true);
           this.clock.runAll();
-          chai.assert.equal(this.workspace.getTopBlocks(false).length, 0);
-          chai.assert.isNull(this.workspace.getVariableById('id1'));
+          assert.equal(this.workspace.getTopBlocks(false).length, 0);
+          assert.isNull(this.workspace.getVariableById('id1'));
         });
       });
 
@@ -1572,7 +1573,7 @@ export function testAWorkspace() {
             this.workspace.undo(true);
             this.clock.runAll();
             assertVariableValues(this.workspace, 'name2', 'type1', 'id2');
-            chai.assert.isNull(this.workspace.getVariableById('id1'));
+            assert.isNull(this.workspace.getVariableById('id1'));
           });
 
           test('Same type with usages rename variable with id1 to name2', function () {
@@ -1591,7 +1592,7 @@ export function testAWorkspace() {
             this.workspace.undo(true);
             this.clock.runAll();
             assertVariableValues(this.workspace, 'name2', 'type1', 'id2');
-            chai.assert.isNull(this.workspace.getVariableById('id1'));
+            assert.isNull(this.workspace.getVariableById('id1'));
           });
 
           test('Same type different capitalization no usages rename variable with id1 to Name2', function () {
@@ -1607,7 +1608,7 @@ export function testAWorkspace() {
             this.workspace.undo(true);
             this.clock.runAll();
             assertVariableValues(this.workspace, 'Name2', 'type1', 'id2');
-            chai.assert.isNull(this.workspace.getVariable('name1'));
+            assert.isNull(this.workspace.getVariable('name1'));
           });
 
           test('Same type different capitalization with usages rename variable with id1 to Name2', function () {
@@ -1626,7 +1627,7 @@ export function testAWorkspace() {
             this.workspace.undo(true);
             this.clock.runAll();
             assertVariableValues(this.workspace, 'Name2', 'type1', 'id2');
-            chai.assert.isNull(this.workspace.getVariableById('id1'));
+            assert.isNull(this.workspace.getVariableById('id1'));
             assertBlockVarModelName(this.workspace, 0, 'Name2');
             assertBlockVarModelName(this.workspace, 1, 'Name2');
           });

--- a/tests/mocha/theme_test.js
+++ b/tests/mocha/theme_test.js
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import {assert} from '../../node_modules/chai/chai.js';
 import {assertEventFired} from './test_helpers/events.js';
 import * as eventUtils from '../../build/src/core/events/utils.js';
 import {
@@ -75,7 +76,7 @@ suite('Theme', function () {
   function stringifyAndCompare(val1, val2) {
     const stringVal1 = JSON.stringify(val1);
     const stringVal2 = JSON.stringify(val2);
-    chai.assert.equal(stringVal1, stringVal2);
+    assert.equal(stringVal1, stringVal2);
   }
 
   test('Set All BlockStyles', function () {
@@ -144,7 +145,7 @@ suite('Theme', function () {
       stringifyAndCompare(workspace.getTheme(), theme);
 
       // Checks that the setTheme function was called on the block
-      chai.assert.equal(blockA.getStyleName(), 'styleTwo');
+      assert.equal(blockA.getStyleName(), 'styleTwo');
 
       // Checks that the toolbox refreshed method was called
       sinon.assert.calledOnce(refreshToolboxSelectionStub);
@@ -300,7 +301,7 @@ suite('Theme', function () {
   suite('defineTheme', function () {
     test('Normalizes to lowercase', function () {
       const theme = Blockly.Theme.defineTheme('TEST', {});
-      chai.assert.equal(theme.name, 'test');
+      assert.equal(theme.name, 'test');
     });
   });
 });

--- a/tests/mocha/toolbox_test.js
+++ b/tests/mocha/toolbox_test.js
@@ -361,10 +361,7 @@ suite('Toolbox', function () {
         this.toolbox.selectedItem_ = item;
         const handled = this.toolbox.selectNext_();
         assert.isTrue(handled);
-        assert.equal(
-          this.toolbox.selectedItem_,
-          this.toolbox.contents_[1],
-        );
+        assert.equal(this.toolbox.selectedItem_, this.toolbox.contents_[1]);
       });
       test('Selected item is last item -> Should not handle event', function () {
         const item = this.toolbox.contents_[this.toolbox.contents_.length - 1];
@@ -521,11 +518,7 @@ suite('Toolbox', function () {
     });
 
     function checkHorizontalToolbox(toolbox) {
-      assert.equal(
-        toolbox.HtmlDiv.style.left,
-        '0px',
-        'Check left position',
-      );
+      assert.equal(toolbox.HtmlDiv.style.left, '0px', 'Check left position');
       assert.equal(toolbox.HtmlDiv.style.height, 'auto', 'Check height');
       assert.equal(toolbox.HtmlDiv.style.width, '100%', 'Check width');
       assert.equal(
@@ -536,11 +529,7 @@ suite('Toolbox', function () {
     }
     function checkVerticalToolbox(toolbox) {
       assert.equal(toolbox.HtmlDiv.style.height, '100%', 'Check height');
-      assert.equal(
-        toolbox.width_,
-        toolbox.HtmlDiv.offsetWidth,
-        'Check width',
-      );
+      assert.equal(toolbox.width_, toolbox.HtmlDiv.offsetWidth, 'Check width');
     }
     test('HtmlDiv is not created -> Should not resize', function () {
       const toolbox = this.toolbox;

--- a/tests/mocha/toolbox_test.js
+++ b/tests/mocha/toolbox_test.js
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import {assert} from '../../node_modules/chai/chai.js';
 import {defineStackBlock} from './test_helpers/block_definitions.js';
 import {
   sharedTestSetup,
@@ -41,12 +42,12 @@ suite('Toolbox', function () {
     });
 
     test('Init called -> HtmlDiv is created', function () {
-      chai.assert.isDefined(this.toolbox.HtmlDiv);
+      assert.isDefined(this.toolbox.HtmlDiv);
     });
     test('Init called -> HtmlDiv is inserted before parent node', function () {
       const toolboxDiv = Blockly.common.getMainWorkspace().getInjectionDiv()
         .childNodes[0];
-      chai.assert.equal(
+      assert.equal(
         toolboxDiv.className,
         'blocklyToolboxDiv blocklyNonSelectable',
       );
@@ -81,7 +82,7 @@ suite('Toolbox', function () {
       const componentManager = this.toolbox.workspace_.getComponentManager();
       sinon.stub(componentManager, 'addComponent');
       this.toolbox.init();
-      chai.assert.isDefined(this.toolbox.flyout_);
+      assert.isDefined(this.toolbox.flyout_);
     });
   });
 
@@ -100,7 +101,7 @@ suite('Toolbox', function () {
           {'kind': 'category', 'contents': []},
         ],
       });
-      chai.assert.lengthOf(this.toolbox.contents_, 2);
+      assert.lengthOf(this.toolbox.contents_, 2);
       sinon.assert.called(positionStub);
     });
     // TODO: Uncomment once implemented.
@@ -114,7 +115,7 @@ suite('Toolbox', function () {
           'kind': 'category',
         },
       ];
-      chai.assert.throws(function () {
+      assert.throws(function () {
         toolbox.render({'contents': badToolboxDef});
       }, 'Toolbox cannot have both blocks and categories in the root level.');
     });
@@ -122,7 +123,7 @@ suite('Toolbox', function () {
     test.skip('Expanded set to true for a non collapsible toolbox item -> Should open flyout', function () {
       this.toolbox.render(this.toolboxXml);
       const selectedNode = this.toolbox.tree_.children_[0];
-      chai.assert.isTrue(selectedNode.selected_);
+      assert.isTrue(selectedNode.selected_);
     });
     test('JSON toolbox definition -> Should create toolbox with contents', function () {
       const jsonDef = {
@@ -155,7 +156,7 @@ suite('Toolbox', function () {
         ],
       };
       this.toolbox.render(jsonDef);
-      chai.assert.lengthOf(this.toolbox.contents_, 1);
+      assert.lengthOf(this.toolbox.contents_, 1);
     });
     test('multiple icon classes can be applied', function () {
       const jsonDef = {
@@ -175,10 +176,10 @@ suite('Toolbox', function () {
           },
         ],
       };
-      chai.assert.doesNotThrow(() => {
+      assert.doesNotThrow(() => {
         this.toolbox.render(jsonDef);
       });
-      chai.assert.lengthOf(this.toolbox.contents_, 1);
+      assert.lengthOf(this.toolbox.contents_, 1);
     });
   });
 
@@ -298,20 +299,20 @@ suite('Toolbox', function () {
       test('No item is selected -> Should not handle event', function () {
         this.toolbox.selectedItem_ = null;
         const handled = this.toolbox.selectChild_();
-        chai.assert.isFalse(handled);
+        assert.isFalse(handled);
       });
       test('Selected item is not collapsible -> Should not handle event', function () {
         this.toolbox.selectedItem_ = getNonCollapsibleItem(this.toolbox);
         const handled = this.toolbox.selectChild_();
-        chai.assert.isFalse(handled);
+        assert.isFalse(handled);
       });
       test('Selected item is collapsible -> Should expand', function () {
         const collapsibleItem = getCollapsibleItem(this.toolbox);
         this.toolbox.selectedItem_ = collapsibleItem;
         const handled = this.toolbox.selectChild_();
-        chai.assert.isTrue(handled);
-        chai.assert.isTrue(collapsibleItem.isExpanded());
-        chai.assert.equal(this.toolbox.selectedItem_, collapsibleItem);
+        assert.isTrue(handled);
+        assert.isTrue(collapsibleItem.isExpanded());
+        assert.equal(this.toolbox.selectedItem_, collapsibleItem);
       });
 
       test('Selected item is expanded -> Should select child', function () {
@@ -320,7 +321,7 @@ suite('Toolbox', function () {
         const selectNextStub = sinon.stub(this.toolbox, 'selectNext_');
         this.toolbox.selectedItem_ = collapsibleItem;
         const handled = this.toolbox.selectChild_();
-        chai.assert.isTrue(handled);
+        assert.isTrue(handled);
         sinon.assert.called(selectNextStub);
       });
     });
@@ -329,23 +330,23 @@ suite('Toolbox', function () {
       test('No item selected -> Should not handle event', function () {
         this.toolbox.selectedItem_ = null;
         const handled = this.toolbox.selectParent_();
-        chai.assert.isFalse(handled);
+        assert.isFalse(handled);
       });
       test('Selected item is expanded -> Should collapse', function () {
         const collapsibleItem = getCollapsibleItem(this.toolbox);
         collapsibleItem.expanded_ = true;
         this.toolbox.selectedItem_ = collapsibleItem;
         const handled = this.toolbox.selectParent_();
-        chai.assert.isTrue(handled);
-        chai.assert.isFalse(collapsibleItem.isExpanded());
-        chai.assert.equal(this.toolbox.selectedItem_, collapsibleItem);
+        assert.isTrue(handled);
+        assert.isFalse(collapsibleItem.isExpanded());
+        assert.equal(this.toolbox.selectedItem_, collapsibleItem);
       });
       test('Selected item is not expanded -> Should get parent', function () {
         const childItem = getChildItem(this.toolbox);
         this.toolbox.selectedItem_ = childItem;
         const handled = this.toolbox.selectParent_();
-        chai.assert.isTrue(handled);
-        chai.assert.equal(this.toolbox.selectedItem_, childItem.getParent());
+        assert.isTrue(handled);
+        assert.equal(this.toolbox.selectedItem_, childItem.getParent());
       });
     });
 
@@ -353,14 +354,14 @@ suite('Toolbox', function () {
       test('No item is selected -> Should not handle event', function () {
         this.toolbox.selectedItem_ = null;
         const handled = this.toolbox.selectNext_();
-        chai.assert.isFalse(handled);
+        assert.isFalse(handled);
       });
       test('Next item is selectable -> Should select next item', function () {
         const item = this.toolbox.contents_[0];
         this.toolbox.selectedItem_ = item;
         const handled = this.toolbox.selectNext_();
-        chai.assert.isTrue(handled);
-        chai.assert.equal(
+        assert.isTrue(handled);
+        assert.equal(
           this.toolbox.selectedItem_,
           this.toolbox.contents_[1],
         );
@@ -369,8 +370,8 @@ suite('Toolbox', function () {
         const item = this.toolbox.contents_[this.toolbox.contents_.length - 1];
         this.toolbox.selectedItem_ = item;
         const handled = this.toolbox.selectNext_();
-        chai.assert.isFalse(handled);
-        chai.assert.equal(this.toolbox.selectedItem_, item);
+        assert.isFalse(handled);
+        assert.equal(this.toolbox.selectedItem_, item);
       });
       test('Selected item is collapsed -> Should skip over its children', function () {
         const item = getCollapsibleItem(this.toolbox);
@@ -378,8 +379,8 @@ suite('Toolbox', function () {
         item.expanded_ = false;
         this.toolbox.selectedItem_ = item;
         const handled = this.toolbox.selectNext_();
-        chai.assert.isTrue(handled);
-        chai.assert.notEqual(this.toolbox.selectedItem_, childItem);
+        assert.isTrue(handled);
+        assert.notEqual(this.toolbox.selectedItem_, childItem);
       });
     });
 
@@ -387,22 +388,22 @@ suite('Toolbox', function () {
       test('No item is selected -> Should not handle event', function () {
         this.toolbox.selectedItem_ = null;
         const handled = this.toolbox.selectPrevious_();
-        chai.assert.isFalse(handled);
+        assert.isFalse(handled);
       });
       test('Selected item is first item -> Should not handle event', function () {
         const item = this.toolbox.contents_[0];
         this.toolbox.selectedItem_ = item;
         const handled = this.toolbox.selectPrevious_();
-        chai.assert.isFalse(handled);
-        chai.assert.equal(this.toolbox.selectedItem_, item);
+        assert.isFalse(handled);
+        assert.equal(this.toolbox.selectedItem_, item);
       });
       test('Previous item is selectable -> Should select previous item', function () {
         const item = this.toolbox.contents_[1];
         const prevItem = this.toolbox.contents_[0];
         this.toolbox.selectedItem_ = item;
         const handled = this.toolbox.selectPrevious_();
-        chai.assert.isTrue(handled);
-        chai.assert.equal(this.toolbox.selectedItem_, prevItem);
+        assert.isTrue(handled);
+        assert.equal(this.toolbox.selectedItem_, prevItem);
       });
       test('Previous item is collapsed -> Should skip over children of the previous item', function () {
         const childItem = getChildItem(this.toolbox);
@@ -412,8 +413,8 @@ suite('Toolbox', function () {
         const item = this.toolbox.contents_[parentIdx + 1];
         this.toolbox.selectedItem_ = item;
         const handled = this.toolbox.selectPrevious_();
-        chai.assert.isTrue(handled);
-        chai.assert.notEqual(this.toolbox.selectedItem_, childItem);
+        assert.isTrue(handled);
+        assert.notEqual(this.toolbox.selectedItem_, childItem);
       });
     });
   });
@@ -520,22 +521,22 @@ suite('Toolbox', function () {
     });
 
     function checkHorizontalToolbox(toolbox) {
-      chai.assert.equal(
+      assert.equal(
         toolbox.HtmlDiv.style.left,
         '0px',
         'Check left position',
       );
-      chai.assert.equal(toolbox.HtmlDiv.style.height, 'auto', 'Check height');
-      chai.assert.equal(toolbox.HtmlDiv.style.width, '100%', 'Check width');
-      chai.assert.equal(
+      assert.equal(toolbox.HtmlDiv.style.height, 'auto', 'Check height');
+      assert.equal(toolbox.HtmlDiv.style.width, '100%', 'Check width');
+      assert.equal(
         toolbox.height_,
         toolbox.HtmlDiv.offsetHeight,
         'Check height',
       );
     }
     function checkVerticalToolbox(toolbox) {
-      chai.assert.equal(toolbox.HtmlDiv.style.height, '100%', 'Check height');
-      chai.assert.equal(
+      assert.equal(toolbox.HtmlDiv.style.height, '100%', 'Check height');
+      assert.equal(
         toolbox.width_,
         toolbox.HtmlDiv.offsetWidth,
         'Check width',
@@ -546,7 +547,7 @@ suite('Toolbox', function () {
       toolbox.HtmlDiv = null;
       toolbox.horizontalLayout_ = true;
       toolbox.position();
-      chai.assert.equal(toolbox.height_, 0);
+      assert.equal(toolbox.height_, 0);
     });
     test('Horizontal toolbox at top -> Should anchor horizontal toolbox to top', function () {
       const toolbox = this.toolbox;
@@ -554,7 +555,7 @@ suite('Toolbox', function () {
       toolbox.horizontalLayout_ = true;
       toolbox.position();
       checkHorizontalToolbox(toolbox);
-      chai.assert.equal(toolbox.HtmlDiv.style.top, '0px', 'Check top');
+      assert.equal(toolbox.HtmlDiv.style.top, '0px', 'Check top');
     });
     test('Horizontal toolbox at bottom -> Should anchor horizontal toolbox to bottom', function () {
       const toolbox = this.toolbox;
@@ -562,14 +563,14 @@ suite('Toolbox', function () {
       toolbox.horizontalLayout_ = true;
       toolbox.position();
       checkHorizontalToolbox(toolbox);
-      chai.assert.equal(toolbox.HtmlDiv.style.bottom, '0px', 'Check bottom');
+      assert.equal(toolbox.HtmlDiv.style.bottom, '0px', 'Check bottom');
     });
     test('Vertical toolbox at right -> Should anchor to right', function () {
       const toolbox = this.toolbox;
       toolbox.toolboxPosition = Blockly.utils.toolbox.Position.RIGHT;
       toolbox.horizontalLayout_ = false;
       toolbox.position();
-      chai.assert.equal(toolbox.HtmlDiv.style.right, '0px', 'Check right');
+      assert.equal(toolbox.HtmlDiv.style.right, '0px', 'Check right');
       checkVerticalToolbox(toolbox);
     });
     test('Vertical toolbox at left -> Should anchor to left', function () {
@@ -577,7 +578,7 @@ suite('Toolbox', function () {
       toolbox.toolboxPosition = Blockly.utils.toolbox.Position.LEFT;
       toolbox.horizontalLayout_ = false;
       toolbox.position();
-      chai.assert.equal(toolbox.HtmlDiv.style.left, '0px', 'Check left');
+      assert.equal(toolbox.HtmlDiv.style.left, '0px', 'Check left');
       checkVerticalToolbox(toolbox);
     });
   });
@@ -591,17 +592,17 @@ suite('Toolbox', function () {
     function checkValue(actual, expected, value) {
       const actualVal = actual[value];
       const expectedVal = expected[value];
-      chai.assert.equal(
+      assert.equal(
         actualVal.toUpperCase(),
         expectedVal.toUpperCase(),
         'Checking value for: ' + value,
       );
     }
     function checkContents(actualContents, expectedContents) {
-      chai.assert.equal(actualContents.length, expectedContents.length);
+      assert.equal(actualContents.length, expectedContents.length);
       for (let i = 0; i < actualContents.length; i++) {
         // TODO: Check the values as well as all the keys.
-        chai.assert.containsAllKeys(
+        assert.containsAllKeys(
           actualContents[i],
           Object.keys(expectedContents[i]),
         );
@@ -610,13 +611,13 @@ suite('Toolbox', function () {
     function checkCategory(actual, expected) {
       checkValue(actual, expected, 'kind');
       checkValue(actual, expected, 'name');
-      chai.assert.deepEqual(actual['cssconfig'], expected['cssconfig']);
+      assert.deepEqual(actual['cssconfig'], expected['cssconfig']);
       checkContents(actual.contents, expected.contents);
     }
     function checkCategoryToolbox(actual, expected) {
       const actualContents = actual['contents'];
       const expectedContents = expected['contents'];
-      chai.assert.equal(actualContents.length, expectedContents.length);
+      assert.equal(actualContents.length, expectedContents.length);
       for (let i = 0; i < expected.length; i++) {
         checkCategory(actualContents[i], expected[i]);
       }
@@ -630,28 +631,28 @@ suite('Toolbox', function () {
         const toolboxDef = Blockly.utils.toolbox.convertToolboxDefToJson(
           this.categoryToolboxJSON,
         );
-        chai.assert.isNotNull(toolboxDef);
+        assert.isNotNull(toolboxDef);
         checkCategoryToolbox(toolboxDef, this.categoryToolboxJSON);
       });
       test('Simple Toolbox: JSON', function () {
         const toolboxDef = Blockly.utils.toolbox.convertToolboxDefToJson(
           this.simpleToolboxJSON,
         );
-        chai.assert.isNotNull(toolboxDef);
+        assert.isNotNull(toolboxDef);
         checkSimpleToolbox(toolboxDef, this.simpleToolboxJSON);
       });
       test('Category Toolbox: xml', function () {
         const toolboxXml = document.getElementById('toolbox-categories');
         const toolboxDef =
           Blockly.utils.toolbox.convertToolboxDefToJson(toolboxXml);
-        chai.assert.isNotNull(toolboxDef);
+        assert.isNotNull(toolboxDef);
         checkCategoryToolbox(toolboxDef, this.categoryToolboxJSON);
       });
       test('Simple Toolbox: xml', function () {
         const toolboxXml = document.getElementById('toolbox-simple');
         const toolboxDef =
           Blockly.utils.toolbox.convertToolboxDefToJson(toolboxXml);
-        chai.assert.isNotNull(toolboxDef);
+        assert.isNotNull(toolboxDef);
         checkSimpleToolbox(toolboxDef, this.simpleToolboxJSON);
       });
       test('Simple Toolbox: string', function () {
@@ -675,7 +676,7 @@ suite('Toolbox', function () {
 
         const toolboxDef =
           Blockly.utils.toolbox.convertToolboxDefToJson(toolbox);
-        chai.assert.isNotNull(toolboxDef);
+        assert.isNotNull(toolboxDef);
         checkSimpleToolbox(toolboxDef, toolboxJson);
       });
       test('Category Toolbox: string', function () {
@@ -699,7 +700,7 @@ suite('Toolbox', function () {
 
         const toolboxDef =
           Blockly.utils.toolbox.convertToolboxDefToJson(toolbox);
-        chai.assert.isNotNull(toolboxDef);
+        assert.isNotNull(toolboxDef);
         checkSimpleToolbox(toolboxDef, toolboxJson);
       });
     });
@@ -747,7 +748,7 @@ suite('Toolbox', function () {
       middleCategory.toggleExpanded();
       innerCategory.show();
 
-      chai.assert.isTrue(
+      assert.isTrue(
         innerCategory.isVisible(),
         'All ancestors are expanded, so category should be visible',
       );
@@ -763,7 +764,7 @@ suite('Toolbox', function () {
       middleCategory.toggleExpanded();
       innerCategory.show();
 
-      chai.assert.isFalse(
+      assert.isFalse(
         innerCategory.isVisible(),
         'Not all ancestors are expanded, so category should not be visible',
       );

--- a/tests/mocha/tooltip_test.js
+++ b/tests/mocha/tooltip_test.js
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import {assert} from '../../node_modules/chai/chai.js';
 import {
   sharedTestSetup,
   sharedTestTeardown,
@@ -64,7 +65,7 @@ suite('Tooltip', function () {
       );
       this.clock.runAll();
 
-      chai.assert.isTrue(
+      assert.isTrue(
         wasCalled,
         'Expected custom tooltip function to have been called',
       );
@@ -75,7 +76,7 @@ suite('Tooltip', function () {
     const tooltipText = 'testTooltip';
 
     function assertTooltip(obj) {
-      chai.assert.equal(obj.getTooltip(), tooltipText);
+      assert.equal(obj.getTooltip(), tooltipText);
     }
 
     function setStringTooltip(obj) {
@@ -130,7 +131,7 @@ suite('Tooltip', function () {
 
       test('Function returning object', function () {
         setFunctionReturningObjectTooltip(this.block);
-        chai.assert.throws(
+        assert.throws(
           this.block.getTooltip.bind(this.block),
           'Tooltip function must return a string.',
         );
@@ -171,7 +172,7 @@ suite('Tooltip', function () {
 
       test('Function returning object', function () {
         setFunctionReturningObjectTooltip(this.block);
-        chai.assert.throws(
+        assert.throws(
           this.block.getTooltip.bind(this.block),
           'Tooltip function must return a string.',
         );
@@ -206,7 +207,7 @@ suite('Tooltip', function () {
 
       test('Function returning object', function () {
         setFunctionReturningObjectTooltip(this.field);
-        chai.assert.throws(
+        assert.throws(
           this.field.getTooltip.bind(this.field),
           'Tooltip function must return a string.',
         );
@@ -254,7 +255,7 @@ suite('Tooltip', function () {
 
       test('Function returning object', function () {
         setFunctionReturningObjectTooltip(this.field);
-        chai.assert.throws(
+        assert.throws(
           this.field.getTooltip.bind(this.field),
           'Tooltip function must return a string.',
         );

--- a/tests/mocha/touch_test.js
+++ b/tests/mocha/touch_test.js
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import {assert} from '../../node_modules/chai/chai.js';
 import {
   sharedTestSetup,
   sharedTestTeardown,
@@ -22,19 +23,19 @@ suite('Touch', function () {
   suite('shouldHandleTouch', function () {
     test('handles pointerdown event', function () {
       const pointerEvent = new PointerEvent('pointerdown');
-      chai.assert.isTrue(Blockly.Touch.shouldHandleEvent(pointerEvent));
+      assert.isTrue(Blockly.Touch.shouldHandleEvent(pointerEvent));
     });
 
     test('handles multiple pointerdown events', function () {
       const pointerEvent1 = new PointerEvent('pointerdown');
       const pointerEvent2 = new PointerEvent('pointerdown');
       Blockly.Touch.shouldHandleEvent(pointerEvent1);
-      chai.assert.isTrue(Blockly.Touch.shouldHandleEvent(pointerEvent2));
+      assert.isTrue(Blockly.Touch.shouldHandleEvent(pointerEvent2));
     });
 
     test('does not handle pointerup if not tracking touch', function () {
       const pointerEvent = new PointerEvent('pointerup');
-      chai.assert.isFalse(Blockly.Touch.shouldHandleEvent(pointerEvent));
+      assert.isFalse(Blockly.Touch.shouldHandleEvent(pointerEvent));
     });
 
     test('handles pointerup if already tracking a touch', function () {
@@ -42,7 +43,7 @@ suite('Touch', function () {
       const pointerup = new PointerEvent('pointerup');
       // Register the pointerdown event first
       Blockly.Touch.shouldHandleEvent(pointerdown);
-      chai.assert.isTrue(Blockly.Touch.shouldHandleEvent(pointerup));
+      assert.isTrue(Blockly.Touch.shouldHandleEvent(pointerup));
     });
 
     test('handles pointerdown if this is a new touch', function () {
@@ -50,7 +51,7 @@ suite('Touch', function () {
         pointerId: 1,
         pointerType: 'touch',
       });
-      chai.assert.isTrue(Blockly.Touch.shouldHandleEvent(pointerdown));
+      assert.isTrue(Blockly.Touch.shouldHandleEvent(pointerdown));
     });
 
     test('does not handle pointerdown if part of a different touch', function () {
@@ -63,7 +64,7 @@ suite('Touch', function () {
         pointerType: 'touch',
       });
       Blockly.Touch.shouldHandleEvent(pointerdown1);
-      chai.assert.isFalse(Blockly.Touch.shouldHandleEvent(pointerdown2));
+      assert.isFalse(Blockly.Touch.shouldHandleEvent(pointerdown2));
     });
 
     test('does not handle pointerup if not tracking touch', function () {
@@ -71,7 +72,7 @@ suite('Touch', function () {
         pointerId: 1,
         pointerType: 'touch',
       });
-      chai.assert.isFalse(Blockly.Touch.shouldHandleEvent(pointerup));
+      assert.isFalse(Blockly.Touch.shouldHandleEvent(pointerup));
     });
 
     test('handles pointerup if part of existing touch', function () {
@@ -84,7 +85,7 @@ suite('Touch', function () {
         pointerType: 'touch',
       });
       Blockly.Touch.shouldHandleEvent(pointerdown);
-      chai.assert.isTrue(Blockly.Touch.shouldHandleEvent(pointerup));
+      assert.isTrue(Blockly.Touch.shouldHandleEvent(pointerup));
     });
   });
 
@@ -94,7 +95,7 @@ suite('Touch', function () {
         pointerId: 7,
         pointerType: 'mouse',
       });
-      chai.assert.equal(
+      assert.equal(
         Blockly.Touch.getTouchIdentifierFromEvent(pointerdown),
         7,
       );
@@ -105,7 +106,7 @@ suite('Touch', function () {
         pointerId: 42,
         pointerType: 'touch',
       });
-      chai.assert.equal(
+      assert.equal(
         Blockly.Touch.getTouchIdentifierFromEvent(pointerdown),
         42,
       );

--- a/tests/mocha/touch_test.js
+++ b/tests/mocha/touch_test.js
@@ -95,10 +95,7 @@ suite('Touch', function () {
         pointerId: 7,
         pointerType: 'mouse',
       });
-      assert.equal(
-        Blockly.Touch.getTouchIdentifierFromEvent(pointerdown),
-        7,
-      );
+      assert.equal(Blockly.Touch.getTouchIdentifierFromEvent(pointerdown), 7);
     });
 
     test('is pointerId for touch PointerEvents', function () {
@@ -106,10 +103,7 @@ suite('Touch', function () {
         pointerId: 42,
         pointerType: 'touch',
       });
-      assert.equal(
-        Blockly.Touch.getTouchIdentifierFromEvent(pointerdown),
-        42,
-      );
+      assert.equal(Blockly.Touch.getTouchIdentifierFromEvent(pointerdown), 42);
     });
   });
 });

--- a/tests/mocha/trashcan_test.js
+++ b/tests/mocha/trashcan_test.js
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import {assert} from '../../node_modules/chai/chai.js';
 import {assertEventFired, assertEventNotFired} from './test_helpers/events.js';
 import {
   sharedTestSetup,
@@ -66,11 +67,11 @@ suite('Trashcan', function () {
   suite('Events', function () {
     test('Delete', function () {
       fireDeleteEvent(this.workspace, '<block type="test_field_block"/>');
-      chai.assert.equal(this.trashcan.contents.length, 1);
+      assert.equal(this.trashcan.contents.length, 1);
     });
     test('Non-Delete', function () {
       fireNonDeleteEvent(this.workspace);
-      chai.assert.equal(this.trashcan.contents.length, 0);
+      assert.equal(this.trashcan.contents.length, 0);
     });
     test('Non-Delete w/ oldXml', function () {
       let xml = Blockly.utils.xml.textToDom(
@@ -80,11 +81,11 @@ suite('Trashcan', function () {
       );
       xml = xml.children[0];
       fireNonDeleteEvent(this.workspace, xml);
-      chai.assert.equal(this.trashcan.contents.length, 0);
+      assert.equal(this.trashcan.contents.length, 0);
     });
     test('Shadow Delete', function () {
       fireDeleteEvent(this.workspace, '<shadow type="test_field_block"/>');
-      chai.assert.equal(this.trashcan.contents.length, 0);
+      assert.equal(this.trashcan.contents.length, 0);
     });
     test('Click without contents - fires workspace click', function () {
       simulateClick(this.trashcan.svgGroup);
@@ -102,7 +103,7 @@ suite('Trashcan', function () {
     });
     test('Click with contents - fires trashcanOpen', function () {
       fireDeleteEvent(this.workspace, '<block type="test_field_block"/>');
-      chai.assert.equal(this.trashcan.contents.length, 1);
+      assert.equal(this.trashcan.contents.length, 1);
       // Stub flyout interaction.
       const showFlyoutStub = sinon.stub(this.trashcan.flyout, 'show');
 
@@ -125,7 +126,7 @@ suite('Trashcan', function () {
 
       simulateClick(this.workspace.svgGroup_);
 
-      chai.assert.isFalse(
+      assert.isFalse(
         this.trashcan.flyout.isVisible(),
         'Expected flyout to be hidden',
       );
@@ -148,7 +149,7 @@ suite('Trashcan', function () {
     test('Simple', function () {
       fireDeleteEvent(this.workspace, '<block type="test_field_block"/>');
       fireDeleteEvent(this.workspace, '<block type="test_field_block"/>');
-      chai.assert.equal(this.trashcan.contents.length, 1);
+      assert.equal(this.trashcan.contents.length, 1);
     });
     test('Different Coords', function () {
       fireDeleteEvent(
@@ -159,7 +160,7 @@ suite('Trashcan', function () {
         this.workspace,
         '<block type="test_field_block" x="20" y="20"/>',
       );
-      chai.assert.equal(this.trashcan.contents.length, 1);
+      assert.equal(this.trashcan.contents.length, 1);
     });
     test('Different IDs', function () {
       fireDeleteEvent(
@@ -170,7 +171,7 @@ suite('Trashcan', function () {
         this.workspace,
         '<block type="test_field_block" id="id2"/>',
       );
-      chai.assert.equal(this.trashcan.contents.length, 1);
+      assert.equal(this.trashcan.contents.length, 1);
     });
     test('No Disabled - Disabled True', function () {
       fireDeleteEvent(this.workspace, '<block type="test_field_block"/>');
@@ -180,7 +181,7 @@ suite('Trashcan', function () {
       );
       // Disabled tags get removed because disabled blocks aren't allowed to
       // be dragged from flyouts. See #2239 and #3243.
-      chai.assert.equal(this.trashcan.contents.length, 1);
+      assert.equal(this.trashcan.contents.length, 1);
     });
     test('Different Field Values', function () {
       fireDeleteEvent(
@@ -195,7 +196,7 @@ suite('Trashcan', function () {
           '  <field name="NAME">dummy_value2</field>' +
           '</block>',
       );
-      chai.assert.equal(this.trashcan.contents.length, 2);
+      assert.equal(this.trashcan.contents.length, 2);
     });
     test('No Values - Values', function () {
       fireDeleteEvent(this.workspace, '<block type="row_block"/>');
@@ -207,7 +208,7 @@ suite('Trashcan', function () {
           '  </value>' +
           '</block>',
       );
-      chai.assert.equal(this.trashcan.contents.length, 2);
+      assert.equal(this.trashcan.contents.length, 2);
     });
     test('Different Value Blocks', function () {
       fireDeleteEvent(
@@ -226,7 +227,7 @@ suite('Trashcan', function () {
           '  </value>' +
           '</block>',
       );
-      chai.assert.equal(this.trashcan.contents.length, 2);
+      assert.equal(this.trashcan.contents.length, 2);
     });
     test('No Statements - Statements', function () {
       fireDeleteEvent(this.workspace, '<block type="statement_block"/>');
@@ -238,7 +239,7 @@ suite('Trashcan', function () {
           '  </statement>' +
           '</block>',
       );
-      chai.assert.equal(this.trashcan.contents.length, 2);
+      assert.equal(this.trashcan.contents.length, 2);
     });
     test('Different Statement Blocks', function () {
       fireDeleteEvent(
@@ -257,7 +258,7 @@ suite('Trashcan', function () {
           '  </statement>' +
           '</block>',
       );
-      chai.assert.equal(this.trashcan.contents.length, 2);
+      assert.equal(this.trashcan.contents.length, 2);
     });
     test('No Next - Next', function () {
       fireDeleteEvent(this.workspace, '<block type="stack_block"/>');
@@ -269,7 +270,7 @@ suite('Trashcan', function () {
           '  </next>' +
           '</block>',
       );
-      chai.assert.equal(this.trashcan.contents.length, 2);
+      assert.equal(this.trashcan.contents.length, 2);
     });
     test('Different Next Blocks', function () {
       fireDeleteEvent(
@@ -288,7 +289,7 @@ suite('Trashcan', function () {
           '  </next>' +
           '</block>',
       );
-      chai.assert.equal(this.trashcan.contents.length, 2);
+      assert.equal(this.trashcan.contents.length, 2);
     });
     test('No Comment - Comment', function () {
       fireDeleteEvent(this.workspace, '<block type="test_field_block"/>');
@@ -298,7 +299,7 @@ suite('Trashcan', function () {
           '  <comment>comment_text</comment>' +
           '</block>',
       );
-      chai.assert.equal(this.trashcan.contents.length, 2);
+      assert.equal(this.trashcan.contents.length, 2);
     });
     test('Different Comment Text', function () {
       fireDeleteEvent(
@@ -313,7 +314,7 @@ suite('Trashcan', function () {
           '  <comment>comment_text2</comment>' +
           '</block>',
       );
-      chai.assert.equal(this.trashcan.contents.length, 2);
+      assert.equal(this.trashcan.contents.length, 2);
     });
     test('Different Comment Size', function () {
       fireDeleteEvent(
@@ -329,7 +330,7 @@ suite('Trashcan', function () {
           '</block>',
       );
       // h & w tags are removed b/c the blocks appear the same.
-      chai.assert.equal(this.trashcan.contents.length, 1);
+      assert.equal(this.trashcan.contents.length, 1);
     });
     test('Different Comment Pinned', function () {
       fireDeleteEvent(
@@ -345,7 +346,7 @@ suite('Trashcan', function () {
           '</block>',
       );
       // pinned tags are removed b/c the blocks appear the same.
-      chai.assert.equal(this.trashcan.contents.length, 1);
+      assert.equal(this.trashcan.contents.length, 1);
     });
     test('Different Mutator', function () {
       fireDeleteEvent(
@@ -360,14 +361,14 @@ suite('Trashcan', function () {
           '  <mutation hasInputt="false"></mutation>' +
           '</block>',
       );
-      chai.assert.equal(this.trashcan.contents.length, 2);
+      assert.equal(this.trashcan.contents.length, 2);
     });
   });
   suite('Max Contents', function () {
     test('Max 0', function () {
       this.workspace.options.maxTrashcanContents = 0;
       fireDeleteEvent(this.workspace, '<block type="test_field_block"/>');
-      chai.assert.equal(this.trashcan.contents.length, 0);
+      assert.equal(this.trashcan.contents.length, 0);
       this.workspace.options.maxTrashcanContents = Infinity;
     });
   });

--- a/tests/mocha/utils_test.js
+++ b/tests/mocha/utils_test.js
@@ -31,17 +31,13 @@ suite('Utils', function () {
   suite('tokenizeInterpolation', function () {
     suite('Basic', function () {
       test('Empty string', function () {
-        assert.deepEqual(
-          Blockly.utils.parsing.tokenizeInterpolation(''),
-          [],
-        );
+        assert.deepEqual(Blockly.utils.parsing.tokenizeInterpolation(''), []);
       });
 
       test('No interpolation', function () {
-        assert.deepEqual(
-          Blockly.utils.parsing.tokenizeInterpolation('Hello'),
-          ['Hello'],
-        );
+        assert.deepEqual(Blockly.utils.parsing.tokenizeInterpolation('Hello'), [
+          'Hello',
+        ]);
       });
 
       test('Unescaped %', function () {
@@ -167,10 +163,9 @@ suite('Utils', function () {
 
       test('Not prefixed, number', function () {
         Blockly.Msg['1'] = 'test string';
-        assert.deepEqual(
-          Blockly.utils.parsing.tokenizeInterpolation('%{1}'),
-          ['%{1}'],
-        );
+        assert.deepEqual(Blockly.utils.parsing.tokenizeInterpolation('%{1}'), [
+          '%{1}',
+        ]);
       });
 
       test('Space in ref', function () {
@@ -239,11 +234,7 @@ suite('Utils', function () {
 
     resultString =
       Blockly.utils.parsing.replaceMessageReferences('Hello\nWorld');
-    assert.equal(
-      resultString,
-      'Hello\nWorld',
-      'Newlines are not tokenized',
-    );
+    assert.equal(resultString, 'Hello\nWorld', 'Newlines are not tokenized');
 
     resultString = Blockly.utils.parsing.replaceMessageReferences('%1');
     assert.equal(resultString, '%1', 'Interpolation tokens ignored.');
@@ -330,11 +321,7 @@ suite('Utils', function () {
     assert.equal(m[3], '16', 'translate(15 16), y');
 
     m = 'translate(1.23456e+42 0.123456e-42)'.match(regex);
-    assert.equal(
-      m[1],
-      '1.23456e+42',
-      'translate(1.23456e+42 0.123456e-42), x',
-    );
+    assert.equal(m[1], '1.23456e+42', 'translate(1.23456e+42 0.123456e-42), x');
     assert.equal(
       m[3],
       '0.123456e-42',
@@ -426,10 +413,7 @@ suite('Utils', function () {
       assert.isTrue(Blockly.utils.dom.hasClass(p, 'one'), 'Has "one"');
       assert.isTrue(Blockly.utils.dom.hasClass(p, 'two'), 'Has "two"');
       assert.isTrue(Blockly.utils.dom.hasClass(p, 'three'), 'Has "three"');
-      assert.isFalse(
-        Blockly.utils.dom.hasClass(p, 'four'),
-        'Has no "four"',
-      );
+      assert.isFalse(Blockly.utils.dom.hasClass(p, 'four'), 'Has no "four"');
       assert.isFalse(Blockly.utils.dom.hasClass(p, 't'), 'Has no "t"');
     });
 
@@ -535,11 +519,7 @@ suite('Utils', function () {
       assert.equal(Blockly.utils.math.toRadians(180), 2 * quarter, '180');
       assert.equal(Blockly.utils.math.toRadians(270), 3 * quarter, '270');
       assert.equal(Blockly.utils.math.toRadians(360), 4 * quarter, '360');
-      assert.equal(
-        Blockly.utils.math.toRadians(360 + 90),
-        5 * quarter,
-        '450',
-      );
+      assert.equal(Blockly.utils.math.toRadians(360 + 90), 5 * quarter, '450');
     });
 
     test('toDegrees', function () {
@@ -550,11 +530,7 @@ suite('Utils', function () {
       assert.equal(Blockly.utils.math.toDegrees(2 * quarter), 180, '180');
       assert.equal(Blockly.utils.math.toDegrees(3 * quarter), 270, '270');
       assert.equal(Blockly.utils.math.toDegrees(4 * quarter), 360, '360');
-      assert.equal(
-        Blockly.utils.math.toDegrees(5 * quarter),
-        360 + 90,
-        '450',
-      );
+      assert.equal(Blockly.utils.math.toDegrees(5 * quarter), 360 + 90, '450');
     });
   });
 });

--- a/tests/mocha/utils_test.js
+++ b/tests/mocha/utils_test.js
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import {assert} from '../../node_modules/chai/chai.js';
 import {
   sharedTestSetup,
   sharedTestTeardown,
@@ -19,10 +20,10 @@ suite('Utils', function () {
 
   test('genUid', function () {
     const uuids = {};
-    chai.assert.equal([1, 2, 3].indexOf(4), -1);
+    assert.equal([1, 2, 3].indexOf(4), -1);
     for (let i = 0; i < 1000; i++) {
       const uuid = Blockly.utils.idGenerator.genUid();
-      chai.assert.isFalse(uuid in uuids, 'UUID different: ' + uuid);
+      assert.isFalse(uuid in uuids, 'UUID different: ' + uuid);
       uuids[uuid] = true;
     }
   });
@@ -30,35 +31,35 @@ suite('Utils', function () {
   suite('tokenizeInterpolation', function () {
     suite('Basic', function () {
       test('Empty string', function () {
-        chai.assert.deepEqual(
+        assert.deepEqual(
           Blockly.utils.parsing.tokenizeInterpolation(''),
           [],
         );
       });
 
       test('No interpolation', function () {
-        chai.assert.deepEqual(
+        assert.deepEqual(
           Blockly.utils.parsing.tokenizeInterpolation('Hello'),
           ['Hello'],
         );
       });
 
       test('Unescaped %', function () {
-        chai.assert.deepEqual(
+        assert.deepEqual(
           Blockly.utils.parsing.tokenizeInterpolation('Hello%World'),
           ['Hello%World'],
         );
       });
 
       test('Escaped %', function () {
-        chai.assert.deepEqual(
+        assert.deepEqual(
           Blockly.utils.parsing.tokenizeInterpolation('Hello%%World'),
           ['Hello%World'],
         );
       });
 
       test('Newlines are tokenized', function () {
-        chai.assert.deepEqual(
+        assert.deepEqual(
           Blockly.utils.parsing.tokenizeInterpolation('Hello\nWorld'),
           ['Hello', '\n', 'World'],
         );
@@ -67,21 +68,21 @@ suite('Utils', function () {
 
     suite('Number interpolation', function () {
       test('Single-digit number interpolation', function () {
-        chai.assert.deepEqual(
+        assert.deepEqual(
           Blockly.utils.parsing.tokenizeInterpolation('Hello%1World'),
           ['Hello', 1, 'World'],
         );
       });
 
       test('Multi-digit number interpolation', function () {
-        chai.assert.deepEqual(
+        assert.deepEqual(
           Blockly.utils.parsing.tokenizeInterpolation('%123Hello%456World%789'),
           [123, 'Hello', 456, 'World', 789],
         );
       });
 
       test('Escaped number', function () {
-        chai.assert.deepEqual(
+        assert.deepEqual(
           Blockly.utils.parsing.tokenizeInterpolation('Hello %%1 World'),
           ['Hello %1 World'],
         );
@@ -90,7 +91,7 @@ suite('Utils', function () {
       test('Crazy interpolation', function () {
         // No idea what this is supposed to tell you if it breaks. But might
         // as well keep it.
-        chai.assert.deepEqual(
+        assert.deepEqual(
           Blockly.utils.parsing.tokenizeInterpolation('%%%x%%0%00%01%'),
           ['%%x%0', 0, 1, '%'],
         );
@@ -100,7 +101,7 @@ suite('Utils', function () {
     suite('String table interpolation', function () {
       test('Simple interpolation', function () {
         Blockly.Msg.STRING_REF = 'test string';
-        chai.assert.deepEqual(
+        assert.deepEqual(
           Blockly.utils.parsing.tokenizeInterpolation('%{bky_string_ref}'),
           ['test string'],
         );
@@ -108,7 +109,7 @@ suite('Utils', function () {
 
       test('Case', function () {
         Blockly.Msg.STRING_REF = 'test string';
-        chai.assert.deepEqual(
+        assert.deepEqual(
           Blockly.utils.parsing.tokenizeInterpolation('%{BkY_StRiNg_ReF}'),
           ['test string'],
         );
@@ -116,7 +117,7 @@ suite('Utils', function () {
 
       test('Surrounding text', function () {
         Blockly.Msg.STRING_REF = 'test string';
-        chai.assert.deepEqual(
+        assert.deepEqual(
           Blockly.utils.parsing.tokenizeInterpolation(
             'before %{bky_string_ref} after',
           ),
@@ -126,7 +127,7 @@ suite('Utils', function () {
 
       test('With param', function () {
         Blockly.Msg.WITH_PARAM = 'before %1 after';
-        chai.assert.deepEqual(
+        assert.deepEqual(
           Blockly.utils.parsing.tokenizeInterpolation('%{bky_with_param}'),
           ['before ', 1, ' after'],
         );
@@ -135,7 +136,7 @@ suite('Utils', function () {
       test('Recursive reference', function () {
         Blockly.Msg.STRING_REF = 'test string';
         Blockly.Msg.RECURSE = 'before %{bky_string_ref} after';
-        chai.assert.deepEqual(
+        assert.deepEqual(
           Blockly.utils.parsing.tokenizeInterpolation('%{bky_recurse}'),
           ['before test string after'],
         );
@@ -143,14 +144,14 @@ suite('Utils', function () {
 
       test('Number reference', function () {
         Blockly.Msg['1'] = 'test string';
-        chai.assert.deepEqual(
+        assert.deepEqual(
           Blockly.utils.parsing.tokenizeInterpolation('%{bky_1}'),
           ['test string'],
         );
       });
 
       test('Undefined reference', function () {
-        chai.assert.deepEqual(
+        assert.deepEqual(
           Blockly.utils.parsing.tokenizeInterpolation('%{bky_undefined}'),
           ['%{bky_undefined}'],
         );
@@ -158,7 +159,7 @@ suite('Utils', function () {
 
       test('Not prefixed', function () {
         Blockly.Msg.STRING_REF = 'test string';
-        chai.assert.deepEqual(
+        assert.deepEqual(
           Blockly.utils.parsing.tokenizeInterpolation('%{string_ref}'),
           ['%{string_ref}'],
         );
@@ -166,7 +167,7 @@ suite('Utils', function () {
 
       test('Not prefixed, number', function () {
         Blockly.Msg['1'] = 'test string';
-        chai.assert.deepEqual(
+        assert.deepEqual(
           Blockly.utils.parsing.tokenizeInterpolation('%{1}'),
           ['%{1}'],
         );
@@ -174,7 +175,7 @@ suite('Utils', function () {
 
       test('Space in ref', function () {
         Blockly.Msg['string ref'] = 'test string';
-        chai.assert.deepEqual(
+        assert.deepEqual(
           Blockly.utils.parsing.tokenizeInterpolation('%{bky_string ref}'),
           ['%{bky_string ref}'],
         );
@@ -182,7 +183,7 @@ suite('Utils', function () {
 
       test('Dash in ref', function () {
         Blockly.Msg['string-ref'] = 'test string';
-        chai.assert.deepEqual(
+        assert.deepEqual(
           Blockly.utils.parsing.tokenizeInterpolation('%{bky_string-ref}'),
           ['%{bky_string-ref}'],
         );
@@ -190,7 +191,7 @@ suite('Utils', function () {
 
       test('Period in ref', function () {
         Blockly.Msg['string.ref'] = 'test string';
-        chai.assert.deepEqual(
+        assert.deepEqual(
           Blockly.utils.parsing.tokenizeInterpolation('%{bky_string.ref}'),
           ['%{bky_string.ref}'],
         );
@@ -198,7 +199,7 @@ suite('Utils', function () {
 
       test('Ampersand in ref', function () {
         Blockly.Msg['string&ref'] = 'test string';
-        chai.assert.deepEqual(
+        assert.deepEqual(
           Blockly.utils.parsing.tokenizeInterpolation('%{bky_string&ref}'),
           ['%{bky_string&ref}'],
         );
@@ -206,7 +207,7 @@ suite('Utils', function () {
 
       test('Unclosed reference', function () {
         Blockly.Msg.UNCLOSED = 'test string';
-        chai.assert.deepEqual(
+        assert.deepEqual(
           Blockly.utils.parsing.tokenizeInterpolation('%{bky_unclosed'),
           ['%{bky_unclosed'],
         );
@@ -221,16 +222,16 @@ suite('Utils', function () {
     Blockly.Msg.STRING_REF_WITH_SUBREF = 'test %{bky_subref} string';
 
     let resultString = Blockly.utils.parsing.replaceMessageReferences('');
-    chai.assert.equal(resultString, '', 'Empty string produces empty string');
+    assert.equal(resultString, '', 'Empty string produces empty string');
 
     resultString = Blockly.utils.parsing.replaceMessageReferences('%%');
-    chai.assert.equal(resultString, '%', 'Escaped %');
+    assert.equal(resultString, '%', 'Escaped %');
     resultString =
       Blockly.utils.parsing.replaceMessageReferences('%%{bky_string_ref}');
-    chai.assert.equal(resultString, '%{bky_string_ref}', 'Escaped %');
+    assert.equal(resultString, '%{bky_string_ref}', 'Escaped %');
 
     resultString = Blockly.utils.parsing.replaceMessageReferences('%a');
-    chai.assert.equal(
+    assert.equal(
       resultString,
       '%a',
       'Unrecognized % escape code treated as literal',
@@ -238,19 +239,19 @@ suite('Utils', function () {
 
     resultString =
       Blockly.utils.parsing.replaceMessageReferences('Hello\nWorld');
-    chai.assert.equal(
+    assert.equal(
       resultString,
       'Hello\nWorld',
       'Newlines are not tokenized',
     );
 
     resultString = Blockly.utils.parsing.replaceMessageReferences('%1');
-    chai.assert.equal(resultString, '%1', 'Interpolation tokens ignored.');
+    assert.equal(resultString, '%1', 'Interpolation tokens ignored.');
     resultString = Blockly.utils.parsing.replaceMessageReferences('%1 %2');
-    chai.assert.equal(resultString, '%1 %2', 'Interpolation tokens ignored.');
+    assert.equal(resultString, '%1 %2', 'Interpolation tokens ignored.');
     resultString =
       Blockly.utils.parsing.replaceMessageReferences('before %1 after');
-    chai.assert.equal(
+    assert.equal(
       resultString,
       'before %1 after',
       'Interpolation tokens ignored.',
@@ -259,11 +260,11 @@ suite('Utils', function () {
     // Blockly.Msg.STRING_REF cases:
     resultString =
       Blockly.utils.parsing.replaceMessageReferences('%{bky_string_ref}');
-    chai.assert.equal(resultString, 'test string', 'Message ref dereferenced.');
+    assert.equal(resultString, 'test string', 'Message ref dereferenced.');
     resultString = Blockly.utils.parsing.replaceMessageReferences(
       'before %{bky_string_ref} after',
     );
-    chai.assert.equal(
+    assert.equal(
       resultString,
       'before test string after',
       'Message ref dereferenced.',
@@ -273,7 +274,7 @@ suite('Utils', function () {
     resultString = Blockly.utils.parsing.replaceMessageReferences(
       '%{bky_string_ref_with_arg}',
     );
-    chai.assert.equal(
+    assert.equal(
       resultString,
       'test %1 string',
       'Message ref dereferenced with argument preserved.',
@@ -281,7 +282,7 @@ suite('Utils', function () {
     resultString = Blockly.utils.parsing.replaceMessageReferences(
       'before %{bky_string_ref_with_arg} after',
     );
-    chai.assert.equal(
+    assert.equal(
       resultString,
       'before test %1 string after',
       'Message ref dereferenced with argument preserved.',
@@ -291,7 +292,7 @@ suite('Utils', function () {
     resultString = Blockly.utils.parsing.replaceMessageReferences(
       '%{bky_string_ref_with_subref}',
     );
-    chai.assert.equal(
+    assert.equal(
       resultString,
       'test subref string',
       'Message ref and subref dereferenced.',
@@ -299,7 +300,7 @@ suite('Utils', function () {
     resultString = Blockly.utils.parsing.replaceMessageReferences(
       'before %{bky_string_ref_with_subref} after',
     );
-    chai.assert.equal(
+    assert.equal(
       resultString,
       'before test subref string after',
       'Message ref and subref dereferenced.',
@@ -310,31 +311,31 @@ suite('Utils', function () {
     const regex = Blockly.utils.svgMath.TEST_ONLY.XY_REGEX;
     let m;
     m = 'INVALID'.match(regex);
-    chai.assert.isNull(m);
+    assert.isNull(m);
 
     m = 'translate(10)'.match(regex);
-    chai.assert.equal(m[1], '10', 'translate(10), x');
-    chai.assert.isUndefined(m[3], 'translate(10), y');
+    assert.equal(m[1], '10', 'translate(10), x');
+    assert.isUndefined(m[3], 'translate(10), y');
 
     m = 'translate(11, 12)'.match(regex);
-    chai.assert.equal(m[1], '11', 'translate(11, 12), x');
-    chai.assert.equal(m[3], '12', 'translate(11, 12), y');
+    assert.equal(m[1], '11', 'translate(11, 12), x');
+    assert.equal(m[3], '12', 'translate(11, 12), y');
 
     m = 'translate(13,14)'.match(regex);
-    chai.assert.equal(m[1], '13', 'translate(13,14), x');
-    chai.assert.equal(m[3], '14', 'translate(13,14), y');
+    assert.equal(m[1], '13', 'translate(13,14), x');
+    assert.equal(m[3], '14', 'translate(13,14), y');
 
     m = 'translate(15 16)'.match(regex);
-    chai.assert.equal(m[1], '15', 'translate(15 16), x');
-    chai.assert.equal(m[3], '16', 'translate(15 16), y');
+    assert.equal(m[1], '15', 'translate(15 16), x');
+    assert.equal(m[3], '16', 'translate(15 16), y');
 
     m = 'translate(1.23456e+42 0.123456e-42)'.match(regex);
-    chai.assert.equal(
+    assert.equal(
       m[1],
       '1.23456e+42',
       'translate(1.23456e+42 0.123456e-42), x',
     );
-    chai.assert.equal(
+    assert.equal(
       m[3],
       '0.123456e-42',
       'translate(1.23456e+42 0.123456e-42), y',
@@ -345,59 +346,59 @@ suite('Utils', function () {
     const regex = Blockly.utils.svgMath.TEST_ONLY.XY_STYLE_REGEX;
     let m;
     m = 'INVALID'.match(regex);
-    chai.assert.isNull(m);
+    assert.isNull(m);
 
     m = 'transform:translate(9px)'.match(regex);
-    chai.assert.equal(m[1], '9', 'transform:translate(9px), x');
-    chai.assert.isUndefined(m[3], 'transform:translate(9px), y');
+    assert.equal(m[1], '9', 'transform:translate(9px), x');
+    assert.isUndefined(m[3], 'transform:translate(9px), y');
 
     m = 'transform:translate3d(10px)'.match(regex);
-    chai.assert.equal(m[1], '10', 'transform:translate3d(10px), x');
-    chai.assert.isUndefined(m[3], 'transform:translate(10px), y');
+    assert.equal(m[1], '10', 'transform:translate3d(10px), x');
+    assert.isUndefined(m[3], 'transform:translate(10px), y');
 
     m = 'transform: translate(11px, 12px)'.match(regex);
-    chai.assert.equal(m[1], '11', 'transform: translate(11px, 12px), x');
-    chai.assert.equal(m[3], '12', 'transform: translate(11px, 12px), y');
+    assert.equal(m[1], '11', 'transform: translate(11px, 12px), x');
+    assert.equal(m[3], '12', 'transform: translate(11px, 12px), y');
 
     m = 'transform: translate(13px,14px)'.match(regex);
-    chai.assert.equal(m[1], '13', 'transform: translate(13px,14px), x');
-    chai.assert.equal(m[3], '14', 'transform: translate(13px,14px), y');
+    assert.equal(m[1], '13', 'transform: translate(13px,14px), x');
+    assert.equal(m[3], '14', 'transform: translate(13px,14px), y');
 
     m = 'transform: translate(15px 16px)'.match(regex);
-    chai.assert.equal(m[1], '15', 'transform: translate(15px 16px), x');
-    chai.assert.equal(m[3], '16', 'transform: translate(15px 16px), y');
+    assert.equal(m[1], '15', 'transform: translate(15px 16px), x');
+    assert.equal(m[3], '16', 'transform: translate(15px 16px), y');
 
     m = 'transform: translate(1.23456e+42px 0.123456e-42px)'.match(regex);
-    chai.assert.equal(
+    assert.equal(
       m[1],
       '1.23456e+42',
       'transform: translate(1.23456e+42px 0.123456e-42px), x',
     );
-    chai.assert.equal(
+    assert.equal(
       m[3],
       '0.123456e-42',
       'transform: translate(1.23456e+42px 0.123456e-42px), y',
     );
 
     m = 'transform:translate3d(20px, 21px, 22px)'.match(regex);
-    chai.assert.equal(m[1], '20', 'transform:translate3d(20px, 21px, 22px), x');
-    chai.assert.equal(m[3], '21', 'transform:translate3d(20px, 21px, 22px), y');
+    assert.equal(m[1], '20', 'transform:translate3d(20px, 21px, 22px), x');
+    assert.equal(m[3], '21', 'transform:translate3d(20px, 21px, 22px), y');
 
     m = 'transform:translate3d(23px,24px,25px)'.match(regex);
-    chai.assert.equal(m[1], '23', 'transform:translate3d(23px,24px,25px), x');
-    chai.assert.equal(m[3], '24', 'transform:translate3d(23px,24px,25px), y');
+    assert.equal(m[1], '23', 'transform:translate3d(23px,24px,25px), x');
+    assert.equal(m[3], '24', 'transform:translate3d(23px,24px,25px), y');
 
     m = 'transform:translate3d(26px 27px 28px)'.match(regex);
-    chai.assert.equal(m[1], '26', 'transform:translate3d(26px 27px 28px), x');
-    chai.assert.equal(m[3], '27', 'transform:translate3d(26px 27px 28px), y');
+    assert.equal(m[1], '26', 'transform:translate3d(26px 27px 28px), x');
+    assert.equal(m[3], '27', 'transform:translate3d(26px 27px 28px), y');
 
     m = 'transform:translate3d(1.23456e+42px 0.123456e-42px 42px)'.match(regex);
-    chai.assert.equal(
+    assert.equal(
       m[1],
       '1.23456e+42',
       'transform:translate3d(1.23456e+42px 0.123456e-42px 42px), x',
     );
-    chai.assert.equal(
+    assert.equal(
       m[3],
       '0.123456e-42',
       'transform:translate3d(1.23456e+42px 0.123456e-42px 42px), y',
@@ -408,45 +409,45 @@ suite('Utils', function () {
     test('addClass', function () {
       const p = document.createElement('p');
       Blockly.utils.dom.addClass(p, 'one');
-      chai.assert.equal(p.className, 'one', 'Adding "one"');
+      assert.equal(p.className, 'one', 'Adding "one"');
       Blockly.utils.dom.addClass(p, 'one');
-      chai.assert.equal(p.className, 'one', 'Adding duplicate "one"');
+      assert.equal(p.className, 'one', 'Adding duplicate "one"');
       Blockly.utils.dom.addClass(p, 'two');
-      chai.assert.equal(p.className, 'one two', 'Adding "two"');
+      assert.equal(p.className, 'one two', 'Adding "two"');
       Blockly.utils.dom.addClass(p, 'two');
-      chai.assert.equal(p.className, 'one two', 'Adding duplicate "two"');
+      assert.equal(p.className, 'one two', 'Adding duplicate "two"');
       Blockly.utils.dom.addClass(p, 'three');
-      chai.assert.equal(p.className, 'one two three', 'Adding "three"');
+      assert.equal(p.className, 'one two three', 'Adding "three"');
     });
 
     test('hasClass', function () {
       const p = document.createElement('p');
       p.className = ' one three  two three  ';
-      chai.assert.isTrue(Blockly.utils.dom.hasClass(p, 'one'), 'Has "one"');
-      chai.assert.isTrue(Blockly.utils.dom.hasClass(p, 'two'), 'Has "two"');
-      chai.assert.isTrue(Blockly.utils.dom.hasClass(p, 'three'), 'Has "three"');
-      chai.assert.isFalse(
+      assert.isTrue(Blockly.utils.dom.hasClass(p, 'one'), 'Has "one"');
+      assert.isTrue(Blockly.utils.dom.hasClass(p, 'two'), 'Has "two"');
+      assert.isTrue(Blockly.utils.dom.hasClass(p, 'three'), 'Has "three"');
+      assert.isFalse(
         Blockly.utils.dom.hasClass(p, 'four'),
         'Has no "four"',
       );
-      chai.assert.isFalse(Blockly.utils.dom.hasClass(p, 't'), 'Has no "t"');
+      assert.isFalse(Blockly.utils.dom.hasClass(p, 't'), 'Has no "t"');
     });
 
     test('removeClass', function () {
       const p = document.createElement('p');
       p.className = ' one three  two three  ';
       Blockly.utils.dom.removeClass(p, 'two');
-      chai.assert.equal(p.className, 'one three', 'Removing "two"');
+      assert.equal(p.className, 'one three', 'Removing "two"');
       Blockly.utils.dom.removeClass(p, 'four');
-      chai.assert.equal(p.className, 'one three', 'Removing "four"');
+      assert.equal(p.className, 'one three', 'Removing "four"');
       Blockly.utils.dom.removeClass(p, 'three');
-      chai.assert.equal(p.className, 'one', 'Removing "three"');
+      assert.equal(p.className, 'one', 'Removing "three"');
       Blockly.utils.dom.removeClass(p, 'ne');
-      chai.assert.equal(p.className, 'one', 'Removing "ne"');
+      assert.equal(p.className, 'one', 'Removing "ne"');
       Blockly.utils.dom.removeClass(p, 'one');
-      chai.assert.equal(p.className, '', 'Removing "one"');
+      assert.equal(p.className, '', 'Removing "one"');
       Blockly.utils.dom.removeClass(p, 'zero');
-      chai.assert.equal(p.className, '', 'Removing "zero"');
+      assert.equal(p.className, '', 'Removing "zero"');
     });
   });
 
@@ -455,86 +456,86 @@ suite('Utils', function () {
       let len = Blockly.utils.string.shortestStringLength(
         'one,two,three,four,five'.split(','),
       );
-      chai.assert.equal(len, 3, 'Length of "one"');
+      assert.equal(len, 3, 'Length of "one"');
       len = Blockly.utils.string.shortestStringLength(
         'one,two,three,four,five,'.split(','),
       );
-      chai.assert.equal(len, 0, 'Length of ""');
+      assert.equal(len, 0, 'Length of ""');
       len = Blockly.utils.string.shortestStringLength(['Hello World']);
-      chai.assert.equal(len, 11, 'List of one');
+      assert.equal(len, 11, 'List of one');
       len = Blockly.utils.string.shortestStringLength([]);
-      chai.assert.equal(len, 0, 'Empty list');
+      assert.equal(len, 0, 'Empty list');
     });
 
     test('comment word prefix', function () {
       let len = Blockly.utils.string.commonWordPrefix(
         'one,two,three,four,five'.split(','),
       );
-      chai.assert.equal(len, 0, 'No prefix');
+      assert.equal(len, 0, 'No prefix');
       len = Blockly.utils.string.commonWordPrefix(
         'Xone,Xtwo,Xthree,Xfour,Xfive'.split(','),
       );
-      chai.assert.equal(len, 0, 'No word prefix');
+      assert.equal(len, 0, 'No word prefix');
       len = Blockly.utils.string.commonWordPrefix(
         'abc de,abc de,abc de,abc de'.split(','),
       );
-      chai.assert.equal(len, 6, 'Full equality');
+      assert.equal(len, 6, 'Full equality');
       len = Blockly.utils.string.commonWordPrefix('abc deX,abc deY'.split(','));
-      chai.assert.equal(len, 4, 'One word prefix');
+      assert.equal(len, 4, 'One word prefix');
       len = Blockly.utils.string.commonWordPrefix('abc de,abc deY'.split(','));
-      chai.assert.equal(len, 4, 'Overflow no');
+      assert.equal(len, 4, 'Overflow no');
       len = Blockly.utils.string.commonWordPrefix('abc de,abc de Y'.split(','));
-      chai.assert.equal(len, 6, 'Overflow yes');
+      assert.equal(len, 6, 'Overflow yes');
       len = Blockly.utils.string.commonWordPrefix(['Hello World']);
-      chai.assert.equal(len, 11, 'List of one');
+      assert.equal(len, 11, 'List of one');
       len = Blockly.utils.string.commonWordPrefix([]);
-      chai.assert.equal(len, 0, 'Empty list');
+      assert.equal(len, 0, 'Empty list');
       len = Blockly.utils.string.commonWordPrefix(
         'turn&nbsp;left,turn&nbsp;right'.split(','),
       );
-      chai.assert.equal(len, 0, 'No prefix due to &amp;nbsp;');
+      assert.equal(len, 0, 'No prefix due to &amp;nbsp;');
       len = Blockly.utils.string.commonWordPrefix(
         'turn\u00A0left,turn\u00A0right'.split(','),
       );
-      chai.assert.equal(len, 0, 'No prefix due to \\u00A0');
+      assert.equal(len, 0, 'No prefix due to \\u00A0');
     });
 
     test('comment word suffix', function () {
       let len = Blockly.utils.string.commonWordSuffix(
         'one,two,three,four,five'.split(','),
       );
-      chai.assert.equal(len, 0, 'No suffix');
+      assert.equal(len, 0, 'No suffix');
       len = Blockly.utils.string.commonWordSuffix(
         'oneX,twoX,threeX,fourX,fiveX'.split(','),
       );
-      chai.assert.equal(len, 0, 'No word suffix');
+      assert.equal(len, 0, 'No word suffix');
       len = Blockly.utils.string.commonWordSuffix(
         'abc de,abc de,abc de,abc de'.split(','),
       );
-      chai.assert.equal(len, 6, 'Full equality');
+      assert.equal(len, 6, 'Full equality');
       len = Blockly.utils.string.commonWordSuffix('Xabc de,Yabc de'.split(','));
-      chai.assert.equal(len, 3, 'One word suffix');
+      assert.equal(len, 3, 'One word suffix');
       len = Blockly.utils.string.commonWordSuffix('abc de,Yabc de'.split(','));
-      chai.assert.equal(len, 3, 'Overflow no');
+      assert.equal(len, 3, 'Overflow no');
       len = Blockly.utils.string.commonWordSuffix('abc de,Y abc de'.split(','));
-      chai.assert.equal(len, 6, 'Overflow yes');
+      assert.equal(len, 6, 'Overflow yes');
       len = Blockly.utils.string.commonWordSuffix(['Hello World']);
-      chai.assert.equal(len, 11, 'List of one');
+      assert.equal(len, 11, 'List of one');
       len = Blockly.utils.string.commonWordSuffix([]);
-      chai.assert.equal(len, 0, 'Empty list');
+      assert.equal(len, 0, 'Empty list');
     });
   });
 
   suite('Math', function () {
     test('toRadians', function () {
       const quarter = Math.PI / 2;
-      chai.assert.equal(Blockly.utils.math.toRadians(-90), -quarter, '-90');
-      chai.assert.equal(Blockly.utils.math.toRadians(0), 0, '0');
-      chai.assert.equal(Blockly.utils.math.toRadians(90), quarter, '90');
-      chai.assert.equal(Blockly.utils.math.toRadians(180), 2 * quarter, '180');
-      chai.assert.equal(Blockly.utils.math.toRadians(270), 3 * quarter, '270');
-      chai.assert.equal(Blockly.utils.math.toRadians(360), 4 * quarter, '360');
-      chai.assert.equal(
+      assert.equal(Blockly.utils.math.toRadians(-90), -quarter, '-90');
+      assert.equal(Blockly.utils.math.toRadians(0), 0, '0');
+      assert.equal(Blockly.utils.math.toRadians(90), quarter, '90');
+      assert.equal(Blockly.utils.math.toRadians(180), 2 * quarter, '180');
+      assert.equal(Blockly.utils.math.toRadians(270), 3 * quarter, '270');
+      assert.equal(Blockly.utils.math.toRadians(360), 4 * quarter, '360');
+      assert.equal(
         Blockly.utils.math.toRadians(360 + 90),
         5 * quarter,
         '450',
@@ -543,13 +544,13 @@ suite('Utils', function () {
 
     test('toDegrees', function () {
       const quarter = Math.PI / 2;
-      chai.assert.equal(Blockly.utils.math.toDegrees(-quarter), -90, '-90');
-      chai.assert.equal(Blockly.utils.math.toDegrees(0), 0, '0');
-      chai.assert.equal(Blockly.utils.math.toDegrees(quarter), 90, '90');
-      chai.assert.equal(Blockly.utils.math.toDegrees(2 * quarter), 180, '180');
-      chai.assert.equal(Blockly.utils.math.toDegrees(3 * quarter), 270, '270');
-      chai.assert.equal(Blockly.utils.math.toDegrees(4 * quarter), 360, '360');
-      chai.assert.equal(
+      assert.equal(Blockly.utils.math.toDegrees(-quarter), -90, '-90');
+      assert.equal(Blockly.utils.math.toDegrees(0), 0, '0');
+      assert.equal(Blockly.utils.math.toDegrees(quarter), 90, '90');
+      assert.equal(Blockly.utils.math.toDegrees(2 * quarter), 180, '180');
+      assert.equal(Blockly.utils.math.toDegrees(3 * quarter), 270, '270');
+      assert.equal(Blockly.utils.math.toDegrees(4 * quarter), 360, '360');
+      assert.equal(
         Blockly.utils.math.toDegrees(5 * quarter),
         360 + 90,
         '450',

--- a/tests/mocha/variable_map_test.js
+++ b/tests/mocha/variable_map_test.js
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import {assert} from '../../node_modules/chai/chai.js';
 import {assertVariableValues} from './test_helpers/variables.js';
 import {
   createGenUidStubWithReturns,
@@ -39,17 +40,17 @@ suite('Variable Map', function () {
 
       // Assert there is only one variable in the this.variableMap.
       let keys = Array.from(this.variableMap.variableMap.keys());
-      chai.assert.equal(keys.length, 1);
+      assert.equal(keys.length, 1);
       let varMapLength = this.variableMap.variableMap.get(keys[0]).length;
-      chai.assert.equal(varMapLength, 1);
+      assert.equal(varMapLength, 1);
 
       this.variableMap.createVariable('name1', 'type1');
       assertVariableValues(this.variableMap, 'name1', 'type1', 'id1');
       // Check that the size of the variableMap did not change.
       keys = Array.from(this.variableMap.variableMap.keys());
-      chai.assert.equal(keys.length, 1);
+      assert.equal(keys.length, 1);
       varMapLength = this.variableMap.variableMap.get(keys[0]).length;
-      chai.assert.equal(varMapLength, 1);
+      assert.equal(varMapLength, 1);
     });
 
     test('Name already exists', function () {
@@ -59,16 +60,16 @@ suite('Variable Map', function () {
 
       // Assert there is only one variable in the this.variableMap.
       let keys = Array.from(this.variableMap.variableMap.keys());
-      chai.assert.equal(keys.length, 1);
+      assert.equal(keys.length, 1);
       const varMapLength = this.variableMap.variableMap.get(keys[0]).length;
-      chai.assert.equal(varMapLength, 1);
+      assert.equal(varMapLength, 1);
 
       this.variableMap.createVariable('name1', 'type2', 'id2');
       assertVariableValues(this.variableMap, 'name1', 'type1', 'id1');
       assertVariableValues(this.variableMap, 'name1', 'type2', 'id2');
       // Check that the size of the variableMap did change.
       keys = Array.from(this.variableMap.variableMap.keys());
-      chai.assert.equal(keys.length, 2);
+      assert.equal(keys.length, 2);
     });
 
     test('Null type', function () {
@@ -113,7 +114,7 @@ suite('Variable Map', function () {
       test('Id already exists', function () {
         this.variableMap.createVariable('name1', 'type1', 'id1');
         const variableMap = this.variableMap;
-        chai.assert.throws(function () {
+        assert.throws(function () {
           variableMap.createVariable('name2', 'type2', 'id1');
         }, /"id1".*in use/);
         assertVariableValues(this.variableMap, 'name1', 'type1', 'id1');
@@ -122,7 +123,7 @@ suite('Variable Map', function () {
       test('Mismatched id', function () {
         this.variableMap.createVariable('name1', 'type1', 'id1');
         const variableMap = this.variableMap;
-        chai.assert.throws(function () {
+        assert.throws(function () {
           variableMap.createVariable('name1', 'type1', 'id2');
         }, /"name1".*in use/);
         assertVariableValues(this.variableMap, 'name1', 'type1', 'id1');
@@ -131,11 +132,11 @@ suite('Variable Map', function () {
       test('Mismatched type', function () {
         this.variableMap.createVariable('name1', 'type1', 'id1');
         const variableMap = this.variableMap;
-        chai.assert.throws(function () {
+        assert.throws(function () {
           variableMap.createVariable('name1', 'type2', 'id1');
         });
         assertVariableValues(this.variableMap, 'name1', 'type1', 'id1');
-        chai.assert.isNull(this.variableMap.getVariableById('id2'));
+        assert.isNull(this.variableMap.getVariableById('id2'));
       });
     });
   });
@@ -150,19 +151,19 @@ suite('Variable Map', function () {
       const result3 = this.variableMap.getVariable('name3', 'type2');
 
       // Searching by name + type is correct.
-      chai.assert.equal(result1, var1);
-      chai.assert.equal(result2, var2);
-      chai.assert.equal(result3, var3);
+      assert.equal(result1, var1);
+      assert.equal(result2, var2);
+      assert.equal(result3, var3);
 
       // Searching only by name defaults to the '' type.
-      chai.assert.isNull(this.variableMap.getVariable('name1'));
-      chai.assert.isNull(this.variableMap.getVariable('name2'));
-      chai.assert.isNull(this.variableMap.getVariable('name3'));
+      assert.isNull(this.variableMap.getVariable('name1'));
+      assert.isNull(this.variableMap.getVariable('name2'));
+      assert.isNull(this.variableMap.getVariable('name3'));
     });
 
     test('Not found', function () {
       const result = this.variableMap.getVariable('name1');
-      chai.assert.isNull(result);
+      assert.isNull(result);
     });
   });
 
@@ -175,14 +176,14 @@ suite('Variable Map', function () {
       const result2 = this.variableMap.getVariableById('id2');
       const result3 = this.variableMap.getVariableById('id3');
 
-      chai.assert.equal(result1, var1);
-      chai.assert.equal(result2, var2);
-      chai.assert.equal(result3, var3);
+      assert.equal(result1, var1);
+      assert.equal(result2, var2);
+      assert.equal(result3, var3);
     });
 
     test('Not found', function () {
       const result = this.variableMap.getVariableById('id1');
-      chai.assert.isNull(result);
+      assert.isNull(result);
     });
   });
 
@@ -194,13 +195,13 @@ suite('Variable Map', function () {
       this.variableMap.createVariable('name4', 'type3', 'id4');
       const resultArray = this.variableMap.getVariableTypes();
       // The empty string is always an option.
-      chai.assert.deepEqual(resultArray, ['type1', 'type2', 'type3', '']);
+      assert.deepEqual(resultArray, ['type1', 'type2', 'type3', '']);
     });
 
     test('None', function () {
       // The empty string is always an option.
       const resultArray = this.variableMap.getVariableTypes();
-      chai.assert.deepEqual(resultArray, ['']);
+      assert.deepEqual(resultArray, ['']);
     });
   });
 
@@ -212,8 +213,8 @@ suite('Variable Map', function () {
       this.variableMap.createVariable('name4', 'type3', 'id4');
       const resultArray1 = this.variableMap.getVariablesOfType('type1');
       const resultArray2 = this.variableMap.getVariablesOfType('type5');
-      chai.assert.deepEqual(resultArray1, [var1, var2]);
-      chai.assert.deepEqual(resultArray2, []);
+      assert.deepEqual(resultArray1, [var1, var2]);
+      assert.deepEqual(resultArray2, []);
     });
 
     test('Null', function () {
@@ -222,26 +223,26 @@ suite('Variable Map', function () {
       const var3 = this.variableMap.createVariable('name3', '', 'id3');
       this.variableMap.createVariable('name4', 'type1', 'id4');
       const resultArray = this.variableMap.getVariablesOfType(null);
-      chai.assert.deepEqual(resultArray, [var1, var2, var3]);
+      assert.deepEqual(resultArray, [var1, var2, var3]);
     });
 
     test('Empty string', function () {
       const var1 = this.variableMap.createVariable('name1', null, 'id1');
       const var2 = this.variableMap.createVariable('name2', null, 'id2');
       const resultArray = this.variableMap.getVariablesOfType('');
-      chai.assert.deepEqual(resultArray, [var1, var2]);
+      assert.deepEqual(resultArray, [var1, var2]);
     });
 
     test('Deleted', function () {
       const variable = this.variableMap.createVariable('name1', null, 'id1');
       this.variableMap.deleteVariable(variable);
       const resultArray = this.variableMap.getVariablesOfType('');
-      chai.assert.deepEqual(resultArray, []);
+      assert.deepEqual(resultArray, []);
     });
 
     test('Does not exist', function () {
       const resultArray = this.variableMap.getVariablesOfType('type1');
-      chai.assert.deepEqual(resultArray, []);
+      assert.deepEqual(resultArray, []);
     });
   });
 
@@ -251,12 +252,12 @@ suite('Variable Map', function () {
       const var2 = this.variableMap.createVariable('name2', 'type1', 'id2');
       const var3 = this.variableMap.createVariable('name3', 'type2', 'id3');
       const resultArray = this.variableMap.getAllVariables();
-      chai.assert.deepEqual(resultArray, [var1, var2, var3]);
+      assert.deepEqual(resultArray, [var1, var2, var3]);
     });
 
     test('None', function () {
       const resultArray = this.variableMap.getAllVariables();
-      chai.assert.deepEqual(resultArray, []);
+      assert.deepEqual(resultArray, []);
     });
   });
 
@@ -457,7 +458,7 @@ suite('Variable Map', function () {
         test('renaming throws if the variable does not exist', function () {
           // Not sure why this throws when the other one doesn't but might
           // as well test it.
-          chai.assert.throws(() => {
+          assert.throws(() => {
             this.variableMap.renameVariableById('test id', 'test name');
           }, `Tried to rename a variable that didn't exist`);
         });

--- a/tests/mocha/variable_model_test.js
+++ b/tests/mocha/variable_model_test.js
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import {assert} from '../../node_modules/chai/chai.js';
 import {
   sharedTestSetup,
   sharedTestTeardown,
@@ -26,9 +27,9 @@ suite('Variable Model', function () {
       'test_type',
       'test_id',
     );
-    chai.assert.equal(variable.name, 'test');
-    chai.assert.equal(variable.type, 'test_type');
-    chai.assert.equal(variable.id_, 'test_id');
+    assert.equal(variable.name, 'test');
+    assert.equal(variable.type, 'test_type');
+    assert.equal(variable.id_, 'test_id');
   });
 
   test('Null type', function () {
@@ -38,7 +39,7 @@ suite('Variable Model', function () {
       null,
       'test_id',
     );
-    chai.assert.equal(variable.type, '');
+    assert.equal(variable.type, '');
   });
 
   test('Undefined type', function () {
@@ -48,7 +49,7 @@ suite('Variable Model', function () {
       undefined,
       'test_id',
     );
-    chai.assert.equal(variable.type, '');
+    assert.equal(variable.type, '');
   });
 
   test('Null id', function () {
@@ -58,9 +59,9 @@ suite('Variable Model', function () {
       'test_type',
       null,
     );
-    chai.assert.equal(variable.name, 'test');
-    chai.assert.equal(variable.type, 'test_type');
-    chai.assert.exists(variable.id_);
+    assert.equal(variable.name, 'test');
+    assert.equal(variable.type, 'test_type');
+    assert.exists(variable.id_);
   });
 
   test('Undefined id', function () {
@@ -70,15 +71,15 @@ suite('Variable Model', function () {
       'test_type',
       undefined,
     );
-    chai.assert.equal(variable.name, 'test');
-    chai.assert.equal(variable.type, 'test_type');
-    chai.assert.exists(variable.id_);
+    assert.equal(variable.name, 'test');
+    assert.equal(variable.type, 'test_type');
+    assert.exists(variable.id_);
   });
 
   test('Only name provided', function () {
     const variable = new Blockly.VariableModel(this.workspace, 'test');
-    chai.assert.equal(variable.name, 'test');
-    chai.assert.equal(variable.type, '');
-    chai.assert.exists(variable.id_);
+    assert.equal(variable.name, 'test');
+    assert.equal(variable.type, '');
+    assert.exists(variable.id_);
   });
 });

--- a/tests/mocha/widget_div_test.js
+++ b/tests/mocha/widget_div_test.js
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import {assert} from '../../node_modules/chai/chai.js';
 import {
   sharedTestSetup,
   sharedTestTeardown,
@@ -55,9 +56,9 @@ suite('WidgetDiv', function () {
           rtl,
         );
         const style = Blockly.WidgetDiv.getDiv().style;
-        chai.assert.equal(style.left, expectedX + 'px', 'Left');
-        chai.assert.equal(style.top, expectedY + 'px', 'Top');
-        chai.assert.equal(style.height, expectedHeight + 'px', 'Height');
+        assert.equal(style.left, expectedX + 'px', 'Left');
+        assert.equal(style.top, expectedY + 'px', 'Top');
+        assert.equal(style.height, expectedHeight + 'px', 'Height');
       };
     });
 

--- a/tests/mocha/workspace_svg_test.js
+++ b/tests/mocha/workspace_svg_test.js
@@ -61,17 +61,9 @@ suite('WorkspaceSvg', function () {
         '</xml>',
     );
     Blockly.Xml.appendDomToWorkspace(dom, this.workspace);
-    assert.equal(
-      this.workspace.getAllBlocks(false).length,
-      1,
-      'Block count',
-    );
+    assert.equal(this.workspace.getAllBlocks(false).length, 1, 'Block count');
     Blockly.Xml.appendDomToWorkspace(dom, this.workspace);
-    assert.equal(
-      this.workspace.getAllBlocks(false).length,
-      2,
-      'Block count',
-    );
+    assert.equal(this.workspace.getAllBlocks(false).length, 2, 'Block count');
     const blocks = this.workspace.getAllBlocks(false);
     assert.equal(
       blocks[0].getRelativeToSurfaceXY().x,

--- a/tests/mocha/workspace_svg_test.js
+++ b/tests/mocha/workspace_svg_test.js
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import {assert} from '../../node_modules/chai/chai.js';
 import {
   assertEventFired,
   assertEventNotFired,
@@ -60,35 +61,35 @@ suite('WorkspaceSvg', function () {
         '</xml>',
     );
     Blockly.Xml.appendDomToWorkspace(dom, this.workspace);
-    chai.assert.equal(
+    assert.equal(
       this.workspace.getAllBlocks(false).length,
       1,
       'Block count',
     );
     Blockly.Xml.appendDomToWorkspace(dom, this.workspace);
-    chai.assert.equal(
+    assert.equal(
       this.workspace.getAllBlocks(false).length,
       2,
       'Block count',
     );
     const blocks = this.workspace.getAllBlocks(false);
-    chai.assert.equal(
+    assert.equal(
       blocks[0].getRelativeToSurfaceXY().x,
       21,
       'Block 1 position x',
     );
-    chai.assert.equal(
+    assert.equal(
       blocks[0].getRelativeToSurfaceXY().y,
       23,
       'Block 1 position y',
     );
-    chai.assert.equal(
+    assert.equal(
       blocks[1].getRelativeToSurfaceXY().x,
       21,
       'Block 2 position x',
     );
     // Y separation value defined in appendDomToWorkspace as 10
-    chai.assert.equal(
+    assert.equal(
       blocks[1].getRelativeToSurfaceXY().y,
       23 + blocks[0].getHeightWidth().height + 10,
       'Block 2 position y',
@@ -108,9 +109,9 @@ suite('WorkspaceSvg', function () {
 
     Blockly.Xml.appendDomToWorkspace(dom, this.workspace);
     const blocks = this.workspace.getAllBlocks(false);
-    chai.assert.equal(blocks.length, 2, 'Block count');
+    assert.equal(blocks.length, 2, 'Block count');
     const shadowBlock = blocks[1];
-    chai.assert.equal(false, shadowBlock.isDeadOrDying());
+    assert.equal(false, shadowBlock.isDeadOrDying());
 
     const block = this.workspace.newBlock('simple_test_block');
     block.initSvg();
@@ -119,13 +120,13 @@ suite('WorkspaceSvg', function () {
       .getTopBlocks()[0]
       .getInput('NAME').connection;
     inputConnection.connect(block.outputConnection);
-    chai.assert.equal(false, block.isDeadOrDying());
-    chai.assert.equal(true, shadowBlock.isDeadOrDying());
+    assert.equal(false, block.isDeadOrDying());
+    assert.equal(true, shadowBlock.isDeadOrDying());
   });
 
   suite('updateToolbox', function () {
     test('Passes in null when toolbox exists', function () {
-      chai.assert.throws(
+      assert.throws(
         function () {
           this.workspace.updateToolbox(null);
         }.bind(this),
@@ -134,7 +135,7 @@ suite('WorkspaceSvg', function () {
     });
     test('Passes in toolbox def when current toolbox is null', function () {
       this.workspace.options.languageTree = null;
-      chai.assert.throws(
+      assert.throws(
         function () {
           this.workspace.updateToolbox({'contents': []});
         }.bind(this),
@@ -146,7 +147,7 @@ suite('WorkspaceSvg', function () {
         .stub(Blockly.utils.toolbox.TEST_ONLY, 'hasCategoriesInternal')
         .returns(true);
       this.workspace.toolbox_ = null;
-      chai.assert.throws(
+      assert.throws(
         function () {
           this.workspace.updateToolbox({'contents': []});
         }.bind(this),
@@ -158,7 +159,7 @@ suite('WorkspaceSvg', function () {
         .stub(Blockly.utils.toolbox.TEST_ONLY, 'hasCategoriesInternal')
         .returns(false);
       this.workspace.flyout_ = null;
-      chai.assert.throws(
+      assert.throws(
         function () {
           this.workspace.updateToolbox({'contents': []});
         }.bind(this),

--- a/tests/mocha/xml_test.js
+++ b/tests/mocha/xml_test.js
@@ -86,11 +86,7 @@ suite('XML', function () {
     test('Basic', function () {
       const dom = Blockly.utils.xml.textToDom(this.complexXmlText);
       assertXmlDoc(dom);
-      assert.equal(
-        dom.getElementsByTagName('block').length,
-        6,
-        'Block tags',
-      );
+      assert.equal(dom.getElementsByTagName('block').length, 6, 'Block tags');
     });
 
     test(
@@ -765,11 +761,7 @@ suite('XML', function () {
           '</xml>',
       );
       Blockly.Xml.domToWorkspace(dom, this.workspace);
-      assert.equal(
-        this.workspace.getAllBlocks(false).length,
-        1,
-        'Block count',
-      );
+      assert.equal(this.workspace.getAllBlocks(false).length, 1, 'Block count');
       assertVariableValues(this.workspace, 'name1', '', '1');
     });
     test('Variables at top', function () {
@@ -786,11 +778,7 @@ suite('XML', function () {
           '</xml>',
       );
       Blockly.Xml.domToWorkspace(dom, this.workspace);
-      assert.equal(
-        this.workspace.getAllBlocks(false).length,
-        1,
-        'Block count',
-      );
+      assert.equal(this.workspace.getAllBlocks(false).length, 1, 'Block count');
       assertVariableValues(this.workspace, 'name1', 'type1', 'id1');
       assertVariableValues(this.workspace, 'name2', 'type2', 'id2');
       assertVariableValues(this.workspace, 'name3', '', 'id3');
@@ -862,17 +850,9 @@ suite('XML', function () {
           '</xml>',
       );
       Blockly.Xml.appendDomToWorkspace(dom, this.workspace);
-      assert.equal(
-        this.workspace.getAllBlocks(false).length,
-        1,
-        'Block count',
-      );
+      assert.equal(this.workspace.getAllBlocks(false).length, 1, 'Block count');
       const newBlockIds = Blockly.Xml.appendDomToWorkspace(dom, this.workspace);
-      assert.equal(
-        this.workspace.getAllBlocks(false).length,
-        2,
-        'Block count',
-      );
+      assert.equal(this.workspace.getAllBlocks(false).length, 2, 'Block count');
       assert.equal(newBlockIds.length, 1, 'Number of new block ids');
     });
   });

--- a/tests/mocha/xml_test.js
+++ b/tests/mocha/xml_test.js
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import {assert} from '../../node_modules/chai/chai.js';
 import {
   addBlockTypeToCleanup,
   createGenUidStubWithReturns,
@@ -15,29 +16,29 @@ import {assertVariableValues} from './test_helpers/variables.js';
 
 suite('XML', function () {
   const assertSimpleFieldDom = function (fieldDom, name, text) {
-    chai.assert.equal(text, fieldDom.textContent);
-    chai.assert.equal(name, fieldDom.getAttribute('name'));
+    assert.equal(text, fieldDom.textContent);
+    assert.equal(name, fieldDom.getAttribute('name'));
   };
   const assertNonSerializingFieldDom = function (fieldDom) {
-    chai.assert.isUndefined(fieldDom.childNodes[0]);
+    assert.isUndefined(fieldDom.childNodes[0]);
   };
   const assertNonVariableField = function (fieldDom, name, text) {
     assertSimpleFieldDom(fieldDom, name, text);
-    chai.assert.isNull(fieldDom.getAttribute('id'), 'id');
-    chai.assert.isNull(fieldDom.getAttribute('variabletype'), 'variabletype');
+    assert.isNull(fieldDom.getAttribute('id'), 'id');
+    assert.isNull(fieldDom.getAttribute('variabletype'), 'variabletype');
   };
   const assertVariableDomField = function (fieldDom, name, type, id, text) {
     assertSimpleFieldDom(fieldDom, name, text);
-    chai.assert.equal(fieldDom.getAttribute('variabletype'), type);
-    chai.assert.equal(fieldDom.getAttribute('id'), id);
+    assert.equal(fieldDom.getAttribute('variabletype'), type);
+    assert.equal(fieldDom.getAttribute('id'), id);
   };
   const assertVariableDom = function (fieldDom, type, id, text) {
-    chai.assert.equal(fieldDom.getAttribute('type'), type);
-    chai.assert.equal(fieldDom.getAttribute('id'), id);
-    chai.assert.equal(fieldDom.textContent, text);
+    assert.equal(fieldDom.getAttribute('type'), type);
+    assert.equal(fieldDom.getAttribute('id'), id);
+    assert.equal(fieldDom.textContent, text);
   };
   const assertXmlDoc = function (doc) {
-    chai.assert.equal(doc.nodeName.toLowerCase(), 'xml', 'XML tag');
+    assert.equal(doc.nodeName.toLowerCase(), 'xml', 'XML tag');
   };
   setup(function () {
     sharedTestSetup.call(this);
@@ -85,7 +86,7 @@ suite('XML', function () {
     test('Basic', function () {
       const dom = Blockly.utils.xml.textToDom(this.complexXmlText);
       assertXmlDoc(dom);
-      chai.assert.equal(
+      assert.equal(
         dom.getElementsByTagName('block').length,
         6,
         'Block tags',
@@ -98,7 +99,7 @@ suite('XML', function () {
       function () {
         const dom = Blockly.utils.xml.textToDom('<xml>&#x1;&#x9;&#x1F;</xml>');
         assertXmlDoc(dom);
-        chai.assert.equal(dom.firstChild.textContent, '\u0001\t\u001f');
+        assert.equal(dom.firstChild.textContent, '\u0001\t\u001f');
       },
     );
 
@@ -108,14 +109,14 @@ suite('XML', function () {
       function () {
         const dom = Blockly.utils.xml.textToDom('<xml>&#1;&#9;&#31</xml>');
         assertXmlDoc(dom);
-        chai.assert.equal(dom.firstChild.textContent, '\u0001\u0009\u001f');
+        assert.equal(dom.firstChild.textContent, '\u0001\u0009\u001f');
       },
     );
 
     test('text with an escaped ampersand is properly deserialized', function () {
       const dom = Blockly.utils.xml.textToDom('<xml>&amp;</xml>');
       assertXmlDoc(dom);
-      chai.assert.equal(dom.firstChild.textContent, '&');
+      assert.equal(dom.firstChild.textContent, '&');
     });
   });
 
@@ -354,17 +355,17 @@ suite('XML', function () {
           this.block.setCommentText('test text');
           const xml = Blockly.Xml.blockToDom(this.block);
           const commentXml = xml.firstChild;
-          chai.assert.equal(commentXml.tagName, 'comment');
-          chai.assert.equal(commentXml.innerHTML, 'test text');
+          assert.equal(commentXml.tagName, 'comment');
+          assert.equal(commentXml.innerHTML, 'test text');
         });
         test('No Text', function () {
           const xml = Blockly.Xml.blockToDom(this.block);
-          chai.assert.isNull(xml.firstChild);
+          assert.isNull(xml.firstChild);
         });
         test('Empty Text', function () {
           this.block.setCommentText('');
           const xml = Blockly.Xml.blockToDom(this.block);
-          chai.assert.isNull(xml.firstChild);
+          assert.isNull(xml.firstChild);
         });
       });
       suite('Rendered', function () {
@@ -383,17 +384,17 @@ suite('XML', function () {
           this.block.setCommentText('test text');
           const xml = Blockly.Xml.blockToDom(this.block);
           const commentXml = xml.firstChild;
-          chai.assert.equal(commentXml.tagName, 'comment');
-          chai.assert.equal(commentXml.innerHTML, 'test text');
+          assert.equal(commentXml.tagName, 'comment');
+          assert.equal(commentXml.innerHTML, 'test text');
         });
         test('No Text', function () {
           const xml = Blockly.Xml.blockToDom(this.block);
-          chai.assert.isNull(xml.firstChild);
+          assert.isNull(xml.firstChild);
         });
         test('Empty Text', function () {
           this.block.setCommentText('');
           const xml = Blockly.Xml.blockToDom(this.block);
-          chai.assert.isNull(xml.firstChild);
+          assert.isNull(xml.firstChild);
         });
         test('Size', function () {
           this.block.setCommentText('test text');
@@ -402,9 +403,9 @@ suite('XML', function () {
             .setBubbleSize(new Blockly.utils.Size(100, 200));
           const xml = Blockly.Xml.blockToDom(this.block);
           const commentXml = xml.firstChild;
-          chai.assert.equal(commentXml.tagName, 'comment');
-          chai.assert.equal(commentXml.getAttribute('w'), 100);
-          chai.assert.equal(commentXml.getAttribute('h'), 200);
+          assert.equal(commentXml.tagName, 'comment');
+          assert.equal(commentXml.getAttribute('w'), 100);
+          assert.equal(commentXml.getAttribute('h'), 200);
         });
         test('Pinned True', function () {
           this.block.setCommentText('test text');
@@ -413,15 +414,15 @@ suite('XML', function () {
             .setBubbleVisible(true);
           const xml = Blockly.Xml.blockToDom(this.block);
           const commentXml = xml.firstChild;
-          chai.assert.equal(commentXml.tagName, 'comment');
-          chai.assert.equal(commentXml.getAttribute('pinned'), 'true');
+          assert.equal(commentXml.tagName, 'comment');
+          assert.equal(commentXml.getAttribute('pinned'), 'true');
         });
         test('Pinned False', function () {
           this.block.setCommentText('test text');
           const xml = Blockly.Xml.blockToDom(this.block);
           const commentXml = xml.firstChild;
-          chai.assert.equal(commentXml.tagName, 'comment');
-          chai.assert.equal(commentXml.getAttribute('pinned'), 'false');
+          assert.equal(commentXml.tagName, 'comment');
+          assert.equal(commentXml.getAttribute('pinned'), 'false');
         });
       });
     });
@@ -452,11 +453,11 @@ suite('XML', function () {
       const resultDom = Blockly.Xml.variablesToDom(
         this.workspace.getAllVariables(),
       );
-      chai.assert.equal(resultDom.children.length, 1);
+      assert.equal(resultDom.children.length, 1);
       const resultVariableDom = resultDom.children[0];
-      chai.assert.equal(resultVariableDom.textContent, 'name1');
-      chai.assert.isNull(resultVariableDom.getAttribute('type'));
-      chai.assert.equal(resultVariableDom.getAttribute('id'), '1');
+      assert.equal(resultVariableDom.textContent, 'name1');
+      assert.isNull(resultVariableDom.getAttribute('type'));
+      assert.equal(resultVariableDom.getAttribute('id'), '1');
     });
     test('Two Variable one block', function () {
       this.workspace.createVariable('name1', '', 'id1');
@@ -474,7 +475,7 @@ suite('XML', function () {
       const resultDom = Blockly.Xml.variablesToDom(
         this.workspace.getAllVariables(),
       );
-      chai.assert.equal(resultDom.children.length, 2);
+      assert.equal(resultDom.children.length, 2);
       assertVariableDom(resultDom.children[0], null, 'id1', 'name1');
       assertVariableDom(resultDom.children[1], 'type2', 'id2', 'name2');
     });
@@ -482,7 +483,7 @@ suite('XML', function () {
       const resultDom = Blockly.Xml.variablesToDom(
         this.workspace.getAllVariables(),
       );
-      chai.assert.equal(resultDom.children.length, 0);
+      assert.equal(resultDom.children.length, 0);
     });
   });
 
@@ -490,7 +491,7 @@ suite('XML', function () {
     test('Round tripping', function () {
       const dom = Blockly.utils.xml.textToDom(this.complexXmlText);
       const text = Blockly.Xml.domToText(dom);
-      chai.assert.equal(
+      assert.equal(
         text.replace(/\s+/g, ''),
         this.complexXmlText.replace(/\s+/g, ''),
         'Round trip',
@@ -500,7 +501,7 @@ suite('XML', function () {
     test('control characters are escaped', function () {
       const dom = Blockly.utils.xml.createElement('xml');
       dom.appendChild(Blockly.utils.xml.createTextNode('')); // u0001
-      chai.assert.equal(
+      assert.equal(
         Blockly.utils.xml.domToText(dom),
         '<xml xmlns="https://developers.google.com/blockly/xml">&#1;</xml>',
       );
@@ -509,7 +510,7 @@ suite('XML', function () {
     test('ampersands are escaped', function () {
       const dom = Blockly.utils.xml.createElement('xml');
       dom.appendChild(Blockly.utils.xml.createTextNode('&'));
-      chai.assert.equal(
+      assert.equal(
         Blockly.Xml.domToText(dom),
         '<xml xmlns="https://developers.google.com/blockly/xml">&amp;</xml>',
       );
@@ -520,7 +521,7 @@ suite('XML', function () {
     test('Round tripping', function () {
       const dom = Blockly.utils.xml.textToDom(this.complexXmlText);
       const text = Blockly.Xml.domToPrettyText(dom);
-      chai.assert.equal(
+      assert.equal(
         text.replace(/\s+/g, ''),
         this.complexXmlText.replace(/\s+/g, ''),
         'Round trip',
@@ -567,7 +568,7 @@ suite('XML', function () {
             ),
             this.workspace,
           );
-          chai.assert.equal(block.getCommentText(), 'test text');
+          assert.equal(block.getCommentText(), 'test text');
         });
         test('No Text', function () {
           const block = Blockly.Xml.domToBlock(
@@ -578,7 +579,7 @@ suite('XML', function () {
             ),
             this.workspace,
           );
-          chai.assert.equal(block.getCommentText(), '');
+          assert.equal(block.getCommentText(), '');
         });
         test('Size', function () {
           const block = Blockly.Xml.domToBlock(
@@ -589,7 +590,7 @@ suite('XML', function () {
             ),
             this.workspace,
           );
-          chai.assert.deepEqual(
+          assert.deepEqual(
             block.getIcon(Blockly.icons.CommentIcon.TYPE).getBubbleSize(),
             {
               width: 100,
@@ -606,7 +607,7 @@ suite('XML', function () {
             ),
             this.workspace,
           );
-          chai.assert.isTrue(
+          assert.isTrue(
             block.getIcon(Blockly.icons.CommentIcon.TYPE).bubbleIsVisible(),
           );
         });
@@ -619,7 +620,7 @@ suite('XML', function () {
             ),
             this.workspace,
           );
-          chai.assert.isFalse(
+          assert.isFalse(
             block.getIcon(Blockly.icons.CommentIcon.TYPE).bubbleIsVisible(),
           );
         });
@@ -632,7 +633,7 @@ suite('XML', function () {
             ),
             this.workspace,
           );
-          chai.assert.isFalse(
+          assert.isFalse(
             block.getIcon(Blockly.icons.CommentIcon.TYPE).bubbleIsVisible(),
           );
         });
@@ -654,8 +655,8 @@ suite('XML', function () {
             ),
             this.workspace,
           );
-          chai.assert.equal(block.getCommentText(), 'test text');
-          chai.assert.isOk(block.getIcon(Blockly.icons.CommentIcon.TYPE));
+          assert.equal(block.getCommentText(), 'test text');
+          assert.isOk(block.getIcon(Blockly.icons.CommentIcon.TYPE));
         });
         test('No Text', function () {
           const block = Blockly.Xml.domToBlock(
@@ -666,8 +667,8 @@ suite('XML', function () {
             ),
             this.workspace,
           );
-          chai.assert.equal(block.getCommentText(), '');
-          chai.assert.isOk(block.getIcon(Blockly.icons.CommentIcon.TYPE));
+          assert.equal(block.getCommentText(), '');
+          assert.isOk(block.getIcon(Blockly.icons.CommentIcon.TYPE));
         });
         test('Size', function () {
           const block = Blockly.Xml.domToBlock(
@@ -678,8 +679,8 @@ suite('XML', function () {
             ),
             this.workspace,
           );
-          chai.assert.isOk(block.getIcon(Blockly.icons.CommentIcon.TYPE));
-          chai.assert.deepEqual(
+          assert.isOk(block.getIcon(Blockly.icons.CommentIcon.TYPE));
+          assert.deepEqual(
             block.getIcon(Blockly.icons.CommentIcon.TYPE).getBubbleSize(),
             {
               width: 100,
@@ -699,8 +700,8 @@ suite('XML', function () {
             );
             this.clock.runAll();
             const icon = block.getIcon(Blockly.icons.CommentIcon.TYPE);
-            chai.assert.isOk(icon);
-            chai.assert.isTrue(icon.bubbleIsVisible());
+            assert.isOk(icon);
+            assert.isTrue(icon.bubbleIsVisible());
           });
           test('Pinned False', function () {
             const block = Blockly.Xml.domToBlock(
@@ -713,8 +714,8 @@ suite('XML', function () {
             );
             this.clock.runAll();
             const icon = block.getIcon(Blockly.icons.CommentIcon.TYPE);
-            chai.assert.isOk(icon);
-            chai.assert.isFalse(icon.bubbleIsVisible());
+            assert.isOk(icon);
+            assert.isFalse(icon.bubbleIsVisible());
           });
           test('Pinned Undefined', function () {
             const block = Blockly.Xml.domToBlock(
@@ -727,8 +728,8 @@ suite('XML', function () {
             );
             this.clock.runAll();
             const icon = block.getIcon(Blockly.icons.CommentIcon.TYPE);
-            chai.assert.isOk(icon);
-            chai.assert.isFalse(icon.bubbleIsVisible());
+            assert.isOk(icon);
+            assert.isFalse(icon.bubbleIsVisible());
           });
         });
       });
@@ -764,7 +765,7 @@ suite('XML', function () {
           '</xml>',
       );
       Blockly.Xml.domToWorkspace(dom, this.workspace);
-      chai.assert.equal(
+      assert.equal(
         this.workspace.getAllBlocks(false).length,
         1,
         'Block count',
@@ -785,7 +786,7 @@ suite('XML', function () {
           '</xml>',
       );
       Blockly.Xml.domToWorkspace(dom, this.workspace);
-      chai.assert.equal(
+      assert.equal(
         this.workspace.getAllBlocks(false).length,
         1,
         'Block count',
@@ -803,7 +804,7 @@ suite('XML', function () {
           '  </variables>' +
           '</xml>',
       );
-      chai.assert.throws(function () {
+      assert.throws(function () {
         Blockly.Xml.domToWorkspace(dom, this.workspace);
       });
     });
@@ -818,7 +819,7 @@ suite('XML', function () {
           '  </block>' +
           '</xml>',
       );
-      chai.assert.throws(function () {
+      assert.throws(function () {
         Blockly.Xml.domToWorkspace(dom, this.workspace);
       });
     });
@@ -833,7 +834,7 @@ suite('XML', function () {
           '  </block>' +
           '</xml>',
       );
-      chai.assert.throws(function () {
+      assert.throws(function () {
         Blockly.Xml.domToWorkspace(dom, this.workspace);
       });
     });
@@ -861,18 +862,18 @@ suite('XML', function () {
           '</xml>',
       );
       Blockly.Xml.appendDomToWorkspace(dom, this.workspace);
-      chai.assert.equal(
+      assert.equal(
         this.workspace.getAllBlocks(false).length,
         1,
         'Block count',
       );
       const newBlockIds = Blockly.Xml.appendDomToWorkspace(dom, this.workspace);
-      chai.assert.equal(
+      assert.equal(
         this.workspace.getAllBlocks(false).length,
         2,
         'Block count',
       );
-      chai.assert.equal(newBlockIds.length, 1, 'Number of new block ids');
+      assert.equal(newBlockIds.length, 1, 'Number of new block ids');
     });
   });
   suite('workspaceToDom -> domToWorkspace -> workspaceToDom', function () {
@@ -897,7 +898,7 @@ suite('XML', function () {
       const expectedXmlText = Blockly.Xml.domToText(originXml);
       const actualXmlText = Blockly.Xml.domToText(targetXml);
 
-      chai.assert.equal(actualXmlText, expectedXmlText);
+      assert.equal(actualXmlText, expectedXmlText);
     };
     suite('Rendered -> XML -> Headless -> XML', function () {
       test('Comment', function () {
@@ -958,7 +959,7 @@ suite('XML', function () {
         '>' +
         name +
         '</field>';
-      chai.assert.equal(generatedXml, expectedXml);
+      assert.equal(generatedXml, expectedXml);
     });
   });
 });

--- a/tests/mocha/zoom_controls_test.js
+++ b/tests/mocha/zoom_controls_test.js
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import {assert} from '../../node_modules/chai/chai.js';
 import {assertEventFired, assertEventNotFired} from './test_helpers/events.js';
 import * as eventUtils from '../../build/src/core/events/utils.js';
 import {
@@ -42,7 +43,7 @@ suite('Zoom Controls', function () {
         targetType: 'workspace',
         type: eventUtils.CLICK,
       });
-      chai.assert.closeTo(this.workspace.getScale(), 1.2, 0.05);
+      assert.closeTo(this.workspace.getScale(), 1.2, 0.05);
     });
     test('Zoom out', function () {
       simulateClick(this.zoomControls.zoomOutGroup);
@@ -58,7 +59,7 @@ suite('Zoom Controls', function () {
         targetType: 'workspace',
         type: eventUtils.CLICK,
       });
-      chai.assert.closeTo(this.workspace.getScale(), 0.8, 0.05);
+      assert.closeTo(this.workspace.getScale(), 0.8, 0.05);
     });
     test('Reset zoom', function () {
       simulateClick(this.zoomControls.zoomResetGroup);
@@ -74,7 +75,7 @@ suite('Zoom Controls', function () {
         targetType: 'workspace',
         type: eventUtils.CLICK,
       });
-      chai.assert.equal(this.workspace.getScale(), 1);
+      assert.equal(this.workspace.getScale(), 1);
     });
   });
 });

--- a/tests/node/run_node_test.mjs
+++ b/tests/node/run_node_test.mjs
@@ -22,9 +22,9 @@ console.log(process.cwd());
 // copied when packaged), resulting in require() looking for the
 // compressed bundles in the wrong place.
 
-const assert = require('chai').assert;
-const Blockly = require('blockly-test');
-const {javascriptGenerator} = require('blockly-test/javascript');
+import {assert} from 'chai';
+import * as Blockly from 'blockly-test';
+import {javascriptGenerator} from 'blockly-test/javascript';
 
 const xmlText =
   '<xml xmlns="https://developers.google.com/blockly/xml">\n' +


### PR DESCRIPTION
## The basics

- [X] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

Fixes test failures in PR #8197

### Proposed Changes

Make changes in the branch for PR #8197 to load chai via `import` (instead of via `require` or `<script>` as previously), to fix test failures in that PR.  Specifically:

* Migrate node and browser tests from CJS to ESM so they can use `import`.
* Add explicit `import` statements for chai to mocha tests.
* Remove previous `<script>` load of chai from `tests/mocha/index.html`.

### Reason for Changes

Upgrade of chai to `^5.0.0` is a breaking change due to that package dropping support for CJS and script.

### Test Coverage

Unchanged but modernised.

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

This PR targets the `dependabot/npm_and_yarn/develop/chai-5.1.1` branch as the changes need to be atomic with the chai upgrade, but I thought (due to CJS->ESM migrations) were significant enough to warrant being subject of a separate PR rather than just being tacked on as additional commits to that PR.

