### PR TITLE
test(CI): Have GitHub use `npm ci` instead of `npm install`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,8 +37,8 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
 
-      - name: Npm Install
-        run: npm install
+      - name: Npm Clean Install
+        run: npm ci
 
       - name: Linux Test Setup
         if: runner.os == 'Linux'


### PR DESCRIPTION
## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [ ] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Proposed Changes

Have the GitHub `build` workflow, which runs our tests, use `npm ci` instead of `npm install` when installing dependencies.

### Reason for Changes

This should help ensure that CI catches PRs that update `package.json` without updating `package-lock.json` to match.

### Additional Information

Proposed in response to breakage caused by PR #8209.
