### PR TITLE
fix!: rename the blockly icon CSS classes to use camelCase (#8329)

### DIFF
--- a/core/icons/comment_icon.ts
+++ b/core/icons/comment_icon.ts
@@ -114,7 +114,7 @@ export class CommentIcon extends Icon implements IHasBubble, ISerializable {
       },
       this.svgRoot,
     );
-    dom.addClass(this.svgRoot!, 'blockly-icon-comment');
+    dom.addClass(this.svgRoot!, 'blocklyCommentIcon');
   }
 
   override dispose() {

--- a/core/icons/mutator_icon.ts
+++ b/core/icons/mutator_icon.ts
@@ -116,7 +116,7 @@ export class MutatorIcon extends Icon implements IHasBubble {
       {'class': 'blocklyIconShape', 'r': '2.7', 'cx': '8', 'cy': '8'},
       this.svgRoot,
     );
-    dom.addClass(this.svgRoot!, 'blockly-icon-mutator');
+    dom.addClass(this.svgRoot!, 'blocklyMutatorIcon');
   }
 
   override dispose(): void {

--- a/core/icons/warning_icon.ts
+++ b/core/icons/warning_icon.ts
@@ -89,7 +89,7 @@ export class WarningIcon extends Icon implements IHasBubble {
       },
       this.svgRoot,
     );
-    dom.addClass(this.svgRoot!, 'blockly-icon-warning');
+    dom.addClass(this.svgRoot!, 'blocklyWarningIcon');
   }
 
   override dispose() {


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes Rename the blockly icon CSS classes to use camelCase [#8329](https://github.com/google/blockly/issues/8329)

### Proposed Changes

Rename the following CSS classes and references to them:

.blockly-icon-comment -> blocklyCommentIcon
.blockly-icon-warning -> blocklyWarningIcon
.blockly-icon-mutator -> blocklyMutatorIcon


### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
