### PR TITLE
fix: drag strategy only clear group id set by us

### DIFF
--- a/core/dragging/block_drag_strategy.ts
+++ b/core/dragging/block_drag_strategy.ts
@@ -61,6 +61,9 @@ export class BlockDragStrategy implements IDragStrategy {
    */
   private dragOffset = new Coordinate(0, 0);
 
+  /** Was there already an event group in progress when the drag started? */
+  private inGroup: boolean = false;
+
   constructor(private block: BlockSvg) {
     this.workspace = block.workspace;
   }
@@ -92,7 +95,8 @@ export class BlockDragStrategy implements IDragStrategy {
     }
 
     this.dragging = true;
-    if (!eventUtils.getGroup()) {
+    this.inGroup = !!eventUtils.getGroup();
+    if (!this.inGroup) {
       eventUtils.setGroup(true);
     }
     this.fireDragStartEvent();
@@ -389,7 +393,9 @@ export class BlockDragStrategy implements IDragStrategy {
     this.connectionPreviewer!.dispose();
     this.workspace.setResizesEnabled(true);
 
-    eventUtils.setGroup(false);
+    if (!this.inGroup) {
+      eventUtils.setGroup(false);
+    }
   }
 
   /** Connects the given candidate connections. */

--- a/core/dragging/bubble_drag_strategy.ts
+++ b/core/dragging/bubble_drag_strategy.ts
@@ -13,6 +13,9 @@ import * as layers from '../layers.js';
 export class BubbleDragStrategy implements IDragStrategy {
   private startLoc: Coordinate | null = null;
 
+  /** Was there already an event group in progress when the drag started? */
+  private inGroup: boolean = false;
+
   constructor(
     private bubble: IBubble,
     private workspace: WorkspaceSvg,
@@ -23,7 +26,8 @@ export class BubbleDragStrategy implements IDragStrategy {
   }
 
   startDrag(): void {
-    if (!eventUtils.getGroup()) {
+    this.inGroup = !!eventUtils.getGroup();
+    if (!this.inGroup) {
       eventUtils.setGroup(true);
     }
     this.startLoc = this.bubble.getRelativeToSurfaceXY();
@@ -38,7 +42,9 @@ export class BubbleDragStrategy implements IDragStrategy {
 
   endDrag(): void {
     this.workspace.setResizesEnabled(true);
-    eventUtils.setGroup(false);
+    if (!this.inGroup) {
+      eventUtils.setGroup(false);
+    }
 
     this.workspace
       .getLayerManager()

--- a/core/dragging/comment_drag_strategy.ts
+++ b/core/dragging/comment_drag_strategy.ts
@@ -17,6 +17,9 @@ export class CommentDragStrategy implements IDragStrategy {
 
   private workspace: WorkspaceSvg;
 
+  /** Was there already an event group in progress when the drag started? */
+  private inGroup: boolean = false;
+
   constructor(private comment: RenderedWorkspaceComment) {
     this.workspace = comment.workspace;
   }
@@ -26,7 +29,8 @@ export class CommentDragStrategy implements IDragStrategy {
   }
 
   startDrag(): void {
-    if (!eventUtils.getGroup()) {
+    this.inGroup = !!eventUtils.getGroup();
+    if (!this.inGroup) {
       eventUtils.setGroup(true);
     }
     this.fireDragStartEvent();
@@ -52,7 +56,9 @@ export class CommentDragStrategy implements IDragStrategy {
     this.comment.snapToGrid();
 
     this.workspace.setResizesEnabled(true);
-    eventUtils.setGroup(false);
+    if (!this.inGroup) {
+      eventUtils.setGroup(false);
+    }
   }
 
   /** Fire a UI event at the start of a comment drag. */


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes https://github.com/mit-cml/workspace-multiselect/pull/62#issuecomment-2225465398

### Proposed Changes

We should add a condition check so that we don't unset the group ID that is not set by us, otherwise, the multi-select plugin undo/redo will be broken (apply individually instead of all together)

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->

### Reason for Changes

If not, then a monkey patch will be needed on the multi-selection plugin side.
<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
