### PR TITLE
chore(deps): Enable `legacy-peer-deps`, update `@blockly/` plugins

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
 registry=https://registry.npmjs.org/
+legacy-peer-deps=true

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,9 +13,9 @@
         "jsdom": "24.1.0"
       },
       "devDependencies": {
-        "@blockly/block-test": "^5.0.0",
-        "@blockly/dev-tools": "^7.0.2",
-        "@blockly/theme-modern": "^5.0.0",
+        "@blockly/block-test": "^6.0.4",
+        "@blockly/dev-tools": "^8.0.4",
+        "@blockly/theme-modern": "^6.0.3",
         "@hyperjump/json-schema": "^1.5.0",
         "@microsoft/api-documenter": "^7.22.4",
         "@microsoft/api-extractor": "^7.29.5",
@@ -78,28 +78,30 @@
       }
     },
     "node_modules/@blockly/block-test": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@blockly/block-test/-/block-test-5.1.0.tgz",
-      "integrity": "sha512-beqBTJbrrDGECohJo6uczeLAvRxKgMFn9Ew1po6d8PBka/aNwSkT33jHRUAeasHnraBdFBx8pwYh7By2gVZURQ==",
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@blockly/block-test/-/block-test-6.0.4.tgz",
+      "integrity": "sha512-T8uod/uIt3QSvS5nIRGTa6i3h/UZXWJPUOiNY+RW0/azHZLBSOH8udyw1a22u9iOSpA7gDmw3WBbFgooCytDcw==",
       "dev": true,
+      "license": "Apache 2.0",
       "engines": {
         "node": ">=8.17.0"
       },
       "peerDependencies": {
-        "blockly": "^10.0.0"
+        "blockly": "^11.0.0"
       }
     },
     "node_modules/@blockly/dev-tools": {
-      "version": "7.1.7",
-      "resolved": "https://registry.npmjs.org/@blockly/dev-tools/-/dev-tools-7.1.7.tgz",
-      "integrity": "sha512-ar/6A7JyTSzhJ6ojEOzoCxnm4jRTQJeYn87g+iTEJrM9K8tk/Ccn4sZY34T+ULhy8A2MbFkbtmERCLx6HNrAkA==",
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/@blockly/dev-tools/-/dev-tools-8.0.4.tgz",
+      "integrity": "sha512-YTb3dj8msWWz4hfpQTRIE3NLX2xbTjkluuazA55jOBWSnkPRo0ZeCmjMVwOAG3GECBrjt3IanwuNIuwwBLkbkg==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
-        "@blockly/block-test": "^5.1.0",
-        "@blockly/theme-dark": "^6.0.5",
-        "@blockly/theme-deuteranopia": "^5.0.6",
-        "@blockly/theme-highcontrast": "^5.0.5",
-        "@blockly/theme-tritanopia": "^5.0.5",
+        "@blockly/block-test": "^6.0.4",
+        "@blockly/theme-dark": "^7.0.3",
+        "@blockly/theme-deuteranopia": "^6.0.3",
+        "@blockly/theme-highcontrast": "^6.0.3",
+        "@blockly/theme-tritanopia": "^6.0.3",
         "chai": "^4.2.0",
         "dat.gui": "^0.7.7",
         "lodash.assign": "^4.2.0",
@@ -111,7 +113,7 @@
         "node": ">=8.0.0"
       },
       "peerDependencies": {
-        "blockly": "^10.0.0"
+        "blockly": "^11.0.0"
       }
     },
     "node_modules/@blockly/dev-tools/node_modules/assertion-error": {
@@ -184,63 +186,68 @@
       }
     },
     "node_modules/@blockly/theme-dark": {
-      "version": "6.0.5",
-      "resolved": "https://registry.npmjs.org/@blockly/theme-dark/-/theme-dark-6.0.5.tgz",
-      "integrity": "sha512-6vftqOY4ZfwqiAUh2lR12TL16t+7UcmiGVYOBSs4dj1emP89UEO7EMaj0RQ+m0BsV9IHsf2fN6iKZu1gWkmnnA==",
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/@blockly/theme-dark/-/theme-dark-7.0.3.tgz",
+      "integrity": "sha512-lRV9V5vjijbJAlUdZqtEhUt81OjHjZK8vagxir1cUqTrZ/+MNS2m7wkhIVPba4RWInJ1LY/nHEoQn6demZqRRQ==",
       "dev": true,
+      "license": "Apache-2.0",
       "engines": {
         "node": ">=8.17.0"
       },
       "peerDependencies": {
-        "blockly": "^10.0.0"
+        "blockly": "^11.0.0"
       }
     },
     "node_modules/@blockly/theme-deuteranopia": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/@blockly/theme-deuteranopia/-/theme-deuteranopia-5.0.6.tgz",
-      "integrity": "sha512-bYQz2TrkbwPxYjZXlQGf6pMEnSBD/If4FtBqAavt/lutwib0awM0NbPWu8RP89z4aRcAlsByYYSzFQMNqYBaiA==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/@blockly/theme-deuteranopia/-/theme-deuteranopia-6.0.3.tgz",
+      "integrity": "sha512-56nkKRoRMzArtz14sMp4sQ8nd2oYQGToadAzx9JfOl0otx2RoeZLnMnZlKa6ZeTsdJXspPRfkrwHcSyuDTA/6g==",
       "dev": true,
+      "license": "Apache-2.0",
       "engines": {
         "node": ">=8.17.0"
       },
       "peerDependencies": {
-        "blockly": "^10.0.0"
+        "blockly": "^11.0.0"
       }
     },
     "node_modules/@blockly/theme-highcontrast": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/@blockly/theme-highcontrast/-/theme-highcontrast-5.0.5.tgz",
-      "integrity": "sha512-5pi7urLW7UNZhAoDbsb7C0vqFGHEeWi7pp1+OyFSmB+xMNkcVv1Es4X35QQCuUmM6FXfCFeqoDH+N/DYNDHHjg==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/@blockly/theme-highcontrast/-/theme-highcontrast-6.0.3.tgz",
+      "integrity": "sha512-AXaB6ELmOZ+2z8ENbdaFDGVorNmcLn10JE9+fMICGTKBTs0T+N5LYH7q7dok04qrV3ZTrhw+rV8Xxp9tYio0Cw==",
       "dev": true,
+      "license": "Apache-2.0",
       "engines": {
         "node": ">=8.17.0"
       },
       "peerDependencies": {
-        "blockly": "^10.0.0"
+        "blockly": "^11.0.0"
       }
     },
     "node_modules/@blockly/theme-modern": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/@blockly/theme-modern/-/theme-modern-5.0.5.tgz",
-      "integrity": "sha512-rbVOGxKHAatzHI6Yhy9lJbIRPzAW2Xgf+N1U1KSkyVmUziLKKaNKwwYvnOSx4MmoDD49SrZMdUgT8G+VBLFhYw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/@blockly/theme-modern/-/theme-modern-6.0.3.tgz",
+      "integrity": "sha512-pGtwrxqUHfFmT2s8DRZ/FGuBo3hdoVZt66FDFWicripRv5OteXlmLiw3zjbVnca34LHwJ0lKCvUvARAVbPVnHg==",
       "dev": true,
+      "license": "Apache-2.0",
       "engines": {
         "node": ">=8.17.0"
       },
       "peerDependencies": {
-        "blockly": "^10.0.0"
+        "blockly": "^11.0.0"
       }
     },
     "node_modules/@blockly/theme-tritanopia": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/@blockly/theme-tritanopia/-/theme-tritanopia-5.0.5.tgz",
-      "integrity": "sha512-vVFMwvdreQoPDR8y6/5ymOoVYK/kE7zcH3Ra0NCEG4w/CBOlEYMYpNnCkpmM8HTjQj4fvDSTwh2HybiHMlfLrQ==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/@blockly/theme-tritanopia/-/theme-tritanopia-6.0.3.tgz",
+      "integrity": "sha512-U4Y7WB2jzFQbNtt7D74gixfPHFBK0FW5CqGCFFOO+mHz2AfKHA+s/cZiVblYomhlA1938mvjzIxbdnafzmaCiw==",
       "dev": true,
+      "license": "Apache-2.0",
       "engines": {
         "node": ">=8.17.0"
       },
       "peerDependencies": {
-        "blockly": "^10.0.0"
+        "blockly": "^11.0.0"
       }
     },
     "node_modules/@es-joy/jsdoccomment": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1079,16 +1079,6 @@
         "node": ">=14.16"
       }
     },
-    "node_modules/@tootallnate/once": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
-      "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
-      "dev": true,
-      "peer": true,
-      "engines": {
-        "node": ">= 10"
-      }
-    },
     "node_modules/@tootallnate/quickjs-emscripten": {
       "version": "0.23.0",
       "resolved": "https://registry.npmjs.org/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz",
@@ -1271,53 +1261,6 @@
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
-    "node_modules/@typescript-eslint/parser": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-7.3.1.tgz",
-      "integrity": "sha512-Rq49+pq7viTRCH48XAbTA+wdLRrB/3sRq4Lpk0oGDm0VmnjBrAOVXH/Laalmwsv2VpekiEfVFwJYVk6/e8uvQw==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "@typescript-eslint/scope-manager": "7.3.1",
-        "@typescript-eslint/types": "7.3.1",
-        "@typescript-eslint/typescript-estree": "7.3.1",
-        "@typescript-eslint/visitor-keys": "7.3.1",
-        "debug": "^4.3.4"
-      },
-      "engines": {
-        "node": "^18.18.0 || >=20.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependencies": {
-        "eslint": "^8.56.0"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@typescript-eslint/scope-manager": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-7.3.1.tgz",
-      "integrity": "sha512-fVS6fPxldsKY2nFvyT7IP78UO1/I2huG+AYu5AMjCT9wtl6JFiDnsv4uad4jQ0GTFzcUV5HShVeN96/17bTBag==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "@typescript-eslint/types": "7.3.1",
-        "@typescript-eslint/visitor-keys": "7.3.1"
-      },
-      "engines": {
-        "node": "^18.18.0 || >=20.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
     "node_modules/@typescript-eslint/type-utils": {
       "version": "7.16.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-7.16.0.tgz",
@@ -1452,61 +1395,6 @@
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
-    "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-7.3.1.tgz",
-      "integrity": "sha512-tLpuqM46LVkduWP7JO7yVoWshpJuJzxDOPYIVWUUZbW+4dBpgGeUdl/fQkhuV0A8eGnphYw3pp8d2EnvPOfxmQ==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "@typescript-eslint/types": "7.3.1",
-        "@typescript-eslint/visitor-keys": "7.3.1",
-        "debug": "^4.3.4",
-        "globby": "^11.1.0",
-        "is-glob": "^4.0.3",
-        "minimatch": "9.0.3",
-        "semver": "^7.5.4",
-        "ts-api-utils": "^1.0.1"
-      },
-      "engines": {
-        "node": "^18.18.0 || >=20.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
-      "version": "9.0.3",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
-      "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/@typescript-eslint/utils": {
       "version": "7.16.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-7.16.0.tgz",
@@ -1638,24 +1526,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-7.3.1.tgz",
-      "integrity": "sha512-9RMXwQF8knsZvfv9tdi+4D/j7dMG28X/wMJ8Jj6eOHyHWwDW4ngQJcqEczSsqIKKjFiLFr40Mnr7a5ulDD3vmw==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "@typescript-eslint/types": "7.3.1",
-        "eslint-visitor-keys": "^3.4.1"
-      },
-      "engines": {
-        "node": "^18.18.0 || >=20.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
       }
     },
     "node_modules/@ungap/structured-clone": {
@@ -1879,14 +1749,6 @@
         "deno": ">=1.0.0",
         "node": ">=16.5.0"
       }
-    },
-    "node_modules/abab": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.6.tgz",
-      "integrity": "sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA==",
-      "deprecated": "Use your platform's native atob() and btoa() methods instead",
-      "dev": true,
-      "peer": true
     },
     "node_modules/abort-controller": {
       "version": "3.0.0",
@@ -2727,176 +2589,6 @@
       },
       "funding": {
         "url": "https://bevry.me/fund"
-      }
-    },
-    "node_modules/blockly": {
-      "version": "10.0.2",
-      "resolved": "https://registry.npmjs.org/blockly/-/blockly-10.0.2.tgz",
-      "integrity": "sha512-d4o8x/cyJt6KkeStcQxbihvOVFADIrYQaHt85+TOTgUZKPHSTDPKqjKzrUQRJ3ouwYGF9KXC6y2V+oordnDLKA==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "jsdom": "22.1.0"
-      }
-    },
-    "node_modules/blockly/node_modules/agent-base": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
-      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6.0.0"
-      }
-    },
-    "node_modules/blockly/node_modules/data-urls": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-4.0.0.tgz",
-      "integrity": "sha512-/mMTei/JXPqvFqQtfyTowxmJVwr2PVAeCcDxyFf6LhoOu/09TX2OX3kb2wzi4DMXcfj4OItwDOnhl5oziPnT6g==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "abab": "^2.0.6",
-        "whatwg-mimetype": "^3.0.0",
-        "whatwg-url": "^12.0.0"
-      },
-      "engines": {
-        "node": ">=14"
-      }
-    },
-    "node_modules/blockly/node_modules/http-proxy-agent": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
-      "integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "@tootallnate/once": "2",
-        "agent-base": "6",
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/blockly/node_modules/https-proxy-agent": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
-      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "agent-base": "6",
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/blockly/node_modules/jsdom": {
-      "version": "22.1.0",
-      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-22.1.0.tgz",
-      "integrity": "sha512-/9AVW7xNbsBv6GfWho4TTNjEo9fe6Zhf9O7s0Fhhr3u+awPwAJMKwAMXnkk5vBxflqLW9hTHX/0cs+P3gW+cQw==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "abab": "^2.0.6",
-        "cssstyle": "^3.0.0",
-        "data-urls": "^4.0.0",
-        "decimal.js": "^10.4.3",
-        "domexception": "^4.0.0",
-        "form-data": "^4.0.0",
-        "html-encoding-sniffer": "^3.0.0",
-        "http-proxy-agent": "^5.0.0",
-        "https-proxy-agent": "^5.0.1",
-        "is-potential-custom-element-name": "^1.0.1",
-        "nwsapi": "^2.2.4",
-        "parse5": "^7.1.2",
-        "rrweb-cssom": "^0.6.0",
-        "saxes": "^6.0.0",
-        "symbol-tree": "^3.2.4",
-        "tough-cookie": "^4.1.2",
-        "w3c-xmlserializer": "^4.0.0",
-        "webidl-conversions": "^7.0.0",
-        "whatwg-encoding": "^2.0.0",
-        "whatwg-mimetype": "^3.0.0",
-        "whatwg-url": "^12.0.1",
-        "ws": "^8.13.0",
-        "xml-name-validator": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=16"
-      },
-      "peerDependencies": {
-        "canvas": "^2.5.0"
-      },
-      "peerDependenciesMeta": {
-        "canvas": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/blockly/node_modules/tr46": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-4.1.1.tgz",
-      "integrity": "sha512-2lv/66T7e5yNyhAAC4NaKe5nVavzuGJQVVtRYLyQ2OI8tsJ61PMLlelehb0wi2Hx6+hT/OJUWZcw8MjlSRnxvw==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "punycode": "^2.3.0"
-      },
-      "engines": {
-        "node": ">=14"
-      }
-    },
-    "node_modules/blockly/node_modules/w3c-xmlserializer": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-4.0.0.tgz",
-      "integrity": "sha512-d+BFHzbiCx6zGfz0HyQ6Rg69w9k19nviJspaj4yNscGjrHu94sVP+aRm75yEbCh+r2/yR+7q6hux9LVtbuTGBw==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "xml-name-validator": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=14"
-      }
-    },
-    "node_modules/blockly/node_modules/whatwg-mimetype": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
-      "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==",
-      "dev": true,
-      "peer": true,
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/blockly/node_modules/whatwg-url": {
-      "version": "12.0.1",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-12.0.1.tgz",
-      "integrity": "sha512-Ed/LrqB8EPlGxjS+TrsXcpUond1mhccS3pchLhzSgPCnTimUCKj3IZE75pAs5m6heB2U2TMerKFUXheyHY+VDQ==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "tr46": "^4.1.1",
-        "webidl-conversions": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=14"
-      }
-    },
-    "node_modules/blockly/node_modules/xml-name-validator": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-4.0.0.tgz",
-      "integrity": "sha512-ICP2e+jsHvAj2E2lIHxa5tjXRlKDJo4IdvPvCXbXQGdzSfmSpNVyIKMvoZHjDY9DP0zV17iI85o90vRFXNccRw==",
-      "dev": true,
-      "peer": true,
-      "engines": {
-        "node": ">=12"
       }
     },
     "node_modules/brace-expansion": {
@@ -3790,19 +3482,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/cssstyle": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-3.0.0.tgz",
-      "integrity": "sha512-N4u2ABATi3Qplzf0hWbVCdjenim8F3ojEXpBDF5hBpjzW182MjNGLqfmQ0SkSPeQ+V86ZXgeH8aXj6kayd4jgg==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "rrweb-cssom": "^0.6.0"
-      },
-      "engines": {
-        "node": ">=14"
-      }
-    },
     "node_modules/d": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/d/-/d-1.0.1.tgz",
@@ -4121,20 +3800,6 @@
       },
       "engines": {
         "node": ">=6.0.0"
-      }
-    },
-    "node_modules/domexception": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/domexception/-/domexception-4.0.0.tgz",
-      "integrity": "sha512-A2is4PLG+eeSfoTMA95/s4pvAoSo2mKtiM5jlHkAVewmiO8ISFTFKZjH7UAM1Atli/OT/7JHOrJRJiMKUZKYBw==",
-      "deprecated": "Use your platform's native DOMException instead",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "webidl-conversions": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=12"
       }
     },
     "node_modules/duplexify": {
@@ -10301,13 +9966,6 @@
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
-    },
-    "node_modules/rrweb-cssom": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.6.0.tgz",
-      "integrity": "sha512-APM0Gt1KoXBz0iIkkdB/kfvGOwC4UuJFeG/c+yV7wSc7q96cG/kJ0HiYCnzivD9SB53cLV1MlHFNfOuPaadYSw==",
-      "dev": true,
-      "peer": true
     },
     "node_modules/run-parallel": {
       "version": "1.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "@microsoft/api-documenter": "^7.22.4",
         "@microsoft/api-extractor": "^7.29.5",
         "@typescript-eslint/eslint-plugin": "^7.3.1",
+        "@typescript-eslint/parser": "^7.16.1",
         "async-done": "^2.0.0",
         "chai": "^5.1.1",
         "concurrently": "^8.0.1",
@@ -1268,6 +1269,53 @@
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
+    "node_modules/@typescript-eslint/parser": {
+      "version": "7.16.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-7.16.1.tgz",
+      "integrity": "sha512-u+1Qx86jfGQ5i4JjK33/FnawZRpsLxRnKzGE6EABZ40KxVT/vWsiZFEBBHjFOljmmV3MBYOHEKi0Jm9hbAOClA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "7.16.1",
+        "@typescript-eslint/types": "7.16.1",
+        "@typescript-eslint/typescript-estree": "7.16.1",
+        "@typescript-eslint/visitor-keys": "7.16.1",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": "^18.18.0 || >=20.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.56.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/scope-manager": {
+      "version": "7.16.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-7.16.1.tgz",
+      "integrity": "sha512-nYpyv6ALte18gbMz323RM+vpFpTjfNdyakbf3nsLvF43uF9KeNC289SUEW3QLZ1xPtyINJ1dIsZOuWuSRIWygw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "7.16.1",
+        "@typescript-eslint/visitor-keys": "7.16.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || >=20.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
     "node_modules/@typescript-eslint/type-utils": {
       "version": "7.16.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-7.16.0.tgz",
@@ -1390,16 +1438,85 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.3.1.tgz",
-      "integrity": "sha512-2tUf3uWggBDl4S4183nivWQ2HqceOZh1U4hhu4p1tPiIJoRRXrab7Y+Y0p+dozYwZVvLPRI6r5wKe9kToF9FIw==",
+      "version": "7.16.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.16.1.tgz",
+      "integrity": "sha512-AQn9XqCzUXd4bAVEsAXM/Izk11Wx2u4H3BAfQVhSfzfDOm/wAON9nP7J5rpkCxts7E5TELmN845xTUCQrD1xIQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": "^18.18.0 || >=20.0.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree": {
+      "version": "7.16.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-7.16.1.tgz",
+      "integrity": "sha512-0vFPk8tMjj6apaAZ1HlwM8w7jbghC8jc1aRNJG5vN8Ym5miyhTQGMqU++kuBFDNKe9NcPeZ6x0zfSzV8xC1UlQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@typescript-eslint/types": "7.16.1",
+        "@typescript-eslint/visitor-keys": "7.16.1",
+        "debug": "^4.3.4",
+        "globby": "^11.1.0",
+        "is-glob": "^4.0.3",
+        "minimatch": "^9.0.4",
+        "semver": "^7.6.0",
+        "ts-api-utils": "^1.3.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || >=20.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
+      "version": "7.6.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
+      "integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/@typescript-eslint/utils": {
@@ -1533,6 +1650,24 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys": {
+      "version": "7.16.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-7.16.1.tgz",
+      "integrity": "sha512-Qlzzx4sE4u3FsHTPQAAQFJFNOuqtuY0LFrZHwQ8IHK705XxBiWOFkfKRWu6niB7hwfgnwIpO4jTC75ozW1PHWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "7.16.1",
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || >=20.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
       }
     },
     "node_modules/@ungap/structured-clone": {

--- a/package.json
+++ b/package.json
@@ -107,6 +107,7 @@
     "@microsoft/api-documenter": "^7.22.4",
     "@microsoft/api-extractor": "^7.29.5",
     "@typescript-eslint/eslint-plugin": "^7.3.1",
+    "@typescript-eslint/parser": "^7.16.1",
     "async-done": "^2.0.0",
     "chai": "^5.1.1",
     "concurrently": "^8.0.1",

--- a/package.json
+++ b/package.json
@@ -100,9 +100,9 @@
   },
   "license": "Apache-2.0",
   "devDependencies": {
-    "@blockly/block-test": "^5.0.0",
-    "@blockly/dev-tools": "^7.0.2",
-    "@blockly/theme-modern": "^5.0.0",
+    "@blockly/block-test": "^6.0.4",
+    "@blockly/dev-tools": "^8.0.4",
+    "@blockly/theme-modern": "^6.0.3",
     "@hyperjump/json-schema": "^1.5.0",
     "@microsoft/api-documenter": "^7.22.4",
     "@microsoft/api-extractor": "^7.29.5",


### PR DESCRIPTION
## The basics

- [X] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

Fixes CI failures in (and obsoletes) #8248.

### Proposed Changes

* Set `legacy-peer-deps=true` in `.npmrc`.
* Add one peer dependency that had not been explicitly (dev)depended upon.
* Upgrade `@blockly/` plugin dev deps to `@latest`.

### Reason for Changes

Enabling `legacy-peer-deps`:

* Doesn't install a second, probably out-of-date copy of Blockly in `node_modules/blockly/`.
* Prevents version conflicts when trying to update `@blockly/*` dev dependencies, beacuse npm doesn't seem to be clever enough to resolve peer dependency version conflicts for the `blockly` package when updating plugins (which have blockly as a peer), even if all plugins are updated at the same time.
* Brings the configuration of the blockly repo in line with blockly-samples, for whatever that is worth.  (Might avoid problems during monorepo migration.)

Upgrading `@blockly/` plugin dev dependencies:

* Stops dependabot from sending us PRs to update them one-at-a-time, which PRs fail CI due to `npm ci` failures due to version conflicts for the `blockly` peer dependency of those plugins.

### Test Coverage

Passes `npm test`.
