### PR TITLE
feat: Add css classes from json block definitions

### DIFF
--- a/core/block_svg.ts
+++ b/core/block_svg.ts
@@ -1720,4 +1720,20 @@ export class BlockSvg
     traverseJson(json as unknown as {[key: string]: unknown});
     return [json];
   }
+
+  override jsonInit(json: AnyDuringMigration): void {    
+    super.jsonInit(json);
+      
+    if (json['classes']) {
+      let classesToAdd = '';
+
+      if (Array.isArray(json['classes'])) {        
+        classesToAdd = json['classes'].join(' ');
+      } else {        
+        classesToAdd = json['classes'];
+      }
+      
+      this.addClass(classesToAdd);
+    }
+  }
 }

--- a/core/block_svg.ts
+++ b/core/block_svg.ts
@@ -1721,7 +1721,7 @@ export class BlockSvg
     return [json];
   }
 
-  override jsonInit(json: AnyDuringMigration): void {    
+  override jsonInit(json: AnyDuringMigration): void {
     super.jsonInit(json);
       
     if (json['classes']) {

--- a/core/block_svg.ts
+++ b/core/block_svg.ts
@@ -1723,17 +1723,13 @@ export class BlockSvg
 
   override jsonInit(json: AnyDuringMigration): void {
     super.jsonInit(json);
-      
-    if (json['classes']) {
-      let classesToAdd = '';
 
-      if (Array.isArray(json['classes'])) {        
-        classesToAdd = json['classes'].join(' ');
-      } else {        
-        classesToAdd = json['classes'];
-      }
-      
-      this.addClass(classesToAdd);
+    if (json['classes']) {
+      this.addClass(
+        Array.isArray(json['classes'])
+          ? json['classes'].join(' ')
+          : json['classes'],
+      );
     }
   }
 }


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
This PR overrides the `jsonInit` method in the `BlockSvg` class to get the css class names from the `classes` field and apply the same using the `addClass` method. 

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #8271
