### PR TITLE
feat: allow fetching block bounds not including children.

### DIFF
--- a/core/block_svg.ts
+++ b/core/block_svg.ts
@@ -407,6 +407,8 @@ export class BlockSvg
   moveTo(xy: Coordinate, reason?: string[]) {
     const curXY = this.getRelativeToSurfaceXY();
     this.moveBy(xy.x - curXY.x, xy.y - curXY.y, reason);
+    console.log(this.getBoundingRectangle());
+    console.log(this.getBoundingRectangleWithoutChildren());
   }
 
   /**
@@ -444,7 +446,7 @@ export class BlockSvg
    * @returns Object with coordinates of the bounding box.
    */
   getBoundingRectangle(): Rect {
-    return this.getBoundingRectangleWithWidth(this.getHeightWidth().width);
+    return this.getBoundingRectangleWithDimensions(this.getHeightWidth());
   }
 
   /**
@@ -455,20 +457,25 @@ export class BlockSvg
    * @returns Object with coordinates of the bounding box.
    */
   getBoundingRectangleWithoutChildren(): Rect {
-    return this.getBoundingRectangleWithWidth(this.childlessWidth);
+    return this.getBoundingRectangleWithDimensions({
+      height: this.height,
+      width: this.width,
+    });
   }
 
-  private getBoundingRectangleWithWidth(blockWidth: number) {
+  private getBoundingRectangleWithDimensions(blockBounds: {
+    height: number;
+    width: number;
+  }) {
     const blockXY = this.getRelativeToSurfaceXY();
-    const blockBounds = this.getHeightWidth();
     let left;
     let right;
     if (this.RTL) {
-      left = blockXY.x - blockWidth;
+      left = blockXY.x - blockBounds.width;
       right = blockXY.x;
     } else {
       left = blockXY.x;
-      right = blockXY.x + blockWidth;
+      right = blockXY.x + blockBounds.width;
     }
     return new Rect(blockXY.y, blockXY.y + blockBounds.height, left, right);
   }

--- a/core/block_svg.ts
+++ b/core/block_svg.ts
@@ -108,7 +108,7 @@ export class BlockSvg
    * Width is in workspace units.
    */
   width = 0;
-  
+
   /**
    * Width of this block, not including any connected value blocks.
    * Width is in workspace units.
@@ -446,7 +446,7 @@ export class BlockSvg
   getBoundingRectangle(): Rect {
     return this.getBoundingRectangleWithWidth(this.getHeightWidth().width);
   }
-  
+
   /**
    * Returns the coordinates of a bounding box describing the dimensions of this
    * block alone.
@@ -457,7 +457,7 @@ export class BlockSvg
   getBoundingRectangleWithoutChildren(): Rect {
     return this.getBoundingRectangleWithWidth(this.childlessWidth);
   }
-  
+
   private getBoundingRectangleWithWidth(blockWidth: number) {
     const blockXY = this.getRelativeToSurfaceXY();
     const blockBounds = this.getHeightWidth();

--- a/core/block_svg.ts
+++ b/core/block_svg.ts
@@ -112,6 +112,7 @@ export class BlockSvg
   /**
    * Width of this block, not including any connected value blocks.
    * Width is in workspace units.
+   *
    * @internal
    */
   childlessWidth = 0;

--- a/core/block_svg.ts
+++ b/core/block_svg.ts
@@ -407,8 +407,6 @@ export class BlockSvg
   moveTo(xy: Coordinate, reason?: string[]) {
     const curXY = this.getRelativeToSurfaceXY();
     this.moveBy(xy.x - curXY.x, xy.y - curXY.y, reason);
-    console.log(this.getBoundingRectangle());
-    console.log(this.getBoundingRectangleWithoutChildren());
   }
 
   /**

--- a/core/block_svg.ts
+++ b/core/block_svg.ts
@@ -108,6 +108,13 @@ export class BlockSvg
    * Width is in workspace units.
    */
   width = 0;
+  
+  /**
+   * Width of this block, not including any connected value blocks.
+   * Width is in workspace units.
+   * @internal
+   */
+  childlessWidth = 0;
 
   /**
    * Map from IDs for warnings text to PIDs of functions to apply them.
@@ -436,16 +443,31 @@ export class BlockSvg
    * @returns Object with coordinates of the bounding box.
    */
   getBoundingRectangle(): Rect {
+    return this.getBoundingRectangleWithWidth(this.getHeightWidth().width);
+  }
+  
+  /**
+   * Returns the coordinates of a bounding box describing the dimensions of this
+   * block alone.
+   * Coordinate system: workspace coordinates.
+   *
+   * @returns Object with coordinates of the bounding box.
+   */
+  getBoundingRectangleWithoutChildren(): Rect {
+    return this.getBoundingRectangleWithWidth(this.childlessWidth);
+  }
+  
+  private getBoundingRectangleWithWidth(blockWidth: number) {
     const blockXY = this.getRelativeToSurfaceXY();
     const blockBounds = this.getHeightWidth();
     let left;
     let right;
     if (this.RTL) {
-      left = blockXY.x - blockBounds.width;
+      left = blockXY.x - blockWidth;
       right = blockXY.x;
     } else {
       left = blockXY.x;
-      right = blockXY.x + blockBounds.width;
+      right = blockXY.x + blockWidth;
     }
     return new Rect(blockXY.y, blockXY.y + blockBounds.height, left, right);
   }

--- a/core/renderers/common/drawer.ts
+++ b/core/renderers/common/drawer.ts
@@ -80,6 +80,7 @@ export class Drawer {
     // The dark path adds to the size of the block in both X and Y.
     this.block_.height = this.info_.height;
     this.block_.width = this.info_.widthWithChildren;
+    this.block_.childlessWidth = this.info_.width;
   }
 
   /** Create the outline of the block.  This is a single continuous path. */


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves 

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #7212

### Proposed Changes
This PR adds a `getBoundingRectangleWithoutChildren()` method to BlockSvg that returns the bounding box for the block alone, not including its children (for C blocks) or subsequent blocks in the stack.

### Reason for Changes
There was no public API to retrieve this information, and it's useful.
