### PR TITLE
fix: Enable blocks if user can't manually enable them.

### DIFF
--- a/tests/mocha/blocks/procedures_test.js
+++ b/tests/mocha/blocks/procedures_test.js
@@ -25,7 +25,7 @@ import {defineRowBlock} from '../test_helpers/block_definitions.js';
 suite('Procedures', function () {
   setup(function () {
     sharedTestSetup.call(this, {fireEventsNow: false});
-    this.workspace = Blockly.inject('blocklyDiv', {});
+    this.workspace = Blockly.inject('blocklyDiv', {disable: true});
     this.workspace.createVariable('preCreatedVar', '', 'preCreatedVarId');
     this.workspace.createVariable(
       'preCreatedTypedVar',

--- a/tests/mocha/blocks/procedures_test.js
+++ b/tests/mocha/blocks/procedures_test.js
@@ -25,7 +25,7 @@ import {defineRowBlock} from '../test_helpers/block_definitions.js';
 suite('Procedures', function () {
   setup(function () {
     sharedTestSetup.call(this, {fireEventsNow: false});
-    this.workspace = Blockly.inject('blocklyDiv', {disable: true});
+    this.workspace = Blockly.inject('blocklyDiv', {});
     this.workspace.createVariable('preCreatedVar', '', 'preCreatedVarId');
     this.workspace.createVariable(
       'preCreatedTypedVar',
@@ -862,6 +862,7 @@ suite('Procedures', function () {
       'if a procedure caller block was already disabled before ' +
         'its definition was disabled, it is not reenabled',
       function () {
+        this.workspace.options.disable = true;
         const defBlock = createProcDefBlock(this.workspace);
         const callBlock = createProcCallBlock(this.workspace);
         this.clock.runAll();


### PR DESCRIPTION
## The basics

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

Fixes https://github.com/google/blockly/issues/8310

### Proposed Changes

When any disabled reason is removed, and the workspace is configured to not allow manually disabling/enabling, and a block is currently disabled for the manual reason, remove the manual reason in addition to whatever reason initiated the change.

### Reason for Changes

A legacy serialized workspace does not specify the reason why blocks are disabled. When loaded with blocks that had been disabled due to being orphaned but without a recorded reason, Blockly defaults to using the manually disabled reason. However, some workspaces are configured to disallow disabling/enabling blocks, in which case the user can't remove the manually disabled reason.

For the specific case where a workspace does not allow manually disabling or enabling blocks, and a block currently has the manually disabled reason, and some other disabled reason is being removed (e.g. the block is no longer orphaned), then removing the manually disabled reason will allow the block to be fully enabled again.

### Test Coverage

I haven't created any unit tests for this legacy workaround yet, but I did have to explicitly set the option `{disable: true}` in a test workspace to get one test method to pass since it was designed for the common case where users are allowed to manually disable blocks. 

I manually tested that the workaround behaves as intended by using the browser console to set `Blockly.getMainWorkspace().options.disable = false` after manually disabling a block.

### Documentation

N/A

### Additional Information

N/A