### PR TITLE
fix: added blocklyHighlighted CSS class to highlighted block's root

### DIFF
--- a/core/renderers/common/path_object.ts
+++ b/core/renderers/common/path_object.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright 2019 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// Former goog.module ID: Blockly.blockRendering.PathObject
+
 import type {BlockSvg} from '../../block_svg.js';
 import type {Connection} from '../../connection.js';
 import {RenderedConnection} from '../../rendered_connection.js';

--- a/core/renderers/common/path_object.ts
+++ b/core/renderers/common/path_object.ts
@@ -1,11 +1,3 @@
-/**
- * @license
- * Copyright 2019 Google LLC
- * SPDX-License-Identifier: Apache-2.0
- */
-
-// Former goog.module ID: Blockly.blockRendering.PathObject
-
 import type {BlockSvg} from '../../block_svg.js';
 import type {Connection} from '../../connection.js';
 import {RenderedConnection} from '../../rendered_connection.js';
@@ -174,8 +166,10 @@ export class PathObject implements IPathObject {
         'filter',
         'url(#' + this.constants.embossFilterId + ')',
       );
+      this.setClass_('blocklyHighlighted', true);
     } else {
       this.svgPath.setAttribute('filter', 'none');
+      this.setClass_('blocklyHighlighted', false);
     }
   }
 


### PR DESCRIPTION
# Issue -> https://github.com/google/blockly/issues/8263
Fixes https://github.com/google/blockly/issues/8263
# Description : 

## Summary:

This pull request addresses issue  by updating the `PathObject` class to use the existing `setClass_` method for adding and removing CSS classes. This change ensures consistency and adherence to existing codebase practices.

## Details:

- **Removed**: The newly introduced `addClass` and `removeClass` methods that were previously added for class management.
- **Updated**: The `updateHighlighted` method to use the existing `setClass_` method for managing CSS classes instead of the removed methods.

**Benefits:**

- **Consistency**: Aligns with the established method for class management in the codebase.
- **Maintainability**: Simplifies the code by using the existing utility methods, making it easier to maintain.

This fix resolves the issue by ensuring that the `blocklyHighlighted` CSS class is correctly managed using the standardized approach.

