### PR TITLE
fix!: Make `IPathObject` styling methods optional

### DIFF
--- a/core/block_svg.ts
+++ b/core/block_svg.ts
@@ -849,7 +849,7 @@ export class BlockSvg
    * @internal
    */
   applyColour() {
-    this.pathObject.applyColour(this);
+    this.pathObject.applyColour?.(this);
 
     const icons = this.getIcons();
     for (let i = 0; i < icons.length; i++) {
@@ -1115,7 +1115,7 @@ export class BlockSvg
       .getConstants()
       .getBlockStyleForColour(this.colour_);
 
-    this.pathObject.setStyle(styleObj.style);
+    this.pathObject.setStyle?.(styleObj.style);
     this.style = styleObj.style;
     this.styleName_ = styleObj.name;
 
@@ -1137,7 +1137,7 @@ export class BlockSvg
 
     if (blockStyle) {
       this.hat = blockStyle.hat;
-      this.pathObject.setStyle(blockStyle);
+      this.pathObject.setStyle?.(blockStyle);
       // Set colour to match Block.
       this.colour_ = blockStyle.colourPrimary;
       this.style = blockStyle;

--- a/core/renderers/common/i_path_object.ts
+++ b/core/renderers/common/i_path_object.ts
@@ -50,21 +50,6 @@ export interface IPathObject {
   setPath(pathString: string): void;
 
   /**
-   * Apply the stored colours to the block's path, taking into account whether
-   * the paths belong to a shadow block.
-   *
-   * @param block The source block.
-   */
-  applyColour(block: BlockSvg): void;
-
-  /**
-   * Update the style.
-   *
-   * @param blockStyle The block style to use.
-   */
-  setStyle(blockStyle: BlockStyle): void;
-
-  /**
    * Flip the SVG paths in RTL.
    */
   flipRTL(): void;
@@ -131,7 +116,22 @@ export interface IPathObject {
   ): void;
 
   /**
+   * Apply the stored colours to the block's path, taking into account whether
+   * the paths belong to a shadow block.
+   *
+   * @param block The source block.
+   */
+  applyColour?(block: BlockSvg): void;
+
+  /**
    * Removes any highlight associated with the given connection, if it exists.
    */
   removeConnectionHighlight?(connection: RenderedConnection): void;
+
+  /**
+   * Update the style.
+   *
+   * @param blockStyle The block style to use.
+   */
+  setStyle?(blockStyle: BlockStyle): void;
 }


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
This PR updates the `IPathObject` Interface to make following methods optional:
- `applyColour`
- `setStyle`

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #8279 


