### PR TITLE
feat: Add a blocklyNumberField CSS class to number fields 

### DIFF
--- a/core/field_number.ts
+++ b/core/field_number.ts
@@ -310,8 +310,10 @@ export class FieldNumber extends FieldInput<number> {
 
   /**
    * Initialize the field's DOM.
+   *
    * @override
    */
+
   public override initView() {
     super.initView();
     if (this.fieldGroup_) {

--- a/core/field_number.ts
+++ b/core/field_number.ts
@@ -19,6 +19,7 @@ import {
   FieldInputValidator,
 } from './field_input.js';
 import * as aria from './utils/aria.js';
+import * as dom from './utils/dom.js';
 
 /**
  * Class for an editable number field.
@@ -305,6 +306,17 @@ export class FieldNumber extends FieldInput<number> {
       aria.setState(htmlInput, aria.State.VALUEMAX, this.max_);
     }
     return htmlInput;
+  }
+
+  /**
+   * Initialize the field's DOM.
+   * @override
+   */
+  public override initView() {
+    super.initView();
+    if (this.fieldGroup_) {
+      dom.addClass(this.fieldGroup_, 'blocklyNumberField');
+    }
   }
 
   /**


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->
## The basics
<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->
- [X] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)
## The details
### Resolves
<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #8313

### Proposed Changes
<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
This PR adds a 'blocklyNumberField' CSS class to the FieldNumber element. Specifically:
- Implements the `initView` method in the FieldNumber class
- Applies the 'blocklyNumberField' class to the fieldGroup_ element
- Adds a null check for fieldGroup_ to prevent TypeScript errors

### Reason for Changes
<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
This change allows for more specific styling of number fields in Blockly, as requested in issue #8313. It provides a way to target number fields specifically in CSS, enhancing the ability to customize the appearance of these fields.

### Test Coverage
<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->
I manually tested these changes by:
1. Creating a block with a number field
2. Inspecting the DOM to verify that the 'blocklyNumberField' class was applied
3. Applying CSS to the new class and verifying that it affected only number fields

Additional unit tests could be created to ensure the `initView` method is called and applies the class correctly.

### Documentation
<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->
No documentation updates are required for this change, as it doesn't affect the public API or usage of Blockly. However, it might be beneficial to add a note in the theming documentation about the availability of this new CSS class for styling number fields.

### Additional Information
<!-- Anything else we should know? -->
This change is backwards-compatible and should not affect existing Blockly implementations. It simply adds an additional CSS class that can be used for more specific styling if desired.