### PR TITLE
refactor!: Use IVariableMap instead of VariableMap

### DIFF
--- a/core/names.ts
+++ b/core/names.ts
@@ -12,8 +12,11 @@
 // Former goog.module ID: Blockly.Names
 
 import {Msg} from './msg.js';
-// import * as Procedures from './procedures.js';
-import type {VariableMap} from './variable_map.js';
+import type {IVariableMap} from './interfaces/i_variable_map.js';
+import type {
+  IVariableModel,
+  IVariableState,
+} from './interfaces/i_variable_model.js';
 import * as Variables from './variables.js';
 import type {Workspace} from './workspace.js';
 
@@ -39,7 +42,8 @@ export class Names {
   /**
    * The variable map from the workspace, containing Blockly variable models.
    */
-  private variableMap: VariableMap | null = null;
+  private variableMap: IVariableMap<IVariableModel<IVariableState>> | null =
+    null;
 
   /**
    * @param reservedWordsList A comma-separated string of words that are illegal
@@ -70,7 +74,7 @@ export class Names {
    *
    * @param map The map to track.
    */
-  setVariableMap(map: VariableMap) {
+  setVariableMap(map: IVariableMap<IVariableModel<IVariableState>>) {
     this.variableMap = map;
   }
 

--- a/core/variable_map.ts
+++ b/core/variable_map.ts
@@ -18,11 +18,9 @@ import './events/events_var_rename.js';
 
 import type {Block} from './block.js';
 import * as deprecation from './utils/deprecation.js';
-import * as dialog from './dialog.js';
 import * as eventUtils from './events/utils.js';
 import * as registry from './registry.js';
 import * as Variables from './variables.js';
-import {Msg} from './msg.js';
 import {Names} from './names.js';
 import * as idGenerator from './utils/idgenerator.js';
 import {IVariableModel, IVariableState} from './interfaces/i_variable_model.js';

--- a/core/variable_map.ts
+++ b/core/variable_map.ts
@@ -431,7 +431,7 @@ export class VariableMap
   getVariableTypes(ws: Workspace | null): string[] {
     const variableTypes = new Set<string>(this.variableMap.keys());
     if (ws && ws.getPotentialVariableMap()) {
-      for (const key of ws.getPotentialVariableMap()!.variableMap.keys()) {
+      for (const key of ws.getPotentialVariableMap()!.getTypes()) {
         variableTypes.add(key);
       }
     }

--- a/core/variable_map.ts
+++ b/core/variable_map.ts
@@ -17,9 +17,11 @@ import './events/events_var_delete.js';
 import './events/events_var_rename.js';
 
 import type {Block} from './block.js';
+import * as deprecation from './utils/deprecation.js';
 import * as dialog from './dialog.js';
 import * as eventUtils from './events/utils.js';
 import * as registry from './registry.js';
+import * as Variables from './variables.js';
 import {Msg} from './msg.js';
 import {Names} from './names.js';
 import * as idGenerator from './utils/idgenerator.js';
@@ -247,7 +249,6 @@ export class VariableMap
       this.variableMap.set(type, variables);
     }
     eventUtils.fire(new (eventUtils.get(eventUtils.VAR_CREATE))(variable));
-
     return variable;
   }
 
@@ -269,77 +270,12 @@ export class VariableMap
 
   /* Begin functions for variable deletion. */
   /**
-   * Delete a variable.
+   * Delete a variable and all of its uses without confirmation.
    *
    * @param variable Variable to delete.
    */
   deleteVariable(variable: IVariableModel<IVariableState>) {
-    const variables = this.variableMap.get(variable.getType());
-    if (!variables || !variables.has(variable.getId())) return;
-    variables.delete(variable.getId());
-    eventUtils.fire(new (eventUtils.get(eventUtils.VAR_DELETE))(variable));
-    if (variables.size === 0) {
-      this.variableMap.delete(variable.getType());
-    }
-  }
-
-  /**
-   * Delete a variables by the passed in ID and all of its uses from this
-   * workspace. May prompt the user for confirmation.
-   *
-   * @param id ID of variable to delete.
-   */
-  deleteVariableById(id: string) {
-    const variable = this.getVariableById(id);
-    if (variable) {
-      // Check whether this variable is a function parameter before deleting.
-      const variableName = variable.getName();
-      const uses = this.getVariableUsesById(id);
-      for (let i = 0, block; (block = uses[i]); i++) {
-        if (
-          block.type === 'procedures_defnoreturn' ||
-          block.type === 'procedures_defreturn'
-        ) {
-          const procedureName = String(block.getFieldValue('NAME'));
-          const deleteText = Msg['CANNOT_DELETE_VARIABLE_PROCEDURE']
-            .replace('%1', variableName)
-            .replace('%2', procedureName);
-          dialog.alert(deleteText);
-          return;
-        }
-      }
-
-      if (uses.length > 1) {
-        // Confirm before deleting multiple blocks.
-        const confirmText = Msg['DELETE_VARIABLE_CONFIRMATION']
-          .replace('%1', String(uses.length))
-          .replace('%2', variableName);
-        dialog.confirm(confirmText, (ok) => {
-          if (ok && variable) {
-            this.deleteVariableInternal(variable, uses);
-          }
-        });
-      } else {
-        // No confirmation necessary for a single block.
-        this.deleteVariableInternal(variable, uses);
-      }
-    } else {
-      console.warn("Can't delete non-existent variable: " + id);
-    }
-  }
-
-  /**
-   * Deletes a variable and all of its uses from this workspace without asking
-   * the user for confirmation.
-   *
-   * @param variable Variable to delete.
-   * @param uses An array of uses of the variable.
-   * @internal
-   */
-  deleteVariableInternal(
-    variable: IVariableModel<IVariableState>,
-    uses: Block[],
-  ) {
+    const uses = this.getVariableUsesById(variable.getId());
     const existingGroup = eventUtils.getGroup();
     if (!existingGroup) {
       eventUtils.setGroup(true);
@@ -348,11 +284,37 @@ export class VariableMap
       for (let i = 0; i < uses.length; i++) {
         uses[i].dispose(true);
       }
-      this.deleteVariable(variable);
+      const variables = this.variableMap.get(variable.getType());
+      if (!variables || !variables.has(variable.getId())) return;
+      variables.delete(variable.getId());
+      eventUtils.fire(new (eventUtils.get(eventUtils.VAR_DELETE))(variable));
+      if (variables.size === 0) {
+        this.variableMap.delete(variable.getType());
+      }
     } finally {
       eventUtils.setGroup(existingGroup);
     }
   }
+
+  /**
+   * @deprecated v12 - Delete a variables by the passed in ID and all of its
+   * uses from this workspace. May prompt the user for confirmation.
+   *
+   * @param id ID of variable to delete.
+   */
+  deleteVariableById(id: string) {
+    deprecation.warn(
+      'VariableMap.deleteVariableById',
+      'v12',
+      'v13',
+      'Blockly.Variables.deleteVariable',
+    );
+    const variable = this.getVariableById(id);
+    if (variable) {
+      Variables.deleteVariable(this.workspace, variable);
+    }
+  }
+
   /* End functions for variable deletion. */
   /**
    * Find the variable by the given name and type and return it.  Return null if
@@ -470,26 +432,19 @@ export class VariableMap
   }
 
   /**
-   * Find all the uses of a named variable.
+   * @deprecated v12 - Find all the uses of a named variable.
    *
    * @param id ID of the variable to find.
    * @returns Array of block usages.
    */
   getVariableUsesById(id: string): Block[] {
-    const uses = [];
-    const blocks = this.workspace.getAllBlocks(false);
-    // Iterate through every block and check the name.
-    for (let i = 0; i < blocks.length; i++) {
-      const blockVariables = blocks[i].getVarModels();
-      if (blockVariables) {
-        for (let j = 0; j < blockVariables.length; j++) {
-          if (blockVariables[j].getId() === id) {
-            uses.push(blocks[i]);
-          }
-        }
-      }
-    }
-    return uses;
+    deprecation.warn(
+      'VariableMap.getVariableUsesById',
+      'v12',
+      'v13',
+      'Blockly.Variables.getVariableUsesById',
+    );
+    return Variables.getVariableUsesById(this.workspace, id);
   }
 }
 

--- a/core/workspace.ts
+++ b/core/workspace.ts
@@ -28,6 +28,7 @@ import * as arrayUtils from './utils/array.js';
 import * as idGenerator from './utils/idgenerator.js';
 import * as math from './utils/math.js';
 import type * as toolbox from './utils/toolbox.js';
+import * as Variables from './variables.js';
 import type {IVariableMap} from './interfaces/i_variable_map.js';
 import type {
   IVariableModel,
@@ -422,20 +423,7 @@ export class Workspace implements IASTNodeLocation {
    * @returns Array of block usages.
    */
   getVariableUsesById(id: string): Block[] {
-    const uses = [];
-    const blocks = this.getAllBlocks(false);
-    // Iterate through every block and check the name.
-    for (let i = 0; i < blocks.length; i++) {
-      const blockVariables = blocks[i].getVarModels();
-      if (blockVariables) {
-        for (let j = 0; j < blockVariables.length; j++) {
-          if (blockVariables[j].getId() === id) {
-            uses.push(blocks[i]);
-          }
-        }
-      }
-    }
-    return uses;
+    return Variables.getVariableUsesById(this, id);
   }
 
   /**
@@ -446,8 +434,11 @@ export class Workspace implements IASTNodeLocation {
    */
   deleteVariableById(id: string) {
     const variable = this.variableMap.getVariableById(id);
-    if (!variable) return;
-    this.variableMap.deleteVariable(variable);
+    if (!variable) {
+      console.warn(`Can't delete non-existent variable: ${id}`);
+      return;
+    }
+    Variables.deleteVariable(this, variable);
   }
 
   /**

--- a/tests/mocha/variable_map_test.js
+++ b/tests/mocha/variable_map_test.js
@@ -21,7 +21,7 @@ suite('Variable Map', function () {
   setup(function () {
     sharedTestSetup.call(this);
     this.workspace = new Blockly.Workspace();
-    this.variableMap = new Blockly.VariableMap(this.workspace);
+    this.variableMap = this.workspace.getVariableMap();
   });
 
   teardown(function () {


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

-[x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #8371, #8079, #8075

### Proposed Changes
This PR uses IVariableMap in place of hardcoding VariableMap. It also refactors variable deletion handling; the VariableMap methods `getVariableUsesById` and `deleteVariableById` are deprecated and moved to the `Variables` namespace.

### Breaking Change
The `VariableMap.deleteVariable` method now unconditionally deletes uses of the variable in question as well.