### PR TITLE
refactor(events): Don't filter events before undo

### DIFF
--- a/core/workspace.ts
+++ b/core/workspace.ts
@@ -634,7 +634,7 @@ export class Workspace implements IASTNodeLocation {
     if (!inputEvent) {
       return;
     }
-    let events = [inputEvent];
+    const events = [inputEvent];
     // Do another undo/redo if the next one is of the same group.
     while (
       inputStack.length &&
@@ -650,7 +650,6 @@ export class Workspace implements IASTNodeLocation {
       const event = events[i];
       outputStack.push(event);
     }
-    events = eventUtils.filter(events, redo);
     eventUtils.setRecordUndo(false);
     try {
       for (let i = 0; i < events.length; i++) {


### PR DESCRIPTION
## The basics

- [X] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

Cleanup work adjacent to fixes for #2037 and #8225.

### Proposed Changes

* Don't call `filter` function from `Workspace.prototype.undo`.
* Delete post-fire undo/redo queue filtering from `fireNow`.

### Reason for Changes

Use of the `filter` function in `Workspace.prototype.undo` was intended to reduce the number of events that would need to be run when undoing or redoing, but because it mutates and sometimes deletes stacked events this has caused problems with repeated undo/redo (see issue #7026).  The originally-chosen fix for which was the addition (in PR #7069) of code to `fireNow` to post-filter the `.undoStack_` and `.redoStack_` of any workspace that had just been involved in dispatching events; this apparently resolved the issue but added considerable additional complexity and made it difficult to reason about how events are processed for undo/redo.

Instead, since this filtering typically does nothing (at least nothing _desirable_), simply don't re-filter events on the undo stack before replaying them.

### Test Coverage

Although this PR should reduce the overall likelihood of event-mechanics-related problems with undo/redo, those functions should nevertheless be subject to thorough testing before our next release.

### Documentation

No changes required.

### Additional Information

<!-- Anything else we should know? -->
