### PR TITLE
fix: use `:focus` pseudo class instead of `blocklyFocused`

### DIFF
--- a/core/css.ts
+++ b/core/css.ts
@@ -444,6 +444,10 @@ input[type=number] {
   z-index: 20000;  /* Arbitrary, but some apps depend on it... */
 }
 
+.blocklyWidgetDiv .blocklyMenu:focus {
+  box-shadow: 0 0 6px 1px rgba(0,0,0,.3);
+}
+
 .blocklyDropDownDiv .blocklyMenu {
   background: inherit;  /* Compatibility with gapi, reset from goog-menu */
   border: inherit;  /* Compatibility with gapi, reset from goog-menu */

--- a/core/css.ts
+++ b/core/css.ts
@@ -444,10 +444,6 @@ input[type=number] {
   z-index: 20000;  /* Arbitrary, but some apps depend on it... */
 }
 
-.blocklyWidgetDiv .blocklyMenu.blocklyFocused {
-  box-shadow: 0 0 6px 1px rgba(0,0,0,.3);
-}
-
 .blocklyDropDownDiv .blocklyMenu {
   background: inherit;  /* Compatibility with gapi, reset from goog-menu */
   border: inherit;  /* Compatibility with gapi, reset from goog-menu */

--- a/core/css.ts
+++ b/core/css.ts
@@ -5,7 +5,6 @@
  */
 
 // Former goog.module ID: Blockly.Css
-
 /** Has CSS already been injected? */
 let injected = false;
 
@@ -119,7 +118,7 @@ let content = `
   box-shadow: 0 0 3px 1px rgba(0,0,0,.3);
 }
 
-.blocklyDropDownDiv.blocklyFocused {
+.blocklyDropDownDiv:focus {
   box-shadow: 0 0 6px 1px rgba(0,0,0,.3);
 }
 

--- a/core/dropdowndiv.ts
+++ b/core/dropdowndiv.ts
@@ -136,12 +136,6 @@ export function createDom() {
 
   // Handle focusin/out events to add a visual indicator when
   // a child is focused or blurred.
-  div.addEventListener('focusin', function () {
-    dom.addClass(div, 'blocklyFocused');
-  });
-  div.addEventListener('focusout', function () {
-    dom.removeClass(div, 'blocklyFocused');
-  });
 }
 
 /**

--- a/core/menu.ts
+++ b/core/menu.ts
@@ -164,7 +164,6 @@ export class Menu {
     const el = this.getElement();
     if (el) {
       el.blur();
-      dom.removeClass(el, 'blocklyFocused');
     }
   }
 

--- a/core/menu.ts
+++ b/core/menu.ts
@@ -156,7 +156,6 @@ export class Menu {
     const el = this.getElement();
     if (el) {
       el.focus({preventScroll: true});
-      dom.addClass(el, 'blocklyFocused');
     }
   }
 

--- a/core/menu.ts
+++ b/core/menu.ts
@@ -15,7 +15,6 @@ import * as browserEvents from './browser_events.js';
 import type {MenuItem} from './menuitem.js';
 import * as aria from './utils/aria.js';
 import {Coordinate} from './utils/coordinate.js';
-import * as dom from './utils/dom.js';
 import type {Size} from './utils/size.js';
 import * as style from './utils/style.js';
 


### PR DESCRIPTION
… style to :focus

<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x ] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #8326

### Proposed Changes

Remove the blocklyFocused class from being assigned in menu.ts and dropdowndiv.ts
Change the styles in css.ts to use the :focus css pseudo class

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->

Removed the blocklyFocused class from being assigned in menu.ts and dropdowndiv.ts
Changed the styles in css.ts to use the :focus css pseudo class

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->

Not necessary 

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

No it won't affect anything. just some minor css changes

### Additional Information

<!-- Anything else we should know? -->
