### PR TITLE
feat: Add blocklyField to field's SVG Group

### DIFF
--- a/core/field.ts
+++ b/core/field.ts
@@ -323,6 +323,9 @@ export abstract class Field<T = any>
   protected initView() {
     this.createBorderRect_();
     this.createTextElement_();
+    if (this.fieldGroup_) {
+      dom.addClass(this.fieldGroup_, 'blocklyField');
+    }
   }
 
   /**


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)
## The details
Added  `.blocklyField` to `fieldGroup_` using `dom.addClass()`
### Resolves
https://github.com/google/blockly/issues/8289
