### PR TITLE
fix!: removed redundant blockyTreeRowContentContainer div

### DIFF
--- a/core/toolbox/category.ts
+++ b/core/toolbox/category.ts
@@ -70,9 +70,6 @@ export class ToolboxCategory
   /** The HTML element for the category row. */
   protected rowDiv_: HTMLDivElement | null = null;
 
-  /** The HTML element that holds children elements of the category row. */
-  protected rowContents_: HTMLDivElement | null = null;
-
   /** The HTML element for the toolbox icon. */
   protected iconDom_: Element | null = null;
 
@@ -131,10 +128,6 @@ export class ToolboxCategory
    */
   protected makeDefaultCssConfig_(): CssConfig {
     return {
-      'container': 'blocklyToolboxCategoryContainer',
-      'row': 'blocklyToolboxCategory',
-      'rowcontentcontainer': 'blocklyTreeRowContentContainer',
-      'icon': 'blocklyToolboxCategoryIcon',
       'label': 'blocklyTreeLabel',
       'contents': 'blocklyToolboxCategoryGroup',
       'selected': 'blocklyTreeSelected',
@@ -195,19 +188,15 @@ export class ToolboxCategory
     aria.setState(this.htmlDiv_, aria.State.LEVEL, this.level_ + 1);
 
     this.rowDiv_ = this.createRowContainer_();
-    this.rowDiv_.style.pointerEvents = 'auto';
+    this.rowDiv_.style.pointerEvents = 'none';
     this.htmlDiv_.appendChild(this.rowDiv_);
-
-    this.rowContents_ = this.createRowContentsContainer_();
-    this.rowContents_.style.pointerEvents = 'none';
-    this.rowDiv_.appendChild(this.rowContents_);
 
     this.iconDom_ = this.createIconDom_();
     aria.setRole(this.iconDom_, aria.Role.PRESENTATION);
-    this.rowContents_.appendChild(this.iconDom_);
+    this.rowDiv_.appendChild(this.iconDom_);
 
     this.labelDom_ = this.createLabelDom_(this.name_);
-    this.rowContents_.appendChild(this.labelDom_);
+    this.rowDiv_.appendChild(this.labelDom_);
 
     const id = this.labelDom_.getAttribute('id');
     if (id) {
@@ -254,20 +243,6 @@ export class ToolboxCategory
     return rowDiv;
   }
 
-  /**
-   * Creates the container for the label and icon.
-   * This is necessary so we can set all subcategory pointer events to none.
-   *
-   * @returns The div that holds the icon and the label.
-   */
-  protected createRowContentsContainer_(): HTMLDivElement {
-    const contentsContainer = document.createElement('div');
-    const className = this.cssConfig_['rowcontentcontainer'];
-    if (className) {
-      dom.addClass(contentsContainer, className);
-    }
-    return contentsContainer;
-  }
 
   /**
    * Creates the span that holds the category icon.

--- a/core/toolbox/category.ts
+++ b/core/toolbox/category.ts
@@ -127,7 +127,8 @@ export class ToolboxCategory
    *     category.
    */
   protected makeDefaultCssConfig_(): CssConfig {
-    return {'container': 'blocklyToolboxCategory',
+    return {
+      'container': 'blocklyToolboxCategory',
       'row': 'blocklyTreeRow',
       'icon': 'blocklyTreeIcon',
       'label': 'blocklyTreeLabel',

--- a/core/toolbox/category.ts
+++ b/core/toolbox/category.ts
@@ -247,7 +247,6 @@ export class ToolboxCategory
     return rowDiv;
   }
 
-
   /**
    * Creates the span that holds the category icon.
    *

--- a/core/toolbox/category.ts
+++ b/core/toolbox/category.ts
@@ -71,10 +71,10 @@ export class ToolboxCategory
   protected rowDiv_: HTMLDivElement | null = null;
 
   /** The HTML element for the toolbox icon. */
-  protected iconDom_: Element | null = null;
+  protected iconDom_: HTMLElement | null = null;
 
   /** The HTML element for the toolbox label. */
-  protected labelDom_: Element | null = null;
+  protected labelDom_: HTMLElement | null = null;
   protected cssConfig_: CssConfig;
 
   /** True if the category is meant to be hidden, false otherwise. */
@@ -190,17 +190,19 @@ export class ToolboxCategory
     aria.setState(this.htmlDiv_, aria.State.LEVEL, this.level_ + 1);
 
     this.rowDiv_ = this.createRowContainer_();
-    this.rowDiv_.style.pointerEvents = 'none';
+    this.rowDiv_.style.pointerEvents = 'auto';
     this.htmlDiv_.appendChild(this.rowDiv_);
 
     this.iconDom_ = this.createIconDom_();
-    aria.setRole(this.iconDom_, aria.Role.PRESENTATION);
-    this.rowDiv_.appendChild(this.iconDom_);
+    this.iconDom_.style.pointerEvents = 'none';
+    aria.setRole(this.iconDom_ as Element, aria.Role.PRESENTATION);
+    this.rowDiv_.appendChild(this.iconDom_ as Node);
 
     this.labelDom_ = this.createLabelDom_(this.name_);
-    this.rowDiv_.appendChild(this.labelDom_);
-
+    this.labelDom_.style.pointerEvents = 'none';
+    this.rowDiv_.appendChild(this.labelDom_ as Node);
     const id = this.labelDom_.getAttribute('id');
+
     if (id) {
       aria.setState(this.htmlDiv_, aria.State.LABELLEDBY, id);
     }
@@ -251,7 +253,7 @@ export class ToolboxCategory
    *
    * @returns The span that holds the category icon.
    */
-  protected createIconDom_(): Element {
+  protected createIconDom_(): HTMLElement {
     const toolboxIcon = document.createElement('span');
     if (!this.parentToolbox_.isHorizontal()) {
       const className = this.cssConfig_['icon'];
@@ -271,7 +273,7 @@ export class ToolboxCategory
    * @param name The name of the category.
    * @returns The span that holds the category label.
    */
-  protected createLabelDom_(name: string): Element {
+  protected createLabelDom_(name: string): HTMLElement {
     const toolboxLabel = document.createElement('span');
     toolboxLabel.setAttribute('id', this.getId() + '.label');
     toolboxLabel.textContent = name;

--- a/core/toolbox/category.ts
+++ b/core/toolbox/category.ts
@@ -127,9 +127,11 @@ export class ToolboxCategory
    *     category.
    */
   protected makeDefaultCssConfig_(): CssConfig {
-    return {
+    return {'container': 'blocklyToolboxCategory',
+      'row': 'blocklyTreeRow',
+      'icon': 'blocklyTreeIcon',
       'label': 'blocklyTreeLabel',
-      'contents': 'blocklyToolboxCategoryGroup',
+      'contents': 'blocklyToolboxContents',
       'selected': 'blocklyTreeSelected',
       'openicon': 'blocklyTreeIconOpen',
       'closedicon': 'blocklyTreeIconClosed',


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #8346 

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
removed the extra attribute rowContents_ from ToolboxCategory class 
and added the icons and lables of categories directly to the rowDiv_ attributes

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
the div blockyTreeRowContentContainer was redundant which was used to style but was not given css styling

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
