### PR TITLE
feat!: Add support for preserving block comment locations.

### DIFF
--- a/core/bubbles/textinput_bubble.ts
+++ b/core/bubbles/textinput_bubble.ts
@@ -47,6 +47,9 @@ export class TextInputBubble extends Bubble {
   /** Functions listening for changes to the size of this bubble. */
   private sizeChangeListeners: (() => void)[] = [];
 
+  /** Functions listening for changes to the location of this bubble. */
+  private locationChangeListeners: (() => void)[] = [];
+
   /** The text of this bubble. */
   private text = '';
 
@@ -103,6 +106,11 @@ export class TextInputBubble extends Bubble {
   /** Adds a change listener to be notified when this bubble's size changes. */
   addSizeChangeListener(listener: () => void) {
     this.sizeChangeListeners.push(listener);
+  }
+
+  /** Adds a change listener to be notified when this bubble's location changes. */
+  addLocationChangeListener(listener: () => void) {
+    this.locationChangeListeners.push(listener);
   }
 
   /** Creates the editor UI for this bubble. */
@@ -212,8 +220,23 @@ export class TextInputBubble extends Bubble {
 
   /** @returns the size of this bubble. */
   getSize(): Size {
-    // Overriden to be public.
+    // Overridden to be public.
     return super.getSize();
+  }
+
+  override moveDuringDrag(newLoc: Coordinate) {
+    super.moveDuringDrag(newLoc);
+    this.onLocationChange();
+  }
+
+  override setPositionRelativeToAnchor(left: number, top: number) {
+    super.setPositionRelativeToAnchor(left, top);
+    this.onLocationChange();
+  }
+
+  protected override positionByRect(rect = new Rect(0, 0, 0, 0)) {
+    super.positionByRect(rect);
+    this.onLocationChange();
   }
 
   /** Handles mouse down events on the resize target. */
@@ -294,6 +317,13 @@ export class TextInputBubble extends Bubble {
   /** Handles a size change event for the text area. Calls event listeners. */
   private onSizeChange() {
     for (const listener of this.sizeChangeListeners) {
+      listener();
+    }
+  }
+
+  /** Handles a location change event for the text area. Calls event listeners. */
+  private onLocationChange() {
+    for (const listener of this.locationChangeListeners) {
       listener();
     }
   }

--- a/core/icons/comment_icon.ts
+++ b/core/icons/comment_icon.ts
@@ -58,6 +58,9 @@ export class CommentIcon extends Icon implements IHasBubble, ISerializable {
   /** The size of this comment (which is applied to the editable bubble). */
   private bubbleSize = new Size(DEFAULT_BUBBLE_WIDTH, DEFAULT_BUBBLE_HEIGHT);
 
+  /** The location of the comment bubble in workspace coordinates. */
+  private bubbleLocation?: Coordinate;
+
   /**
    * The visibility of the bubble for this comment.
    *
@@ -149,7 +152,13 @@ export class CommentIcon extends Icon implements IHasBubble, ISerializable {
   }
 
   override onLocationChange(blockOrigin: Coordinate): void {
+    const oldLocation = this.workspaceLocation;
     super.onLocationChange(blockOrigin);
+    if (this.bubbleLocation) {
+      const newLocation = this.workspaceLocation;
+      const delta = Coordinate.difference(newLocation, oldLocation);
+      this.bubbleLocation = Coordinate.sum(this.bubbleLocation, delta);
+    }
     const anchorLocation = this.getAnchorLocation();
     this.textInputBubble?.setAnchorLocation(anchorLocation);
     this.textBubble?.setAnchorLocation(anchorLocation);
@@ -192,17 +201,42 @@ export class CommentIcon extends Icon implements IHasBubble, ISerializable {
   }
 
   /**
+   * Sets the location of the comment bubble in the workspace.
+   */
+  setBubbleLocation(location: Coordinate) {
+    this.bubbleLocation = location;
+    this.textInputBubble?.moveDuringDrag(location);
+    this.textBubble?.moveDuringDrag(location);
+  }
+
+  /**
+   * @returns the location of the comment bubble in the workspace.
+   */
+  getBubbleLocation(): Coordinate | undefined {
+    return this.bubbleLocation;
+  }
+
+  /**
    * @returns the state of the comment as a JSON serializable value if the
    * comment has text. Otherwise returns null.
    */
   saveState(): CommentState | null {
     if (this.text) {
-      return {
+      const state: CommentState = {
         'text': this.text,
         'pinned': this.bubbleIsVisible(),
         'height': this.bubbleSize.height,
         'width': this.bubbleSize.width,
       };
+      const location = this.getBubbleLocation();
+      if (location) {
+        state['x'] = this.sourceBlock.workspace.RTL
+          ? this.sourceBlock.workspace.getWidth() -
+            (location.x + this.bubbleSize.width)
+          : location.x;
+        state['y'] = location.y;
+      }
+      return state;
     }
     return null;
   }
@@ -216,6 +250,16 @@ export class CommentIcon extends Icon implements IHasBubble, ISerializable {
     );
     this.bubbleVisiblity = state['pinned'] ?? false;
     this.setBubbleVisible(this.bubbleVisiblity);
+    let x = state['x'];
+    const y = state['y'];
+    renderManagement.finishQueuedRenders().then(() => {
+      if (x && y) {
+        x = this.sourceBlock.workspace.RTL
+          ? this.sourceBlock.workspace.getWidth() - (x + this.bubbleSize.width)
+          : x;
+        this.setBubbleLocation(new Coordinate(x, y));
+      }
+    });
   }
 
   override onClick(): void {
@@ -256,6 +300,12 @@ export class CommentIcon extends Icon implements IHasBubble, ISerializable {
   onSizeChange(): void {
     if (this.textInputBubble) {
       this.bubbleSize = this.textInputBubble.getSize();
+    }
+  }
+
+  onBubbleLocationChange(): void {
+    if (this.textInputBubble) {
+      this.bubbleLocation = this.textInputBubble.getRelativeToSurfaceXY();
     }
   }
 
@@ -308,8 +358,14 @@ export class CommentIcon extends Icon implements IHasBubble, ISerializable {
     );
     this.textInputBubble.setText(this.getText());
     this.textInputBubble.setSize(this.bubbleSize, true);
+    if (this.bubbleLocation) {
+      this.textInputBubble.moveDuringDrag(this.bubbleLocation);
+    }
     this.textInputBubble.addTextChangeListener(() => this.onTextChange());
     this.textInputBubble.addSizeChangeListener(() => this.onSizeChange());
+    this.textInputBubble.addLocationChangeListener(() =>
+      this.onBubbleLocationChange(),
+    );
   }
 
   /** Shows the non editable text bubble for this comment. */
@@ -320,6 +376,9 @@ export class CommentIcon extends Icon implements IHasBubble, ISerializable {
       this.getAnchorLocation(),
       this.getBubbleOwnerRect(),
     );
+    if (this.bubbleLocation) {
+      this.textBubble.moveDuringDrag(this.bubbleLocation);
+    }
   }
 
   /** Hides any open bubbles owned by this comment. */
@@ -365,6 +424,12 @@ export interface CommentState {
 
   /** The width of the comment bubble. */
   width?: number;
+
+  /** The X coordinate of the comment bubble. */
+  x?: number;
+
+  /** The Y coordinate of the comment bubble. */
+  y?: number;
 }
 
 registry.register(CommentIcon.TYPE, CommentIcon);

--- a/core/interfaces/i_comment_icon.ts
+++ b/core/interfaces/i_comment_icon.ts
@@ -8,6 +8,7 @@ import {IconType} from '../icons/icon_types.js';
 import {CommentState} from '../icons/comment_icon.js';
 import {IIcon, isIcon} from './i_icon.js';
 import {Size} from '../utils/size.js';
+import {Coordinate} from '../utils/coordinate.js';
 import {IHasBubble, hasBubble} from './i_has_bubble.js';
 import {ISerializable, isSerializable} from './i_serializable.js';
 
@@ -19,6 +20,10 @@ export interface ICommentIcon extends IIcon, IHasBubble, ISerializable {
   setBubbleSize(size: Size): void;
 
   getBubbleSize(): Size;
+
+  setBubbleLocation(location: Coordinate): void;
+
+  getBubbleLocation(): Coordinate | undefined;
 
   saveState(): CommentState;
 
@@ -35,6 +40,8 @@ export function isCommentIcon(obj: Object): obj is ICommentIcon {
     (obj as any)['getText'] !== undefined &&
     (obj as any)['setBubbleSize'] !== undefined &&
     (obj as any)['getBubbleSize'] !== undefined &&
+    (obj as any)['setBubbleLocation'] !== undefined &&
+    (obj as any)['getBubbleLocation'] !== undefined &&
     obj.getType() === IconType.COMMENT
   );
 }

--- a/tests/mocha/block_test.js
+++ b/tests/mocha/block_test.js
@@ -1387,9 +1387,9 @@ suite('Blocks', function () {
         getBubbleSize() {
           return Blockly.utils.Size(0, 0);
         }
-        
+
         setBubbleLocation() {}
-        
+
         getBubbleLocation() {}
 
         bubbleIsVisible() {

--- a/tests/mocha/block_test.js
+++ b/tests/mocha/block_test.js
@@ -1387,6 +1387,10 @@ suite('Blocks', function () {
         getBubbleSize() {
           return Blockly.utils.Size(0, 0);
         }
+        
+        setBubbleLocation() {}
+        
+        getBubbleLocation() {}
 
         bubbleIsVisible() {
           return true;

--- a/tests/mocha/comment_test.js
+++ b/tests/mocha/comment_test.js
@@ -152,17 +152,17 @@ suite('Comments', function () {
     }
     test('Set Location While Visible', function () {
       this.comment.setBubbleVisible(true);
-  
+
       this.comment.setBubbleLocation(new Blockly.utils.Coordinate(100, 100));
       assertBubbleLocation(this.comment, 100, 100);
-  
+
       this.comment.setBubbleVisible(false);
       assertBubbleLocation(this.comment, 100, 100);
     });
     test('Set Location While Invisible', function () {
       this.comment.setBubbleLocation(new Blockly.utils.Coordinate(100, 100));
       assertBubbleLocation(this.comment, 100, 100);
-  
+
       this.comment.setBubbleVisible(true);
       assertBubbleLocation(this.comment, 100, 100);
     });

--- a/tests/mocha/comment_test.js
+++ b/tests/mocha/comment_test.js
@@ -141,4 +141,30 @@ suite('Comments', function () {
       assertBubbleSize(this.comment, 100, 100);
     });
   });
+  suite('Set/Get Bubble Location', function () {
+    teardown(function () {
+      sinon.restore();
+    });
+    function assertBubbleLocation(comment, x, y) {
+      const location = comment.getBubbleLocation();
+      assert.equal(location.x, x);
+      assert.equal(location.y, y);
+    }
+    test('Set Location While Visible', function () {
+      this.comment.setBubbleVisible(true);
+  
+      this.comment.setBubbleLocation(new Blockly.utils.Coordinate(100, 100));
+      assertBubbleLocation(this.comment, 100, 100);
+  
+      this.comment.setBubbleVisible(false);
+      assertBubbleLocation(this.comment, 100, 100);
+    });
+    test('Set Location While Invisible', function () {
+      this.comment.setBubbleLocation(new Blockly.utils.Coordinate(100, 100));
+      assertBubbleLocation(this.comment, 100, 100);
+  
+      this.comment.setBubbleVisible(true);
+      assertBubbleLocation(this.comment, 100, 100);
+    });
+  });
 });


### PR DESCRIPTION
## The basics
- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

Fixes  #8230

### Proposed Changes
This PR preserves the positions of block comments when (de)serializing a workspace.

### Reason for Changes
We allow users to position block comments arbitrarily, but while we preserve the location of workspace comments when (de)serializing the workspace, block comments have their positions lost. This is also needed to support the Scratch modernization effort, since Scratch persists block comment locations as well.

### Breaking Change
This PR modifies the ICommentIcon interface to have two additional methods: `setBubbleLocation(location: Coordinate): void` and `getBubbleLocation(): Coordinate | undefined`. If you have a class that implements ICommentIcon, you'll need to implement these methods as well. They should set and retrieve the location of the comment bubble/box, in workspace coordinates.