### PR TITLE
fix: use the correct with in getBoundingRectangleWithoutChildren().

### DIFF
--- a/core/block_svg.ts
+++ b/core/block_svg.ts
@@ -457,7 +457,7 @@ export class BlockSvg
   getBoundingRectangleWithoutChildren(): Rect {
     return this.getBoundingRectangleWithDimensions({
       height: this.height,
-      width: this.width,
+      width: this.childlessWidth,
     });
   }
 


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
Fixes a bug in the just-introduced getBoundingRectangleWithoutChildren() where it used the childful instead of childless width field.