### PR TITLE
Added blocklyImageField CSS class to image fields 

### DIFF
--- a/core/field_image.ts
+++ b/core/field_image.ts
@@ -151,6 +151,10 @@ export class FieldImage extends Field<string> {
       this.value_ as string,
     );
 
+    if (this.fieldGroup_) {
+      dom.addClass(this.fieldGroup_, 'blocklyImageField');
+    }
+
     if (this.clickHandler) {
       this.imageElement.style.cursor = 'pointer';
     }


### PR DESCRIPTION
# Issue -> https://github.com/google/blockly/issues/8314

fixes #8314 

## Description :
This pull request introduces a change to the `FieldImage` class in Blockly to enhance the styling capabilities of image fields. By adding the `blocklyImageField` CSS class to the `fieldGroup_` element, developers can now apply custom styles more easily to image fields within Blockly.

### Changes Made :
- Modified the `initView` method in `core/field_image.ts` to call `dom.addClass` with `this.fieldGroup_` and `'blocklyImageField'`.

### Details:
The `initView` method has been updated to ensure that the `blocklyImageField` CSS class is applied to the `fieldGroup_` element whenever an image field is initialized. This addition enhances the flexibility for developers to customize the appearance of image fields using CSS.

### Branch :
- This change has been made against the `rc/v12.0.0` branch.

By adding the `blocklyImageField` class, developers can now easily apply CSS styles specific to image fields, enhancing the visual customization options available in Blockly.