### PR TITLE
fix: Detect if deleting shadow block affects selection highlight

### DIFF
--- a/core/block.ts
+++ b/core/block.ts
@@ -319,9 +319,18 @@ export class Block implements IASTNodeLocation {
     }
   }
 
-  descendsFrom(other: Block): boolean {
-    if (this === other) return true;
-    return this.getParent()?.descendsFrom(other) ?? false;
+  /**
+   * Returns true if this block is the same block as the given block or contains
+   * the provided block as a descendent.
+   *
+   * @param other the other block to compare to.
+   */
+  contains(other: Block | null): boolean {
+    while (other !== null) {
+      if (other === this) return true;
+      other = other.parentBlock_;
+    }
+    return false;
   }
 
   /**

--- a/core/block.ts
+++ b/core/block.ts
@@ -319,6 +319,11 @@ export class Block implements IASTNodeLocation {
     }
   }
 
+  descendsFrom(other: Block): boolean {
+    if (this === other) return true;
+    return this.getParent()?.descendsFrom(other) ?? false;
+  }
+
   /**
    * Dispose of this block.
    *

--- a/core/block.ts
+++ b/core/block.ts
@@ -320,20 +320,6 @@ export class Block implements IASTNodeLocation {
   }
 
   /**
-   * Returns true if this block is the same block as the given block or contains
-   * the provided block as a descendent.
-   *
-   * @param other the other block to compare to.
-   */
-  contains(other: Block | null): boolean {
-    while (other !== null) {
-      if (other === this) return true;
-      other = other.parentBlock_;
-    }
-    return false;
-  }
-
-  /**
    * Dispose of this block.
    *
    * @param healStack If true, then try to heal any gap by connecting the next

--- a/core/block_svg.ts
+++ b/core/block_svg.ts
@@ -278,7 +278,7 @@ export class BlockSvg
     this.addSelect();
   }
 
-  /** Unselects this block. Unhighlights the blockv visually.   */
+  /** Unselects this block. Unhighlights the block visually. */
   unselect() {
     if (this.isShadow()) {
       this.getParent()?.unselect();
@@ -796,6 +796,16 @@ export class BlockSvg
     if (animate) {
       this.unplug(healStack);
       blockAnimations.disposeUiEffect(this);
+    }
+
+    // Selecting a shadow block highlights an ancestor block, but that highlight
+    // should be removed if the shadow block will be deleted. So, before
+    // deleting blocks and severing the connections between them, check whether
+    // doing so would delete a selected block and make sure that any associated
+    // parent is updated.
+    const selection = common.getSelected();
+    if (selection instanceof Block && selection.descendsFrom(this)) {
+      selection.unselect();
     }
 
     super.dispose(!!healStack);

--- a/core/block_svg.ts
+++ b/core/block_svg.ts
@@ -804,8 +804,17 @@ export class BlockSvg
     // doing so would delete a selected block and make sure that any associated
     // parent is updated.
     const selection = common.getSelected();
-    if (selection instanceof Block && this.contains(selection)) {
-      selection.unselect();
+    if (selection instanceof Block) {
+      let selectionAncestor: Block | null = selection;
+      while (selectionAncestor !== null) {
+        if (selectionAncestor === this) {
+          // The block to be deleted contains the selected block, so remove any
+          // selection highlight associated with the selected block before
+          // deleting them.
+          selection.unselect();
+        }
+        selectionAncestor = selectionAncestor.getParent();
+      }
     }
 
     super.dispose(!!healStack);

--- a/core/block_svg.ts
+++ b/core/block_svg.ts
@@ -804,7 +804,7 @@ export class BlockSvg
     // doing so would delete a selected block and make sure that any associated
     // parent is updated.
     const selection = common.getSelected();
-    if (selection instanceof Block && selection.descendsFrom(this)) {
+    if (selection instanceof Block && this.contains(selection)) {
       selection.unselect();
     }
 

--- a/tests/mocha/block_test.js
+++ b/tests/mocha/block_test.js
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import * as common from '../../build/src/core/common.js';
 import {ConnectionType} from '../../build/src/core/connection_type.js';
 import * as eventUtils from '../../build/src/core/events/utils.js';
 import {EndRowInput} from '../../build/src/core/inputs/end_row_input.js';
@@ -205,6 +206,44 @@ suite('Blocks', function () {
         // healed because shadows always stay with the parent.
         assertUnpluggedNoheal(blocks);
       });
+    });
+  });
+
+  suite('Contains', function () {
+    setup(function () {
+      this.blocks = createTestBlocks(this.workspace, true);
+    });
+
+    test('contains parent is false', function () {
+      const blocks = this.blocks;
+      assert.isFalse(
+        blocks.B.contains(blocks.A),
+        'Expected child to not contain parent.',
+      );
+    });
+
+    test('contains self is true', function () {
+      const blocks = this.blocks;
+      assert.isTrue(
+        blocks.A.contains(blocks.A),
+        'Expected block to contain self.',
+      );
+    });
+
+    test('contains child is true', function () {
+      const blocks = this.blocks;
+      assert.isTrue(
+        blocks.A.contains(blocks.B),
+        'Expected block to contain child.',
+      );
+    });
+
+    test('contains grand child is true', function () {
+      const blocks = this.blocks;
+      assert.isTrue(
+        blocks.A.contains(blocks.C),
+        'Expected block to contain grandchild.',
+      );
     });
   });
 
@@ -441,6 +480,39 @@ suite('Blocks', function () {
           // healed because shadows always get destroyed.
           assertDisposedNoheal(blocks);
         });
+      });
+    });
+
+    suite('Disposing selected shadow block', function () {
+      setup(function () {
+        this.workspace = Blockly.inject('blocklyDiv');
+        this.parentBlock = this.workspace.newBlock('row_block');
+        this.parentBlock.initSvg();
+        this.parentBlock.render();
+        this.parentBlock.inputList[0].connection.setShadowState({
+          'type': 'row_block',
+          'id': 'shadow_child',
+        });
+        this.shadowChild =
+          this.parentBlock.inputList[0].connection.targetConnection.getSourceBlock();
+      });
+
+      teardown(function () {
+        workspaceTeardown.call(this, this.workspace);
+      });
+
+      test('Disposing selected shadow unhighlights parent', function () {
+        const parentBlock = this.parentBlock;
+        common.setSelected(this.shadowChild);
+        assert.isTrue(
+          parentBlock.pathObject.svgRoot.classList.contains('blocklySelected'),
+          'Expected parent to be highlighted after selecting shadow child',
+        );
+        this.shadowChild.dispose();
+        assert.isFalse(
+          parentBlock.pathObject.svgRoot.classList.contains('blocklySelected'),
+          'Expected parent to be unhighlighted after deleting shadow child',
+        );
       });
     });
   });

--- a/tests/mocha/block_test.js
+++ b/tests/mocha/block_test.js
@@ -209,44 +209,6 @@ suite('Blocks', function () {
     });
   });
 
-  suite('Contains', function () {
-    setup(function () {
-      this.blocks = createTestBlocks(this.workspace, true);
-    });
-
-    test('contains parent is false', function () {
-      const blocks = this.blocks;
-      assert.isFalse(
-        blocks.B.contains(blocks.A),
-        'Expected child to not contain parent.',
-      );
-    });
-
-    test('contains self is true', function () {
-      const blocks = this.blocks;
-      assert.isTrue(
-        blocks.A.contains(blocks.A),
-        'Expected block to contain self.',
-      );
-    });
-
-    test('contains child is true', function () {
-      const blocks = this.blocks;
-      assert.isTrue(
-        blocks.A.contains(blocks.B),
-        'Expected block to contain child.',
-      );
-    });
-
-    test('contains grand child is true', function () {
-      const blocks = this.blocks;
-      assert.isTrue(
-        blocks.A.contains(blocks.C),
-        'Expected block to contain grandchild.',
-      );
-    });
-  });
-
   suite('Disposal', function () {
     suite('calling destroy', function () {
       setup(function () {


### PR DESCRIPTION
## The basics

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

Partially addresses: https://github.com/google/blockly-samples/issues/2426

### Proposed Changes

Detects whether deleting a block would delete the currently selected block, and if so, deselects it *before* severing connections.

### Reason for Changes

When a shadow block is selected, an ancestor of that block receives a visual highlight. If the shadow block is then deleted (e.g. because it was replaced with a real block via the shadow block converter plugin), then the highlighted block no longer has any relationship to any selected block. That highlight should go away, but currently it persists and may continue to persist while making further changes to the selection.

Note that `Block.dispose()` severs a connection, and `Block.disposeInternal()` also severs connections, so we need to determine whether any parent block needs to be updated before this happens. The subclass `BlockSvg` overrides these methods, so I chose to perform the detection and resolution in `BlockSvg.dispose()`.

### Test Coverage

Existing tests pass. I added new  tests for the new features.

### Documentation

N/A

### Additional Information

I think it feels unintuitive that, when using the shadow block converter plugin and the user edits a shadow block, the current selection gets cleared. As far as the user is concerned, nothing appears to have been deleted (since the real clone of the shadow block seamlessly replaces the shadow block) so it's weird that editing a field of a shadow block deselects the selection.

I propose that we fix this in the shadow block converter plugin by transferring the selection to the new real clone of the selected shadow block after replacing it. Since that's in the samples repo, it would have to be a separate PR. In the meantime, the shadow block converter plugin is already broken and I don't think this PR makes it worse.