### PR TITLE
#8344 resolved

### DIFF
--- a/core/toolbox/category.ts
+++ b/core/toolbox/category.ts
@@ -136,7 +136,7 @@ export class ToolboxCategory
       'rowcontentcontainer': 'blocklyTreeRowContentContainer',
       'icon': 'blocklyTreeIcon',
       'label': 'blocklyTreeLabel',
-      'contents': 'blocklyToolboxContents',
+      'contents': 'blocklyToolboxCategoryGroup',
       'selected': 'blocklyTreeSelected',
       'openicon': 'blocklyTreeIconOpen',
       'closedicon': 'blocklyTreeIconClosed',

--- a/core/toolbox/collapsible_category.ts
+++ b/core/toolbox/collapsible_category.ts
@@ -58,7 +58,7 @@ export class CollapsibleToolboxCategory
 
   override makeDefaultCssConfig_() {
     const cssConfig = super.makeDefaultCssConfig_();
-    cssConfig['contents'] = 'blocklyToolboxContents';
+    cssConfig['contents'] = 'blocklyToolboxCategoryGroup';
     return cssConfig;
   }
 

--- a/core/toolbox/toolbox.ts
+++ b/core/toolbox/toolbox.ts
@@ -209,7 +209,7 @@ export class Toolbox
    */
   protected createContentsContainer_(): HTMLDivElement {
     const contentsContainer = document.createElement('div');
-    dom.addClass(contentsContainer, 'blocklyToolboxContents');
+    dom.addClass(contentsContainer, 'blocklyToolboxCategoryGroup');
     if (this.isHorizontal()) {
       contentsContainer.style.flexDirection = 'row';
     }
@@ -1111,13 +1111,13 @@ Css.register(`
   -webkit-tap-highlight-color: transparent;  /* issue #1345 */
 }
 
-.blocklyToolboxContents {
+.blocklyToolboxCategoryGroup {
   display: flex;
   flex-wrap: wrap;
   flex-direction: column;
 }
 
-.blocklyToolboxContents:focus {
+.blocklyToolboxCategoryGroup:focus {
   outline: none;
 }
 `);


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details 
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes [#8344](https://github.com/google/blockly/issues/8344)

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
This pull request renames all references of the `blocklyToolboxContents` CSS class to `blocklyToolboxCategoryGroup` throughout the codebase.


