### PR TITLE
fix!: Rename blocklyTreeIconOpen to `blocklyToolboxCategoryIconOpen`

### DIFF
--- a/core/toolbox/category.ts
+++ b/core/toolbox/category.ts
@@ -138,7 +138,7 @@ export class ToolboxCategory
       'label': 'blocklyTreeLabel',
       'contents': 'blocklyToolboxContents',
       'selected': 'blocklyTreeSelected',
-      'openicon': 'blocklyTreeIconOpen',
+      'openicon': 'blocklyToolboxCategoryIconOpen',
       'closedicon': 'blocklyTreeIconClosed',
     };
   }
@@ -708,11 +708,11 @@ Css.register(`
   background-position: 0 -17px;
 }
 
-.blocklyTreeIconOpen {
+.blocklyToolboxCategoryIconOpen {
   background-position: -16px -1px;
 }
 
-.blocklyTreeSelected>.blocklyTreeIconOpen {
+.blocklyTreeSelected>.blocklyToolboxCategoryIconOpen {
   background-position: -16px -17px;
 }
 


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The Details
The pull request renames all references to blocklyTreeIconOpen to blocklyToolboxCategoryIconOpen
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->

Fixes #8348 


