### PR TITLE
fix(events): Simplify `filter` function, add new `enqueueEvent` function

### DIFF
--- a/core/events/utils.ts
+++ b/core/events/utils.ts
@@ -84,8 +84,8 @@ const FIRE_QUEUE: Abstract[] = [];
  * Notes:
  *
  * - Events are enqueued until a timeout, generally after rendering is
- *   complete but or at the end of the current microtask, if not
- *   running in a browser.
+ *   complete or at the end of the current microtask, if not running
+ *   in a browser.
  * - Queued events are subject to destructive modification by being
  *   combined with later-enqueued events, but only until they are
  *   fired.
@@ -214,7 +214,7 @@ function enqueueEvent(event: Abstract) {
  * addition (in PR #7069) of code to fireNow to post-filter the
  * .undoStack_ and .redoStack_ of any workspace that had just been
  * involved in dispatching events; this apparently resolved the issue
- * but added considerable additional complexity and made it difficlut
+ * but added considerable additional complexity and made it difficult
  * to reason about how events are processed for undo/redo, so both the
  * call from undo and the post-processing code was removed, and
  * forward=true was made the default while calling the function with
@@ -234,7 +234,8 @@ function enqueueEvent(event: Abstract) {
  * @param queue Array of events.
  * @param forward True if forward (redo), false if backward (undo).
  *     This parameter is deprecated: true is now the default and
- *     calling filter with it false will in future not be supported.
+ *     calling filter with it set to false will in future not be
+ *     supported.
  * @returns Array of filtered events.
  */
 export function filter(queue: Abstract[], forward = true): Abstract[] {

--- a/core/events/utils.ts
+++ b/core/events/utils.ts
@@ -9,6 +9,7 @@
 import type {Block} from '../block.js';
 import * as common from '../common.js';
 import * as registry from '../registry.js';
+import * as deprecation from '../utils/deprecation.js';
 import * as idGenerator from '../utils/idgenerator.js';
 import type {Workspace} from '../workspace.js';
 import type {WorkspaceSvg} from '../workspace_svg.js';
@@ -216,7 +217,9 @@ function enqueueEvent(event: Abstract) {
  * involved in dispatching events; this apparently resolved the issue
  * but added considerable additional complexity and made it difficlut
  * to reason about how events are processed for undo/redo, so both the
- * call from undo and the post-processing code was removed.
+ * call from undo and the post-processing code was removed, and
+ * forward=true was made the default while calling the function with
+ * forward=false was deprecated.
  *
  * At the same time, the buggy code to reorder BlockChange events was
  * replaced by a less-buggy version of the same functionality in a new
@@ -226,14 +229,17 @@ function enqueueEvent(event: Abstract) {
  *
  * @param queueIn Array of events.
  * @param forward True if forward (redo), false if backward (undo).
+ *     This parameter is deprecated: true is now the default and
+ *     calling filter with it false will in future not be supported.
  * @returns Array of filtered events.
  */
-export function filter(queueIn: Abstract[], forward: boolean): Abstract[] {
+export function filter(queueIn: Abstract[], forward = true): Abstract[] {
   let queue = queueIn.slice();
   // Shallow copy of queue.
   if (!forward) {
-    // Undo is merged in reverse order.
-    queue.reverse();
+    deprecation.warn('filter(queue, /*forward=*/false)', 'v11.2', 'v12');
+    // Undo was merged in reverse order.
+    queue = queue.slice().reverse(); // Copy before reversing in place.
   }
   const mergedQueue = [];
   const hash = Object.create(null);

--- a/core/events/utils.ts
+++ b/core/events/utils.ts
@@ -126,7 +126,7 @@ function fireInternal(event: Abstract) {
 function fireNow() {
   const queue = filter(FIRE_QUEUE, true);
   FIRE_QUEUE.length = 0;
-  for (let i = 0, event; (event = queue[i]); i++) {
+  for (const event of queue) {
     if (!event.workspaceId) {
       continue;
     }
@@ -265,14 +265,11 @@ export function filter(queue: Abstract[], forward = true): Abstract[] {
       lastEvent.newParentId = event.newParentId;
       lastEvent.newInputName = event.newInputName;
       lastEvent.newCoordinate = event.newCoordinate;
-      if (event.reason) {
-        if (lastEvent.reason) {
-          // Concatenate reasons without duplicates.
-          const reasonSet = new Set(event.reason.concat(lastEvent.reason));
-          lastEvent.reason = Array.from(reasonSet);
-        } else {
-          lastEvent.reason = event.reason;
-        }
+      // Concatenate reasons without duplicates.
+      if (lastEvent.reason || event.reason) {
+        lastEvent.reason = Array.from(
+          new Set((lastEvent.reason ?? []).concat(event.reason ?? [])),
+        );
       }
     } else if (
       isBlockChange(event) &&
@@ -296,9 +293,7 @@ export function filter(queue: Abstract[], forward = true): Abstract[] {
     }
   }
   // Filter out any events that have become null due to merging.
-  queue = mergedQueue.filter(function (e) {
-    return !e.isNull();
-  });
+  queue = mergedQueue.filter((e) => !e.isNull());
   if (!forward) {
     // Restore undo order.
     queue.reverse();

--- a/tests/mocha/event_test.js
+++ b/tests/mocha/event_test.js
@@ -1142,7 +1142,7 @@ suite('Events', function () {
       event.workspaceId = workspaceId;
       event.oldParentId = undefined;
       event.oldInputName = undefined;
-      event.oleCoordinate = new Blockly.utils.Coordinate(0, 0);
+      event.oldCoordinate = new Blockly.utils.Coordinate(0, 0);
       event.newParentId = parent.id;
       event.newInputName = inputName;
       event.newCoordinate = undefined;

--- a/tests/mocha/event_test.js
+++ b/tests/mocha/event_test.js
@@ -42,6 +42,26 @@ suite('Events', function () {
         'type': 'simple_test_block',
         'message0': 'simple test block',
       },
+      {
+        'type': 'inputs_test_block',
+        'message0': 'first %1 second %2',
+        'args0': [
+          {
+            'type': 'input_statement',
+            'name': 'STATEMENT1',
+          },
+          {
+            'type': 'input_statement',
+            'name': 'STATEMENT2',
+          },
+        ],
+      },
+      {
+        'type': 'statement_test_block',
+        'message0': '',
+        'previousStatement': null,
+        'nextStatement': null,
+      },
     ]);
   });
 
@@ -1099,6 +1119,165 @@ suite('Events', function () {
         assert.isNull(this.workspace.getVariable('name2'));
         checkVariableValues(this.workspace, 'name1', 'type1', 'id1');
       });
+    });
+  });
+
+  suite('enqueueEvent', function () {
+    const {FIRE_QUEUE, enqueueEvent} = eventUtils.TEST_ONLY;
+
+    function newDisconnectEvent(parent, child, inputName, workspaceId) {
+      const event = new Blockly.Events.BlockMove(child);
+      event.workspaceId = workspaceId;
+      event.oldParentId = parent.id;
+      event.oldInputName = inputName;
+      event.oldCoordinate = undefined;
+      event.newParentId = undefined;
+      event.newInputName = undefined;
+      event.newCoordinate = new Blockly.utils.Coordinate(0, 0);
+      return event;
+    }
+
+    function newConnectEvent(parent, child, inputName, workspaceId) {
+      const event = new Blockly.Events.BlockMove(child);
+      event.workspaceId = workspaceId;
+      event.oldParentId = undefined;
+      event.oldInputName = undefined;
+      event.oleCoordinate = new Blockly.utils.Coordinate(0, 0);
+      event.newParentId = parent.id;
+      event.newInputName = inputName;
+      event.newCoordinate = undefined;
+      return event;
+    }
+
+    function newMutationEvent(block, workspaceId) {
+      const event = new Blockly.Events.BlockChange(block);
+      event.workspaceId = workspaceId;
+      event.element = 'mutation';
+      return event;
+    }
+
+    test('Events are enqueued', function () {
+      // Disable events during block creation to avoid firing BlockCreate
+      // events.
+      eventUtils.disable();
+      const block = this.workspace.newBlock('simple_test_block', '1');
+      eventUtils.enable();
+
+      try {
+        assert.equal(FIRE_QUEUE.length, 0);
+        const events = [
+          new Blockly.Events.BlockCreate(block),
+          new Blockly.Events.BlockMove(block),
+          new Blockly.Events.Click(block),
+        ];
+        events.map((e) => enqueueEvent(e));
+        assert.equal(FIRE_QUEUE.length, events.length, 'FIRE_QUEUE.length');
+        for (let i = 0; i < events.length; i++) {
+          assert.equal(FIRE_QUEUE[i], events[i], `FIRE_QUEUE[${i}]`);
+        }
+      } finally {
+        FIRE_QUEUE.length = 0;
+      }
+    });
+
+    test('BlockChange event reordered', function () {
+      eventUtils.disable();
+      const parent = this.workspace.newBlock('inputs_test_block', 'parent');
+      const child1 = this.workspace.newBlock('statement_test_block', 'child1');
+      const child2 = this.workspace.newBlock('statement_test_block', 'child2');
+      eventUtils.enable();
+
+      try {
+        assert.equal(FIRE_QUEUE.length, 0);
+        const events = [
+          newDisconnectEvent(parent, child1, 'STATEMENT1'),
+          newDisconnectEvent(parent, child2, 'STATEMENT2'),
+          newConnectEvent(parent, child1, 'STATEMENT1'),
+          newConnectEvent(parent, child2, 'STATEMENT2'),
+          newMutationEvent(parent),
+        ];
+        events.map((e) => enqueueEvent(e));
+        assert.equal(FIRE_QUEUE.length, events.length, 'FIRE_QUEUE.length');
+        assert.equal(FIRE_QUEUE[0], events[0], 'FIRE_QUEUE[0]');
+        assert.equal(FIRE_QUEUE[1], events[1], 'FIRE_QUEUE[1]');
+        assert.equal(FIRE_QUEUE[2], events[4], 'FIRE_QUEUE[2]');
+        assert.equal(FIRE_QUEUE[3], events[2], 'FIRE_QUEUE[3]');
+        assert.equal(FIRE_QUEUE[4], events[3], 'FIRE_QUEUE[4]');
+      } finally {
+        FIRE_QUEUE.length = 0;
+      }
+    });
+
+    test('BlockChange event for other workspace not reordered', function () {
+      eventUtils.disable();
+      const parent = this.workspace.newBlock('inputs_test_block', 'parent');
+      const child = this.workspace.newBlock('statement_test_block', 'child');
+      eventUtils.enable();
+
+      try {
+        assert.equal(FIRE_QUEUE.length, 0);
+        const events = [
+          newDisconnectEvent(parent, child, 'STATEMENT1', 'ws1'),
+          newConnectEvent(parent, child, 'STATEMENT1', 'ws1'),
+          newMutationEvent(parent, 'ws2'),
+        ];
+        events.map((e) => enqueueEvent(e));
+        assert.equal(FIRE_QUEUE.length, events.length, 'FIRE_QUEUE.length');
+        for (let i = 0; i < events.length; i++) {
+          assert.equal(FIRE_QUEUE[i], events[i], `FIRE_QUEUE[${i}]`);
+        }
+      } finally {
+        FIRE_QUEUE.length = 0;
+      }
+    });
+
+    test('BlockChange event for other group not reordered', function () {
+      eventUtils.disable();
+      const parent = this.workspace.newBlock('inputs_test_block', 'parent');
+      const child = this.workspace.newBlock('statement_test_block', 'child');
+      eventUtils.enable();
+
+      try {
+        assert.equal(FIRE_QUEUE.length, 0);
+        const events = [];
+        eventUtils.setGroup('group1');
+        events.push(newDisconnectEvent(parent, child, 'STATEMENT1'));
+        events.push(newConnectEvent(parent, child, 'STATEMENT1'));
+        eventUtils.setGroup('group2');
+        events.push(newMutationEvent(parent, 'ws2'));
+        events.map((e) => enqueueEvent(e));
+        assert.equal(FIRE_QUEUE.length, events.length, 'FIRE_QUEUE.length');
+        for (let i = 0; i < events.length; i++) {
+          assert.equal(FIRE_QUEUE[i], events[i], `FIRE_QUEUE[${i}]`);
+        }
+      } finally {
+        FIRE_QUEUE.length = 0;
+        eventUtils.setGroup(false);
+      }
+    });
+
+    test('BlockChange event for other parent not reordered', function () {
+      eventUtils.disable();
+      const parent1 = this.workspace.newBlock('inputs_test_block', 'parent1');
+      const parent2 = this.workspace.newBlock('inputs_test_block', 'parent2');
+      const child = this.workspace.newBlock('statement_test_block', 'child');
+      eventUtils.enable();
+
+      try {
+        assert.equal(FIRE_QUEUE.length, 0);
+        const events = [
+          newDisconnectEvent(parent1, child, 'STATEMENT1', 'ws1'),
+          newConnectEvent(parent1, child, 'STATEMENT1', 'ws1'),
+          newMutationEvent(parent2, 'ws2'),
+        ];
+        events.map((e) => enqueueEvent(e));
+        assert.equal(FIRE_QUEUE.length, events.length, 'FIRE_QUEUE.length');
+        for (let i = 0; i < events.length; i++) {
+          assert.equal(FIRE_QUEUE[i], events[i], `FIRE_QUEUE[${i}]`);
+        }
+      } finally {
+        FIRE_QUEUE.length = 0;
+      }
     });
   });
 


### PR DESCRIPTION
## The basics

- [X] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

Fixes #2037, #8225

### Proposed Changes

* Remove the broken `BlockChange` event reordering code from `filter`.  Instead, do necessary event reordering in a new (and hopefully more robust and less buggy) `enqueueEvent` function called from `fireInternal` as events are fired.
* Since (as of #8537) we don't filter in undo any more, and filtering in reverse order is confusing and can cause problems, prepare to remove this opportunity for error by deprecating calling `filter` with `forward=false`.
* Simplify `filter` by having it consider only adjacent events in the queue for merging.  Previously any events in the queue could potentially be merged if they were of suitable (typically identical) `.type`, even if other events had occurred between them (with the sole exception of `BlockMove` events, which would only be merged with adjacent ones).  This could potentially result in replay failures during undo/redo/mirroring, though it is unknown whether any such problems occurred in practice.
* Use `for…of` loop where appropriate.
* Make filter reason-merging code more concise.
* Use arrow functions when calling `Array.prototype.filter`.

### Reason for Changes

* Remove code from `filter` that has been the source of multiple current and previous bugs, and actively breaks other attempts to fix those bugs (e.g. by emitting events in the correct order to start with).
* Simplify `filter` so it is easier to reason about its behaviour.

### Test Coverage

* Added unit tests for `enqueueEvent`.
* There are existing unit tests for `filter`, none of which fail due to the changes made in this PR.

