### PR TITLE
fix!: Remove the blocklyMenuItemHighlight CSS class and use the hover

### DIFF
--- a/core/css.ts
+++ b/core/css.ts
@@ -445,6 +445,10 @@ input[type=number] {
   cursor: inherit;
 }
 
+.blocklyMenuItem:hover {
+  background-color: rgba(0,0,0,.1);
+}
+
 /* State: hover. */
 .blocklyMenuItemHighlight {
   background-color: rgba(0,0,0,.1);

--- a/core/css.ts
+++ b/core/css.ts
@@ -449,11 +449,6 @@ input[type=number] {
   background-color: rgba(0,0,0,.1);
 }
 
-/* State: hover. */
-.blocklyMenuItemHighlight {
-  background-color: rgba(0,0,0,.1);
-}
-
 /* State: selected/checked. */
 .blocklyMenuItemCheckbox {
   height: 16px;

--- a/core/menu.ts
+++ b/core/menu.ts
@@ -249,11 +249,9 @@ export class Menu {
   setHighlighted(item: MenuItem | null) {
     const currentHighlighted = this.highlightedItem;
     if (currentHighlighted) {
-      currentHighlighted.setHighlighted(false);
       this.highlightedItem = null;
     }
     if (item) {
-      item.setHighlighted(true);
       this.highlightedItem = item;
       // Bring the highlighted item into view. This has no effect if the menu is
       // not scrollable.

--- a/core/menuitem.ts
+++ b/core/menuitem.ts
@@ -12,7 +12,6 @@
 // Former goog.module ID: Blockly.MenuItem
 
 import * as aria from './utils/aria.js';
-import * as dom from './utils/dom.js';
 import * as idGenerator from './utils/idgenerator.js';
 
 /**
@@ -68,7 +67,6 @@ export class MenuItem {
       'blocklyMenuItem ' +
       (this.enabled ? '' : 'blocklyMenuItemDisabled ') +
       (this.checked ? 'blocklyMenuItemSelected ' : '') +
-      (this.highlight ? 'blocklyMenuItemHighlight ' : '') +
       (this.rightToLeft ? 'blocklyMenuItemRtl ' : '');
 
     const content = document.createElement('div');
@@ -185,15 +183,6 @@ export class MenuItem {
    */
   setHighlighted(highlight: boolean) {
     this.highlight = highlight;
-    const el = this.getElement();
-    if (el && this.isEnabled()) {
-      const name = 'blocklyMenuItemHighlight';
-      if (highlight) {
-        dom.addClass(el, name);
-      } else {
-        dom.removeClass(el, name);
-      }
-    }
   }
 
   /**

--- a/core/menuitem.ts
+++ b/core/menuitem.ts
@@ -176,16 +176,6 @@ export class MenuItem {
   }
 
   /**
-   * Highlights or unhighlights the component.
-   *
-   * @param highlight Whether to highlight or unhighlight the component.
-   * @internal
-   */
-  setHighlighted(highlight: boolean) {
-    this.highlight = highlight;
-  }
-
-  /**
    * Returns true if the menu item is enabled, false otherwise.
    *
    * @returns Whether the menu item is enabled.


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes Remove blocklyMenuItemHighlight CSS class and use :hover CSS selector #8327 

### Proposed Changes
Remove the blocklyMenuItemHighlight CSS class from the [menu item](https://github.com/google/blockly/blob/f8025a1bdd12025ecb8830159509148ff27ad3c8/core/menuitem.ts#L73).
Use the [:hover CSS pseudo class](https://developer.mozilla.org/en-US/docs/Web/CSS/:hover) in [css.ts](https://github.com/google/blockly/blob/f8025a1bdd12025ecb8830159509148ff27ad3c8/core/css.ts#L481).
<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
