### PR TITLE
feat: Add the block's style as a CSS class to the block's root SVG (#8269)

### DIFF
--- a/core/block_svg.ts
+++ b/core/block_svg.ts
@@ -1135,6 +1135,9 @@ export class BlockSvg
       .getBlockStyle(blockStyleName);
     this.styleName_ = blockStyleName;
 
+    dom.removeClass(this.svgGroup_, this.styleName_)
+    dom.addClass(this.svgGroup_, blockStyleName)
+
     if (blockStyle) {
       this.hat = blockStyle.hat;
       this.pathObject.setStyle(blockStyle);


### PR DESCRIPTION
Fixes: #8269 

**feat: Add the block's style as a CSS class to the block's root SVG (#8269)**