### PR TITLE
fix: rename blocklyTreeLabel to blocklyToolboxCategoryLabel

### DIFF
--- a/core/toolbox/category.ts
+++ b/core/toolbox/category.ts
@@ -135,7 +135,7 @@ export class ToolboxCategory
       'row': 'blocklyTreeRow',
       'rowcontentcontainer': 'blocklyTreeRowContentContainer',
       'icon': 'blocklyTreeIcon',
-      'label': 'blocklyTreeLabel',
+      'label': 'blocklyToolboxCategoryLabel',
       'contents': 'blocklyToolboxContents',
       'selected': 'blocklyTreeSelected',
       'openicon': 'blocklyTreeIconOpen',
@@ -716,18 +716,18 @@ Css.register(`
   background-position: -16px -17px;
 }
 
-.blocklyTreeLabel {
+.blocklyToolboxCategoryLabel {
   cursor: default;
   font: 16px sans-serif;
   padding: 0 3px;
   vertical-align: middle;
 }
 
-.blocklyToolboxDelete .blocklyTreeLabel {
+.blocklyToolboxDelete .blocklyToolboxCategoryLabel {
   cursor: url("<<<PATH>>>/handdelete.cur"), auto;
 }
 
-.blocklyTreeSelected .blocklyTreeLabel {
+.blocklyTreeSelected .blocklyToolboxCategoryLabel {
   color: #fff;
 }
 `);


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What GitHub issue does this resolve? Please include a link. -->
Fixes [#8350](https://github.com/google/blockly/issues/8350)

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
This Pull Request renames all occurrences of the CSS class `blocklyTreeLabel` to `blocklyToolboxCategoryLabel` as specified in issue #8350. The change is made against the `rc/v12.0.0` branch and is marked as a breaking change due to its impact on CSS class names.

### Reason for Changes

<!-- TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
The rename improves code consistency and clarity, aligning the CSS class names with their intended usage within the Blockly project. The updated class name better reflects the role of the CSS in the toolbox category.

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->
The changes have been manually tested to ensure that all instances of the renamed class are correctly updated and that the styling remains consistent. No new unit tests are added since this change is primarily cosmetic.

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain. -->
No additional documentation is required for this change.

### Additional Information

<!-- Anything else we should know? -->
Please review the CSS changes to confirm that there are no unintended side effects. Ensure that all UI components using the `blocklyTreeLabel` class have been correctly updated to the new class name.

