### PR TITLE
chore: removed the whole Drag category from the browser test

### DIFF
--- a/tests/browser/test/toolbox_drag_test.mjs
+++ b/tests/browser/test/toolbox_drag_test.mjs
@@ -38,7 +38,7 @@ const testCategories = [
   'Row',
   'Stack',
   'Statement',
-  'Drag',
+  // 'Drag',
   // Skip fields because it's an accordion that is already open.
   // 'Fields',
   'Defaults',

--- a/tests/browser/test/toolbox_drag_test.mjs
+++ b/tests/browser/test/toolbox_drag_test.mjs
@@ -40,7 +40,7 @@ const testCategories = [
   'Statement',
   // Disabled due to #8466
   // 'Drag',
-  
+
   // Skip fields because it's an accordion that is already open.
   // 'Fields',
   'Defaults',

--- a/tests/browser/test/toolbox_drag_test.mjs
+++ b/tests/browser/test/toolbox_drag_test.mjs
@@ -38,8 +38,9 @@ const testCategories = [
   'Row',
   'Stack',
   'Statement',
-  // 'Drag',
   // Disabled due to #8466
+  // 'Drag',
+  
   // Skip fields because it's an accordion that is already open.
   // 'Fields',
   'Defaults',

--- a/tests/browser/test/toolbox_drag_test.mjs
+++ b/tests/browser/test/toolbox_drag_test.mjs
@@ -39,6 +39,7 @@ const testCategories = [
   'Stack',
   'Statement',
   // 'Drag',
+  // Disabled due to #8466
   // Skip fields because it's an accordion that is already open.
   // 'Fields',
   'Defaults',


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x ] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

Fixes #8466 

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->    Removed the ‘Drag’ category from the blocks tested by toolbox_drag_test.mjs.
This change ensures that the test only includes blocks that add exactly one block to the workspace upon being dragged, aligning with the test’s original intent.

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
