### PR TITLE
feat: Add a blocklyTextBubble CSS class to the text bubble #8331

### DIFF
--- a/core/bubbles/text_bubble.ts
+++ b/core/bubbles/text_bubble.ts
@@ -27,6 +27,7 @@ export class TextBubble extends Bubble {
     super(workspace, anchor, ownerRect);
     this.paragraph = this.stringToSvg(text, this.contentContainer);
     this.updateBubbleSize();
+    dom.addClass(this.svgRoot, 'blocklyTextBubble');
   }
 
   /** @returns the current text of this text bubble. */


### PR DESCRIPTION
## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #8331 Add a blocklyTextBubble CSS class to the text bubble

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
Added a call to dom.addClass that adds a blocklyTextBubble CSS class to the this.svgRoot

`dom.addClass(this.svgRoot, 'blocklyTextBubble');`