### PR TITLE
fix!: Rename editing CSS class to blocklyEditing (#8287)

### DIFF
--- a/core/field_input.ts
+++ b/core/field_input.ts
@@ -500,7 +500,7 @@ export abstract class FieldInput<T extends InputTypes> extends Field<
 
     const clickTarget = this.getClickTarget_();
     if (!clickTarget) throw new Error('A click target has not been set.');
-    dom.removeClass(clickTarget, 'editing');
+    dom.removeClass(clickTarget, 'blocklyEditing');
   }
 
   /**

--- a/core/field_input.ts
+++ b/core/field_input.ts
@@ -405,7 +405,7 @@ export abstract class FieldInput<T extends InputTypes> extends Field<
 
     const clickTarget = this.getClickTarget_();
     if (!clickTarget) throw new Error('A click target has not been set.');
-    dom.addClass(clickTarget, 'editing');
+    dom.addClass(clickTarget, 'blocklyEditing');
 
     const htmlInput = document.createElement('input');
     htmlInput.className = 'blocklyHtmlInput';

--- a/core/renderers/common/constants.ts
+++ b/core/renderers/common/constants.ts
@@ -1154,7 +1154,7 @@ export class ConstantProvider {
       `}`,
 
       // Editable field hover.
-      `${selector} .blocklyEditableText:not(.editing):hover>rect {`,
+      `${selector} .blocklyEditableText:not(.blocklyEditing):hover>rect {`,
         `stroke: #fff;`,
         `stroke-width: 2;`,
       `}`,

--- a/core/renderers/zelos/constants.ts
+++ b/core/renderers/zelos/constants.ts
@@ -825,9 +825,9 @@ export class ConstantProvider extends BaseConstantProvider {
 
       // Editable field hover.
       `${selector} .blocklyDraggable:not(.blocklyDisabled)`,
-      ` .blocklyEditableText:not(.editing):hover>rect,`,
+      ` .blocklyEditableText:not(.blocklyEditing):hover>rect,`,
       `${selector} .blocklyDraggable:not(.blocklyDisabled)`,
-      ` .blocklyEditableText:not(.editing):hover>.blocklyPath {`,
+      ` .blocklyEditableText:not(.blocklyEditing):hover>.blocklyPath {`,
       `stroke: #fff;`,
       `stroke-width: 2;`,
       `}`,


### PR DESCRIPTION
Fixes: #8287

**chore!: Rename editing CSS class to blocklyEditing (#8287)**