### PR TITLE
fix: Let workspace comment have delete cursor over trash.

### DIFF
--- a/core/comments/comment_view.ts
+++ b/core/comments/comment_view.ts
@@ -827,7 +827,6 @@ css.register(`
 }
 
 .blocklyCommentTopbarBackground {
-  cursor: grab;
   fill: var(--commentBorderColour);
   height: 24px;
 }


### PR DESCRIPTION
## The basics

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes https://github.com/google/blockly/issues/8413

### Proposed Changes

This removes an obsolete CSS property on the workspace comment top bar that overrides the mouse cursor style to be the grab cursor. Other CSS rules affecting the workspace comment have the same cursor, and additionally switch to a different cursor when dragging over the trash can, so removing this property allows those switches to take effect.

### Reason for Changes

The CSS property was added in https://github.com/google/blockly/commit/e4b734c0db537032a36ae907ba7af20bb5bb41f7 a couple months ago and was necessary at the time because there wasn't any other style at the time that provided the drag cursor for workspace comments. However,  https://github.com/google/blockly/commit/4cdca28fe5c92ce883cc597d517d01531bf8770e was added more recently and provides the drag cursor for the parent element along with the necessary variations, making the previous commit obsolete.

### Test Coverage

I manually tested the mouse cursor behavior for dragging workspace comments over the trash can.