### PR TITLE
fix:  comments and bubbles on click

### DIFF
--- a/core/bubbles/bubble.ts
+++ b/core/bubbles/bubble.ts
@@ -212,9 +212,10 @@ export abstract class Bubble implements IBubble, ISelectable {
     this.background.setAttribute('fill', colour);
   }
 
-  /** Passes the pointer event off to the gesture system. */
+  /** Brings the bubble to the front and passes the pointer event off to the gesture system. */
   private onMouseDown(e: PointerEvent) {
     this.workspace.getGesture(e)?.handleBubbleStart(e, this);
+    this.bringToFront();
     common.setSelected(this);
   }
 

--- a/core/comments/rendered_workspace_comment.ts
+++ b/core/comments/rendered_workspace_comment.ts
@@ -28,6 +28,7 @@ import {
 import {IContextMenu} from '../interfaces/i_contextmenu.js';
 import * as contextMenu from '../contextmenu.js';
 import {ContextMenuRegistry} from '../contextmenu_registry.js';
+import * as layers from '../layers.js';
 
 export class RenderedWorkspaceComment
   extends WorkspaceComment
@@ -208,6 +209,7 @@ export class RenderedWorkspaceComment
     const gesture = this.workspace.getGesture(e);
     if (gesture) {
       gesture.handleCommentStart(e, this);
+      this.workspace.getLayerManager()?.append(this, layers.BLOCK);
       common.setSelected(this);
     }
   }


### PR DESCRIPTION
## The basics

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

Fixes 
#7675 (https://github.com/google/blockly/issues/7675)

### Proposed Changes

1. Workspace comments now move to the block layers when selected.
2. All bubbles (including block comments) move to the top layer when selected.

### Reason for Changes

The comments/bubbles raise when dragged a pixel, so it make sense for them to be raised when they are selected.

### Test Coverage

I don't see how automated tests could be used here.

I tested the changes with comments, block comments, and bubbles opened by mutators. 

### Documentation

No changes needed

### Additional Information

No additional information
