### PR TITLE
Issue 8147 resolved

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,3 +78,26 @@ We typically triage all bugs within 1 week, which includes adding any appropriat
 
 - Cross-browser Testing Platform and Open Source <3 Provided by [Sauce Labs](https://saucelabs.com)
 - We test browsers using [BrowserStack](https://browserstack.com)
+
+##  How to set max-height of dropdowns dynamically 
+
+Blockly sets the maximum height of dropdowns to 300px by default to prevent them from overflowing the workspace. However, this can sometimes force the user to scroll unnecessarily, especially when working with large bitmaps or other extensive content.
+
+You can override this default maximum height with your own CSS. Here's how:
+
+Add a Custom CSS Class:
+
+In your HTML file or stylesheet, define a custom CSS class to set the desired maximum height. For example:
+```css
+.custom-dropdown {
+  max-height: 500px !important;
+}
+```
+Apply the Custom CSS Class:
+
+In your Blockly code, apply the custom CSS class to the dropdown element. This might involve modifying the Blockly source code or using a Blockly event to add the class dynamically.
+Example:
+
+```javascript
+dropdownElement.classList.add('custom-dropdown');
+```

--- a/core/block_svg.ts
+++ b/core/block_svg.ts
@@ -193,7 +193,17 @@ export class BlockSvg
 
     this.doInit_();
   }
-
+  
+  updateEditable() {
+    const isEditable = this.isEditable();
+    const root = this.getSvgRoot();
+    
+    if (isEditable) {
+      root.classList.add('blocklyFieldCursor');
+    } else {
+      root.classList.remove('blocklyFieldCursor');
+    }
+  }
   /**
    * Create and initialize the SVG representation of the block.
    * May be called more than once.

--- a/core/css.ts
+++ b/core/css.ts
@@ -56,6 +56,26 @@ export function inject(hasCss: boolean, pathToMedia: string) {
   document.head.insertBefore(cssNode, document.head.firstChild);
 }
 
+
+.blocklyFieldCursor {
+  cursor: pointer;
+}
+
+.blocklyFieldTextInputCursor {
+  cursor: text;
+}
+
+.blocklyFieldDropdownCursor {
+  cursor: pointer;
+}
+
+.blocklyFieldCheckboxCursor {
+  cursor: pointer;
+}
+
+.blocklyFieldColourCursor {
+  cursor: pointer;
+}
 /**
  * The CSS content for Blockly.
  */

--- a/core/field.ts
+++ b/core/field.ts
@@ -530,22 +530,22 @@ export abstract class Field<T = any>
   }
 
   /** Add or remove the UI indicating if this field is editable or not. */
-  updateEditable() {
-    const group = this.fieldGroup_;
-    const block = this.getSourceBlock();
-    if (!this.EDITABLE || !group || !block) {
-      return;
-    }
-    if (this.enabled_ && block.isEditable()) {
-      dom.addClass(group, 'blocklyEditableText');
-      dom.removeClass(group, 'blocklyNonEditableText');
-      group.style.cursor = this.CURSOR;
-    } else {
-      dom.addClass(group, 'blocklyNonEditableText');
-      dom.removeClass(group, 'blocklyEditableText');
-      group.style.cursor = '';
-    }
-  }
+  // updateEditable() {
+  //   const group = this.fieldGroup_;
+  //   const block = this.getSourceBlock();
+  //   if (!this.EDITABLE || !group || !block) {
+  //     return;
+  //   }
+  //   if (this.enabled_ && block.isEditable()) {
+  //     dom.addClass(group, 'blocklyEditableText');
+  //     dom.removeClass(group, 'blocklyNonEditableText');
+  //     group.style.cursor = this.CURSOR;
+  //   } else {
+  //     dom.addClass(group, 'blocklyNonEditableText');
+  //     dom.removeClass(group, 'blocklyEditableText');
+  //     group.style.cursor = '';
+  //   }
+  // }
 
   /**
    * Set whether this field's value can be changed using the editor when the
@@ -1382,18 +1382,18 @@ export abstract class Field<T = any>
    * @param cursorSvg The SVG root of the cursor to be added to the field group.
    * @internal
    */
-  setCursorSvg(cursorSvg: SVGElement) {
-    if (!cursorSvg) {
-      this.cursorSvg_ = null;
-      return;
-    }
+  // setCursorSvg(cursorSvg: SVGElement) {
+  //   if (!cursorSvg) {
+  //     this.cursorSvg_ = null;
+  //     return;
+  //   }
 
-    if (!this.fieldGroup_) {
-      throw new Error(`The field group is ${this.fieldGroup_}.`);
-    }
-    this.fieldGroup_.appendChild(cursorSvg);
-    this.cursorSvg_ = cursorSvg;
-  }
+  //   if (!this.fieldGroup_) {
+  //     throw new Error(`The field group is ${this.fieldGroup_}.`);
+  //   }
+  //   this.fieldGroup_.appendChild(cursorSvg);
+  //   this.cursorSvg_ = cursorSvg;
+  // }
 
   /**
    * Add the marker SVG to this fields SVG group.
@@ -1419,20 +1419,20 @@ export abstract class Field<T = any>
    *
    * @internal
    */
-  updateMarkers_() {
-    const block = this.getSourceBlock();
-    if (!block) {
-      throw new UnattachedFieldError();
-    }
-    const workspace = block.workspace as WorkspaceSvg;
-    if (workspace.keyboardAccessibilityMode && this.cursorSvg_) {
-      workspace.getCursor()!.draw();
-    }
-    if (workspace.keyboardAccessibilityMode && this.markerSvg_) {
-      // TODO(#4592): Update all markers on the field.
-      workspace.getMarker(MarkerManager.LOCAL_MARKER)!.draw();
-    }
-  }
+  // updateMarkers_() {
+  //   const block = this.getSourceBlock();
+  //   if (!block) {
+  //     throw new UnattachedFieldError();
+  //   }
+  //   const workspace = block.workspace as WorkspaceSvg;
+  //   if (workspace.keyboardAccessibilityMode && this.cursorSvg_) {
+  //     workspace.getCursor()!.draw();
+  //   }
+  //   if (workspace.keyboardAccessibilityMode && this.markerSvg_) {
+  //     // TODO(#4592): Update all markers on the field.
+  //     workspace.getMarker(MarkerManager.LOCAL_MARKER)!.draw();
+  //   }
+  // }
 
   /**
    * Subclasses should reimplement this method to construct their Field

--- a/core/field_checkbox.ts
+++ b/core/field_checkbox.ts
@@ -33,18 +33,18 @@ export class FieldCheckbox extends Field<CheckboxBool> {
    * Serializable fields are saved by the serializer, non-serializable fields
    * are not. Editable fields should also be serializable.
    */
-  override SERIALIZABLE = true;
+   SERIALIZABLE = true;
 
   /**
    * Mouse cursor style when over the hotspot that initiates editability.
    */
-  override CURSOR = 'default';
+   CURSOR = 'default';
 
   /**
    * NOTE: The default value is set in `Field`, so maintain that value instead
    * of overwriting it here or in the constructor.
    */
-  override value_: boolean | null = this.value_;
+   value_: boolean | null = this.value_;
 
   /**
    * @param value The initial value of the field. Should either be 'TRUE',
@@ -88,7 +88,7 @@ export class FieldCheckbox extends Field<CheckboxBool> {
    *
    * @param config A map of options to configure the field based on.
    */
-  protected override configure_(config: FieldCheckboxConfig) {
+  protected  configure_(config: FieldCheckboxConfig) {
     super.configure_(config);
     if (config.checkCharacter) this.checkChar = config.checkCharacter;
   }
@@ -99,7 +99,7 @@ export class FieldCheckbox extends Field<CheckboxBool> {
    * @returns The boolean value held by this field.
    * @internal
    */
-  override saveState(): AnyDuringMigration {
+   saveState(): AnyDuringMigration {
     const legacyState = this.saveLegacyState(FieldCheckbox);
     if (legacyState !== null) {
       return legacyState;
@@ -110,7 +110,7 @@ export class FieldCheckbox extends Field<CheckboxBool> {
   /**
    * Create the block UI for this checkbox.
    */
-  override initView() {
+   initView() {
     super.initView();
 
     const textElement = this.getTextElement();
@@ -118,14 +118,14 @@ export class FieldCheckbox extends Field<CheckboxBool> {
     textElement.style.display = this.value_ ? 'block' : 'none';
   }
 
-  override render_() {
+   render_() {
     if (this.textContent_) {
       this.textContent_.nodeValue = this.getDisplayText_();
     }
     this.updateSize_(this.getConstants()!.FIELD_CHECKBOX_X_OFFSET);
   }
 
-  override getDisplayText_() {
+   getDisplayText_() {
     return this.checkChar;
   }
 
@@ -141,7 +141,7 @@ export class FieldCheckbox extends Field<CheckboxBool> {
   }
 
   /** Toggle the state of the checkbox on click. */
-  protected override showEditor_() {
+  protected  showEditor_() {
     this.setValue(!this.value_);
   }
 
@@ -151,7 +151,7 @@ export class FieldCheckbox extends Field<CheckboxBool> {
    * @param newValue The input value.
    * @returns A valid value ('TRUE' or 'FALSE), or null if invalid.
    */
-  protected override doClassValidation_(
+  protected  doClassValidation_(
     newValue?: AnyDuringMigration,
   ): BoolString | null {
     if (newValue === true || newValue === 'TRUE') {
@@ -169,7 +169,7 @@ export class FieldCheckbox extends Field<CheckboxBool> {
    * @param newValue The value to be saved. The default validator guarantees
    *     that this is a either 'TRUE' or 'FALSE'.
    */
-  protected override doValueUpdate_(newValue: BoolString) {
+  protected  doValueUpdate_(newValue: BoolString) {
     this.value_ = this.convertValueToBool_(newValue);
     // Update visual.
     if (this.textElement_) {
@@ -182,7 +182,7 @@ export class FieldCheckbox extends Field<CheckboxBool> {
    *
    * @returns The value of this field.
    */
-  override getValue(): BoolString {
+   getValue(): BoolString {
     return this.value_ ? 'TRUE' : 'FALSE';
   }
 
@@ -200,7 +200,7 @@ export class FieldCheckbox extends Field<CheckboxBool> {
    *
    * @returns Text representing the value of this field ('true' or 'false').
    */
-  override getText(): string {
+   getText(): string {
     return String(this.convertValueToBool_(this.value_));
   }
 
@@ -226,7 +226,7 @@ export class FieldCheckbox extends Field<CheckboxBool> {
    * @nocollapse
    * @internal
    */
-  static override fromJson(
+  static  fromJson(
     options: FieldCheckboxFromJsonConfig,
   ): FieldCheckbox {
     // `this` might be a subclass of FieldCheckbox if that class doesn't

--- a/core/field_dropdown.ts
+++ b/core/field_dropdown.ts
@@ -68,10 +68,10 @@ export class FieldDropdown extends Field<string> {
    * Serializable fields are saved by the serializer, non-serializable fields
    * are not. Editable fields should also be serializable.
    */
-  override SERIALIZABLE = true;
+  SERIALIZABLE = true;
 
   /** Mouse cursor style when over the hotspot that initiates the editor. */
-  override CURSOR = 'default';
+   CURSOR = 'default';
 
   protected menuGenerator_?: MenuGenerator;
 
@@ -83,17 +83,17 @@ export class FieldDropdown extends Field<string> {
    *
    * @internal
    */
-  override prefixField: string | null = null;
+  prefixField: string | null = null;
 
   /**
    * The suffix field label, of common words set after options are trimmed.
    *
    * @internal
    */
-  override suffixField: string | null = null;
+   suffixField: string | null = null;
   // TODO(b/109816955): remove '!', see go/strict-prop-init-fix.
   private selectedOption!: MenuOption;
-  override clickTarget_: SVGElement | null = null;
+ clickTarget_: SVGElement | null = null;
 
   /**
    * @param menuGenerator A non-empty array of options for a dropdown list, or a
@@ -159,7 +159,7 @@ export class FieldDropdown extends Field<string> {
    * @param fieldElement The element containing info about the field's state.
    * @internal
    */
-  override fromXml(fieldElement: Element) {
+  fromXml(fieldElement: Element) {
     if (this.isOptionListDynamic()) {
       this.getOptions(false);
     }
@@ -172,7 +172,7 @@ export class FieldDropdown extends Field<string> {
    * @param state The state to apply to the dropdown field.
    * @internal
    */
-  override loadState(state: AnyDuringMigration) {
+   loadState(state: AnyDuringMigration) {
     if (this.loadLegacyState(FieldDropdown, state)) {
       return;
     }
@@ -185,7 +185,7 @@ export class FieldDropdown extends Field<string> {
   /**
    * Create the block UI for this dropdown.
    */
-  override initView() {
+  initView() {
     if (this.shouldAddBorderRect_()) {
       this.createBorderRect_();
     } else {
@@ -262,7 +262,7 @@ export class FieldDropdown extends Field<string> {
    * @param e Optional mouse event that triggered the field to open, or
    *     undefined if triggered programmatically.
    */
-  protected override showEditor_(e?: MouseEvent) {
+  protected showEditor_(e?: MouseEvent) {
     const block = this.getSourceBlock();
     if (!block) {
       throw new UnattachedFieldError();
@@ -411,11 +411,11 @@ export class FieldDropdown extends Field<string> {
    * @param newValue The input value.
    * @returns A valid language-neutral option, or null if invalid.
    */
-  protected override doClassValidation_(
+  protected  doClassValidation_(
     newValue: string,
   ): string | null | undefined;
-  protected override doClassValidation_(newValue?: string): string | null;
-  protected override doClassValidation_(
+  protected  doClassValidation_(newValue?: string): string | null;
+  protected  doClassValidation_(
     newValue?: string,
   ): string | null | undefined {
     const options = this.getOptions(true);
@@ -444,7 +444,7 @@ export class FieldDropdown extends Field<string> {
    * @param newValue The value to be saved. The default validator guarantees
    *     that this is one of the valid dropdown options.
    */
-  protected override doValueUpdate_(newValue: string) {
+  protected doValueUpdate_(newValue: string) {
     super.doValueUpdate_(newValue);
     const options = this.getOptions(true);
     for (let i = 0, option; (option = options[i]); i++) {
@@ -457,7 +457,7 @@ export class FieldDropdown extends Field<string> {
   /**
    * Updates the dropdown arrow to match the colour/style of the block.
    */
-  override applyColour() {
+  applyColour() {
     const style = (this.sourceBlock_ as BlockSvg).style;
     if (this.borderRect_) {
       this.borderRect_.setAttribute('stroke', style.colourTertiary);
@@ -478,7 +478,7 @@ export class FieldDropdown extends Field<string> {
   }
 
   /** Draws the border with the correct width. */
-  protected override render_() {
+  protected  render_() {
     // Hide both elements.
     this.getTextContent().nodeValue = '';
     this.imageElement!.style.display = 'none';
@@ -628,7 +628,7 @@ export class FieldDropdown extends Field<string> {
    *
    * @returns Selected option text.
    */
-  protected override getText_(): string | null {
+  protected  getText_(): string | null {
     if (!this.selectedOption) {
       return null;
     }
@@ -647,7 +647,7 @@ export class FieldDropdown extends Field<string> {
    * @nocollapse
    * @internal
    */
-  static override fromJson(
+  static fromJson(
     options: FieldDropdownFromJsonConfig,
   ): FieldDropdown {
     if (!options.options) {

--- a/core/field_input.ts
+++ b/core/field_input.ts
@@ -97,10 +97,10 @@ export abstract class FieldInput<T extends InputTypes> extends Field<
    * Serializable fields are saved by the serializer, non-serializable fields
    * are not. Editable fields should also be serializable.
    */
-  override SERIALIZABLE = true;
+   SERIALIZABLE = true;
 
   /** Mouse cursor style when over the hotspot that initiates the editor. */
-  override CURSOR = 'text';
+  CURSOR = 'text';
 
   /**
    * @param value The initial value of the field. Should cast to a string.
@@ -133,14 +133,14 @@ export abstract class FieldInput<T extends InputTypes> extends Field<
     }
   }
 
-  protected override configure_(config: FieldInputConfig) {
+  protected configure_(config: FieldInputConfig) {
     super.configure_(config);
     if (config.spellcheck !== undefined) {
       this.spellcheck_ = config.spellcheck;
     }
   }
 
-  override initView() {
+   initView() {
     const block = this.getSourceBlock();
     if (!block) throw new UnattachedFieldError();
     super.initView();
@@ -150,7 +150,7 @@ export abstract class FieldInput<T extends InputTypes> extends Field<
     }
   }
 
-  protected override isFullBlockField(): boolean {
+  protected  isFullBlockField(): boolean {
     const block = this.getSourceBlock();
     if (!block) throw new UnattachedFieldError();
 
@@ -170,7 +170,7 @@ export abstract class FieldInput<T extends InputTypes> extends Field<
    *     on the htmlInput_.
    * @param fireChangeEvent Whether to fire a change event if the value changes.
    */
-  protected override doValueInvalid_(
+  protected  doValueInvalid_(
     _invalidValue: AnyDuringMigration,
     fireChangeEvent: boolean = true,
   ) {
@@ -207,7 +207,7 @@ export abstract class FieldInput<T extends InputTypes> extends Field<
    * @param newValue The value to be saved. The default validator guarantees
    *     that this is a string.
    */
-  protected override doValueUpdate_(newValue: string | T) {
+  protected  doValueUpdate_(newValue: string | T) {
     this.isDirty_ = true;
     this.isTextValid_ = true;
     this.value_ = newValue;
@@ -216,7 +216,7 @@ export abstract class FieldInput<T extends InputTypes> extends Field<
   /**
    * Updates text field to match the colour/style of the block.
    */
-  override applyColour() {
+   applyColour() {
     const block = this.getSourceBlock() as BlockSvg | null;
     if (!block) throw new UnattachedFieldError();
 
@@ -245,7 +245,7 @@ export abstract class FieldInput<T extends InputTypes> extends Field<
    *
    * @returns Height and width.
    */
-  override getSize(): Size {
+   getSize(): Size {
     if (this.getConstants()?.FULL_BLOCK_FIELDS) {
       // In general, do *not* let fields control the color of blocks. Having the
       // field control the color is unexpected, and could have performance
@@ -274,7 +274,7 @@ export abstract class FieldInput<T extends InputTypes> extends Field<
    * Also updates the colour of the block to reflect whether this is a full
    * block field or not.
    */
-  protected override render_() {
+  protected  render_() {
     super.render_();
     // This logic is done in render_ rather than doValueInvalid_ or
     // doValueUpdate_ so that the code is more centralized.
@@ -330,7 +330,7 @@ export abstract class FieldInput<T extends InputTypes> extends Field<
    * @param quietInput True if editor should be created without focus.
    *     Defaults to false.
    */
-  protected override showEditor_(_e?: Event, quietInput = false) {
+  protected  showEditor_(_e?: Event, quietInput = false) {
     this.workspace_ = (this.sourceBlock_ as BlockSvg).workspace;
     if (
       !quietInput &&
@@ -655,7 +655,7 @@ export abstract class FieldInput<T extends InputTypes> extends Field<
    * @returns True for rendered workspaces, as we never want to hide the widget
    *     div.
    */
-  override repositionForWindowResize(): boolean {
+   repositionForWindowResize(): boolean {
     const block = this.getSourceBlock();
     // This shouldn't be possible. We should never have a WidgetDiv if not using
     // rendered blocks.
@@ -677,7 +677,7 @@ export abstract class FieldInput<T extends InputTypes> extends Field<
    *
    * @returns True if the field is tab navigable.
    */
-  override isTabNavigable(): boolean {
+   isTabNavigable(): boolean {
     return true;
   }
 
@@ -689,7 +689,7 @@ export abstract class FieldInput<T extends InputTypes> extends Field<
    *
    * @returns The HTML value if we're editing, otherwise null.
    */
-  protected override getText_(): string | null {
+  protected  getText_(): string | null {
     if (this.isBeingEdited_ && this.htmlInput_) {
       // We are currently editing, return the HTML input value instead.
       return this.htmlInput_.value;


### PR DESCRIPTION
# #8147 how to set max-height of dropdowns dynamically 

- Added a markdown on how to set max-height of dropdown dynamically

<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [ ] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes 

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
