### PR TITLE
feat: add the block's type as a CSS class to the block's root SVG

### DIFF
--- a/core/block_svg.ts
+++ b/core/block_svg.ts
@@ -184,6 +184,7 @@ export class BlockSvg
     this.workspace = workspace;
     this.svgGroup_ = dom.createSvgElement(Svg.G, {});
 
+    dom.addClass(this.svgGroup_, prototypeName);
     /** A block style object. */
     this.style = workspace.getRenderer().getConstants().getBlockStyle(null);
 

--- a/core/block_svg.ts
+++ b/core/block_svg.ts
@@ -184,7 +184,9 @@ export class BlockSvg
     this.workspace = workspace;
     this.svgGroup_ = dom.createSvgElement(Svg.G, {});
 
-    dom.addClass(this.svgGroup_, prototypeName);
+    if (prototypeName) {
+      dom.addClass(this.svgGroup_, prototypeName);
+    }
     /** A block style object. */
     this.style = workspace.getRenderer().getConstants().getBlockStyle(null);
 


### PR DESCRIPTION
# Issue -> https://github.com/google/blockly/issues/8268

Fixes #8268 

## Description
This PR adds the `prototypeName` as a CSS class to the SVG group element of each block in the `BlockSvg` constructor. This enhancement allows for easier styling and identification of blocks based on their prototype.

## Changes
- Modified the `BlockSvg` constructor to add the `prototypeName` as a CSS class to `this.svgGroup_` using `dom.addClass()`.

## Benefits
- Improved block identification in the DOM
- Enhanced styling capabilities for specific block types

This change is backwards-compatible and provides a hook for future enhancements or debugging.