### PR TITLE
Issue#7428

### DIFF
--- a/core/css.ts
+++ b/core/css.ts
@@ -242,6 +242,10 @@ let content = `
   display: none;
 }
 
+.blocklyDisabled > .blocklyOutlinePath {
+  fill: darkgray !important;
+}
+
 .blocklyInsertionMarker>.blocklyPath,
 .blocklyInsertionMarker>.blocklyPathLight,
 .blocklyInsertionMarker>.blocklyPathDark {

--- a/core/field_label.ts
+++ b/core/field_label.ts
@@ -74,6 +74,9 @@ export class FieldLabel extends Field<string> {
     if (this.class) {
       dom.addClass(this.getTextElement(), this.class);
     }
+    if (this.fieldGroup_) {
+      dom.addClass(this.fieldGroup_, 'blocklyLabelField');
+    }
   }
 
   /**


### PR DESCRIPTION
## The basics

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

Fixes [#7428](https://github.com/google/blockly/issues/7428) - Zelos hides disabled blocks placeholders.

### Proposed Changes

This pull request addresses an issue where placeholders for disabled blocks were not visible in the Zelos renderer. The changes involve modifying the CSS to ensure that the placeholders are displayed consistently, similar to the behavior in the Geras renderer.

### Reason for Changes

The issue made it difficult for users to connect disabled blocks together, as the placeholders were not visible. This fix improves the usability of the Zelos renderer by ensuring that placeholders are always visible, even when blocks are disabled.

### Test Coverage

The changes were manually tested by:
- Disabling blocks in the Zelos renderer and confirming that the placeholders are visible.
- Comparing the behavior with the Geras renderer to ensure consistency.
- Testing across different browsers to confirm that the changes work as expected.

### Documentation

No additional documentation is needed, as this change only affects the internal CSS styling.

### Additional Information

None.
