### PR TITLE
fix: correctly report the pre-resize-drag size to workspace comment size change listeners

### DIFF
--- a/core/comments/comment_view.ts
+++ b/core/comments/comment_view.ts
@@ -98,7 +98,7 @@ export class CommentView implements IRenderedElement {
 
   /** Whether this comment view has been disposed or not. */
   private disposed = false;
-  
+
   /** Size of this comment when the resize drag was initiated. */
   private preResizeSize?: Size;
 
@@ -525,7 +525,7 @@ export class CommentView implements IRenderedElement {
       e.stopPropagation();
       return;
     }
-    
+
     this.preResizeSize = this.getSize();
 
     // TODO(#7926): Move this into a utils file.

--- a/core/comments/comment_view.ts
+++ b/core/comments/comment_view.ts
@@ -337,12 +337,8 @@ export class CommentView implements IRenderedElement {
    * elements to reflect the new size, and triggers size change listeners.
    */
   setSize(size: Size) {
-    let oldSize = this.size;
+    const oldSize = this.preResizeSize || this.size;
     this.setSizeWithoutFiringEvents(size);
-    if (Size.equals(oldSize, this.size) && this.preResizeSize) {
-      oldSize = this.preResizeSize;
-      this.preResizeSize = undefined;
-    }
     this.onSizeChange(oldSize, this.size);
   }
 
@@ -568,6 +564,7 @@ export class CommentView implements IRenderedElement {
     }
     // When ending a resize drag, notify size change listeners to fire an event.
     this.setSize(this.size);
+    this.preResizeSize = undefined;
   }
 
   /** Resizes the comment in response to a drag on the resize handle. */

--- a/core/comments/comment_view.ts
+++ b/core/comments/comment_view.ts
@@ -98,6 +98,9 @@ export class CommentView implements IRenderedElement {
 
   /** Whether this comment view has been disposed or not. */
   private disposed = false;
+  
+  /** Size of this comment when the resize drag was initiated. */
+  private preResizeSize?: Size;
 
   constructor(private readonly workspace: WorkspaceSvg) {
     this.svgRoot = dom.createSvgElement(Svg.G, {
@@ -334,8 +337,12 @@ export class CommentView implements IRenderedElement {
    * elements to reflect the new size, and triggers size change listeners.
    */
   setSize(size: Size) {
-    const oldSize = this.size;
+    let oldSize = this.size;
     this.setSizeWithoutFiringEvents(size);
+    if (Size.equals(oldSize, this.size) && this.preResizeSize) {
+      oldSize = this.preResizeSize;
+      this.preResizeSize = undefined;
+    }
     this.onSizeChange(oldSize, this.size);
   }
 
@@ -518,6 +525,8 @@ export class CommentView implements IRenderedElement {
       e.stopPropagation();
       return;
     }
+    
+    this.preResizeSize = this.getSize();
 
     // TODO(#7926): Move this into a utils file.
     this.workspace.startDrag(


### PR DESCRIPTION
…ize change listeners

<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Proposed Changes
This PR stores the workspace comment size at the start of a drag on the resize handle, and reports that value to size change listeners. Previously, because the comment was continuously resized during the drag, but size change events were only fired at the end, the "old" comment size calculated in the method that fires the size change event was identical to the new size, so size change listeners were misinformed.