### PR TITLE
feat: add `blocklyMiniWorkspaceBubble` css class

### DIFF
--- a/core/bubbles/mini_workspace_bubble.ts
+++ b/core/bubbles/mini_workspace_bubble.ts
@@ -80,6 +80,7 @@ export class MiniWorkspaceBubble extends Bubble {
       flyout?.show(options.languageTree);
     }
 
+    dom.addClass(this.svgRoot, 'blocklyMiniWorkspaceBubble');
     this.miniWorkspace.addChangeListener(this.onWorkspaceChange.bind(this));
     this.miniWorkspace
       .getFlyout()


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
This PR add `blocklyMiniWorkspaceBubble` css class to the `MiniWorkspaceBubble` constructor.

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #8340
