### PR TITLE
feat: Add a blocklyNotEditable CSS class to the block's root SVG

### DIFF
--- a/core/block_svg.ts
+++ b/core/block_svg.ts
@@ -730,7 +730,7 @@ export class BlockSvg
   override setEditable(editable: boolean) {
     super.setEditable(editable);
 
-    if(editable) {
+    if (editable) {
       dom.removeClass(this.svgGroup_, 'blocklyNotEditable');
     } else {
       dom.addClass(this.svgGroup_, 'blocklyNotEditable');

--- a/core/block_svg.ts
+++ b/core/block_svg.ts
@@ -729,6 +729,13 @@ export class BlockSvg
    */
   override setEditable(editable: boolean) {
     super.setEditable(editable);
+
+    if(editable) {
+      dom.removeClass(this.svgGroup_, 'blocklyNotEditable');
+    } else {
+      dom.addClass(this.svgGroup_, 'blocklyNotEditable');
+    }
+
     const icons = this.getIcons();
     for (let i = 0; i < icons.length; i++) {
       icons[i].updateEditable();


### PR DESCRIPTION
Code Changes:

- Added a condition in the setEditable method to check the editability of the block.
- Utilized dom.addClass to add the blocklyNotEditable class when this.editable_ is false.
- Utilized dom.removeClass to remove the blocklyNotEditable class when this.editable_ is true.

Fixes #8266 