### PR TITLE
refactor: make VariableMap implement IVariableMap.

### DIFF
--- a/core/variable_map.ts
+++ b/core/variable_map.ts
@@ -34,7 +34,7 @@ import type {IVariableMap} from './interfaces/i_variable_map.js';
  */
 export class VariableMap implements IVariableMap<VariableModel> {
   /**
-   * A map from variable type to list of variable names.  The lists contain
+   * A map from variable type to map of IDs to variables. The maps contain
    * all of the named variables in the workspace, including variables that are
    * not currently in use.
    */

--- a/core/variable_map.ts
+++ b/core/variable_map.ts
@@ -230,6 +230,11 @@ export class VariableMap implements IVariableMap<VariableModel> {
     return variable;
   }
 
+  /**
+   * Adds the given variable to this variable map.
+   *
+   * @param variable The variable to add.
+   */
   addVariable(variable: VariableModel) {
     const type = variable.getType();
     if (!this.variableMap.has(type)) {
@@ -374,6 +379,11 @@ export class VariableMap implements IVariableMap<VariableModel> {
     return [...variables.values()];
   }
 
+  /**
+   * Returns a list of unique types of variables in this variable map.
+   *
+   * @returns A list of unique types of variables in this variable map.
+   */
   getTypes(): string[] {
     return [...this.variableMap.keys()];
   }

--- a/core/variable_map.ts
+++ b/core/variable_map.ts
@@ -22,7 +22,6 @@ import * as eventUtils from './events/utils.js';
 import * as registry from './registry.js';
 import {Msg} from './msg.js';
 import {Names} from './names.js';
-import * as arrayUtils from './utils/array.js';
 import * as idGenerator from './utils/idgenerator.js';
 import {VariableModel} from './variable_model.js';
 import type {Workspace} from './workspace.js';

--- a/core/variables.ts
+++ b/core/variables.ts
@@ -610,7 +610,11 @@ function createVariable(
   // Create a potential variable if in the flyout.
   let variable = null;
   if (potentialVariableMap) {
-    variable = potentialVariableMap.createVariable(opt_name, opt_type, id);
+    variable = potentialVariableMap.createVariable(
+      opt_name,
+      opt_type,
+      id ?? undefined,
+    );
   } else {
     // In the main workspace, create a real variable.
     variable = workspace.createVariable(opt_name, opt_type, id);

--- a/core/workspace.ts
+++ b/core/workspace.ts
@@ -400,7 +400,11 @@ export class Workspace implements IASTNodeLocation {
     opt_type?: string | null,
     opt_id?: string | null,
   ): VariableModel {
-    return this.variableMap.createVariable(name, opt_type, opt_id);
+    return this.variableMap.createVariable(
+      name,
+      opt_type ?? undefined,
+      opt_id ?? undefined,
+    );
   }
 
   /**
@@ -456,7 +460,7 @@ export class Workspace implements IASTNodeLocation {
    *     if none are found.
    */
   getVariablesOfType(type: string | null): VariableModel[] {
-    return this.variableMap.getVariablesOfType(type);
+    return this.variableMap.getVariablesOfType(type ?? '');
   }
 
   /**

--- a/tests/mocha/variable_map_test.js
+++ b/tests/mocha/variable_map_test.js
@@ -39,17 +39,17 @@ suite('Variable Map', function () {
       this.variableMap.createVariable('name1', 'type1', 'id1');
 
       // Assert there is only one variable in the this.variableMap.
-      let keys = Array.from(this.variableMap.variableMap.keys());
+      let keys = this.variableMap.getTypes();
       assert.equal(keys.length, 1);
-      let varMapLength = this.variableMap.variableMap.get(keys[0]).length;
+      let varMapLength = this.variableMap.getVariablesOfType(keys[0]).length;
       assert.equal(varMapLength, 1);
 
       this.variableMap.createVariable('name1', 'type1');
       assertVariableValues(this.variableMap, 'name1', 'type1', 'id1');
       // Check that the size of the variableMap did not change.
-      keys = Array.from(this.variableMap.variableMap.keys());
+      keys = this.variableMap.getTypes();
       assert.equal(keys.length, 1);
-      varMapLength = this.variableMap.variableMap.get(keys[0]).length;
+      varMapLength = this.variableMap.getVariablesOfType(keys[0]).length;
       assert.equal(varMapLength, 1);
     });
 
@@ -59,16 +59,16 @@ suite('Variable Map', function () {
       this.variableMap.createVariable('name1', 'type1', 'id1');
 
       // Assert there is only one variable in the this.variableMap.
-      let keys = Array.from(this.variableMap.variableMap.keys());
+      let keys = this.variableMap.getTypes();
       assert.equal(keys.length, 1);
-      const varMapLength = this.variableMap.variableMap.get(keys[0]).length;
+      const varMapLength = this.variableMap.getVariablesOfType(keys[0]).length;
       assert.equal(varMapLength, 1);
 
       this.variableMap.createVariable('name1', 'type2', 'id2');
       assertVariableValues(this.variableMap, 'name1', 'type1', 'id1');
       assertVariableValues(this.variableMap, 'name1', 'type2', 'id2');
       // Check that the size of the variableMap did change.
-      keys = Array.from(this.variableMap.variableMap.keys());
+      keys = this.variableMap.getTypes();
       assert.equal(keys.length, 2);
     });
 
@@ -243,6 +243,54 @@ suite('Variable Map', function () {
     test('Does not exist', function () {
       const resultArray = this.variableMap.getVariablesOfType('type1');
       assert.deepEqual(resultArray, []);
+    });
+  });
+
+  suite('changeVariableType', function () {
+    test('normally', function () {
+      const variable = this.variableMap.createVariable('name1', 'type1', 'id1');
+      this.variableMap.changeVariableType(variable, 'type2');
+      const oldTypeVariables = this.variableMap.getVariablesOfType('type1');
+      const newTypeVariables = this.variableMap.getVariablesOfType('type2');
+      assert.deepEqual(oldTypeVariables, []);
+      assert.deepEqual(newTypeVariables, [variable]);
+      assert.equal(variable.getType(), 'type2');
+    });
+
+    test('to empty string', function () {
+      const variable = this.variableMap.createVariable('name1', 'type1', 'id1');
+      this.variableMap.changeVariableType(variable, '');
+      const oldTypeVariables = this.variableMap.getVariablesOfType('type1');
+      const newTypeVariables = this.variableMap.getVariablesOfType('');
+      assert.deepEqual(oldTypeVariables, []);
+      assert.deepEqual(newTypeVariables, [variable]);
+      assert.equal(variable.getType(), '');
+    });
+  });
+
+  suite('addVariable', function () {
+    test('normally', function () {
+      const variable = new Blockly.VariableModel(this.workspace, 'foo', 'int');
+      assert.isNull(this.variableMap.getVariableById(variable.getId()));
+      this.variableMap.addVariable(variable);
+      assert.equal(
+        this.variableMap.getVariableById(variable.getId()),
+        variable,
+      );
+    });
+  });
+
+  suite('getTypes', function () {
+    test('when map is empty', function () {
+      const types = this.variableMap.getTypes();
+      assert.deepEqual(types, []);
+    });
+
+    test('with various types', function () {
+      this.variableMap.createVariable('name1', 'type1', 'id1');
+      this.variableMap.createVariable('name2', '', 'id2');
+      const types = this.variableMap.getTypes();
+      assert.deepEqual(types, ['type1', '']);
     });
   });
 

--- a/tests/mocha/variable_map_test.js
+++ b/tests/mocha/variable_map_test.js
@@ -246,27 +246,38 @@ suite('Variable Map', function () {
     });
   });
 
-  suite('changeVariableType', function () {
-    test('normally', function () {
-      const variable = this.variableMap.createVariable('name1', 'type1', 'id1');
-      this.variableMap.changeVariableType(variable, 'type2');
-      const oldTypeVariables = this.variableMap.getVariablesOfType('type1');
-      const newTypeVariables = this.variableMap.getVariablesOfType('type2');
-      assert.deepEqual(oldTypeVariables, []);
-      assert.deepEqual(newTypeVariables, [variable]);
-      assert.equal(variable.getType(), 'type2');
-    });
+  suite(
+    'Using changeVariableType to change the type of a variable',
+    function () {
+      test('updates it to a new non-empty value', function () {
+        const variable = this.variableMap.createVariable(
+          'name1',
+          'type1',
+          'id1',
+        );
+        this.variableMap.changeVariableType(variable, 'type2');
+        const oldTypeVariables = this.variableMap.getVariablesOfType('type1');
+        const newTypeVariables = this.variableMap.getVariablesOfType('type2');
+        assert.deepEqual(oldTypeVariables, []);
+        assert.deepEqual(newTypeVariables, [variable]);
+        assert.equal(variable.getType(), 'type2');
+      });
 
-    test('to empty string', function () {
-      const variable = this.variableMap.createVariable('name1', 'type1', 'id1');
-      this.variableMap.changeVariableType(variable, '');
-      const oldTypeVariables = this.variableMap.getVariablesOfType('type1');
-      const newTypeVariables = this.variableMap.getVariablesOfType('');
-      assert.deepEqual(oldTypeVariables, []);
-      assert.deepEqual(newTypeVariables, [variable]);
-      assert.equal(variable.getType(), '');
-    });
-  });
+      test('updates it to a new empty value', function () {
+        const variable = this.variableMap.createVariable(
+          'name1',
+          'type1',
+          'id1',
+        );
+        this.variableMap.changeVariableType(variable, '');
+        const oldTypeVariables = this.variableMap.getVariablesOfType('type1');
+        const newTypeVariables = this.variableMap.getVariablesOfType('');
+        assert.deepEqual(oldTypeVariables, []);
+        assert.deepEqual(newTypeVariables, [variable]);
+        assert.equal(variable.getType(), '');
+      });
+    },
+  );
 
   suite('addVariable', function () {
     test('normally', function () {


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #8074 

### Proposed Changes
This PR makes the existing VariableMap class implement the new IVariableMap interface. I also changed the backing store from a map of arrays to a map of maps, since this made implementing the new methods easier and allowed for efficiency improvements in some of the existing ones.