### PR TITLE
fix: improve prompting when deleting variables

### DIFF
--- a/blocks/variables.ts
+++ b/blocks/variables.ts
@@ -165,11 +165,12 @@ const deleteOptionCallbackFactory = function (
   block: VariableBlock,
 ): () => void {
   return function () {
-    const workspace = block.workspace;
     const variableField = block.getField('VAR') as FieldVariable;
-    const variable = variableField.getVariable()!;
-    workspace.deleteVariableById(variable.getId());
-    (workspace as WorkspaceSvg).refreshToolboxSelection();
+    const variable = variableField.getVariable();
+    if (variable) {
+      Variables.deleteVariable(variable.getWorkspace(), variable, block);
+    }
+    (block.workspace as WorkspaceSvg).refreshToolboxSelection();
   };
 };
 

--- a/blocks/variables_dynamic.ts
+++ b/blocks/variables_dynamic.ts
@@ -176,11 +176,12 @@ const renameOptionCallbackFactory = function (block: VariableBlock) {
  */
 const deleteOptionCallbackFactory = function (block: VariableBlock) {
   return function () {
-    const workspace = block.workspace;
     const variableField = block.getField('VAR') as FieldVariable;
-    const variable = variableField.getVariable()!;
-    workspace.deleteVariableById(variable.getId());
-    (workspace as WorkspaceSvg).refreshToolboxSelection();
+    const variable = variableField.getVariable();
+    if (variable) {
+      Variables.deleteVariable(variable.getWorkspace(), variable, block);
+    }
+    (block.workspace as WorkspaceSvg).refreshToolboxSelection();
   };
 };
 

--- a/core/field_variable.ts
+++ b/core/field_variable.ts
@@ -27,6 +27,7 @@ import * as fieldRegistry from './field_registry.js';
 import * as internalConstants from './internal_constants.js';
 import type {Menu} from './menu.js';
 import type {MenuItem} from './menuitem.js';
+import {WorkspaceSvg} from './workspace_svg.js';
 import {Msg} from './msg.js';
 import * as parsing from './utils/parsing.js';
 import {Size} from './utils/size.js';
@@ -514,7 +515,11 @@ export class FieldVariable extends FieldDropdown {
         return;
       } else if (id === internalConstants.DELETE_VARIABLE_ID && this.variable) {
         // Delete variable.
-        this.sourceBlock_.workspace.deleteVariableById(this.variable.getId());
+        const workspace = this.variable.getWorkspace();
+        Variables.deleteVariable(workspace, this.variable, this.sourceBlock_);
+        if (workspace instanceof WorkspaceSvg) {
+          workspace.refreshToolboxSelection();
+        }
         return;
       }
     }

--- a/core/flyout_button.ts
+++ b/core/flyout_button.ts
@@ -179,7 +179,7 @@ export class FlyoutButton implements IASTNodeLocationSvg {
       fontWeight,
       fontFamily,
     );
-    this.height = fontMetrics.height;
+    this.height = this.height || fontMetrics.height;
 
     if (!this.isFlyoutLabel) {
       this.width += 2 * FlyoutButton.TEXT_MARGIN_X;

--- a/core/variables.ts
+++ b/core/variables.ts
@@ -747,7 +747,7 @@ export function deleteVariable(
   if ((triggeringBlock && uses.length) || uses.length > 1) {
     // Confirm before deleting multiple blocks.
     const confirmText = Msg['DELETE_VARIABLE_CONFIRMATION']
-      .replace('%1', String(uses.length))
+      .replace('%1', String(uses.length + (triggeringBlock ? 1 : 0)))
       .replace('%2', variableName);
     dialog.confirm(confirmText, (ok) => {
       if (ok && variable) {

--- a/core/variables.ts
+++ b/core/variables.ts
@@ -744,7 +744,7 @@ export function deleteVariable(
     }
   }
 
-  if (uses.length) {
+  if ((triggeringBlock && uses.length) || uses.length > 1) {
     // Confirm before deleting multiple blocks.
     const confirmText = Msg['DELETE_VARIABLE_CONFIRMATION']
       .replace('%1', String(uses.length))
@@ -756,7 +756,8 @@ export function deleteVariable(
     });
   } else {
     // No confirmation necessary when the block that triggered the deletion is
-    // the only block referencing this variable.
+    // the only block referencing this variable or if only one block referencing
+    // this variable exists and the deletion was triggered programmatically.
     workspace.getVariableMap().deleteVariable(variable);
   }
 }


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

This PR resolves several issues when deleting variables:
* Fixes a regression introduced in v12 where deleting a variable from the menu in the flyout would prompt to confirm that you wanted to delete the other blocks referencing that variable in the flyout
* Fixes #8528, where deleting a variable from the menu in the flyout would not warn if only one block referencing that variable existed in the main workspace

### Proposed Changes
`Blockly.Variables.deleteVariable()` now takes an optional third argument, `triggeringBlock`, corresponding to the block that triggered the deletion, which is used to filter it out of the list of block references correctly when determining whether to prompt the user. Before, it simply assumed that if there was one reference that was the block that triggered the deletion, but deletion across the flyout/workspace boundary violated that assumption. For backwards compatibility, this arg is optional, and if not provided (legacy apps, or programmatic variable deletion) the old "warn if > 1 references" behavior is preserved.
