### PR TITLE
fix: Codify component weights with toolbox in front of flyouts.

### DIFF
--- a/core/component_manager.ts
+++ b/core/component_manager.ts
@@ -224,6 +224,16 @@ export class ComponentManager {
 }
 
 export namespace ComponentManager {
+  export enum ComponentWeight {
+    // The toolbox weight is lower (higher precedence) than the flyout, so that
+    // if both are under the pointer, the toolbox takes precedence even though
+    // the flyout's drag target area is large enough to include the toolbox.
+    TOOLBOX_WEIGHT = 0,
+    FLYOUT_WEIGHT = 1,
+    TRASHCAN_WEIGHT = 2,
+    ZOOM_CONTROLS_WEIGHT = 3,
+  }
+
   /** An object storing component information. */
   export interface ComponentDatum {
     component: IComponent;
@@ -232,4 +242,6 @@ export namespace ComponentManager {
   }
 }
 
+export type ComponentWeight = ComponentManager.ComponentWeight;
+export const ComponentWeight = ComponentManager.ComponentWeight;
 export type ComponentDatum = ComponentManager.ComponentDatum;

--- a/core/flyout_base.ts
+++ b/core/flyout_base.ts
@@ -427,7 +427,7 @@ export abstract class Flyout
 
     targetWorkspace.getComponentManager().addComponent({
       component: this,
-      weight: 1,
+      weight: ComponentManager.ComponentWeight.FLYOUT_WEIGHT,
       capabilities: [
         ComponentManager.Capability.AUTOHIDEABLE,
         ComponentManager.Capability.DELETE_AREA,

--- a/core/toolbox/toolbox.ts
+++ b/core/toolbox/toolbox.ts
@@ -157,7 +157,7 @@ export class Toolbox
     themeManager.subscribe(this.HtmlDiv, 'toolboxForegroundColour', 'color');
     this.workspace_.getComponentManager().addComponent({
       component: this,
-      weight: 1,
+      weight: ComponentManager.ComponentWeight.TOOLBOX_WEIGHT,
       capabilities: [
         ComponentManager.Capability.AUTOHIDEABLE,
         ComponentManager.Capability.DELETE_AREA,

--- a/core/trashcan.ts
+++ b/core/trashcan.ts
@@ -247,7 +247,7 @@ export class Trashcan
     }
     this.workspace.getComponentManager().addComponent({
       component: this,
-      weight: 1,
+      weight: ComponentManager.ComponentWeight.TRASHCAN_WEIGHT,
       capabilities: [
         ComponentManager.Capability.AUTOHIDEABLE,
         ComponentManager.Capability.DELETE_AREA,

--- a/core/zoom_controls.ts
+++ b/core/zoom_controls.ts
@@ -116,7 +116,7 @@ export class ZoomControls implements IPositionable {
   init() {
     this.workspace.getComponentManager().addComponent({
       component: this,
-      weight: 2,
+      weight: ComponentManager.ComponentWeight.ZOOM_CONTROLS_WEIGHT,
       capabilities: [ComponentManager.Capability.POSITIONABLE],
     });
     this.initialized = true;


### PR DESCRIPTION
## The basics

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

Fixes https://github.com/google/blockly/issues/8417

### Proposed Changes

I created an enum codifying the weights for the flyout, toolbox, trashcan, and zoom buttons, and provided weight values that give the toolbox higher precedence than the flyout.

### Reason for Changes

When the pointer is dragging a block from the workspace to a toolbox or flyout, the drag target areas may overlap, in which case we should decide which should take precedence and handle the event. The flyout's drag area intentionally extends beyond its own bounds, but if the toolbox is also present, then the flyout's bounds include the toolbox. Currently, the flyout and the toolbox have the same weight but the flyout happens to be found first and effectively takes precedence. However, it would be more intuitive for the toolbox to take precedence when the pointer is over it, so I'm giving the toolbox a higher precedence.

### Test Coverage

Existing tests pass. I manually tested that the CSS issue from https://github.com/google/blockly/issues/8417 is resolved.

### Documentation

N/A

### Additional Information

I did not mark this as a breaking change, but if anyone can think of a reason why users might be depending on the current weights assigned to the flyout, toolbox, trashcan, and zoom buttons, then this should be a breaking change. Previously, the weights were all `1` except the zoom buttons which were `2`. I've now assigned different weights to all of them.
