### PR TITLE
feat: add a method for subclasses of FieldVariable to get the default type.

### DIFF
--- a/core/field_variable.ts
+++ b/core/field_variable.ts
@@ -323,6 +323,15 @@ export class FieldVariable extends FieldDropdown {
   }
 
   /**
+   * Gets the type of this field's default variable.
+   *
+   * @returns The default type for this variable field.
+   */
+  protected getDefaultType(): string {
+    return this.defaultType;
+  }
+
+  /**
    * Gets the validation function for this field, or null if not set.
    * Returns null if the variable is not set, because validators should not
    * run on the initial setValue call, because the field won't be attached to


### PR DESCRIPTION
This PR adds a protected `getDefaultType()` method to FieldVariable. Scratch needs this to add menu items to the dropdown dependent on the type (list, regular variable, broadcast message) and it's conceivable that other subclasses may need this information as well, which is currently inaccessible to them.