### PR TITLE
feat: add legacy warning to block factory

### DIFF
--- a/demos/blockfactory/app_controller.js
+++ b/demos/blockfactory/app_controller.js
@@ -507,7 +507,7 @@ AppController.prototype.assignBlockFactoryClickHandlers = function() {
 
   document.getElementById('helpButton').addEventListener('click',
       function() {
-        open('https://developers.google.com/blockly/custom-blocks/block-factory',
+        open('https://developers.google.com/blockly/guides/create-custom-blocks/legacy-blockly-developer-tools',
              'BlockFactoryHelp');
       });
 

--- a/demos/blockfactory/factory.css
+++ b/demos/blockfactory/factory.css
@@ -127,6 +127,13 @@ button, .buttonStyle {
   float: right;
 }
 
+#legacyBanner {
+  border: #ccc 1px solid;
+  background-color: #FFCDD2;
+  margin: 4px;
+  padding: 4px;
+}
+
 #blockFactoryContent {
   height: 85%;
   width: 100%;

--- a/demos/blockfactory/index.html
+++ b/demos/blockfactory/index.html
@@ -53,6 +53,9 @@
     <button class="privacyButton" title="Open Google privacy policy"><a class="privacyLink" href="https://policies.google.com/privacy">Privacy</a>
     </button>
   </h1>
+  <div id="legacyBanner">
+    This version of Developer Tools is only compatible with Blockly version 10 and earlier. Try the <a target="_blank" href="https://google.github.io/blockly-samples/examples/developer-tools/index.html">new Block Factory</a> and <a target="_blank" href="https://developers.google.com/blockly/guides/create-custom-blocks/blockly-developer-tools#import_from_legacy_block_factory">learn how to migrate your blocks</a>.
+  </div>
   <div id="tabContainer">
     <div id="blockFactory_tab" class="tab tabon">Block Factory</div>
     <div id="blocklibraryExporter_tab" class="tab taboff">Block Exporter</div>


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes https://github.com/google/blockly-samples/issues/2292

### Proposed Changes

- Adds a warning banner to old block factory with links to docs and new tool
- Updates "Help" button to point to legacy documentation

![Screenshot 2024-06-28 at 12 47 07 PM](https://github.com/google/blockly/assets/8573958/ebc734b1-c03a-4635-89a7-a6399fe28578)

Do note these links won't work until both the new tool and the documentation have been published but I have checked them for correctness

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->

### Documentation

Already updated!

### Additional Information

<!-- Anything else we should know? -->
