### PR TITLE
Renamed the blocklyTreeIconOpen CSS class to blocklyToolboxCategoryIconOpen

### DIFF
--- a/core/toolbox/category.ts
+++ b/core/toolbox/category.ts
@@ -138,7 +138,7 @@ export class ToolboxCategory
       'label': 'blocklyTreeLabel',
       'contents': 'blocklyToolboxCategoryGroup',
       'selected': 'blocklyTreeSelected',
-      'openicon': 'blocklyTreeIconOpen',
+      'openicon': 'blocklyToolboxCategoryIconOpen',
       'closedicon': 'blocklyTreeIconClosed',
     };
   }
@@ -708,11 +708,11 @@ Css.register(`
   background-position: 0 -17px;
 }
 
-.blocklyTreeIconOpen {
+.blocklyToolboxCategoryIconOpen {
   background-position: -16px -1px;
 }
 
-.blocklyTreeSelected>.blocklyTreeIconOpen {
+.blocklyTreeSelected>.blocklyToolboxCategoryIconOpen {
   background-position: -16px -17px;
 }
 


### PR DESCRIPTION
# Issue -> https://github.com/google/blockly/issues/8348
## Description : 
This pull request addresses an issue related to the naming convention of CSS classes used in the project. The `blocklyTreeIconOpen` class has been renamed to `blocklyToolboxCategoryIconOpen` to enhance clarity and maintain consistency with other class names. This change affects the appearance of the open icon within the toolbox category.

## Changes:
- Renamed the `blocklyTreeIconOpen` CSS class to `blocklyToolboxCategoryIconOpen`.

## Reason for Change:
The renaming improves the readability and maintainability of the codebase by using a more descriptive class name that aligns with the functionality it represents.

### Impact:
This change ensures that the correct styles are applied to the toolbox category's open icon, providing a consistent user interface.
