### PR TITLE
fix!: Remove blocklyMenuItemHighlight

### DIFF
--- a/core/css.ts
+++ b/core/css.ts
@@ -478,7 +478,7 @@ input[type=number] {
 }
 
 /* State: hover. */
-.blocklyMenuItemHighlight {
+.blocklyMenuItemHighlight:hover {
   background-color: rgba(0,0,0,.1);
 }
 

--- a/core/menuitem.ts
+++ b/core/menuitem.ts
@@ -68,7 +68,6 @@ export class MenuItem {
       'blocklyMenuItem ' +
       (this.enabled ? '' : 'blocklyMenuItemDisabled ') +
       (this.checked ? 'blocklyMenuItemSelected ' : '') +
-      (this.highlight ? 'blocklyMenuItemHighlight ' : '') +
       (this.rightToLeft ? 'blocklyMenuItemRtl ' : '');
 
     const content = document.createElement('div');


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes Remove blocklyMenuItemHighlight CSS class and use :hover CSS selector #8327 

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
- Remove the blocklyMenuItemHighlight CSS class from the menu item
- Change blocklyMenuItemHighlight to :hover pseudo-class
### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
