### PR TITLE
combined `blocklyArrowTop` and `blocklyArrowBottom` styling into the `blocklyDropDownArrow` styling

### DIFF
--- a/core/css.ts
+++ b/core/css.ts
@@ -139,6 +139,13 @@ let content = `
   z-index: -1;
   background-color: inherit;
   border-color: inherit;
+  border-bottom: 1px solid;
+  border-right: 1px solid;
+  border-bottom-right-radius: 4px;
+  border-color: inherit;
+  border-top: 1px solid;
+  border-left: 1px solid;
+  border-top-left-radius: 4px;
 }
 
 .blocklyDropDownButton {
@@ -151,20 +158,6 @@ let content = `
   border: 1px solid;
   transition: box-shadow .1s;
   cursor: pointer;
-}
-
-.blocklyArrowTop {
-  border-top: 1px solid;
-  border-left: 1px solid;
-  border-top-left-radius: 4px;
-  border-color: inherit;
-}
-
-.blocklyArrowBottom {
-  border-bottom: 1px solid;
-  border-right: 1px solid;
-  border-bottom-right-radius: 4px;
-  border-color: inherit;
 }
 
 .blocklyResizeSE {

--- a/core/dropdowndiv.ts
+++ b/core/dropdowndiv.ts
@@ -712,9 +712,7 @@ function positionInternal(
       'px) rotate(45deg)';
     arrow.setAttribute(
       'class',
-      metrics.arrowAtTop
-        ? 'blocklyDropDownArrow blocklyArrowTop'
-        : 'blocklyDropDownArrow blocklyArrowBottom',
+      metrics.arrowAtTop ? 'blocklyDropDownArrow' : 'blocklyDropDownArrow',
     );
   } else {
     arrow.style.display = 'none';


### PR DESCRIPTION
## The basics

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details

Combine the styling of `blocklyArrowTop` and `blocklyArrowBottom` into the `blocklyDropDownArrow` and remove the assignment of `blocklyArrowTop` and `blocklyArrowBottom`.

### Resolves

Fixes #8323 

