### PR TITLE
feat: expose `bringToFront()` method

### DIFF
--- a/core/block_svg.ts
+++ b/core/block_svg.ts
@@ -1174,7 +1174,6 @@ export class BlockSvg
    *
    * @param blockOnly: True to only move this block to the front without
    *     adjusting its parents.
-   * @internal
    */
   bringToFront(blockOnly = false) {
     /* eslint-disable-next-line @typescript-eslint/no-this-alias */

--- a/core/block_svg.ts
+++ b/core/block_svg.ts
@@ -1174,7 +1174,7 @@ export class BlockSvg
    * Use sparingly, this method is expensive because it reorders the DOM
    * nodes.
    *
-   * @param blockOnly: True to only move this block to the front without
+   * @param blockOnly True to only move this block to the front without
    *     adjusting its parents.
    */
   bringToFront(blockOnly = false) {

--- a/core/block_svg.ts
+++ b/core/block_svg.ts
@@ -1171,6 +1171,8 @@ export class BlockSvg
    * <g> tags do not respect z-index so SVG renders them in the
    * order that they are in the DOM.  By placing this block first within the
    * block group's <g>, it will render on top of any other blocks.
+   * Use sparingly, this method is expensive because it reorders the DOM
+   * nodes.
    *
    * @param blockOnly: True to only move this block to the front without
    *     adjusting its parents.


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #8233 

### Proposed Changes

Removes the `@internal` from the JSDoc, adds some info about the cost of the function, and also removes an extra colon in the JSDoc.

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->

### Reason for Changes

Described in the original issue #8233 

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->

Tested manually with browser console in the playground (although I believe the function was working before this, as this change only relates to JSDoc).

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

Yes, documentation for [`BlockSvg`](https://developers.google.com/blockly/reference/js/blockly.blocksvg_class) should include the `bringToFront()` method.

### Additional Information

<!-- Anything else we should know? -->
