### PR TITLE
fix: added block's style as a CSS class to block's root SVG 

### DIFF
--- a/core/block_svg.ts
+++ b/core/block_svg.ts
@@ -1180,6 +1180,10 @@ export class BlockSvg
       .getBlockStyle(blockStyleName);
     this.styleName_ = blockStyleName;
 
+    if (this.styleName_) {
+      dom.removeClass(this.svgGroup_, this.styleName_);
+    }
+
     if (blockStyle) {
       this.hat = blockStyle.hat;
       this.pathObject.setStyle?.(blockStyle);
@@ -1188,6 +1192,7 @@ export class BlockSvg
       this.style = blockStyle;
 
       this.applyColour();
+      dom.addClass(this.svgGroup_, blockStyleName);
     } else {
       throw Error('Invalid style name: ' + blockStyleName);
     }


### PR DESCRIPTION
# Issue -> https://github.com/google/blockly/issues/8269
Fixes https://github.com/google/blockly/issues/8269
# Description:

## Summary:

This pull request updates the `setColour` method to ensure that block styles are managed consistently and correctly applied. Previously, the `setColour` method did not handle the removal of the previous style class, which could lead to inconsistencies in the visual representation of blocks when their color was changed.

## Changes Made:

- **Style Management:** Added logic to remove the previous style class before applying the new style class.
- **Consistency:** Updated the `setColour` method to handle style application in a manner consistent with the existing `setStyle` method.

## Issue Addressed:

This change addresses the issue of incorrect or overlapping styles when a block’s color is changed. By removing the previous style class before applying a new one, the block’s visual representation will accurately reflect the intended style.

