### PR TITLE
refactor: field_checkbox `dom.addClass` params

### DIFF
--- a/core/field_checkbox.ts
+++ b/core/field_checkbox.ts
@@ -114,7 +114,7 @@ export class FieldCheckbox extends Field<CheckboxBool> {
     super.initView();
 
     const textElement = this.getTextElement();
-    dom.addClass(textElement, 'blocklyCheckbox');
+    dom.addClass(this.fieldGroup_!, 'blocklyCheckboxField');
     textElement.style.display = this.value_ ? 'block' : 'none';
   }
 


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [ ] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
This PR updates the parameters of `dom.addClass` function call to pass `this.fieldGroup_` and `'blocklyCheckboxField'`.

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #8299 
