### PR TITLE
chore: make getEventWorkspace_() public

### DIFF
--- a/core/events/events_abstract.ts
+++ b/core/events/events_abstract.ts
@@ -108,7 +108,6 @@ export abstract class Abstract {
    *
    * @returns The workspace the event belongs to.
    * @throws {Error} if workspace is null.
-   * @internal
    */
   getEventWorkspace_(): Workspace {
     let workspace;


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Proposed Changes
This makes the `getEventWorkspace_()` method in the abstract event class public. This is widely used and a general purpose convenience function, so probably should have had the internal annotation removed some time ago.