### PR TITLE
fix!: renamed blocklyTreeIcon Css class to blocklyToolboxCategoryIcon #8347

### DIFF
--- a/core/toolbox/category.ts
+++ b/core/toolbox/category.ts
@@ -134,7 +134,7 @@ export class ToolboxCategory
       'container': 'blocklyToolboxCategory',
       'row': 'blocklyTreeRow',
       'rowcontentcontainer': 'blocklyTreeRowContentContainer',
-      'icon': 'blocklyTreeIcon',
+      'icon': 'blocklyToolboxCategoryIcon',
       'label': 'blocklyTreeLabel',
       'contents': 'blocklyToolboxContents',
       'selected': 'blocklyTreeSelected',
@@ -684,7 +684,7 @@ Css.register(`
   padding-right: 0;
 }
 
-.blocklyTreeIcon {
+.blocklyToolboxCategoryIcon {
   background-image: url(<<<PATH>>>/sprites.png);
   height: 16px;
   vertical-align: middle;

--- a/core/toolbox/category.ts
+++ b/core/toolbox/category.ts
@@ -129,7 +129,7 @@ export class ToolboxCategory
    * @returns The configuration object holding all the CSS classes for a
    *     category.
    */
-  protected makeDefaultCssConfig_(): CssConfig {
+  protected makeDefaultCssConfig_(): CssConfig { 
     return {
       'container': 'blocklyToolboxCategory',
       'row': 'blocklyTreeRow',

--- a/core/toolbox/category.ts
+++ b/core/toolbox/category.ts
@@ -129,7 +129,7 @@ export class ToolboxCategory
    * @returns The configuration object holding all the CSS classes for a
    *     category.
    */
-  protected makeDefaultCssConfig_(): CssConfig { 
+  protected makeDefaultCssConfig_(): CssConfig {
     return {
       'container': 'blocklyToolboxCategory',
       'row': 'blocklyTreeRow',


### PR DESCRIPTION


## The basics


<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #8347 

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
This pull request is for renaming blocklyTreeIcon with blocklyToolboxCategoryIcon. 
This is marked as a breaking change.
Pull request is created against rc/v12.0.0 branch.


