### PR TITLE
chore: Pin node.js v22 to v22.4.1 in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,8 @@ jobs:
         # TODO (#2114): re-enable osx build.
         # os: [ubuntu-latest, macos-latest]
         os: [ubuntu-latest]
-        node-version: [18.x, 20.x, 22.x]
+        # TODO(#8392): unpin v22 once npm issue fixed.
+        node-version: [18.x, 20.x, 22.4.1]
         # See supported Node.js release schedule at
         # https://nodejs.org/en/about/releases/
 


### PR DESCRIPTION
## The basics

- [ ] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

Works around https://github.com/nodejs/node/issues/53902 / https://github.com/npm/cli/issues/7657 et al.

### Reason for Changes

CI is currently broken due to upstream issues in node.js and/or npm.

### Test Coverage

We'd like some.

### Additional Information

Issue #8392 created to remind us to unpin.