### PR TITLE
fix: Update dev-tools, remove toolbox category tests Colour and Angles

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
       },
       "devDependencies": {
         "@blockly/block-test": "^6.0.4",
-        "@blockly/dev-tools": "^8.0.4",
+        "@blockly/dev-tools": "^8.0.6",
         "@blockly/theme-modern": "^6.0.3",
         "@hyperjump/browser": "^1.1.4",
         "@hyperjump/json-schema": "^1.5.0",
@@ -80,11 +80,10 @@
       }
     },
     "node_modules/@blockly/block-test": {
-      "version": "6.0.4",
-      "resolved": "https://registry.npmjs.org/@blockly/block-test/-/block-test-6.0.4.tgz",
-      "integrity": "sha512-T8uod/uIt3QSvS5nIRGTa6i3h/UZXWJPUOiNY+RW0/azHZLBSOH8udyw1a22u9iOSpA7gDmw3WBbFgooCytDcw==",
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/@blockly/block-test/-/block-test-6.0.5.tgz",
+      "integrity": "sha512-k71CGCM6A7XZFyFQL/cnZkylhtfCgf3wTTG9Jymt7bkGZR6jVV1FSZYk0vaZ4tj+T2goqc8gb9VA1Jn8YWmoFA==",
       "dev": true,
-      "license": "Apache 2.0",
       "engines": {
         "node": ">=8.17.0"
       },
@@ -93,17 +92,16 @@
       }
     },
     "node_modules/@blockly/dev-tools": {
-      "version": "8.0.4",
-      "resolved": "https://registry.npmjs.org/@blockly/dev-tools/-/dev-tools-8.0.4.tgz",
-      "integrity": "sha512-YTb3dj8msWWz4hfpQTRIE3NLX2xbTjkluuazA55jOBWSnkPRo0ZeCmjMVwOAG3GECBrjt3IanwuNIuwwBLkbkg==",
+      "version": "8.0.6",
+      "resolved": "https://registry.npmjs.org/@blockly/dev-tools/-/dev-tools-8.0.6.tgz",
+      "integrity": "sha512-jC/XG7KKHqt1evxW/2/cnEgNEUsAzigsFjPNqwgCTyouJTORMxPDx/+CDIo3VPfRf2XFkEb/+KecjZz4SC+ToA==",
       "dev": true,
-      "license": "Apache-2.0",
       "dependencies": {
-        "@blockly/block-test": "^6.0.4",
-        "@blockly/theme-dark": "^7.0.3",
-        "@blockly/theme-deuteranopia": "^6.0.3",
-        "@blockly/theme-highcontrast": "^6.0.3",
-        "@blockly/theme-tritanopia": "^6.0.3",
+        "@blockly/block-test": "^6.0.5",
+        "@blockly/theme-dark": "^7.0.4",
+        "@blockly/theme-deuteranopia": "^6.0.4",
+        "@blockly/theme-highcontrast": "^6.0.4",
+        "@blockly/theme-tritanopia": "^6.0.4",
         "chai": "^4.2.0",
         "dat.gui": "^0.7.7",
         "lodash.assign": "^4.2.0",
@@ -188,11 +186,10 @@
       }
     },
     "node_modules/@blockly/theme-dark": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/@blockly/theme-dark/-/theme-dark-7.0.3.tgz",
-      "integrity": "sha512-lRV9V5vjijbJAlUdZqtEhUt81OjHjZK8vagxir1cUqTrZ/+MNS2m7wkhIVPba4RWInJ1LY/nHEoQn6demZqRRQ==",
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/@blockly/theme-dark/-/theme-dark-7.0.4.tgz",
+      "integrity": "sha512-HJgP+3g5YYt8Zqe7DSstT0mM13BgsSKwuXNSD8iC7nNxldKu+uEWcoOdAIOy3oLifmnDJ6cYk924+KM6JLUnhQ==",
       "dev": true,
-      "license": "Apache-2.0",
       "engines": {
         "node": ">=8.17.0"
       },
@@ -201,11 +198,10 @@
       }
     },
     "node_modules/@blockly/theme-deuteranopia": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/@blockly/theme-deuteranopia/-/theme-deuteranopia-6.0.3.tgz",
-      "integrity": "sha512-56nkKRoRMzArtz14sMp4sQ8nd2oYQGToadAzx9JfOl0otx2RoeZLnMnZlKa6ZeTsdJXspPRfkrwHcSyuDTA/6g==",
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@blockly/theme-deuteranopia/-/theme-deuteranopia-6.0.4.tgz",
+      "integrity": "sha512-8nQ6Q+eRpHOA5ZSUWShPavYBE/TDzKrSEW5F2flpYTM/Yepyv55d8hKm/0ZxxKPbYO7deqx2iwfriAVFHwpDOQ==",
       "dev": true,
-      "license": "Apache-2.0",
       "engines": {
         "node": ">=8.17.0"
       },
@@ -214,11 +210,10 @@
       }
     },
     "node_modules/@blockly/theme-highcontrast": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/@blockly/theme-highcontrast/-/theme-highcontrast-6.0.3.tgz",
-      "integrity": "sha512-AXaB6ELmOZ+2z8ENbdaFDGVorNmcLn10JE9+fMICGTKBTs0T+N5LYH7q7dok04qrV3ZTrhw+rV8Xxp9tYio0Cw==",
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@blockly/theme-highcontrast/-/theme-highcontrast-6.0.4.tgz",
+      "integrity": "sha512-c9EBTQbOcBfOun8VRJsRNt8BvMI1Y6K2KZr6XIX4ur04O+XUMXixid8+4xceEajFSZd7IKB19CEwUkO3hjWXNQ==",
       "dev": true,
-      "license": "Apache-2.0",
       "engines": {
         "node": ">=8.17.0"
       },
@@ -240,11 +235,10 @@
       }
     },
     "node_modules/@blockly/theme-tritanopia": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/@blockly/theme-tritanopia/-/theme-tritanopia-6.0.3.tgz",
-      "integrity": "sha512-U4Y7WB2jzFQbNtt7D74gixfPHFBK0FW5CqGCFFOO+mHz2AfKHA+s/cZiVblYomhlA1938mvjzIxbdnafzmaCiw==",
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@blockly/theme-tritanopia/-/theme-tritanopia-6.0.4.tgz",
+      "integrity": "sha512-7bHo8tZcjL3xP7FM23R7kxJSN2K8kwn5KA0jx2GQ5gMbd+woHRo0VBXV/HeH5d6ulFTPUNoCb9XjuTVLRiW6zQ==",
       "dev": true,
-      "license": "Apache-2.0",
       "engines": {
         "node": ">=8.17.0"
       },
@@ -1504,24 +1498,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/@typescript-eslint/scope-manager": {
-      "version": "7.16.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-7.16.1.tgz",
-      "integrity": "sha512-nYpyv6ALte18gbMz323RM+vpFpTjfNdyakbf3nsLvF43uF9KeNC289SUEW3QLZ1xPtyINJ1dIsZOuWuSRIWygw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@typescript-eslint/types": "7.16.1",
-        "@typescript-eslint/visitor-keys": "7.16.1"
-      },
-      "engines": {
-        "node": "^18.18.0 || >=20.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
     "node_modules/@typescript-eslint/type-utils": {
       "version": "7.17.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-7.17.0.tgz",
@@ -1657,74 +1633,6 @@
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
-    "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "7.16.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-7.16.1.tgz",
-      "integrity": "sha512-0vFPk8tMjj6apaAZ1HlwM8w7jbghC8jc1aRNJG5vN8Ym5miyhTQGMqU++kuBFDNKe9NcPeZ6x0zfSzV8xC1UlQ==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "@typescript-eslint/types": "7.16.1",
-        "@typescript-eslint/visitor-keys": "7.16.1",
-        "debug": "^4.3.4",
-        "globby": "^11.1.0",
-        "is-glob": "^4.0.3",
-        "minimatch": "^9.0.4",
-        "semver": "^7.6.0",
-        "ts-api-utils": "^1.3.0"
-      },
-      "engines": {
-        "node": "^18.18.0 || >=20.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
-      "version": "7.6.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
-      "integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/@typescript-eslint/utils": {
       "version": "7.17.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-7.17.0.tgz",
@@ -1856,24 +1764,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "7.16.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-7.16.1.tgz",
-      "integrity": "sha512-Qlzzx4sE4u3FsHTPQAAQFJFNOuqtuY0LFrZHwQ8IHK705XxBiWOFkfKRWu6niB7hwfgnwIpO4jTC75ozW1PHWg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@typescript-eslint/types": "7.16.1",
-        "eslint-visitor-keys": "^3.4.3"
-      },
-      "engines": {
-        "node": "^18.18.0 || >=20.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
       }
     },
     "node_modules/@ungap/structured-clone": {

--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
   "license": "Apache-2.0",
   "devDependencies": {
     "@blockly/block-test": "^6.0.4",
-    "@blockly/dev-tools": "^8.0.4",
+    "@blockly/dev-tools": "^8.0.6",
     "@blockly/theme-modern": "^6.0.3",
     "@hyperjump/browser": "^1.1.4",
     "@hyperjump/json-schema": "^1.5.0",

--- a/tests/browser/test/toolbox_drag_test.mjs
+++ b/tests/browser/test/toolbox_drag_test.mjs
@@ -25,7 +25,6 @@ const basicCategories = [
   'Math',
   'Text',
   'Lists',
-  'Colour',
   'Variables',
   'Functions',
 ];
@@ -44,7 +43,6 @@ const testCategories = [
   // 'Fields',
   'Defaults',
   'Numbers',
-  'Angles',
   'Drop-downs',
   // Note: images has a block that has a bad image source, but still builds and renders
   // just fine.


### PR DESCRIPTION
## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

Addresses the issues described in: https://github.com/google/blockly/issues/8132

### Proposed Changes

Updates the dev-tools dependency, and removes references to obsolete toolbox categories `'Colour'` and `'Angles'`.

### Reason for Changes

dev-tools no longer references obsolete categories, and https://github.com/google/blockly-samples/pull/2346 removed test block categories.

### Test Coverage

Previously passing tests still pass. The `toolbox_drag_test.mjs` file in `npm run test:browser` was failing previously and is still failing, but less badly. In particular, the `'Drag'` test toolbox category is still failing even after my changes, because https://github.com/google/blockly-samples/pull/2377 added a test block to this category called `'drag_to_dupe'` that duplicates itself after dragging, which results in the workspace containing two top-level blocks after the drag, and the `toolbox_drag_test.mjs` test tries to validate that there's only one top block in the workspace after each drag.
