### PR TITLE
fix!: Replace Closure UI CSS classes with Blockly CSS classes

### DIFF
--- a/core/menu.ts
+++ b/core/menu.ts
@@ -85,7 +85,6 @@ export class Menu {
    */
   render(container: Element): HTMLDivElement {
     const element = document.createElement('div');
-    // Removed deprecated goog-menu, used blocklyMenu.  July 2024.
     element.className = 'blocklyMenu blocklyNonSelectable';
     element.tabIndex = 0;
     if (this.roleName) {

--- a/core/menu.ts
+++ b/core/menu.ts
@@ -85,8 +85,8 @@ export class Menu {
    */
   render(container: Element): HTMLDivElement {
     const element = document.createElement('div');
-    // goog-menu is deprecated, use blocklyMenu.  May 2020.
-    element.className = 'blocklyMenu goog-menu blocklyNonSelectable';
+    // Removed deprecated goog-menu, used blocklyMenu.  July 2024.
+    element.className = 'blocklyMenu blocklyNonSelectable';
     element.tabIndex = 0;
     if (this.roleName) {
       aria.setRole(element, this.roleName);

--- a/core/menuitem.ts
+++ b/core/menuitem.ts
@@ -64,7 +64,6 @@ export class MenuItem {
     this.element = element;
 
     // Set class and style
-    // removed deprecated goog-menuitem & goog-menuitem-disabled , used blocklyMenuItem & blocklyMenuItemDisabled.  July 2024.
     element.className =
       'blocklyMenuItem ' +
       (this.enabled ? '' : 'blocklyMenuItemDisabled ') +

--- a/core/menuitem.ts
+++ b/core/menuitem.ts
@@ -68,9 +68,7 @@ export class MenuItem {
       'blocklyMenuItem ' +
       (this.enabled ? '' : 'blocklyMenuItemDisabled ') +
       (this.checked ? 'blocklyMenuItemSelected ' : '') +
-      (this.highlight
-        ? 'blocklyMenuItemHighlight '
-        : '') +
+      (this.highlight ? 'blocklyMenuItemHighlight ' : '') +
       (this.rightToLeft ? 'blocklyMenuItemRtl ' : '');
 
     const content = document.createElement('div');

--- a/core/menuitem.ts
+++ b/core/menuitem.ts
@@ -64,10 +64,10 @@ export class MenuItem {
     this.element = element;
 
     // Set class and style
-    // goog-menuitem* is deprecated, use blocklyMenuItem*.  May 2020.
+    // removed deprecated goog-menuitem & goog-menuitem-disabled , used blocklyMenuItem & blocklyMenuItemDisabled.  July 2024.
     element.className =
-      'blocklyMenuItem goog-menuitem ' +
-      (this.enabled ? '' : 'blocklyMenuItemDisabled goog-menuitem-disabled ') +
+      'blocklyMenuItem ' +
+      (this.enabled ? '' : 'blocklyMenuItemDisabled ') +
       (this.checked ? 'blocklyMenuItemSelected goog-option-selected ' : '') +
       (this.highlight
         ? 'blocklyMenuItemHighlight goog-menuitem-highlight '

--- a/core/menuitem.ts
+++ b/core/menuitem.ts
@@ -67,18 +67,18 @@ export class MenuItem {
     element.className =
       'blocklyMenuItem ' +
       (this.enabled ? '' : 'blocklyMenuItemDisabled ') +
-      (this.checked ? 'blocklyMenuItemSelected goog-option-selected ' : '') +
+      (this.checked ? 'blocklyMenuItemSelected ' : '') +
       (this.highlight
-        ? 'blocklyMenuItemHighlight goog-menuitem-highlight '
+        ? 'blocklyMenuItemHighlight '
         : '') +
-      (this.rightToLeft ? 'blocklyMenuItemRtl goog-menuitem-rtl ' : '');
+      (this.rightToLeft ? 'blocklyMenuItemRtl ' : '');
 
     const content = document.createElement('div');
-    content.className = 'blocklyMenuItemContent goog-menuitem-content';
+    content.className = 'blocklyMenuItemContent';
     // Add a checkbox for checkable menu items.
     if (this.checkable) {
       const checkbox = document.createElement('div');
-      checkbox.className = 'blocklyMenuItemCheckbox goog-menuitem-checkbox';
+      checkbox.className = 'blocklyMenuItemCheckbox ';
       content.appendChild(checkbox);
     }
 
@@ -187,19 +187,13 @@ export class MenuItem {
    */
   setHighlighted(highlight: boolean) {
     this.highlight = highlight;
-
     const el = this.getElement();
     if (el && this.isEnabled()) {
-      // goog-menuitem-highlight is deprecated, use blocklyMenuItemHighlight.
-      // May 2020.
       const name = 'blocklyMenuItemHighlight';
-      const nameDep = 'goog-menuitem-highlight';
       if (highlight) {
         dom.addClass(el, name);
-        dom.addClass(el, nameDep);
       } else {
         dom.removeClass(el, name);
-        dom.removeClass(el, nameDep);
       }
     }
   }


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes Replace Closure UI CSS classes with Blockly CSS classes #8286 

### Proposed Changes
replaces all instances of the deprecated goog-menuitem, goog-menuitem-disabled, and goog-menu CSS classes
  with the corresponding blocklyMenuItem, blocklyMenuItemDisabled, and blocklyMenu classes
<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->

### Reason for Changes
This change ensures that the code
  follows the updated styling guidelines and removes dependency on the old Closure UI library.

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
Please let me know, if any changes are needed.