### PR TITLE
fix!: deleted styles without associated classes from css.ts, issue #8285

### DIFF
--- a/core/css.ts
+++ b/core/css.ts
@@ -134,18 +134,6 @@ let content = `
   border-color: inherit;
 }
 
-.blocklyDropDownButton {
-  display: inline-block;
-  float: left;
-  padding: 0;
-  margin: 4px;
-  border-radius: 4px;
-  outline: none;
-  border: 1px solid;
-  transition: box-shadow .1s;
-  cursor: pointer;
-}
-
 .blocklyArrowTop {
   border-top: 1px solid;
   border-left: 1px solid;
@@ -158,21 +146,6 @@ let content = `
   border-right: 1px solid;
   border-bottom-right-radius: 4px;
   border-color: inherit;
-}
-
-.blocklyResizeSE {
-  cursor: se-resize;
-  fill: #aaa;
-}
-
-.blocklyResizeSW {
-  cursor: sw-resize;
-  fill: #aaa;
-}
-
-.blocklyResizeLine {
-  stroke: #515A5A;
-  stroke-width: 1;
 }
 
 .blocklyHighlightedConnectionPath {
@@ -268,10 +241,6 @@ let content = `
   -ms-user-select: none;
   -webkit-user-select: none;
   cursor: inherit;
-}
-
-.blocklyHidden {
-  display: none;
 }
 
 .blocklyFieldDropdown:not(.blocklyHidden) {


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics
- [x] I have validated my changes
- [x] (https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)
- [x] fix: deleted styles without associated classes from css.ts
- [x] The following styles have been deleted in this fix:
- [x]  1. blocklyHidden, 
         2. blocklyResizeLine
         3. blocklyResizeSW
         4. blocklyResizeSE
         5. blocklyDropDownButton
         
## The details
### Resolves
Fixes issue #8285 
Link: https://github.com/google/blockly/issues/8285

### Proposed Changes
I have deleted the styles blocklyHidden,  blocklyResizeLine, blocklyResizeSW, blocklyResizeSE and blocklyDropDownButton
from css.ts

### Reason for Changes
These styles are deleted as they are not used by any other classes

### Test Coverage
executed commands 
npm run build
npm run format and npm test commands.
All 10 tests passed

### Documentation
No documentation required

### Additional Information
