### PR TITLE
fix: display the correct variable reference count when deleting a variable.

### DIFF
--- a/core/variables.ts
+++ b/core/variables.ts
@@ -747,7 +747,13 @@ export function deleteVariable(
   if ((triggeringBlock && uses.length) || uses.length > 1) {
     // Confirm before deleting multiple blocks.
     const confirmText = Msg['DELETE_VARIABLE_CONFIRMATION']
-      .replace('%1', String(uses.length + (triggeringBlock ? 1 : 0)))
+      .replace(
+        '%1',
+        String(
+          uses.length +
+            (triggeringBlock && !triggeringBlock.workspace.isFlyout ? 1 : 0),
+        ),
+      )
       .replace('%2', variableName);
     dialog.confirm(confirmText, (ok) => {
       if (ok && variable) {


### PR DESCRIPTION

<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
When deleting a variable with one or more references in the workspace from the dropdown/contextual menu of the variable blocks in a non-autoclosing flyout, the number of references in the  prompt confirming the deletion was off by one. This PR fixes this by not including the block triggering the deletion (in the flyout) in the reference count.