### PR TITLE
fix: added id to rendered ws comments; made getCommentById public; ad…

### DIFF
--- a/core/comments/comment_view.ts
+++ b/core/comments/comment_view.ts
@@ -104,7 +104,7 @@ export class CommentView implements IRenderedElement {
 
   constructor(private readonly workspace: WorkspaceSvg) {
     this.svgRoot = dom.createSvgElement(Svg.G, {
-      'class': 'blocklyComment blocklyEditable',
+      'class': 'blocklyComment blocklyEditable blocklyDraggable',
     });
 
     this.highlightRect = this.createHighlightRect(this.svgRoot);

--- a/core/comments/rendered_workspace_comment.ts
+++ b/core/comments/rendered_workspace_comment.ts
@@ -57,6 +57,7 @@ export class RenderedWorkspaceComment
     // Set the size to the default size as defined in the superclass.
     this.view.setSize(this.getSize());
     this.view.setEditable(this.isEditable());
+    this.view.getSvgRoot().setAttribute('data-id', this.id);
 
     this.addModelUpdateBindings();
 

--- a/core/workspace.ts
+++ b/core/workspace.ts
@@ -748,7 +748,6 @@ export class Workspace implements IASTNodeLocation {
    *
    * @param id ID of comment to find.
    * @returns The sought after comment, or null if not found.
-   * @internal
    */
   getCommentById(id: string): WorkspaceComment | null {
     return this.commentDB.get(id) ?? null;


### PR DESCRIPTION
…ded blocklyDraggable class to ws comments

<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes https://github.com/google/blockly/issues/8242 and https://github.com/google/blockly/issues/8253

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
This exposes the rendered workspace comment id in the DOM. It also makes the workspace getCommentById function public. It also added the blocklyDraggable class to the DOM of rendered workspace comments.

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
This will help with the support of the implementation of workspace comments in the multiselect plugin. This is mainly needed as the multiselect plugin uses dragSelect to select the elements' DOM. The id in the DOM is then passed to a respective get[element]ById function to manipulate/work with the actual object (in this case workspace comments).

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->
I tested this by looking at the HTML of the page and seeing whether it had the added classes and data-id field.

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->
Documentation regarding rendered workspace comments having a data-id field may be added, but it would not be of the utmost concern.

### Additional Information

<!-- Anything else we should know? -->
