### PR TITLE
feat: added block's style as a CSS class to block's root SVG

### DIFF
--- a/core/block_svg.ts
+++ b/core/block_svg.ts
@@ -1162,6 +1162,10 @@ export class BlockSvg
       .getConstants()
       .getBlockStyle(blockStyleName);
 
+    if (!this.svgGroup_) {
+      throw new Error('SVG group is not defined');
+    }
+
     if (this.styleName_) {
       dom.removeClass(this.svgGroup_, this.styleName_);
     }
@@ -1176,6 +1180,7 @@ export class BlockSvg
       this.applyColour();
 
       dom.addClass(this.svgGroup_, blockStyleName);
+      this.styleName_ = blockStyleName;
     } else {
       throw Error('Invalid style name: ' + blockStyleName);
     }

--- a/core/block_svg.ts
+++ b/core/block_svg.ts
@@ -1161,7 +1161,10 @@ export class BlockSvg
       .getRenderer()
       .getConstants()
       .getBlockStyle(blockStyleName);
-    this.styleName_ = blockStyleName;
+
+    if (this.styleName_) {
+      dom.removeClass(this.svgGroup_, this.styleName_);
+    }
 
     if (blockStyle) {
       this.hat = blockStyle.hat;
@@ -1171,6 +1174,8 @@ export class BlockSvg
       this.style = blockStyle;
 
       this.applyColour();
+
+      dom.addClass(this.svgGroup_, blockStyleName);
     } else {
       throw Error('Invalid style name: ' + blockStyleName);
     }

--- a/core/block_svg.ts
+++ b/core/block_svg.ts
@@ -1162,10 +1162,6 @@ export class BlockSvg
       .getConstants()
       .getBlockStyle(blockStyleName);
 
-    if (!this.svgGroup_) {
-      throw new Error('SVG group is not defined');
-    }
-
     if (this.styleName_) {
       dom.removeClass(this.svgGroup_, this.styleName_);
     }


### PR DESCRIPTION
# Details :

Added the `blockStyleName` as a CSS class on the block. Also called `dom.removeClass` with `this.styleName_` to remove any previous style.

# Fixes  : 

#8269 