### PR TITLE
refactor: clean up VariableModel.

### DIFF
--- a/tests/mocha/variable_model_test.js
+++ b/tests/mocha/variable_model_test.js
@@ -27,9 +27,9 @@ suite('Variable Model', function () {
       'test_type',
       'test_id',
     );
-    assert.equal(variable.name, 'test');
-    assert.equal(variable.type, 'test_type');
-    assert.equal(variable.id_, 'test_id');
+    assert.equal(variable.getName(), 'test');
+    assert.equal(variable.getType(), 'test_type');
+    assert.equal(variable.getId(), 'test_id');
   });
 
   test('Null type', function () {
@@ -39,7 +39,7 @@ suite('Variable Model', function () {
       null,
       'test_id',
     );
-    assert.equal(variable.type, '');
+    assert.equal(variable.getType(), '');
   });
 
   test('Undefined type', function () {
@@ -49,7 +49,7 @@ suite('Variable Model', function () {
       undefined,
       'test_id',
     );
-    assert.equal(variable.type, '');
+    assert.equal(variable.getType(), '');
   });
 
   test('Null id', function () {
@@ -59,9 +59,9 @@ suite('Variable Model', function () {
       'test_type',
       null,
     );
-    assert.equal(variable.name, 'test');
-    assert.equal(variable.type, 'test_type');
-    assert.exists(variable.id_);
+    assert.equal(variable.getName(), 'test');
+    assert.equal(variable.getType(), 'test_type');
+    assert.exists(variable.getId());
   });
 
   test('Undefined id', function () {
@@ -71,15 +71,15 @@ suite('Variable Model', function () {
       'test_type',
       undefined,
     );
-    assert.equal(variable.name, 'test');
-    assert.equal(variable.type, 'test_type');
-    assert.exists(variable.id_);
+    assert.equal(variable.getName(), 'test');
+    assert.equal(variable.getType(), 'test_type');
+    assert.exists(variable.getId());
   });
 
   test('Only name provided', function () {
     const variable = new Blockly.VariableModel(this.workspace, 'test');
-    assert.equal(variable.name, 'test');
-    assert.equal(variable.type, '');
-    assert.exists(variable.id_);
+    assert.equal(variable.getName(), 'test');
+    assert.equal(variable.getType(), '');
+    assert.exists(variable.getId());
   });
 });


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details

### Proposed Changes
This PR refactors the `VariableModel.load()` method to use the new variable-related APIs, adds docs to methods that were missing them, makes the VariableModel workspace `readonly`, and cleans up the names of private fields and tests that were accessing them.