### PR TITLE
refactor(events): introduce `EventType` enum in separate module

### DIFF
--- a/core/block.ts
+++ b/core/block.ts
@@ -26,6 +26,7 @@ import * as constants from './constants.js';
 import type {Abstract} from './events/events_abstract.js';
 import type {BlockChange} from './events/events_block_change.js';
 import type {BlockMove} from './events/events_block_move.js';
+import {EventType} from './events/type.js';
 import * as eventUtils from './events/utils.js';
 import * as Extensions from './extensions.js';
 import type {Field} from './field.js';
@@ -304,7 +305,7 @@ export class Block implements IASTNodeLocation {
 
       // Fire a create event.
       if (eventUtils.isEnabled()) {
-        eventUtils.fire(new (eventUtils.get(eventUtils.BLOCK_CREATE))(this));
+        eventUtils.fire(new (eventUtils.get(EventType.BLOCK_CREATE))(this));
       }
     } finally {
       eventUtils.setGroup(existingGroup);
@@ -339,7 +340,7 @@ export class Block implements IASTNodeLocation {
     this.unplug(healStack);
     if (eventUtils.isEnabled()) {
       // Constructing the delete event is costly. Only perform if necessary.
-      eventUtils.fire(new (eventUtils.get(eventUtils.BLOCK_DELETE))(this));
+      eventUtils.fire(new (eventUtils.get(EventType.BLOCK_DELETE))(this));
     }
     this.workspace.removeTopBlock(this);
     this.disposeInternal();
@@ -1329,7 +1330,7 @@ export class Block implements IASTNodeLocation {
   setInputsInline(newBoolean: boolean) {
     if (this.inputsInline !== newBoolean) {
       eventUtils.fire(
-        new (eventUtils.get(eventUtils.BLOCK_CHANGE))(
+        new (eventUtils.get(EventType.BLOCK_CHANGE))(
           this,
           'inline',
           null,
@@ -1491,7 +1492,7 @@ export class Block implements IASTNodeLocation {
       } else {
         this.disabledReasons.delete(reason);
       }
-      const blockChangeEvent = new (eventUtils.get(eventUtils.BLOCK_CHANGE))(
+      const blockChangeEvent = new (eventUtils.get(EventType.BLOCK_CHANGE))(
         this,
         'disabled',
         /* name= */ null,
@@ -1559,7 +1560,7 @@ export class Block implements IASTNodeLocation {
   setCollapsed(collapsed: boolean) {
     if (this.collapsed_ !== collapsed) {
       eventUtils.fire(
-        new (eventUtils.get(eventUtils.BLOCK_CHANGE))(
+        new (eventUtils.get(EventType.BLOCK_CHANGE))(
           this,
           'collapsed',
           null,
@@ -2358,7 +2359,7 @@ export class Block implements IASTNodeLocation {
     }
 
     eventUtils.fire(
-      new (eventUtils.get(eventUtils.BLOCK_CHANGE))(
+      new (eventUtils.get(EventType.BLOCK_CHANGE))(
         this,
         'comment',
         null,
@@ -2458,12 +2459,8 @@ export class Block implements IASTNodeLocation {
     if (this.parentBlock_) {
       throw Error('Block has parent');
     }
-    const event = new (eventUtils.get(eventUtils.BLOCK_MOVE))(
-      this,
-    ) as BlockMove;
-    if (reason) {
-      event.setReason(reason);
-    }
+    const event = new (eventUtils.get(EventType.BLOCK_MOVE))(this) as BlockMove;
+    if (reason) event.setReason(reason);
     this.xy_.translate(dx, dy);
     event.recordNew();
     eventUtils.fire(event);

--- a/core/block_svg.ts
+++ b/core/block_svg.ts
@@ -32,6 +32,7 @@ import {
 } from './contextmenu_registry.js';
 import {BlockDragStrategy} from './dragging/block_drag_strategy.js';
 import type {BlockMove} from './events/events_block_move.js';
+import {EventType} from './events/type.js';
 import * as eventUtils from './events/utils.js';
 import type {Field} from './field.js';
 import {FieldLabel} from './field_label.js';
@@ -377,10 +378,8 @@ export class BlockSvg
     const eventsEnabled = eventUtils.isEnabled();
     let event: BlockMove | null = null;
     if (eventsEnabled) {
-      event = new (eventUtils.get(eventUtils.BLOCK_MOVE)!)(this) as BlockMove;
-      if (reason) {
-        event.setReason(reason);
-      }
+      event = new (eventUtils.get(EventType.BLOCK_MOVE)!)(this) as BlockMove;
+      if (reason) event.setReason(reason);
     }
 
     const delta = new Coordinate(dx, dy);

--- a/core/bump_objects.ts
+++ b/core/bump_objects.ts
@@ -14,6 +14,7 @@ import type {CommentCreate} from './events/events_comment_create.js';
 import type {CommentMove} from './events/events_comment_move.js';
 import type {CommentResize} from './events/events_comment_resize.js';
 import type {ViewportChange} from './events/events_viewport.js';
+import {BUMP_EVENTS, EventType} from './events/type.js';
 import * as eventUtils from './events/utils.js';
 import type {IBoundedElement} from './interfaces/i_bounded_element.js';
 import type {ContainerRegion} from './metrics_manager.js';
@@ -99,7 +100,7 @@ export function bumpIntoBoundsHandler(
       return;
     }
 
-    if (eventUtils.BUMP_EVENTS.includes(e.type ?? '')) {
+    if (BUMP_EVENTS.includes(e.type ?? '')) {
       const scrollMetricsInWsCoords = metricsManager.getScrollMetrics(true);
 
       // Triggered by move/create event
@@ -127,7 +128,7 @@ export function bumpIntoBoundsHandler(
         );
       }
       eventUtils.setGroup(existingGroup);
-    } else if (e.type === eventUtils.VIEWPORT_CHANGE) {
+    } else if (e.type === EventType.VIEWPORT_CHANGE) {
       const viewportEvent = e as ViewportChange;
       if (
         viewportEvent.scale &&
@@ -155,16 +156,16 @@ function extractObjectFromEvent(
 ): IBoundedElement | null {
   let object = null;
   switch (e.type) {
-    case eventUtils.BLOCK_CREATE:
-    case eventUtils.BLOCK_MOVE:
+    case EventType.BLOCK_CREATE:
+    case EventType.BLOCK_MOVE:
       object = workspace.getBlockById((e as BlockCreate | BlockMove).blockId!);
       if (object) {
         object = object.getRootBlock();
       }
       break;
-    case eventUtils.COMMENT_CREATE:
-    case eventUtils.COMMENT_MOVE:
-    case eventUtils.COMMENT_RESIZE:
+    case EventType.COMMENT_CREATE:
+    case EventType.COMMENT_MOVE:
+    case EventType.COMMENT_RESIZE:
       object = workspace.getCommentById(
         (e as CommentCreate | CommentMove | CommentResize).commentId!,
       ) as RenderedWorkspaceComment;

--- a/core/clipboard/block_paster.ts
+++ b/core/clipboard/block_paster.ts
@@ -7,6 +7,7 @@
 import {BlockSvg} from '../block_svg.js';
 import * as common from '../common.js';
 import {config} from '../config.js';
+import {EventType} from '../events/type.js';
 import * as eventUtils from '../events/utils.js';
 import {ICopyData} from '../interfaces/i_copyable.js';
 import {IPaster} from '../interfaces/i_paster.js';
@@ -52,7 +53,7 @@ export class BlockPaster implements IPaster<BlockCopyData, BlockSvg> {
     if (!block) return block;
 
     if (eventUtils.isEnabled() && !block.isShadow()) {
-      eventUtils.fire(new (eventUtils.get(eventUtils.BLOCK_CREATE))(block));
+      eventUtils.fire(new (eventUtils.get(EventType.BLOCK_CREATE))(block));
     }
     common.setSelected(block);
     return block;

--- a/core/clipboard/workspace_comment_paster.ts
+++ b/core/clipboard/workspace_comment_paster.ts
@@ -6,6 +6,7 @@
 
 import {RenderedWorkspaceComment} from '../comments/rendered_workspace_comment.js';
 import * as common from '../common.js';
+import {EventType} from '../events/type.js';
 import * as eventUtils from '../events/utils.js';
 import {ICopyData} from '../interfaces/i_copyable.js';
 import {IPaster} from '../interfaces/i_paster.js';
@@ -46,7 +47,7 @@ export class WorkspaceCommentPaster
     if (!comment) return null;
 
     if (eventUtils.isEnabled()) {
-      eventUtils.fire(new (eventUtils.get(eventUtils.COMMENT_CREATE))(comment));
+      eventUtils.fire(new (eventUtils.get(EventType.COMMENT_CREATE))(comment));
     }
     common.setSelected(comment);
     return comment;

--- a/core/comments/workspace_comment.ts
+++ b/core/comments/workspace_comment.ts
@@ -6,6 +6,7 @@
 
 import {CommentMove} from '../events/events_comment_move.js';
 import {CommentResize} from '../events/events_comment_resize.js';
+import {EventType} from '../events/type.js';
 import * as eventUtils from '../events/utils.js';
 import {Coordinate} from '../utils/coordinate.js';
 import * as idGenerator from '../utils/idgenerator.js';
@@ -63,13 +64,13 @@ export class WorkspaceComment {
 
   private fireCreateEvent() {
     if (eventUtils.isEnabled()) {
-      eventUtils.fire(new (eventUtils.get(eventUtils.COMMENT_CREATE))(this));
+      eventUtils.fire(new (eventUtils.get(EventType.COMMENT_CREATE))(this));
     }
   }
 
   private fireDeleteEvent() {
     if (eventUtils.isEnabled()) {
-      eventUtils.fire(new (eventUtils.get(eventUtils.COMMENT_DELETE))(this));
+      eventUtils.fire(new (eventUtils.get(EventType.COMMENT_DELETE))(this));
     }
   }
 
@@ -77,7 +78,7 @@ export class WorkspaceComment {
   private fireChangeEvent(oldText: string, newText: string) {
     if (eventUtils.isEnabled()) {
       eventUtils.fire(
-        new (eventUtils.get(eventUtils.COMMENT_CHANGE))(this, oldText, newText),
+        new (eventUtils.get(EventType.COMMENT_CHANGE))(this, oldText, newText),
       );
     }
   }
@@ -86,7 +87,7 @@ export class WorkspaceComment {
   private fireCollapseEvent(newCollapsed: boolean) {
     if (eventUtils.isEnabled()) {
       eventUtils.fire(
-        new (eventUtils.get(eventUtils.COMMENT_COLLAPSE))(this, newCollapsed),
+        new (eventUtils.get(EventType.COMMENT_COLLAPSE))(this, newCollapsed),
       );
     }
   }
@@ -105,7 +106,7 @@ export class WorkspaceComment {
 
   /** Sets the comment's size in workspace units. */
   setSize(size: Size) {
-    const event = new (eventUtils.get(eventUtils.COMMENT_RESIZE))(
+    const event = new (eventUtils.get(EventType.COMMENT_RESIZE))(
       this,
     ) as CommentResize;
 
@@ -196,7 +197,7 @@ export class WorkspaceComment {
 
   /** Moves the comment to the given location in workspace coordinates. */
   moveTo(location: Coordinate, reason?: string[] | undefined) {
-    const event = new (eventUtils.get(eventUtils.COMMENT_MOVE))(
+    const event = new (eventUtils.get(EventType.COMMENT_MOVE))(
       this,
     ) as CommentMove;
     if (reason) event.setReason(reason);

--- a/core/common.ts
+++ b/core/common.ts
@@ -10,6 +10,7 @@ import type {Block} from './block.js';
 import {ISelectable} from './blockly.js';
 import {BlockDefinition, Blocks} from './blocks.js';
 import type {Connection} from './connection.js';
+import {EventType} from './events/type.js';
 import * as eventUtils from './events/utils.js';
 import type {Workspace} from './workspace.js';
 import type {WorkspaceSvg} from './workspace_svg.js';
@@ -107,7 +108,7 @@ export function getSelected(): ISelectable | null {
 export function setSelected(newSelection: ISelectable | null) {
   if (selected === newSelection) return;
 
-  const event = new (eventUtils.get(eventUtils.SELECTED))(
+  const event = new (eventUtils.get(EventType.SELECTED))(
     selected?.id ?? null,
     newSelection?.id ?? null,
     newSelection?.workspace.id ?? selected?.workspace.id ?? '',

--- a/core/connection.ts
+++ b/core/connection.ts
@@ -14,6 +14,7 @@
 import type {Block} from './block.js';
 import {ConnectionType} from './connection_type.js';
 import type {BlockMove} from './events/events_block_move.js';
+import {EventType} from './events/type.js';
 import * as eventUtils from './events/utils.js';
 import type {Input} from './inputs/input.js';
 import type {IASTNodeLocationWithBlock} from './interfaces/i_ast_node_location_with_block.js';
@@ -114,7 +115,7 @@ export class Connection implements IASTNodeLocationWithBlock {
     // Connect the new connection to the parent.
     let event;
     if (eventUtils.isEnabled()) {
-      event = new (eventUtils.get(eventUtils.BLOCK_MOVE))(
+      event = new (eventUtils.get(EventType.BLOCK_MOVE))(
         childBlock,
       ) as BlockMove;
       event.setReason(['connect']);
@@ -281,7 +282,7 @@ export class Connection implements IASTNodeLocationWithBlock {
 
     let event;
     if (eventUtils.isEnabled()) {
-      event = new (eventUtils.get(eventUtils.BLOCK_MOVE))(
+      event = new (eventUtils.get(EventType.BLOCK_MOVE))(
         childConnection.getSourceBlock(),
       ) as BlockMove;
       event.setReason(['disconnect']);

--- a/core/contextmenu.ts
+++ b/core/contextmenu.ts
@@ -15,6 +15,7 @@ import type {
   ContextMenuOption,
   LegacyContextMenuOption,
 } from './contextmenu_registry.js';
+import {EventType} from './events/type.js';
 import * as eventUtils from './events/utils.js';
 import {Menu} from './menu.js';
 import {MenuItem} from './menuitem.js';
@@ -260,7 +261,7 @@ export function callbackFactory(
       eventUtils.enable();
     }
     if (eventUtils.isEnabled() && !newBlock.isShadow()) {
-      eventUtils.fire(new (eventUtils.get(eventUtils.BLOCK_CREATE))(newBlock));
+      eventUtils.fire(new (eventUtils.get(EventType.BLOCK_CREATE))(newBlock));
     }
     common.setSelected(newBlock);
     return newBlock;

--- a/core/dragging/block_drag_strategy.ts
+++ b/core/dragging/block_drag_strategy.ts
@@ -12,6 +12,7 @@ import {config} from '../config.js';
 import {Connection} from '../connection.js';
 import {ConnectionType} from '../connection_type.js';
 import type {BlockMove} from '../events/events_block_move.js';
+import {EventType} from '../events/type.js';
 import * as eventUtils from '../events/utils.js';
 import {IConnectionPreviewer} from '../interfaces/i_connection_previewer.js';
 import {IDragStrategy} from '../interfaces/i_draggable.js';
@@ -177,7 +178,7 @@ export class BlockDragStrategy implements IDragStrategy {
 
   /** Fire a UI event at the start of a block drag. */
   private fireDragStartEvent() {
-    const event = new (eventUtils.get(eventUtils.BLOCK_DRAG))(
+    const event = new (eventUtils.get(EventType.BLOCK_DRAG))(
       this.block,
       true,
       this.block.getDescendants(false),
@@ -187,7 +188,7 @@ export class BlockDragStrategy implements IDragStrategy {
 
   /** Fire a UI event at the end of a block drag. */
   private fireDragEndEvent() {
-    const event = new (eventUtils.get(eventUtils.BLOCK_DRAG))(
+    const event = new (eventUtils.get(EventType.BLOCK_DRAG))(
       this.block,
       false,
       this.block.getDescendants(false),
@@ -198,7 +199,7 @@ export class BlockDragStrategy implements IDragStrategy {
   /** Fire a move event at the end of a block drag. */
   private fireMoveEvent() {
     if (this.block.isDeadOrDying()) return;
-    const event = new (eventUtils.get(eventUtils.BLOCK_MOVE))(
+    const event = new (eventUtils.get(EventType.BLOCK_MOVE))(
       this.block,
     ) as BlockMove;
     event.setReason(['drag']);

--- a/core/dragging/comment_drag_strategy.ts
+++ b/core/dragging/comment_drag_strategy.ts
@@ -6,6 +6,7 @@
 
 import {RenderedWorkspaceComment} from '../comments.js';
 import {CommentMove} from '../events/events_comment_move.js';
+import {EventType} from '../events/type.js';
 import * as eventUtils from '../events/utils.js';
 import {IDragStrategy} from '../interfaces/i_draggable.js';
 import * as layers from '../layers.js';
@@ -63,7 +64,7 @@ export class CommentDragStrategy implements IDragStrategy {
 
   /** Fire a UI event at the start of a comment drag. */
   private fireDragStartEvent() {
-    const event = new (eventUtils.get(eventUtils.COMMENT_DRAG))(
+    const event = new (eventUtils.get(EventType.COMMENT_DRAG))(
       this.comment,
       true,
     );
@@ -72,7 +73,7 @@ export class CommentDragStrategy implements IDragStrategy {
 
   /** Fire a UI event at the end of a comment drag. */
   private fireDragEndEvent() {
-    const event = new (eventUtils.get(eventUtils.COMMENT_DRAG))(
+    const event = new (eventUtils.get(EventType.COMMENT_DRAG))(
       this.comment,
       false,
     );
@@ -82,7 +83,7 @@ export class CommentDragStrategy implements IDragStrategy {
   /** Fire a move event at the end of a comment drag. */
   private fireMoveEvent() {
     if (this.comment.isDeadOrDying()) return;
-    const event = new (eventUtils.get(eventUtils.COMMENT_MOVE))(
+    const event = new (eventUtils.get(EventType.COMMENT_MOVE))(
       this.comment,
     ) as CommentMove;
     event.setReason(['drag']);

--- a/core/events/events.ts
+++ b/core/events/events.ts
@@ -6,7 +6,7 @@
 
 // Former goog.module ID: Blockly.Events
 
-import * as eventUtils from './utils.js';
+import {EventType} from './type.js';
 
 // Events.
 export {Abstract, AbstractEventJson} from './events_abstract.js';
@@ -52,37 +52,42 @@ export {FinishedLoading} from './workspace_events.js';
 export type {BumpEvent} from './utils.js';
 
 // Event types.
-export const BLOCK_CHANGE = eventUtils.BLOCK_CHANGE;
-export const BLOCK_CREATE = eventUtils.BLOCK_CREATE;
-export const BLOCK_DELETE = eventUtils.BLOCK_DELETE;
-export const BLOCK_DRAG = eventUtils.BLOCK_DRAG;
-export const BLOCK_MOVE = eventUtils.BLOCK_MOVE;
+export const BLOCK_CHANGE = EventType.BLOCK_CHANGE;
+export const BLOCK_CREATE = EventType.BLOCK_CREATE;
+export const BLOCK_DELETE = EventType.BLOCK_DELETE;
+export const BLOCK_DRAG = EventType.BLOCK_DRAG;
+export const BLOCK_MOVE = EventType.BLOCK_MOVE;
 export const BLOCK_FIELD_INTERMEDIATE_CHANGE =
-  eventUtils.BLOCK_FIELD_INTERMEDIATE_CHANGE;
-export const BUBBLE_OPEN = eventUtils.BUBBLE_OPEN;
-export const BUMP_EVENTS = eventUtils.BUMP_EVENTS;
-export const CHANGE = eventUtils.CHANGE;
-export const CLICK = eventUtils.CLICK;
-export const COMMENT_CHANGE = eventUtils.COMMENT_CHANGE;
-export const COMMENT_CREATE = eventUtils.COMMENT_CREATE;
-export const COMMENT_DELETE = eventUtils.COMMENT_DELETE;
-export const COMMENT_MOVE = eventUtils.COMMENT_MOVE;
-export const COMMENT_RESIZE = eventUtils.COMMENT_RESIZE;
-export const COMMENT_DRAG = eventUtils.COMMENT_DRAG;
-export const CREATE = eventUtils.CREATE;
-export const DELETE = eventUtils.DELETE;
-export const FINISHED_LOADING = eventUtils.FINISHED_LOADING;
-export const MARKER_MOVE = eventUtils.MARKER_MOVE;
-export const MOVE = eventUtils.MOVE;
-export const SELECTED = eventUtils.SELECTED;
-export const THEME_CHANGE = eventUtils.THEME_CHANGE;
-export const TOOLBOX_ITEM_SELECT = eventUtils.TOOLBOX_ITEM_SELECT;
-export const TRASHCAN_OPEN = eventUtils.TRASHCAN_OPEN;
-export const UI = eventUtils.UI;
-export const VAR_CREATE = eventUtils.VAR_CREATE;
-export const VAR_DELETE = eventUtils.VAR_DELETE;
-export const VAR_RENAME = eventUtils.VAR_RENAME;
-export const VIEWPORT_CHANGE = eventUtils.VIEWPORT_CHANGE;
+  EventType.BLOCK_FIELD_INTERMEDIATE_CHANGE;
+export const BUBBLE_OPEN = EventType.BUBBLE_OPEN;
+/** @deprecated Use BLOCK_CHANGE instead */
+export const CHANGE = EventType.BLOCK_CHANGE;
+export const CLICK = EventType.CLICK;
+export const COMMENT_CHANGE = EventType.COMMENT_CHANGE;
+export const COMMENT_CREATE = EventType.COMMENT_CREATE;
+export const COMMENT_DELETE = EventType.COMMENT_DELETE;
+export const COMMENT_MOVE = EventType.COMMENT_MOVE;
+export const COMMENT_RESIZE = EventType.COMMENT_RESIZE;
+export const COMMENT_DRAG = EventType.COMMENT_DRAG;
+/** @deprecated Use BLOCK_CREATE instead */
+export const CREATE = EventType.BLOCK_CREATE;
+/** @deprecated Use BLOCK_DELETE instead */
+export const DELETE = EventType.BLOCK_DELETE;
+export const FINISHED_LOADING = EventType.FINISHED_LOADING;
+export const MARKER_MOVE = EventType.MARKER_MOVE;
+/** @deprecated Use BLOCK_MOVE instead */
+export const MOVE = EventType.BLOCK_MOVE;
+export const SELECTED = EventType.SELECTED;
+export const THEME_CHANGE = EventType.THEME_CHANGE;
+export const TOOLBOX_ITEM_SELECT = EventType.TOOLBOX_ITEM_SELECT;
+export const TRASHCAN_OPEN = EventType.TRASHCAN_OPEN;
+export const UI = EventType.UI;
+export const VAR_CREATE = EventType.VAR_CREATE;
+export const VAR_DELETE = EventType.VAR_DELETE;
+export const VAR_RENAME = EventType.VAR_RENAME;
+export const VIEWPORT_CHANGE = EventType.VIEWPORT_CHANGE;
+
+export {BUMP_EVENTS} from './type.js';
 
 // Event utils.
 export {

--- a/core/events/events.ts
+++ b/core/events/events.ts
@@ -6,109 +6,50 @@
 
 // Former goog.module ID: Blockly.Events
 
-import {Abstract, AbstractEventJson} from './events_abstract.js';
-import {BlockBase, BlockBaseJson} from './events_block_base.js';
-import {BlockChange, BlockChangeJson} from './events_block_change.js';
-import {BlockCreate, BlockCreateJson} from './events_block_create.js';
-import {BlockDelete, BlockDeleteJson} from './events_block_delete.js';
-import {BlockDrag, BlockDragJson} from './events_block_drag.js';
-import {
+import * as eventUtils from './utils.js';
+
+// Events.
+export {Abstract, AbstractEventJson} from './events_abstract.js';
+export {BlockBase, BlockBaseJson} from './events_block_base.js';
+export {BlockChange, BlockChangeJson} from './events_block_change.js';
+export {BlockCreate, BlockCreateJson} from './events_block_create.js';
+export {BlockDelete, BlockDeleteJson} from './events_block_delete.js';
+export {BlockDrag, BlockDragJson} from './events_block_drag.js';
+export {
   BlockFieldIntermediateChange,
   BlockFieldIntermediateChangeJson,
 } from './events_block_field_intermediate_change.js';
-import {BlockMove, BlockMoveJson} from './events_block_move.js';
-import {BubbleOpen, BubbleOpenJson, BubbleType} from './events_bubble_open.js';
-import {Click, ClickJson, ClickTarget} from './events_click.js';
-import {CommentBase, CommentBaseJson} from './events_comment_base.js';
-import {CommentChange, CommentChangeJson} from './events_comment_change.js';
-import {
+export {BlockMove, BlockMoveJson} from './events_block_move.js';
+export {BubbleOpen, BubbleOpenJson, BubbleType} from './events_bubble_open.js';
+export {Click, ClickJson, ClickTarget} from './events_click.js';
+export {CommentBase, CommentBaseJson} from './events_comment_base.js';
+export {CommentChange, CommentChangeJson} from './events_comment_change.js';
+export {
   CommentCollapse,
   CommentCollapseJson,
 } from './events_comment_collapse.js';
-import {CommentCreate, CommentCreateJson} from './events_comment_create.js';
-import {CommentDelete} from './events_comment_delete.js';
-import {CommentDrag, CommentDragJson} from './events_comment_drag.js';
-import {CommentMove, CommentMoveJson} from './events_comment_move.js';
-import {CommentResize, CommentResizeJson} from './events_comment_resize.js';
-import {MarkerMove, MarkerMoveJson} from './events_marker_move.js';
-import {Selected, SelectedJson} from './events_selected.js';
-import {ThemeChange, ThemeChangeJson} from './events_theme_change.js';
-import {
+export {CommentCreate, CommentCreateJson} from './events_comment_create.js';
+export {CommentDelete} from './events_comment_delete.js';
+export {CommentDrag, CommentDragJson} from './events_comment_drag.js';
+export {CommentMove, CommentMoveJson} from './events_comment_move.js';
+export {CommentResize, CommentResizeJson} from './events_comment_resize.js';
+export {MarkerMove, MarkerMoveJson} from './events_marker_move.js';
+export {Selected, SelectedJson} from './events_selected.js';
+export {ThemeChange, ThemeChangeJson} from './events_theme_change.js';
+export {
   ToolboxItemSelect,
   ToolboxItemSelectJson,
 } from './events_toolbox_item_select.js';
-import {TrashcanOpen, TrashcanOpenJson} from './events_trashcan_open.js';
-import {UiBase} from './events_ui_base.js';
-import {VarBase, VarBaseJson} from './events_var_base.js';
-import {VarCreate, VarCreateJson} from './events_var_create.js';
-import {VarDelete, VarDeleteJson} from './events_var_delete.js';
-import {VarRename, VarRenameJson} from './events_var_rename.js';
-import {ViewportChange, ViewportChangeJson} from './events_viewport.js';
-import * as eventUtils from './utils.js';
-import {FinishedLoading} from './workspace_events.js';
+export {TrashcanOpen, TrashcanOpenJson} from './events_trashcan_open.js';
+export {UiBase} from './events_ui_base.js';
+export {VarBase, VarBaseJson} from './events_var_base.js';
+export {VarCreate, VarCreateJson} from './events_var_create.js';
+export {VarDelete, VarDeleteJson} from './events_var_delete.js';
+export {VarRename, VarRenameJson} from './events_var_rename.js';
+export {ViewportChange, ViewportChangeJson} from './events_viewport.js';
+export {FinishedLoading} from './workspace_events.js';
 
-// Events.
-export {
-  Abstract,
-  AbstractEventJson,
-  BlockBase,
-  BlockBaseJson,
-  BlockChange,
-  BlockChangeJson,
-  BlockCreate,
-  BlockCreateJson,
-  BlockDelete,
-  BlockDeleteJson,
-  BlockDrag,
-  BlockDragJson,
-  BlockFieldIntermediateChange,
-  BlockFieldIntermediateChangeJson,
-  BlockMove,
-  BlockMoveJson,
-  BubbleOpen,
-  BubbleOpenJson,
-  BubbleType,
-  Click,
-  ClickJson,
-  ClickTarget,
-  CommentBase,
-  CommentBaseJson,
-  CommentChange,
-  CommentChangeJson,
-  CommentCollapse,
-  CommentCollapseJson,
-  CommentCreate,
-  CommentCreateJson,
-  CommentDelete,
-  CommentDrag,
-  CommentDragJson,
-  CommentMove,
-  CommentMoveJson,
-  CommentResize,
-  CommentResizeJson,
-  FinishedLoading,
-  MarkerMove,
-  MarkerMoveJson,
-  Selected,
-  SelectedJson,
-  ThemeChange,
-  ThemeChangeJson,
-  ToolboxItemSelect,
-  ToolboxItemSelectJson,
-  TrashcanOpen,
-  TrashcanOpenJson,
-  UiBase,
-  VarBase,
-  VarBaseJson,
-  VarCreate,
-  VarCreateJson,
-  VarDelete,
-  VarDeleteJson,
-  VarRename,
-  VarRenameJson,
-  ViewportChange,
-  ViewportChangeJson,
-};
+export type {BumpEvent} from './utils.js';
 
 // Event types.
 export const BLOCK_CHANGE = eventUtils.BLOCK_CHANGE;
@@ -119,7 +60,6 @@ export const BLOCK_MOVE = eventUtils.BLOCK_MOVE;
 export const BLOCK_FIELD_INTERMEDIATE_CHANGE =
   eventUtils.BLOCK_FIELD_INTERMEDIATE_CHANGE;
 export const BUBBLE_OPEN = eventUtils.BUBBLE_OPEN;
-export type BumpEvent = eventUtils.BumpEvent;
 export const BUMP_EVENTS = eventUtils.BUMP_EVENTS;
 export const CHANGE = eventUtils.CHANGE;
 export const CLICK = eventUtils.CLICK;
@@ -145,17 +85,19 @@ export const VAR_RENAME = eventUtils.VAR_RENAME;
 export const VIEWPORT_CHANGE = eventUtils.VIEWPORT_CHANGE;
 
 // Event utils.
-export const clearPendingUndo = eventUtils.clearPendingUndo;
-export const disable = eventUtils.disable;
-export const enable = eventUtils.enable;
-export const filter = eventUtils.filter;
-export const fire = eventUtils.fire;
-export const fromJson = eventUtils.fromJson;
-export const getDescendantIds = eventUtils.getDescendantIds;
-export const get = eventUtils.get;
-export const getGroup = eventUtils.getGroup;
-export const getRecordUndo = eventUtils.getRecordUndo;
-export const isEnabled = eventUtils.isEnabled;
-export const setGroup = eventUtils.setGroup;
-export const setRecordUndo = eventUtils.setRecordUndo;
-export const disableOrphans = eventUtils.disableOrphans;
+export {
+  clearPendingUndo,
+  disable,
+  disableOrphans,
+  enable,
+  filter,
+  fire,
+  fromJson,
+  get,
+  getDescendantIds,
+  getGroup,
+  getRecordUndo,
+  isEnabled,
+  setGroup,
+  setRecordUndo,
+} from './utils.js';

--- a/core/events/events_abstract.ts
+++ b/core/events/events_abstract.ts
@@ -14,7 +14,7 @@
 
 import * as common from '../common.js';
 import type {Workspace} from '../workspace.js';
-import * as eventUtils from './utils.js';
+import {getGroup, getRecordUndo} from './utils.js';
 
 /**
  * Abstract class for an event.
@@ -47,8 +47,8 @@ export abstract class Abstract {
   type = '';
 
   constructor() {
-    this.group = eventUtils.getGroup();
-    this.recordUndo = eventUtils.getRecordUndo();
+    this.group = getGroup();
+    this.recordUndo = getRecordUndo();
   }
 
   /**

--- a/core/events/events_block_change.ts
+++ b/core/events/events_block_change.ts
@@ -21,6 +21,7 @@ import * as utilsXml from '../utils/xml.js';
 import {Workspace} from '../workspace.js';
 import * as Xml from '../xml.js';
 import {BlockBase, BlockBaseJson} from './events_block_base.js';
+import {EventType} from './type.js';
 import * as eventUtils from './utils.js';
 
 /**
@@ -28,7 +29,7 @@ import * as eventUtils from './utils.js';
  * field values, comments, etc).
  */
 export class BlockChange extends BlockBase {
-  override type = eventUtils.BLOCK_CHANGE;
+  override type = EventType.BLOCK_CHANGE;
   /**
    * The element that changed; one of 'field', 'comment', 'collapsed',
    * 'disabled', 'inline', or 'mutation'
@@ -255,4 +256,4 @@ export interface BlockChangeJson extends BlockBaseJson {
   disabledReason?: string;
 }
 
-registry.register(registry.Type.EVENT, eventUtils.CHANGE, BlockChange);
+registry.register(registry.Type.EVENT, EventType.BLOCK_CHANGE, BlockChange);

--- a/core/events/events_block_create.ts
+++ b/core/events/events_block_create.ts
@@ -18,6 +18,7 @@ import * as utilsXml from '../utils/xml.js';
 import {Workspace} from '../workspace.js';
 import * as Xml from '../xml.js';
 import {BlockBase, BlockBaseJson} from './events_block_base.js';
+import {EventType} from './type.js';
 import * as eventUtils from './utils.js';
 
 /**
@@ -25,7 +26,7 @@ import * as eventUtils from './utils.js';
  * created.
  */
 export class BlockCreate extends BlockBase {
-  override type = eventUtils.BLOCK_CREATE;
+  override type = EventType.BLOCK_CREATE;
 
   /** The XML representation of the created block(s). */
   xml?: Element | DocumentFragment;
@@ -181,4 +182,4 @@ export interface BlockCreateJson extends BlockBaseJson {
   recordUndo?: boolean;
 }
 
-registry.register(registry.Type.EVENT, eventUtils.CREATE, BlockCreate);
+registry.register(registry.Type.EVENT, EventType.BLOCK_CREATE, BlockCreate);

--- a/core/events/events_block_delete.ts
+++ b/core/events/events_block_delete.ts
@@ -18,6 +18,7 @@ import * as utilsXml from '../utils/xml.js';
 import {Workspace} from '../workspace.js';
 import * as Xml from '../xml.js';
 import {BlockBase, BlockBaseJson} from './events_block_base.js';
+import {EventType} from './type.js';
 import * as eventUtils from './utils.js';
 
 /**
@@ -37,7 +38,7 @@ export class BlockDelete extends BlockBase {
   /** True if the deleted block was a shadow block, false otherwise. */
   wasShadow?: boolean;
 
-  override type = eventUtils.BLOCK_DELETE;
+  override type = EventType.BLOCK_DELETE;
 
   /** @param opt_block The deleted block.  Undefined for a blank event. */
   constructor(opt_block?: Block) {
@@ -178,4 +179,4 @@ export interface BlockDeleteJson extends BlockBaseJson {
   recordUndo?: boolean;
 }
 
-registry.register(registry.Type.EVENT, eventUtils.DELETE, BlockDelete);
+registry.register(registry.Type.EVENT, EventType.BLOCK_DELETE, BlockDelete);

--- a/core/events/events_block_drag.ts
+++ b/core/events/events_block_drag.ts
@@ -16,7 +16,7 @@ import * as registry from '../registry.js';
 import {Workspace} from '../workspace.js';
 import {AbstractEventJson} from './events_abstract.js';
 import {UiBase} from './events_ui_base.js';
-import * as eventUtils from './utils.js';
+import {EventType} from './type.js';
 
 /**
  * Notifies listeners when a block is being manually dragged/dropped.
@@ -34,7 +34,7 @@ export class BlockDrag extends UiBase {
    */
   blocks?: Block[];
 
-  override type = eventUtils.BLOCK_DRAG;
+  override type = EventType.BLOCK_DRAG;
 
   /**
    * @param opt_block The top block in the stack that is being dragged.
@@ -113,4 +113,4 @@ export interface BlockDragJson extends AbstractEventJson {
   blocks?: Block[];
 }
 
-registry.register(registry.Type.EVENT, eventUtils.BLOCK_DRAG, BlockDrag);
+registry.register(registry.Type.EVENT, EventType.BLOCK_DRAG, BlockDrag);

--- a/core/events/events_block_field_intermediate_change.ts
+++ b/core/events/events_block_field_intermediate_change.ts
@@ -16,7 +16,7 @@ import type {Block} from '../block.js';
 import * as registry from '../registry.js';
 import {Workspace} from '../workspace.js';
 import {BlockBase, BlockBaseJson} from './events_block_base.js';
-import * as eventUtils from './utils.js';
+import {EventType} from './type.js';
 
 /**
  * Notifies listeners when the value of a block's field has changed but the
@@ -24,7 +24,7 @@ import * as eventUtils from './utils.js';
  * event.
  */
 export class BlockFieldIntermediateChange extends BlockBase {
-  override type = eventUtils.BLOCK_FIELD_INTERMEDIATE_CHANGE;
+  override type = EventType.BLOCK_FIELD_INTERMEDIATE_CHANGE;
 
   // Intermediate events do not undo or redo. They may be fired frequently while
   // the field editor widget is open. A separate BLOCK_CHANGE event is fired
@@ -161,6 +161,6 @@ export interface BlockFieldIntermediateChangeJson extends BlockBaseJson {
 
 registry.register(
   registry.Type.EVENT,
-  eventUtils.BLOCK_FIELD_INTERMEDIATE_CHANGE,
+  EventType.BLOCK_FIELD_INTERMEDIATE_CHANGE,
   BlockFieldIntermediateChange,
 );

--- a/core/events/events_block_move.ts
+++ b/core/events/events_block_move.ts
@@ -17,7 +17,7 @@ import * as registry from '../registry.js';
 import {Coordinate} from '../utils/coordinate.js';
 import type {Workspace} from '../workspace.js';
 import {BlockBase, BlockBaseJson} from './events_block_base.js';
-import * as eventUtils from './utils.js';
+import {EventType} from './type.js';
 
 interface BlockLocation {
   parentId?: string;
@@ -30,7 +30,7 @@ interface BlockLocation {
  * connection to another, or from one location on the workspace to another.
  */
 export class BlockMove extends BlockBase {
-  override type = eventUtils.BLOCK_MOVE;
+  override type = EventType.BLOCK_MOVE;
 
   /** The ID of the old parent block. Undefined if it was a top-level block. */
   oldParentId?: string;
@@ -303,4 +303,4 @@ export interface BlockMoveJson extends BlockBaseJson {
   recordUndo?: boolean;
 }
 
-registry.register(registry.Type.EVENT, eventUtils.MOVE, BlockMove);
+registry.register(registry.Type.EVENT, EventType.BLOCK_MOVE, BlockMove);

--- a/core/events/events_bubble_open.ts
+++ b/core/events/events_bubble_open.ts
@@ -9,6 +9,7 @@
  *
  * @class
  */
+
 // Former goog.module ID: Blockly.Events.BubbleOpen
 
 import type {BlockSvg} from '../block_svg.js';
@@ -16,7 +17,7 @@ import * as registry from '../registry.js';
 import type {Workspace} from '../workspace.js';
 import type {AbstractEventJson} from './events_abstract.js';
 import {UiBase} from './events_ui_base.js';
-import * as eventUtils from './utils.js';
+import {EventType} from './type.js';
 
 /**
  * Class for a bubble open event.
@@ -31,7 +32,7 @@ export class BubbleOpen extends UiBase {
   /** The type of bubble; one of 'mutator', 'comment', or 'warning'. */
   bubbleType?: BubbleType;
 
-  override type = eventUtils.BUBBLE_OPEN;
+  override type = EventType.BUBBLE_OPEN;
 
   /**
    * @param opt_block The associated block. Undefined for a blank event.
@@ -117,4 +118,4 @@ export interface BubbleOpenJson extends AbstractEventJson {
   blockId: string;
 }
 
-registry.register(registry.Type.EVENT, eventUtils.BUBBLE_OPEN, BubbleOpen);
+registry.register(registry.Type.EVENT, EventType.BUBBLE_OPEN, BubbleOpen);

--- a/core/events/events_click.ts
+++ b/core/events/events_click.ts
@@ -9,6 +9,7 @@
  *
  * @class
  */
+
 // Former goog.module ID: Blockly.Events.Click
 
 import type {Block} from '../block.js';
@@ -16,7 +17,7 @@ import * as registry from '../registry.js';
 import {Workspace} from '../workspace.js';
 import {AbstractEventJson} from './events_abstract.js';
 import {UiBase} from './events_ui_base.js';
-import * as eventUtils from './utils.js';
+import {EventType} from './type.js';
 
 /**
  * Notifies listeners that some blockly element was clicked.
@@ -30,7 +31,7 @@ export class Click extends UiBase {
    * or 'zoom_controls'.
    */
   targetType?: ClickTarget;
-  override type = eventUtils.CLICK;
+  override type = EventType.CLICK;
 
   /**
    * @param opt_block The affected block. Null for click events that do not have
@@ -106,4 +107,4 @@ export interface ClickJson extends AbstractEventJson {
   blockId?: string;
 }
 
-registry.register(registry.Type.EVENT, eventUtils.CLICK, Click);
+registry.register(registry.Type.EVENT, EventType.CLICK, Click);

--- a/core/events/events_comment_base.ts
+++ b/core/events/events_comment_base.ts
@@ -20,7 +20,7 @@ import {
 } from './events_abstract.js';
 import type {CommentCreate} from './events_comment_create.js';
 import type {CommentDelete} from './events_comment_delete.js';
-import * as eventUtils from './utils.js';
+import {getGroup, getRecordUndo} from './utils.js';
 
 /**
  * Abstract class for a comment event.
@@ -44,8 +44,8 @@ export class CommentBase extends AbstractEvent {
 
     this.commentId = opt_comment.id;
     this.workspaceId = opt_comment.workspace.id;
-    this.group = eventUtils.getGroup();
-    this.recordUndo = eventUtils.getRecordUndo();
+    this.group = getGroup();
+    this.recordUndo = getRecordUndo();
   }
 
   /**

--- a/core/events/events_comment_change.ts
+++ b/core/events/events_comment_change.ts
@@ -15,13 +15,13 @@ import type {WorkspaceComment} from '../comments/workspace_comment.js';
 import * as registry from '../registry.js';
 import type {Workspace} from '../workspace.js';
 import {CommentBase, CommentBaseJson} from './events_comment_base.js';
-import * as eventUtils from './utils.js';
+import {EventType} from './type.js';
 
 /**
  * Notifies listeners that the contents of a workspace comment has changed.
  */
 export class CommentChange extends CommentBase {
-  override type = eventUtils.COMMENT_CHANGE;
+  override type = EventType.COMMENT_CHANGE;
 
   // TODO(#6774): We should remove underscores.
   /** The previous contents of the comment. */
@@ -153,8 +153,4 @@ export interface CommentChangeJson extends CommentBaseJson {
   newContents: string;
 }
 
-registry.register(
-  registry.Type.EVENT,
-  eventUtils.COMMENT_CHANGE,
-  CommentChange,
-);
+registry.register(registry.Type.EVENT, EventType.COMMENT_CHANGE, CommentChange);

--- a/core/events/events_comment_collapse.ts
+++ b/core/events/events_comment_collapse.ts
@@ -8,10 +8,10 @@ import {WorkspaceComment} from '../comments/workspace_comment.js';
 import * as registry from '../registry.js';
 import type {Workspace} from '../workspace.js';
 import {CommentBase, CommentBaseJson} from './events_comment_base.js';
-import * as eventUtils from './utils.js';
+import {EventType} from './type.js';
 
 export class CommentCollapse extends CommentBase {
-  override type = eventUtils.COMMENT_COLLAPSE;
+  override type = EventType.COMMENT_COLLAPSE;
 
   constructor(
     comment?: WorkspaceComment,
@@ -98,6 +98,6 @@ export interface CommentCollapseJson extends CommentBaseJson {
 
 registry.register(
   registry.Type.EVENT,
-  eventUtils.COMMENT_COLLAPSE,
+  EventType.COMMENT_COLLAPSE,
   CommentCollapse,
 );

--- a/core/events/events_comment_create.ts
+++ b/core/events/events_comment_create.ts
@@ -18,13 +18,13 @@ import * as utilsXml from '../utils/xml.js';
 import type {Workspace} from '../workspace.js';
 import * as Xml from '../xml.js';
 import {CommentBase, CommentBaseJson} from './events_comment_base.js';
-import * as eventUtils from './utils.js';
+import {EventType} from './type.js';
 
 /**
  * Notifies listeners that a workspace comment was created.
  */
 export class CommentCreate extends CommentBase {
-  override type = eventUtils.COMMENT_CREATE;
+  override type = EventType.COMMENT_CREATE;
 
   /** The XML representation of the created workspace comment. */
   xml?: Element | DocumentFragment;
@@ -111,8 +111,4 @@ export interface CommentCreateJson extends CommentBaseJson {
   json: object;
 }
 
-registry.register(
-  registry.Type.EVENT,
-  eventUtils.COMMENT_CREATE,
-  CommentCreate,
-);
+registry.register(registry.Type.EVENT, EventType.COMMENT_CREATE, CommentCreate);

--- a/core/events/events_comment_delete.ts
+++ b/core/events/events_comment_delete.ts
@@ -18,13 +18,13 @@ import * as utilsXml from '../utils/xml.js';
 import type {Workspace} from '../workspace.js';
 import * as Xml from '../xml.js';
 import {CommentBase, CommentBaseJson} from './events_comment_base.js';
-import * as eventUtils from './utils.js';
+import {EventType} from './type.js';
 
 /**
  * Notifies listeners that a workspace comment has been deleted.
  */
 export class CommentDelete extends CommentBase {
-  override type = eventUtils.COMMENT_DELETE;
+  override type = EventType.COMMENT_DELETE;
 
   /** The XML representation of the deleted workspace comment. */
   xml?: Element;
@@ -110,8 +110,4 @@ export interface CommentDeleteJson extends CommentBaseJson {
   json: object;
 }
 
-registry.register(
-  registry.Type.EVENT,
-  eventUtils.COMMENT_DELETE,
-  CommentDelete,
-);
+registry.register(registry.Type.EVENT, EventType.COMMENT_DELETE, CommentDelete);

--- a/core/events/events_comment_drag.ts
+++ b/core/events/events_comment_drag.ts
@@ -13,7 +13,7 @@ import * as registry from '../registry.js';
 import {Workspace} from '../workspace.js';
 import {AbstractEventJson} from './events_abstract.js';
 import {UiBase} from './events_ui_base.js';
-import * as eventUtils from './utils.js';
+import {EventType} from './type.js';
 
 /**
  * Notifies listeners when a comment is being manually dragged/dropped.
@@ -25,7 +25,7 @@ export class CommentDrag extends UiBase {
   /** True if this is the start of a drag, false if this is the end of one. */
   isStart?: boolean;
 
-  override type = eventUtils.COMMENT_DRAG;
+  override type = EventType.COMMENT_DRAG;
 
   /**
    * @param opt_comment The comment that is being dragged.
@@ -96,4 +96,4 @@ export interface CommentDragJson extends AbstractEventJson {
   commentId: string;
 }
 
-registry.register(registry.Type.EVENT, eventUtils.COMMENT_DRAG, CommentDrag);
+registry.register(registry.Type.EVENT, EventType.COMMENT_DRAG, CommentDrag);

--- a/core/events/events_comment_move.ts
+++ b/core/events/events_comment_move.ts
@@ -16,13 +16,13 @@ import * as registry from '../registry.js';
 import {Coordinate} from '../utils/coordinate.js';
 import type {Workspace} from '../workspace.js';
 import {CommentBase, CommentBaseJson} from './events_comment_base.js';
-import * as eventUtils from './utils.js';
+import {EventType} from './type.js';
 
 /**
  * Notifies listeners that a workspace comment has moved.
  */
 export class CommentMove extends CommentBase {
-  override type = eventUtils.COMMENT_MOVE;
+  override type = EventType.COMMENT_MOVE;
 
   /** The comment that is being moved. */
   comment_?: WorkspaceComment;
@@ -203,4 +203,4 @@ export interface CommentMoveJson extends CommentBaseJson {
   newCoordinate: string;
 }
 
-registry.register(registry.Type.EVENT, eventUtils.COMMENT_MOVE, CommentMove);
+registry.register(registry.Type.EVENT, EventType.COMMENT_MOVE, CommentMove);

--- a/core/events/events_comment_resize.ts
+++ b/core/events/events_comment_resize.ts
@@ -13,13 +13,13 @@ import * as registry from '../registry.js';
 import {Size} from '../utils/size.js';
 import type {Workspace} from '../workspace.js';
 import {CommentBase, CommentBaseJson} from './events_comment_base.js';
-import * as eventUtils from './utils.js';
+import {EventType} from './type.js';
 
 /**
  * Notifies listeners that a workspace comment has resized.
  */
 export class CommentResize extends CommentBase {
-  override type = eventUtils.COMMENT_RESIZE;
+  override type = EventType.COMMENT_RESIZE;
 
   /** The size of the comment before the resize. */
   oldSize?: Size;
@@ -166,8 +166,4 @@ export interface CommentResizeJson extends CommentBaseJson {
   newHeight: number;
 }
 
-registry.register(
-  registry.Type.EVENT,
-  eventUtils.COMMENT_RESIZE,
-  CommentResize,
-);
+registry.register(registry.Type.EVENT, EventType.COMMENT_RESIZE, CommentResize);

--- a/core/events/events_marker_move.ts
+++ b/core/events/events_marker_move.ts
@@ -17,7 +17,7 @@ import * as registry from '../registry.js';
 import type {Workspace} from '../workspace.js';
 import {AbstractEventJson} from './events_abstract.js';
 import {UiBase} from './events_ui_base.js';
-import * as eventUtils from './utils.js';
+import {EventType} from './type.js';
 
 /**
  * Notifies listeners that a marker (used for keyboard navigation) has
@@ -40,7 +40,7 @@ export class MarkerMove extends UiBase {
    */
   isCursor?: boolean;
 
-  override type = eventUtils.MARKER_MOVE;
+  override type = EventType.MARKER_MOVE;
 
   /**
    * @param opt_block The affected block. Null if current node is of type
@@ -130,4 +130,4 @@ export interface MarkerMoveJson extends AbstractEventJson {
   newNode: ASTNode;
 }
 
-registry.register(registry.Type.EVENT, eventUtils.MARKER_MOVE, MarkerMove);
+registry.register(registry.Type.EVENT, EventType.MARKER_MOVE, MarkerMove);

--- a/core/events/events_selected.ts
+++ b/core/events/events_selected.ts
@@ -15,7 +15,7 @@ import * as registry from '../registry.js';
 import type {Workspace} from '../workspace.js';
 import {AbstractEventJson} from './events_abstract.js';
 import {UiBase} from './events_ui_base.js';
-import * as eventUtils from './utils.js';
+import {EventType} from './type.js';
 
 /**
  * Class for a selected event.
@@ -31,7 +31,7 @@ export class Selected extends UiBase {
    */
   newElementId?: string;
 
-  override type = eventUtils.SELECTED;
+  override type = EventType.SELECTED;
 
   /**
    * @param opt_oldElementId The ID of the previously selected element. Null if
@@ -94,4 +94,4 @@ export interface SelectedJson extends AbstractEventJson {
   newElementId?: string;
 }
 
-registry.register(registry.Type.EVENT, eventUtils.SELECTED, Selected);
+registry.register(registry.Type.EVENT, EventType.SELECTED, Selected);

--- a/core/events/events_theme_change.ts
+++ b/core/events/events_theme_change.ts
@@ -15,7 +15,7 @@ import * as registry from '../registry.js';
 import type {Workspace} from '../workspace.js';
 import {AbstractEventJson} from './events_abstract.js';
 import {UiBase} from './events_ui_base.js';
-import * as eventUtils from './utils.js';
+import {EventType} from './type.js';
 
 /**
  * Notifies listeners that the workspace theme has changed.
@@ -24,7 +24,7 @@ export class ThemeChange extends UiBase {
   /** The name of the new theme that has been set. */
   themeName?: string;
 
-  override type = eventUtils.THEME_CHANGE;
+  override type = EventType.THEME_CHANGE;
 
   /**
    * @param opt_themeName The theme name. Undefined for a blank event.
@@ -81,4 +81,4 @@ export interface ThemeChangeJson extends AbstractEventJson {
   themeName: string;
 }
 
-registry.register(registry.Type.EVENT, eventUtils.THEME_CHANGE, ThemeChange);
+registry.register(registry.Type.EVENT, EventType.THEME_CHANGE, ThemeChange);

--- a/core/events/events_toolbox_item_select.ts
+++ b/core/events/events_toolbox_item_select.ts
@@ -15,7 +15,7 @@ import * as registry from '../registry.js';
 import type {Workspace} from '../workspace.js';
 import {AbstractEventJson} from './events_abstract.js';
 import {UiBase} from './events_ui_base.js';
-import * as eventUtils from './utils.js';
+import {EventType} from './type.js';
 
 /**
  * Notifies listeners that a toolbox item has been selected.
@@ -27,7 +27,7 @@ export class ToolboxItemSelect extends UiBase {
   /** The newly selected toolbox item. */
   newItem?: string;
 
-  override type = eventUtils.TOOLBOX_ITEM_SELECT;
+  override type = EventType.TOOLBOX_ITEM_SELECT;
 
   /**
    * @param opt_oldItem The previously selected toolbox item.
@@ -91,6 +91,6 @@ export interface ToolboxItemSelectJson extends AbstractEventJson {
 
 registry.register(
   registry.Type.EVENT,
-  eventUtils.TOOLBOX_ITEM_SELECT,
+  EventType.TOOLBOX_ITEM_SELECT,
   ToolboxItemSelect,
 );

--- a/core/events/events_trashcan_open.ts
+++ b/core/events/events_trashcan_open.ts
@@ -15,7 +15,7 @@ import * as registry from '../registry.js';
 import type {Workspace} from '../workspace.js';
 import {AbstractEventJson} from './events_abstract.js';
 import {UiBase} from './events_ui_base.js';
-import * as eventUtils from './utils.js';
+import {EventType} from './type.js';
 
 /**
  * Notifies listeners when the trashcan is opening or closing.
@@ -26,7 +26,7 @@ export class TrashcanOpen extends UiBase {
    * False if it is currently closing (previously open).
    */
   isOpen?: boolean;
-  override type = eventUtils.TRASHCAN_OPEN;
+  override type = EventType.TRASHCAN_OPEN;
 
   /**
    * @param opt_isOpen Whether the trashcan flyout is opening (false if
@@ -84,4 +84,4 @@ export interface TrashcanOpenJson extends AbstractEventJson {
   isOpen: boolean;
 }
 
-registry.register(registry.Type.EVENT, eventUtils.TRASHCAN_OPEN, TrashcanOpen);
+registry.register(registry.Type.EVENT, EventType.TRASHCAN_OPEN, TrashcanOpen);

--- a/core/events/events_var_create.ts
+++ b/core/events/events_var_create.ts
@@ -15,13 +15,13 @@ import * as registry from '../registry.js';
 import type {VariableModel} from '../variable_model.js';
 import type {Workspace} from '../workspace.js';
 import {VarBase, VarBaseJson} from './events_var_base.js';
-import * as eventUtils from './utils.js';
+import {EventType} from './type.js';
 
 /**
  * Notifies listeners that a variable model has been created.
  */
 export class VarCreate extends VarBase {
-  override type = eventUtils.VAR_CREATE;
+  override type = EventType.VAR_CREATE;
 
   /** The type of the variable that was created. */
   varType?: string;
@@ -122,4 +122,4 @@ export interface VarCreateJson extends VarBaseJson {
   varName: string;
 }
 
-registry.register(registry.Type.EVENT, eventUtils.VAR_CREATE, VarCreate);
+registry.register(registry.Type.EVENT, EventType.VAR_CREATE, VarCreate);

--- a/core/events/events_var_delete.ts
+++ b/core/events/events_var_delete.ts
@@ -10,7 +10,7 @@ import * as registry from '../registry.js';
 import type {VariableModel} from '../variable_model.js';
 import type {Workspace} from '../workspace.js';
 import {VarBase, VarBaseJson} from './events_var_base.js';
-import * as eventUtils from './utils.js';
+import {EventType} from './type.js';
 
 /**
  * Notifies listeners that a variable model has been deleted.
@@ -18,7 +18,7 @@ import * as eventUtils from './utils.js';
  * @class
  */
 export class VarDelete extends VarBase {
-  override type = eventUtils.VAR_DELETE;
+  override type = EventType.VAR_DELETE;
   /** The type of the variable that was deleted. */
   varType?: string;
   /** The name of the variable that was deleted. */
@@ -117,4 +117,4 @@ export interface VarDeleteJson extends VarBaseJson {
   varName: string;
 }
 
-registry.register(registry.Type.EVENT, eventUtils.VAR_DELETE, VarDelete);
+registry.register(registry.Type.EVENT, EventType.VAR_DELETE, VarDelete);

--- a/core/events/events_var_rename.ts
+++ b/core/events/events_var_rename.ts
@@ -10,7 +10,7 @@ import * as registry from '../registry.js';
 import type {VariableModel} from '../variable_model.js';
 import type {Workspace} from '../workspace.js';
 import {VarBase, VarBaseJson} from './events_var_base.js';
-import * as eventUtils from './utils.js';
+import {EventType} from './type.js';
 
 /**
  * Notifies listeners that a variable model was renamed.
@@ -18,7 +18,7 @@ import * as eventUtils from './utils.js';
  * @class
  */
 export class VarRename extends VarBase {
-  override type = eventUtils.VAR_RENAME;
+  override type = EventType.VAR_RENAME;
 
   /** The previous name of the variable. */
   oldName?: string;
@@ -126,4 +126,4 @@ export interface VarRenameJson extends VarBaseJson {
   newName: string;
 }
 
-registry.register(registry.Type.EVENT, eventUtils.VAR_RENAME, VarRename);
+registry.register(registry.Type.EVENT, EventType.VAR_RENAME, VarRename);

--- a/core/events/events_viewport.ts
+++ b/core/events/events_viewport.ts
@@ -15,7 +15,7 @@ import * as registry from '../registry.js';
 import type {Workspace} from '../workspace.js';
 import {AbstractEventJson} from './events_abstract.js';
 import {UiBase} from './events_ui_base.js';
-import * as eventUtils from './utils.js';
+import {EventType} from './type.js';
 
 /**
  * Notifies listeners that the workspace surface's position or scale has
@@ -42,7 +42,7 @@ export class ViewportChange extends UiBase {
   /** The previous scale of the workspace. */
   oldScale?: number;
 
-  override type = eventUtils.VIEWPORT_CHANGE;
+  override type = EventType.VIEWPORT_CHANGE;
 
   /**
    * @param opt_top Top-edge of the visible portion of the workspace, relative
@@ -144,6 +144,6 @@ export interface ViewportChangeJson extends AbstractEventJson {
 
 registry.register(
   registry.Type.EVENT,
-  eventUtils.VIEWPORT_CHANGE,
+  EventType.VIEWPORT_CHANGE,
   ViewportChange,
 );

--- a/core/events/type.ts
+++ b/core/events/type.ts
@@ -1,0 +1,85 @@
+/**
+ * @license
+ * Copyright 2021 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Enum of values for the .type property for event classes (concrete subclasses
+ * of Abstract).
+ */
+export enum EventType {
+  /** Type of event that creates a block. */
+  BLOCK_CREATE = 'create',
+  /** Type of event that deletes a block. */
+  BLOCK_DELETE = 'delete',
+  /** Type of event that changes a block. */
+  BLOCK_CHANGE = 'change',
+  /**
+   * Type of event representing an in-progress change to a field of a
+   * block, which is expected to be followed by a block change event.
+   */
+  BLOCK_FIELD_INTERMEDIATE_CHANGE = 'block_field_intermediate_change',
+  /** Type of event that moves a block. */
+  BLOCK_MOVE = 'move',
+  /** Type of event that creates a variable. */
+  VAR_CREATE = 'var_create',
+  /** Type of event that deletes a variable. */
+  VAR_DELETE = 'var_delete',
+  /** Type of event that renames a variable. */
+  VAR_RENAME = 'var_rename',
+  /**
+   * Type of generic event that records a UI change.
+   *
+   * @deprecated Was only ever intended for internal use.
+   */
+  UI = 'ui',
+  /** Type of event that drags a block. */
+  BLOCK_DRAG = 'drag',
+  /** Type of event that records a change in selected element. */
+  SELECTED = 'selected',
+  /** Type of event that records a click. */
+  CLICK = 'click',
+  /** Type of event that records a marker move. */
+  MARKER_MOVE = 'marker_move',
+  /** Type of event that records a bubble open. */
+  BUBBLE_OPEN = 'bubble_open',
+  /** Type of event that records a trashcan open. */
+  TRASHCAN_OPEN = 'trashcan_open',
+  /** Type of event that records a toolbox item select. */
+  TOOLBOX_ITEM_SELECT = 'toolbox_item_select',
+  /** Type of event that records a theme change. */
+  THEME_CHANGE = 'theme_change',
+  /** Type of event that records a viewport change. */
+  VIEWPORT_CHANGE = 'viewport_change',
+  /** Type of event that creates a comment. */
+  COMMENT_CREATE = 'comment_create',
+  /** Type of event that deletes a comment. */
+  COMMENT_DELETE = 'comment_delete',
+  /** Type of event that changes a comment. */
+  COMMENT_CHANGE = 'comment_change',
+  /** Type of event that moves a comment. */
+  COMMENT_MOVE = 'comment_move',
+  /** Type of event that resizes a comment. */
+  COMMENT_RESIZE = 'comment_resize',
+  /**  Type of event that drags a comment. */
+  COMMENT_DRAG = 'comment_drag',
+  /** Type of event that collapses a comment. */
+  COMMENT_COLLAPSE = 'comment_collapse',
+  /** Type of event that records a workspace load. */
+  FINISHED_LOADING = 'finished_loading',
+}
+
+/**
+ * List of events that cause objects to be bumped back into the visible
+ * portion of the workspace.
+ *
+ * Not to be confused with bumping so that disconnected connections do not
+ * appear connected.
+ */
+export const BUMP_EVENTS: string[] = [
+  EventType.BLOCK_CREATE,
+  EventType.BLOCK_MOVE,
+  EventType.COMMENT_CREATE,
+  EventType.COMMENT_MOVE,
+];

--- a/core/events/workspace_events.ts
+++ b/core/events/workspace_events.ts
@@ -14,7 +14,7 @@
 import * as registry from '../registry.js';
 import type {Workspace} from '../workspace.js';
 import {Abstract as AbstractEvent} from './events_abstract.js';
-import * as eventUtils from './utils.js';
+import {EventType} from './type.js';
 
 /**
  * Notifies listeners when the workspace has finished deserializing from
@@ -23,7 +23,7 @@ import * as eventUtils from './utils.js';
 export class FinishedLoading extends AbstractEvent {
   override isBlank = true;
   override recordUndo = false;
-  override type = eventUtils.FINISHED_LOADING;
+  override type = EventType.FINISHED_LOADING;
 
   /**
    * @param opt_workspace The workspace that has finished loading.  Undefined
@@ -41,6 +41,6 @@ export class FinishedLoading extends AbstractEvent {
 
 registry.register(
   registry.Type.EVENT,
-  eventUtils.FINISHED_LOADING,
+  EventType.FINISHED_LOADING,
   FinishedLoading,
 );

--- a/core/field.ts
+++ b/core/field.ts
@@ -20,6 +20,7 @@ import type {Block} from './block.js';
 import type {BlockSvg} from './block_svg.js';
 import * as browserEvents from './browser_events.js';
 import * as dropDownDiv from './dropdowndiv.js';
+import {EventType} from './events/type.js';
 import * as eventUtils from './events/utils.js';
 import type {Input} from './inputs/input.js';
 import type {IASTNodeLocationSvg} from './interfaces/i_ast_node_location_svg.js';
@@ -1123,7 +1124,7 @@ export abstract class Field<T = any>
     this.doValueUpdate_(localValue);
     if (fireChangeEvent && source && eventUtils.isEnabled()) {
       eventUtils.fire(
-        new (eventUtils.get(eventUtils.BLOCK_CHANGE))(
+        new (eventUtils.get(EventType.BLOCK_CHANGE))(
           source,
           'field',
           this.name || null,

--- a/core/field_input.ts
+++ b/core/field_input.ts
@@ -19,6 +19,7 @@ import * as browserEvents from './browser_events.js';
 import * as bumpObjects from './bump_objects.js';
 import * as dialog from './dialog.js';
 import * as dropDownDiv from './dropdowndiv.js';
+import {EventType} from './events/type.js';
 import * as eventUtils from './events/utils.js';
 import {
   Field,
@@ -187,7 +188,7 @@ export abstract class FieldInput<T extends InputTypes> extends Field<
         fireChangeEvent
       ) {
         eventUtils.fire(
-          new (eventUtils.get(eventUtils.BLOCK_CHANGE))(
+          new (eventUtils.get(EventType.BLOCK_CHANGE))(
             this.sourceBlock_,
             'field',
             this.name || null,
@@ -475,7 +476,7 @@ export abstract class FieldInput<T extends InputTypes> extends Field<
       // multiple times while the editor was open, but this will fire an event
       // containing the value when the editor was opened as well as the new one.
       eventUtils.fire(
-        new (eventUtils.get(eventUtils.BLOCK_CHANGE))(
+        new (eventUtils.get(EventType.BLOCK_CHANGE))(
           this.sourceBlock_,
           'field',
           this.name || null,
@@ -592,7 +593,7 @@ export abstract class FieldInput<T extends InputTypes> extends Field<
       // Fire a special event indicating that the value changed but the change
       // isn't complete yet and normal field change listeners can wait.
       eventUtils.fire(
-        new (eventUtils.get(eventUtils.BLOCK_FIELD_INTERMEDIATE_CHANGE))(
+        new (eventUtils.get(EventType.BLOCK_FIELD_INTERMEDIATE_CHANGE))(
           this.sourceBlock_,
           this.name || null,
           oldValue,

--- a/core/flyout_base.ts
+++ b/core/flyout_base.ts
@@ -19,6 +19,7 @@ import {ComponentManager} from './component_manager.js';
 import {MANUALLY_DISABLED} from './constants.js';
 import {DeleteArea} from './delete_area.js';
 import type {Abstract as AbstractEvent} from './events/events_abstract.js';
+import {EventType} from './events/type.js';
 import * as eventUtils from './events/utils.js';
 import {FlyoutButton} from './flyout_button.js';
 import {FlyoutMetricsManager} from './flyout_metrics_manager.js';
@@ -1138,13 +1139,13 @@ export abstract class Flyout
       for (let i = 0; i < newVariables.length; i++) {
         const thisVariable = newVariables[i];
         eventUtils.fire(
-          new (eventUtils.get(eventUtils.VAR_CREATE))(thisVariable),
+          new (eventUtils.get(EventType.VAR_CREATE))(thisVariable),
         );
       }
 
       // Block events come after var events, in case they refer to newly created
       // variables.
-      eventUtils.fire(new (eventUtils.get(eventUtils.BLOCK_CREATE))(newBlock));
+      eventUtils.fire(new (eventUtils.get(EventType.BLOCK_CREATE))(newBlock));
     }
     if (this.autoClose) {
       this.hide();

--- a/core/gesture.ts
+++ b/core/gesture.ts
@@ -22,6 +22,7 @@ import {RenderedWorkspaceComment} from './comments.js';
 import * as common from './common.js';
 import {config} from './config.js';
 import * as dropDownDiv from './dropdowndiv.js';
+import {EventType} from './events/type.js';
 import * as eventUtils from './events/utils.js';
 import type {Field} from './field.js';
 import type {IBubble} from './interfaces/i_bubble.js';
@@ -776,7 +777,7 @@ export class Gesture {
    */
   private fireWorkspaceClick(ws: WorkspaceSvg) {
     eventUtils.fire(
-      new (eventUtils.get(eventUtils.CLICK))(null, ws.id, 'workspace'),
+      new (eventUtils.get(EventType.CLICK))(null, ws.id, 'workspace'),
     );
   }
 
@@ -909,7 +910,7 @@ export class Gesture {
         );
       }
       // Clicks events are on the start block, even if it was a shadow.
-      const event = new (eventUtils.get(eventUtils.CLICK))(
+      const event = new (eventUtils.get(EventType.CLICK))(
         this.startBlock,
         this.startWorkspace_.id,
         'block',

--- a/core/icons/comment_icon.ts
+++ b/core/icons/comment_icon.ts
@@ -10,6 +10,7 @@ import type {Block} from '../block.js';
 import type {BlockSvg} from '../block_svg.js';
 import {TextBubble} from '../bubbles/text_bubble.js';
 import {TextInputBubble} from '../bubbles/textinput_bubble.js';
+import {EventType} from '../events/type.js';
 import * as eventUtils from '../events/utils.js';
 import type {IHasBubble} from '../interfaces/i_has_bubble.js';
 import type {ISerializable} from '../interfaces/i_serializable.js';
@@ -159,7 +160,7 @@ export class CommentIcon extends Icon implements IHasBubble, ISerializable {
   setText(text: string) {
     const oldText = this.text;
     eventUtils.fire(
-      new (eventUtils.get(eventUtils.BLOCK_CHANGE))(
+      new (eventUtils.get(EventType.BLOCK_CHANGE))(
         this.sourceBlock,
         'comment',
         null,
@@ -238,7 +239,7 @@ export class CommentIcon extends Icon implements IHasBubble, ISerializable {
     if (this.text === newText) return;
 
     eventUtils.fire(
-      new (eventUtils.get(eventUtils.BLOCK_CHANGE))(
+      new (eventUtils.get(EventType.BLOCK_CHANGE))(
         this.sourceBlock,
         'comment',
         null,
@@ -288,7 +289,7 @@ export class CommentIcon extends Icon implements IHasBubble, ISerializable {
     }
 
     eventUtils.fire(
-      new (eventUtils.get(eventUtils.BUBBLE_OPEN))(
+      new (eventUtils.get(EventType.BUBBLE_OPEN))(
         this.sourceBlock,
         visible,
         'comment',

--- a/core/icons/mutator_icon.ts
+++ b/core/icons/mutator_icon.ts
@@ -11,6 +11,7 @@ import type {BlocklyOptions} from '../blockly_options.js';
 import {MiniWorkspaceBubble} from '../bubbles/mini_workspace_bubble.js';
 import type {Abstract} from '../events/events_abstract.js';
 import {BlockChange} from '../events/events_block_change.js';
+import {EventType} from '../events/type.js';
 import * as eventUtils from '../events/utils.js';
 import type {IHasBubble} from '../interfaces/i_has_bubble.js';
 import * as renderManagement from '../render_management.js';
@@ -193,7 +194,7 @@ export class MutatorIcon extends Icon implements IHasBubble {
     }
 
     eventUtils.fire(
-      new (eventUtils.get(eventUtils.BUBBLE_OPEN))(
+      new (eventUtils.get(EventType.BUBBLE_OPEN))(
         this.sourceBlock,
         visible,
         'mutator',
@@ -307,8 +308,8 @@ export class MutatorIcon extends Icon implements IHasBubble {
   static isIgnorableMutatorEvent(e: Abstract) {
     return (
       e.isUiEvent ||
-      e.type === eventUtils.CREATE ||
-      (e.type === eventUtils.CHANGE &&
+      e.type === EventType.BLOCK_CREATE ||
+      (e.type === EventType.BLOCK_CHANGE &&
         (e as BlockChange).element === 'disabled')
     );
   }
@@ -331,7 +332,7 @@ export class MutatorIcon extends Icon implements IHasBubble {
 
     if (oldExtraState !== newExtraState) {
       eventUtils.fire(
-        new (eventUtils.get(eventUtils.BLOCK_CHANGE))(
+        new (eventUtils.get(EventType.BLOCK_CHANGE))(
           this.sourceBlock,
           'mutation',
           null,

--- a/core/icons/warning_icon.ts
+++ b/core/icons/warning_icon.ts
@@ -8,6 +8,7 @@
 
 import type {BlockSvg} from '../block_svg.js';
 import {TextBubble} from '../bubbles/text_bubble.js';
+import {EventType} from '../events/type.js';
 import * as eventUtils from '../events/utils.js';
 import type {IHasBubble} from '../interfaces/i_has_bubble.js';
 import * as renderManagement from '../render_management.js';
@@ -188,7 +189,7 @@ export class WarningIcon extends Icon implements IHasBubble {
     }
 
     eventUtils.fire(
-      new (eventUtils.get(eventUtils.BUBBLE_OPEN))(
+      new (eventUtils.get(EventType.BUBBLE_OPEN))(
         this.sourceBlock,
         visible,
         'warning',

--- a/core/procedures.ts
+++ b/core/procedures.ts
@@ -15,6 +15,7 @@ import {Blocks} from './blocks.js';
 import * as common from './common.js';
 import type {Abstract} from './events/events_abstract.js';
 import type {BubbleOpen} from './events/events_bubble_open.js';
+import {EventType} from './events/type.js';
 import * as eventUtils from './events/utils.js';
 import {Field, UnattachedFieldError} from './field.js';
 import {MutatorIcon} from './icons.js';
@@ -354,7 +355,7 @@ function updateMutatorFlyout(workspace: WorkspaceSvg) {
  * @internal
  */
 export function mutatorOpenListener(e: Abstract) {
-  if (e.type !== eventUtils.BUBBLE_OPEN) {
+  if (e.type !== EventType.BUBBLE_OPEN) {
     return;
   }
   const bubbleEvent = e as BubbleOpen;
@@ -386,10 +387,10 @@ export function mutatorOpenListener(e: Abstract) {
  */
 function mutatorChangeListener(e: Abstract) {
   if (
-    e.type !== eventUtils.BLOCK_CREATE &&
-    e.type !== eventUtils.BLOCK_DELETE &&
-    e.type !== eventUtils.BLOCK_CHANGE &&
-    e.type !== eventUtils.BLOCK_FIELD_INTERMEDIATE_CHANGE
+    e.type !== EventType.BLOCK_CREATE &&
+    e.type !== EventType.BLOCK_DELETE &&
+    e.type !== EventType.BLOCK_CHANGE &&
+    e.type !== EventType.BLOCK_FIELD_INTERMEDIATE_CHANGE
   ) {
     return;
   }
@@ -454,7 +455,7 @@ export function mutateCallers(defBlock: Block) {
       // definition mutation.
       eventUtils.setRecordUndo(false);
       eventUtils.fire(
-        new (eventUtils.get(eventUtils.BLOCK_CHANGE))(
+        new (eventUtils.get(EventType.BLOCK_CHANGE))(
           caller,
           'mutation',
           null,

--- a/core/renderers/common/marker_svg.ts
+++ b/core/renderers/common/marker_svg.ts
@@ -12,6 +12,7 @@ import '../../events/events_marker_move.js';
 import type {BlockSvg} from '../../block_svg.js';
 import type {Connection} from '../../connection.js';
 import {ConnectionType} from '../../connection_type.js';
+import {EventType} from '../../events/type.js';
 import * as eventUtils from '../../events/utils.js';
 import type {Field} from '../../field.js';
 import {FlyoutButton} from '../../flyout_button.js';
@@ -621,7 +622,7 @@ export class MarkerSvg {
    */
   private fireMarkerEvent(oldNode: ASTNode, curNode: ASTNode) {
     const curBlock = curNode.getSourceBlock();
-    const event = new (eventUtils.get(eventUtils.MARKER_MOVE))(
+    const event = new (eventUtils.get(EventType.MARKER_MOVE))(
       curBlock,
       this.isCursor(),
       oldNode,

--- a/core/serialization/blocks.ts
+++ b/core/serialization/blocks.ts
@@ -10,6 +10,7 @@ import type {Block} from '../block.js';
 import type {BlockSvg} from '../block_svg.js';
 import type {Connection} from '../connection.js';
 import {MANUALLY_DISABLED} from '../constants.js';
+import {EventType} from '../events/type.js';
 import * as eventUtils from '../events/utils.js';
 import {inputTypes} from '../inputs/input_types.js';
 import {isSerializable} from '../interfaces/i_serializable.js';
@@ -432,7 +433,7 @@ export function appendInternal(
   if (eventUtils.isEnabled()) {
     // Block events come after var events, in case they refer to newly created
     // variables.
-    eventUtils.fire(new (eventUtils.get(eventUtils.BLOCK_CREATE))(block));
+    eventUtils.fire(new (eventUtils.get(EventType.BLOCK_CREATE))(block));
   }
   eventUtils.setGroup(existingGroup);
   eventUtils.setRecordUndo(prevRecordUndo);
@@ -512,9 +513,7 @@ function checkNewVariables(
     // Fire a VarCreate event for each (if any) new variable created.
     for (let i = 0; i < newVariables.length; i++) {
       const thisVariable = newVariables[i];
-      eventUtils.fire(
-        new (eventUtils.get(eventUtils.VAR_CREATE))(thisVariable),
-      );
+      eventUtils.fire(new (eventUtils.get(EventType.VAR_CREATE))(thisVariable));
     }
   }
 }

--- a/core/serialization/workspaces.ts
+++ b/core/serialization/workspaces.ts
@@ -6,6 +6,7 @@
 
 // Former goog.module ID: Blockly.serialization.workspaces
 
+import {EventType} from '../events/type.js';
 import * as eventUtils from '../events/utils.js';
 import type {ISerializer} from '../interfaces/i_serializer.js';
 import * as registry from '../registry.js';
@@ -86,7 +87,7 @@ export function load(
   }
   dom.stopTextWidthCache();
 
-  eventUtils.fire(new (eventUtils.get(eventUtils.FINISHED_LOADING))(workspace));
+  eventUtils.fire(new (eventUtils.get(EventType.FINISHED_LOADING))(workspace));
 
   eventUtils.setGroup(existingGroup);
   eventUtils.setRecordUndo(prevRecordUndo);

--- a/core/toolbox/toolbox.ts
+++ b/core/toolbox/toolbox.ts
@@ -20,6 +20,7 @@ import {ComponentManager} from '../component_manager.js';
 import * as Css from '../css.js';
 import {DeleteArea} from '../delete_area.js';
 import '../events/events_toolbox_item_select.js';
+import {EventType} from '../events/type.js';
 import * as eventUtils from '../events/utils.js';
 import type {IAutoHideable} from '../interfaces/i_autohideable.js';
 import type {ICollapsibleToolboxItem} from '../interfaces/i_collapsible_toolbox_item.js';
@@ -962,7 +963,7 @@ export class Toolbox
     if (oldItem === newItem) {
       newElement = null;
     }
-    const event = new (eventUtils.get(eventUtils.TOOLBOX_ITEM_SELECT))(
+    const event = new (eventUtils.get(EventType.TOOLBOX_ITEM_SELECT))(
       oldElement,
       newElement,
       this.workspace_.id,

--- a/core/trashcan.ts
+++ b/core/trashcan.ts
@@ -19,6 +19,7 @@ import {DeleteArea} from './delete_area.js';
 import type {Abstract} from './events/events_abstract.js';
 import type {BlockDelete} from './events/events_block_delete.js';
 import './events/events_trashcan_open.js';
+import {EventType} from './events/type.js';
 import * as eventUtils from './events/utils.js';
 import type {IAutoHideable} from './interfaces/i_autohideable.js';
 import type {IDraggable} from './interfaces/i_draggable.js';
@@ -556,7 +557,7 @@ export class Trashcan
    * @param trashcanOpen Whether the flyout is opening.
    */
   private fireUiEvent(trashcanOpen: boolean) {
-    const uiEvent = new (eventUtils.get(eventUtils.TRASHCAN_OPEN))(
+    const uiEvent = new (eventUtils.get(EventType.TRASHCAN_OPEN))(
       trashcanOpen,
       this.workspace.id,
     );
@@ -603,12 +604,12 @@ export class Trashcan
   private onDelete(event: Abstract) {
     if (
       this.workspace.options.maxTrashcanContents <= 0 ||
-      event.type !== eventUtils.BLOCK_DELETE
+      event.type !== EventType.BLOCK_DELETE
     ) {
       return;
     }
     const deleteEvent = event as BlockDelete;
-    if (event.type === eventUtils.BLOCK_DELETE && !deleteEvent.wasShadow) {
+    if (event.type === EventType.BLOCK_DELETE && !deleteEvent.wasShadow) {
       if (!deleteEvent.oldJson) {
         throw new Error('Encountered a delete event without proper oldJson');
       }

--- a/core/variable_map.ts
+++ b/core/variable_map.ts
@@ -18,6 +18,7 @@ import './events/events_var_rename.js';
 
 import type {Block} from './block.js';
 import * as dialog from './dialog.js';
+import {EventType} from './events/type.js';
 import * as eventUtils from './events/utils.js';
 import {Msg} from './msg.js';
 import {Names} from './names.js';
@@ -119,7 +120,7 @@ export class VariableMap {
     blocks: Block[],
   ) {
     eventUtils.fire(
-      new (eventUtils.get(eventUtils.VAR_RENAME))(variable, newName),
+      new (eventUtils.get(EventType.VAR_RENAME))(variable, newName),
     );
     variable.name = newName;
     for (let i = 0; i < blocks.length; i++) {
@@ -158,7 +159,7 @@ export class VariableMap {
       blocks[i].renameVarById(variable.getId(), conflictVar.getId());
     }
     // Finally delete the original variable, which is now unreferenced.
-    eventUtils.fire(new (eventUtils.get(eventUtils.VAR_DELETE))(variable));
+    eventUtils.fire(new (eventUtils.get(EventType.VAR_DELETE))(variable));
     // And remove it from the list.
     arrayUtils.removeElem(this.variableMap.get(type)!, variable);
   }
@@ -213,7 +214,7 @@ export class VariableMap {
     this.variableMap.delete(type);
     this.variableMap.set(type, variables);
 
-    eventUtils.fire(new (eventUtils.get(eventUtils.VAR_CREATE))(variable));
+    eventUtils.fire(new (eventUtils.get(EventType.VAR_CREATE))(variable));
 
     return variable;
   }
@@ -232,9 +233,7 @@ export class VariableMap {
         const tempVar = variableList[i];
         if (tempVar.getId() === variableId) {
           variableList.splice(i, 1);
-          eventUtils.fire(
-            new (eventUtils.get(eventUtils.VAR_DELETE))(variable),
-          );
+          eventUtils.fire(new (eventUtils.get(EventType.VAR_DELETE))(variable));
           if (variableList.length === 0) {
             this.variableMap.delete(variable.type);
           }

--- a/core/workspace_svg.ts
+++ b/core/workspace_svg.ts
@@ -33,6 +33,7 @@ import {
   ContextMenuRegistry,
 } from './contextmenu_registry.js';
 import * as dropDownDiv from './dropdowndiv.js';
+import {EventType} from './events/type.js';
 import * as eventUtils from './events/utils.js';
 import type {FlyoutButton} from './flyout_button.js';
 import {Gesture} from './gesture.js';
@@ -558,7 +559,7 @@ export class WorkspaceSvg extends Workspace implements IASTNodeLocationSvg {
       this.setVisible(true);
     }
 
-    const event = new (eventUtils.get(eventUtils.THEME_CHANGE))(
+    const event = new (eventUtils.get(EventType.THEME_CHANGE))(
       this.getTheme().name,
       this.id,
     );
@@ -1181,7 +1182,7 @@ export class WorkspaceSvg extends Workspace implements IASTNodeLocationSvg {
       // of negligible changes in viewport top/left.
       return;
     }
-    const event = new (eventUtils.get(eventUtils.VIEWPORT_CHANGE))(
+    const event = new (eventUtils.get(EventType.VIEWPORT_CHANGE))(
       top,
       left,
       scale,

--- a/core/xml.ts
+++ b/core/xml.ts
@@ -12,6 +12,7 @@ import {RenderedWorkspaceComment} from './comments/rendered_workspace_comment.js
 import {WorkspaceComment} from './comments/workspace_comment.js';
 import type {Connection} from './connection.js';
 import {MANUALLY_DISABLED} from './constants.js';
+import {EventType} from './events/type.js';
 import * as eventUtils from './events/utils.js';
 import type {Field} from './field.js';
 import {IconType} from './icons/icon_types.js';
@@ -497,7 +498,7 @@ export function domToWorkspace(xml: Element, workspace: Workspace): string[] {
     dom.stopTextWidthCache();
   }
   // Re-enable workspace resizing.
-  eventUtils.fire(new (eventUtils.get(eventUtils.FINISHED_LOADING))(workspace));
+  eventUtils.fire(new (eventUtils.get(EventType.FINISHED_LOADING))(workspace));
   return newBlockIds;
 }
 
@@ -666,13 +667,11 @@ export function domToBlockInternal(
     // Fire a VarCreate event for each (if any) new variable created.
     for (let i = 0; i < newVariables.length; i++) {
       const thisVariable = newVariables[i];
-      eventUtils.fire(
-        new (eventUtils.get(eventUtils.VAR_CREATE))(thisVariable),
-      );
+      eventUtils.fire(new (eventUtils.get(EventType.VAR_CREATE))(thisVariable));
     }
     // Block events come after var events, in case they refer to newly created
     // variables.
-    eventUtils.fire(new (eventUtils.get(eventUtils.CREATE))(topBlock));
+    eventUtils.fire(new (eventUtils.get(EventType.BLOCK_CREATE))(topBlock));
   }
   return topBlock;
 }

--- a/core/zoom_controls.ts
+++ b/core/zoom_controls.ts
@@ -17,6 +17,7 @@ import './events/events_click.js';
 import * as browserEvents from './browser_events.js';
 import {ComponentManager} from './component_manager.js';
 import * as Css from './css.js';
+import {EventType} from './events/type.js';
 import * as eventUtils from './events/utils.js';
 import type {IPositionable} from './interfaces/i_positionable.js';
 import type {UiMetrics} from './metrics_manager.js';
@@ -467,7 +468,7 @@ export class ZoomControls implements IPositionable {
 
   /** Fires a zoom control UI event. */
   private fireZoomEvent() {
-    const uiEvent = new (eventUtils.get(eventUtils.CLICK))(
+    const uiEvent = new (eventUtils.get(EventType.CLICK))(
       null,
       this.workspace.id,
       'zoom_controls',

--- a/tests/mocha/block_test.js
+++ b/tests/mocha/block_test.js
@@ -5,6 +5,7 @@
  */
 
 import {ConnectionType} from '../../build/src/core/connection_type.js';
+import {EventType} from '../../build/src/core/events/type.js';
 import * as eventUtils from '../../build/src/core/events/utils.js';
 import {EndRowInput} from '../../build/src/core/inputs/end_row_input.js';
 import {assert} from '../../node_modules/chai/chai.js';
@@ -1251,7 +1252,7 @@ suite('Blocks', function () {
       function assertCommentEvent(eventSpy, oldValue, newValue) {
         const calls = eventSpy.getCalls();
         const event = calls[calls.length - 1].args[0];
-        assert.equal(event.type, eventUtils.BLOCK_CHANGE);
+        assert.equal(event.type, EventType.BLOCK_CHANGE);
         assert.equal(
           event.element,
           'comment',
@@ -1271,7 +1272,7 @@ suite('Blocks', function () {
       function assertNoCommentEvent(eventSpy) {
         const calls = eventSpy.getCalls();
         const event = calls[calls.length - 1].args[0];
-        assert.notEqual(event.type, eventUtils.BLOCK_CHANGE);
+        assert.notEqual(event.type, EventType.BLOCK_CHANGE);
       }
       setup(function () {
         this.eventsFireSpy = sinon.spy(eventUtils.TEST_ONLY, 'fireInternal');

--- a/tests/mocha/comment_test.js
+++ b/tests/mocha/comment_test.js
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as eventUtils from '../../build/src/core/events/utils.js';
+import {EventType} from '../../build/src/core/events/type.js';
 import {assert} from '../../node_modules/chai/chai.js';
 import {assertEventFired} from './test_helpers/events.js';
 import {
@@ -55,7 +55,7 @@ suite('Comments', function () {
       assertEventFired(
         this.eventsFireStub,
         Blockly.Events.BubbleOpen,
-        {bubbleType: 'comment', isOpen: true, type: eventUtils.BUBBLE_OPEN},
+        {bubbleType: 'comment', isOpen: true, type: EventType.BUBBLE_OPEN},
         this.workspace.id,
         this.block.id,
       );
@@ -70,7 +70,7 @@ suite('Comments', function () {
       assertEventFired(
         this.eventsFireStub,
         Blockly.Events.BubbleOpen,
-        {bubbleType: 'comment', isOpen: true, type: eventUtils.BUBBLE_OPEN},
+        {bubbleType: 'comment', isOpen: true, type: EventType.BUBBLE_OPEN},
         this.workspace.id,
         this.block.id,
       );
@@ -86,7 +86,7 @@ suite('Comments', function () {
       assertEventFired(
         this.eventsFireStub,
         Blockly.Events.BubbleOpen,
-        {bubbleType: 'comment', isOpen: true, type: eventUtils.BUBBLE_OPEN},
+        {bubbleType: 'comment', isOpen: true, type: EventType.BUBBLE_OPEN},
         this.workspace.id,
         this.block.id,
       );
@@ -104,7 +104,7 @@ suite('Comments', function () {
       assertEventFired(
         this.eventsFireStub,
         Blockly.Events.BubbleOpen,
-        {bubbleType: 'comment', isOpen: true, type: eventUtils.BUBBLE_OPEN},
+        {bubbleType: 'comment', isOpen: true, type: EventType.BUBBLE_OPEN},
         this.workspace.id,
         this.block.id,
       );

--- a/tests/mocha/event_block_create_test.js
+++ b/tests/mocha/event_block_create_test.js
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as eventUtils from '../../build/src/core/events/utils.js';
+import {EventType} from '../../build/src/core/events/type.js';
 import {assert} from '../../node_modules/chai/chai.js';
 import {defineRowBlock} from './test_helpers/block_definitions.js';
 import {assertEventFired} from './test_helpers/events.js';
@@ -48,7 +48,7 @@ suite('Block Create Event', function () {
     assertEventFired(
       this.eventsFireStub,
       Blockly.Events.BlockCreate,
-      {'recordUndo': false, 'type': eventUtils.BLOCK_CREATE},
+      {'recordUndo': false, 'type': EventType.BLOCK_CREATE},
       this.workspace.id,
       'shadowId',
     );

--- a/tests/mocha/gesture_test.js
+++ b/tests/mocha/gesture_test.js
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as eventUtils from '../../build/src/core/events/utils.js';
+import {EventType} from '../../build/src/core/events/type.js';
 import {assert} from '../../node_modules/chai/chai.js';
 import {defineBasicBlockWithField} from './test_helpers/block_definitions.js';
 import {assertEventFired, assertEventNotFired} from './test_helpers/events.js';
@@ -39,11 +39,11 @@ suite('Gesture', function () {
     assertEventFired(
       eventsFireStub,
       Blockly.Events.Selected,
-      {newElementId: block.id, type: eventUtils.SELECTED},
+      {newElementId: block.id, type: EventType.SELECTED},
       fieldWorkspace.id,
     );
     assertEventNotFired(eventsFireStub, Blockly.Events.Click, {
-      type: eventUtils.CLICK,
+      type: EventType.CLICK,
     });
   }
 

--- a/tests/mocha/jso_deserialization_test.js
+++ b/tests/mocha/jso_deserialization_test.js
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as eventUtils from '../../build/src/core/events/utils.js';
+import {EventType} from '../../build/src/core/events/type.js';
 import {assert} from '../../node_modules/chai/chai.js';
 import {assertEventFired} from './test_helpers/events.js';
 import {
@@ -66,7 +66,7 @@ suite('JSO Deserialization', function () {
         assertEventFired(
           this.eventsFireStub,
           Blockly.Events.FinishedLoading,
-          {type: eventUtils.FINISHED_LOADING},
+          {type: EventType.FINISHED_LOADING},
           this.workspace.id,
         );
       });
@@ -89,7 +89,7 @@ suite('JSO Deserialization', function () {
         assertEventFired(
           this.eventsFireStub,
           Blockly.Events.FinishedLoading,
-          {'group': 'my group', 'type': eventUtils.FINISHED_LOADING},
+          {'group': 'my group', 'type': EventType.FINISHED_LOADING},
           this.workspace.id,
         );
       });
@@ -144,7 +144,7 @@ suite('JSO Deserialization', function () {
             'varId': 'testId',
             'varType': '',
             'recordUndo': false,
-            'type': eventUtils.VAR_CREATE,
+            'type': EventType.VAR_CREATE,
           },
           this.workspace.id,
         );
@@ -170,7 +170,7 @@ suite('JSO Deserialization', function () {
             'varId': 'testId',
             'varType': '',
             'recordUndo': true,
-            'type': eventUtils.VAR_CREATE,
+            'type': EventType.VAR_CREATE,
           },
           this.workspace.id,
         );
@@ -195,7 +195,7 @@ suite('JSO Deserialization', function () {
             'varId': 'testId',
             'varType': '',
             'group': 'my group',
-            'type': eventUtils.VAR_CREATE,
+            'type': EventType.VAR_CREATE,
           },
           this.workspace.id,
         );
@@ -260,7 +260,7 @@ suite('JSO Deserialization', function () {
             'varName': 'test',
             'varId': 'testId',
             'varType': '',
-            'type': eventUtils.VAR_CREATE,
+            'type': EventType.VAR_CREATE,
           },
           this.workspace.id,
         );
@@ -286,7 +286,7 @@ suite('JSO Deserialization', function () {
           assertEventFired(
             this.eventsFireStub,
             Blockly.Events.BlockCreate,
-            {'recordUndo': false, 'type': eventUtils.BLOCK_CREATE},
+            {'recordUndo': false, 'type': EventType.BLOCK_CREATE},
             this.workspace.id,
             'testId',
           );
@@ -311,7 +311,7 @@ suite('JSO Deserialization', function () {
           assertEventFired(
             this.eventsFireStub,
             Blockly.Events.BlockCreate,
-            {'recordUndo': true, 'type': eventUtils.BLOCK_CREATE},
+            {'recordUndo': true, 'type': EventType.BLOCK_CREATE},
             this.workspace.id,
             'testId',
           );
@@ -335,7 +335,7 @@ suite('JSO Deserialization', function () {
           assertEventFired(
             this.eventsFireStub,
             Blockly.Events.BlockCreate,
-            {'group': 'my group', 'type': eventUtils.BLOCK_CREATE},
+            {'group': 'my group', 'type': EventType.BLOCK_CREATE},
             this.workspace.id,
             'testId',
           );
@@ -397,7 +397,7 @@ suite('JSO Deserialization', function () {
           assertEventFired(
             this.eventsFireStub,
             Blockly.Events.BlockCreate,
-            {type: eventUtils.BLOCK_CREATE},
+            {type: EventType.BLOCK_CREATE},
             this.workspace.id,
             'id1',
           );
@@ -435,7 +435,7 @@ suite('JSO Deserialization', function () {
           assertEventFired(
             this.eventsFireStub,
             Blockly.Events.BlockCreate,
-            {'recordUndo': true, 'type': eventUtils.BLOCK_CREATE},
+            {'recordUndo': true, 'type': EventType.BLOCK_CREATE},
             this.workspace.id,
             'testId',
           );
@@ -453,7 +453,7 @@ suite('JSO Deserialization', function () {
           assertEventFired(
             this.eventsFireStub,
             Blockly.Events.BlockCreate,
-            {'group': 'my group', 'type': eventUtils.BLOCK_CREATE},
+            {'group': 'my group', 'type': EventType.BLOCK_CREATE},
             this.workspace.id,
             'testId',
           );

--- a/tests/mocha/theme_test.js
+++ b/tests/mocha/theme_test.js
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as eventUtils from '../../build/src/core/events/utils.js';
+import {EventType} from '../../build/src/core/events/type.js';
 import {assert} from '../../node_modules/chai/chai.js';
 import {assertEventFired} from './test_helpers/events.js';
 import {
@@ -153,7 +153,7 @@ suite('Theme', function () {
       assertEventFired(
         this.eventsFireStub,
         Blockly.Events.ThemeChange,
-        {themeName: 'themeName', type: eventUtils.THEME_CHANGE},
+        {themeName: 'themeName', type: EventType.THEME_CHANGE},
         workspace.id,
       );
     } finally {

--- a/tests/mocha/trashcan_test.js
+++ b/tests/mocha/trashcan_test.js
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import {EventType} from '../../build/src/core/events/type.js';
 import * as eventUtils from '../../build/src/core/events/utils.js';
 import {assert} from '../../node_modules/chai/chai.js';
 import {
@@ -91,12 +92,12 @@ suite('Trashcan', function () {
       simulateClick(this.trashcan.svgGroup);
 
       assertEventNotFired(this.eventsFireStub, Blockly.Events.TrashcanOpen, {
-        type: eventUtils.CLICK,
+        type: EventType.CLICK,
       });
       assertEventFired(
         this.eventsFireStub,
         Blockly.Events.Click,
-        {targetType: 'workspace', type: eventUtils.CLICK},
+        {targetType: 'workspace', type: EventType.CLICK},
         this.workspace.id,
         undefined,
       );
@@ -114,11 +115,11 @@ suite('Trashcan', function () {
       assertEventFired(
         this.eventsFireStub,
         Blockly.Events.TrashcanOpen,
-        {isOpen: true, type: eventUtils.TRASHCAN_OPEN},
+        {isOpen: true, type: EventType.TRASHCAN_OPEN},
         this.workspace.id,
       );
       assertEventNotFired(this.eventsFireStub, Blockly.Events.Click, {
-        type: eventUtils.TRASHCAN_OPEN,
+        type: EventType.TRASHCAN_OPEN,
       });
     });
     test('Click outside trashcan - fires trashcanClose', function () {
@@ -133,13 +134,13 @@ suite('Trashcan', function () {
       assertEventFired(
         this.eventsFireStub,
         Blockly.Events.TrashcanOpen,
-        {isOpen: false, type: eventUtils.TRASHCAN_OPEN},
+        {isOpen: false, type: EventType.TRASHCAN_OPEN},
         this.workspace.id,
       );
       assertEventFired(
         this.eventsFireStub,
         Blockly.Events.Click,
-        {targetType: 'workspace', type: eventUtils.CLICK},
+        {targetType: 'workspace', type: EventType.CLICK},
         this.workspace.id,
         undefined,
       );

--- a/tests/mocha/workspace_svg_test.js
+++ b/tests/mocha/workspace_svg_test.js
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as eventUtils from '../../build/src/core/events/utils.js';
+import {EventType} from '../../build/src/core/events/type.js';
 import {assert} from '../../node_modules/chai/chai.js';
 import {defineStackBlock} from './test_helpers/block_definitions.js';
 import {
@@ -187,7 +187,7 @@ suite('WorkspaceSvg', function () {
         oldScale: 1,
         viewTop: metrics.viewTop,
         viewLeft: metrics.viewLeft,
-        type: eventUtils.VIEWPORT_CHANGE,
+        type: EventType.VIEWPORT_CHANGE,
       };
       assertSpyFiredViewportEvent(
         changeListenerSpy,
@@ -350,7 +350,7 @@ suite('WorkspaceSvg', function () {
         assertEventNotFired(
           this.changeListenerSpy,
           Blockly.Events.ViewportChange,
-          {type: eventUtils.VIEWPORT_CHANGE},
+          {type: EventType.VIEWPORT_CHANGE},
         );
       });
       test("domToWorkspace at 0,0 that doesn't trigger scroll", function () {
@@ -377,7 +377,7 @@ suite('WorkspaceSvg', function () {
         assertEventNotFired(
           this.changeListenerSpy,
           Blockly.Events.ViewportChange,
-          {type: eventUtils.VIEWPORT_CHANGE},
+          {type: EventType.VIEWPORT_CHANGE},
         );
       });
       test.skip('domToWorkspace multiple blocks triggers one viewport event', function () {

--- a/tests/mocha/zoom_controls_test.js
+++ b/tests/mocha/zoom_controls_test.js
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as eventUtils from '../../build/src/core/events/utils.js';
+import {EventType} from '../../build/src/core/events/type.js';
 import {assert} from '../../node_modules/chai/chai.js';
 import {assertEventFired, assertEventNotFired} from './test_helpers/events.js';
 import {
@@ -35,13 +35,13 @@ suite('Zoom Controls', function () {
       assertEventFired(
         this.eventsFireStub,
         Blockly.Events.Click,
-        {targetType: 'zoom_controls', type: eventUtils.CLICK},
+        {targetType: 'zoom_controls', type: EventType.CLICK},
         this.workspace.id,
         undefined,
       );
       assertEventNotFired(this.eventsFireStub, Blockly.Events.Click, {
         targetType: 'workspace',
-        type: eventUtils.CLICK,
+        type: EventType.CLICK,
       });
       assert.closeTo(this.workspace.getScale(), 1.2, 0.05);
     });
@@ -51,13 +51,13 @@ suite('Zoom Controls', function () {
       assertEventFired(
         this.eventsFireStub,
         Blockly.Events.Click,
-        {targetType: 'zoom_controls', type: eventUtils.CLICK},
+        {targetType: 'zoom_controls', type: EventType.CLICK},
         this.workspace.id,
         undefined,
       );
       assertEventNotFired(this.eventsFireStub, Blockly.Events.Click, {
         targetType: 'workspace',
-        type: eventUtils.CLICK,
+        type: EventType.CLICK,
       });
       assert.closeTo(this.workspace.getScale(), 0.8, 0.05);
     });
@@ -67,13 +67,13 @@ suite('Zoom Controls', function () {
       assertEventFired(
         this.eventsFireStub,
         Blockly.Events.Click,
-        {targetType: 'zoom_controls', type: eventUtils.CLICK},
+        {targetType: 'zoom_controls', type: EventType.CLICK},
         this.workspace.id,
         undefined,
       );
       assertEventNotFired(this.eventsFireStub, Blockly.Events.Click, {
         targetType: 'workspace',
-        type: eventUtils.CLICK,
+        type: EventType.CLICK,
       });
       assert.equal(this.workspace.getScale(), 1);
     });


### PR DESCRIPTION
## The basics

- [X] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Proposed Changes

Introduce an `enum` for the event `.type` values.


### Reason for Changes

Although we can't actually use it as the type of the `.type` property on the `Abstract` event class, because we want to allow developers to add their own custom event types inheriting from this type, this change means we can be reasonably sure that all of our own event subclasses have distinct `.type` values—plus consistent use of enum syntax (`EventType.TYPE_NAME`) is probably good for readability overall.

Additionally, by putting it in a separate module from the rest of `events/utils.ts`, it moves us a step towards being able to write type narrowing checks like

```JS
if (event instanceof SomeEventType) …
```

in `utils.ts`, which is not currently possible due to load ordering problems that arise when there are (non-`type`) circular `import`s between `utils.ts` and the other modules in `events/`.

(A few of the event classes also depend on `utils.ts` for `fire()` or other helper functions; this will be harder to untangle, but at least this commit is a step forward in terms of reducing the circularity of of our dependencies, making _most_ of the event subclass modules dependent on `type.ts`, which has no imports, rather than on `utils.ts` which has multiple imports.)

### Test Coverage

Passes `npm test`; no changes to manual testing expected.

### Documentation

No; API-exported symbols remain unchanged.

### Additional Information

I've also restructured `events/events.ts` to use `expor … from …` for readability and conciseness.

