### PR TITLE
fix: Renamed the blocklyTreeIconClosed CSS class to blocklyToolboxCategoryIconClosed 

### DIFF
--- a/core/toolbox/category.ts
+++ b/core/toolbox/category.ts
@@ -138,7 +138,7 @@ export class ToolboxCategory
       'label': 'blocklyTreeLabel',
       'contents': 'blocklyToolboxCategoryGroup',
       'selected': 'blocklyTreeSelected',
-      'openicon': 'blocklyToolboxCategoryIconOpen',
+      'openicon': 'blocklyTreeIconOpen',
       'closedicon': 'blocklyTreeIconClosed',
     };
   }
@@ -692,19 +692,19 @@ Css.register(`
   width: 16px;
 }
 
-.blocklyTreeIconClosed {
+.blocklyToolboxCategoryIconClosed {
   background-position: -32px -1px;
 }
 
-.blocklyToolboxDiv[dir="RTL"] .blocklyTreeIconClosed {
+.blocklyToolboxDiv[dir="RTL"] .blocklyToolboxCategoryIconClosed {
   background-position: 0 -1px;
 }
 
-.blocklyTreeSelected>.blocklyTreeIconClosed {
+.blocklyTreeSelected>.blocklyToolboxCategoryIconClosed {
   background-position: -32px -17px;
 }
 
-.blocklyToolboxDiv[dir="RTL"] .blocklyTreeSelected>.blocklyTreeIconClosed {
+.blocklyToolboxDiv[dir="RTL"] .blocklyTreeSelected>.blocklyToolboxCategoryIconClosed {
   background-position: 0 -17px;
 }
 

--- a/core/toolbox/category.ts
+++ b/core/toolbox/category.ts
@@ -139,7 +139,7 @@ export class ToolboxCategory
       'contents': 'blocklyToolboxCategoryGroup',
       'selected': 'blocklyTreeSelected',
       'openicon': 'blocklyTreeIconOpen',
-      'closedicon': 'blocklyTreeIconClosed',
+      'closedicon': 'blocklyToolboxCategoryIconClosed',
     };
   }
 


### PR DESCRIPTION
# Issue -> https://github.com/google/blockly/issues/8349
fixes https://github.com/google/blockly/issues/8349
# Description:
This pull request addresses an issue with the naming convention of a CSS class within the `core/toolbox/category.ts` file. Specifically, the `blocklyTreeIconClosed` CSS class has been renamed to `blocklyToolboxCategoryIconClosed` for consistency and clarity. 

## Changes Made
- Updated the `blocklyTreeIconClosed` class name to `blocklyToolboxCategoryIconClosed` in the class assignment object.
- Adjusted the CSS rules to reflect the new class name.
  - Replaced all instances of `blocklyTreeIconClosed` with `blocklyToolboxCategoryIconClosed`.
  - Updated RTL-specific CSS rules to use the new class name.
  - Adjusted the `blocklyTreeSelected` class rules to work with the renamed class.

## Notes
- This change impacts the visual representation of closed toolbox categories within the Blockly interface.
- No functional behavior has been altered, only the class names have been updated for better readability and maintainability.
