### PR TITLE
fix!: Renamed the blocklyTreeSelected CSS class to blocklyToolboxSelected

### DIFF
--- a/core/toolbox/category.ts
+++ b/core/toolbox/category.ts
@@ -137,7 +137,7 @@ export class ToolboxCategory
       'icon': 'blocklyToolboxCategoryIcon',
       'label': 'blocklyTreeLabel',
       'contents': 'blocklyToolboxCategoryGroup',
-      'selected': 'blocklyTreeSelected',
+      'selected': 'blocklyToolboxSelected',
       'openicon': 'blocklyToolboxCategoryIconOpen',
       'closedicon': 'blocklyTreeIconClosed',
     };
@@ -659,7 +659,7 @@ export type CssConfig = ToolboxCategory.CssConfig;
 
 /** CSS for Toolbox.  See css.js for use. */
 Css.register(`
-.blocklyToolboxCategory:not(.blocklyTreeSelected):hover {
+.blocklyToolboxCategory:not(.blocklyToolboxSelected):hover {
   background-color: rgba(255, 255, 255, .2);
 }
 
@@ -700,11 +700,11 @@ Css.register(`
   background-position: 0 -1px;
 }
 
-.blocklyTreeSelected>.blocklyTreeIconClosed {
+.blocklyToolboxSelected>.blocklyTreeIconClosed {
   background-position: -32px -17px;
 }
 
-.blocklyToolboxDiv[dir="RTL"] .blocklyTreeSelected>.blocklyTreeIconClosed {
+.blocklyToolboxDiv[dir="RTL"] .blocklyToolboxSelected>.blocklyTreeIconClosed {
   background-position: 0 -17px;
 }
 
@@ -712,7 +712,7 @@ Css.register(`
   background-position: -16px -1px;
 }
 
-.blocklyTreeSelected>.blocklyToolboxCategoryIconOpen {
+.blocklyToolboxSelected>.blocklyToolboxCategoryIconOpen {
   background-position: -16px -17px;
 }
 
@@ -727,7 +727,7 @@ Css.register(`
   cursor: url("<<<PATH>>>/handdelete.cur"), auto;
 }
 
-.blocklyTreeSelected .blocklyTreeLabel {
+.blocklyToolboxSelected .blocklyTreeLabel {
   color: #fff;
 }
 `);


### PR DESCRIPTION
# Issue -> https://github.com/google/blockly/issues/8351
fixes https://github.com/google/blockly/issues/8351
# Description

This pull request updates the CSS class names associated with the selection state of toolbox categories in Blockly. The changes improve clarity and consistency by aligning the CSS class naming with the context in which they are used.

## Changes Made

- **Renamed CSS Classes:** Updated the CSS class name from `blocklyTreeSelected` to `blocklyToolboxSelected` across the relevant files. This change reflects the role of the class in styling the selected state of toolbox categories rather than tree elements.
  
- **CSS Style Updates:** Adjusted the CSS selectors to use the new class name, ensuring that all styling for selected toolbox categories remains functional.

### Motivation

The renaming of CSS classes enhances code readability and maintainability by making it clear which elements are being targeted for styling. It eliminates ambiguity and aligns with the conventions used throughout the codebase for naming CSS classes associated with toolbox components.
