### PR TITLE
feat: add blocklyLabelField CSS class to label fields

### DIFF
--- a/core/field_label.ts
+++ b/core/field_label.ts
@@ -74,6 +74,9 @@ export class FieldLabel extends Field<string> {
     if (this.class) {
       dom.addClass(this.getTextElement(), this.class);
     }
+    if (this.fieldGroup_) {
+      dom.addClass(this.fieldGroup_, 'blocklyLabelField');
+    }
   }
 
   /**


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes [Issue #8315](https://github.com/google/blockly/issues/8315)

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
This pull request adds a `blocklyLabelField` CSS class to label fields in the `FieldLabel` class by modifying the `initView` method to call `dom.addClass` with `this.fieldGroup_` and `blocklyLabelField`.

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
This change helps in applying specific styles to label fields, allowing better customization and theming of Blockly components.

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->
I tested these changes manually by creating and manipulating label fields in the Blockly playground. Additionally, I verified that the `blocklyLabelField` class is applied correctly in different scenarios.

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->
No additional documentation is needed for this PR.

### Additional Information

<!-- Anything else we should know? -->
No additional information.
