### PR TITLE
fix: no trigger toolbox block deletion style

### DIFF
--- a/core/flyout_vertical.ts
+++ b/core/flyout_vertical.ts
@@ -320,7 +320,7 @@ export class VerticalFlyout extends Flyout {
 
     if (this.toolboxPosition_ === toolbox.Position.LEFT) {
       const width = flyoutRect.width;
-      return new Rect(-BIG_NUM, BIG_NUM, -BIG_NUM, left + width);
+      return new Rect(-BIG_NUM, BIG_NUM, left, left + width);
     } else {
       // Right
       return new Rect(-BIG_NUM, BIG_NUM, left, BIG_NUM);


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details

### Description

When the flyout is open, dragging a Block to the Toolbox does not trigger the Toolbox's Block deletion style(blocklyToolboxDelete)

### Reproduction steps

1. Blockly.getMainWorkspace().getFlyout().setAutoClose(false)
2. Open Flyout
3. Drag Block to Toolbox

### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes https://github.com/google/blockly/issues/8417

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

I'm not sure if this change is appropriate 🤔

The reason is that when the flyout is open, getDragTarget always returns the flyout. Maybe a better way is to add a priority field to dragTargetAreas?

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
