### PR TITLE
refactor: Omit unused exception arguments from `catch` blocks

### DIFF
--- a/appengine/blockly_compressed.js
+++ b/appengine/blockly_compressed.js
@@ -6,6 +6,6 @@ var msg = 'Compiled Blockly files should be loaded from https://unpkg.com/blockl
 console.log(msg);
 try {
   alert(msg);
-} catch (_e) {
+} catch {
   // Can't alert?  Probably node.js.
 }

--- a/scripts/gulpfiles/build_tasks.js
+++ b/scripts/gulpfiles/build_tasks.js
@@ -699,7 +699,7 @@ function buildAdvancedCompilationTest() {
   // a later browser-based test won't check it should the compile fail.
   try {
     fs.unlinkSync('./tests/compile/main_compressed.js');
-  } catch (_e) {
+  } catch {
     // Probably it didn't exist.
   }
 

--- a/tests/compile/main.js
+++ b/tests/compile/main.js
@@ -47,7 +47,7 @@ window['healthCheck'] = function() {
     const blockCount =
         getMainWorkspace().getFlyout().getWorkspace().getTopBlocks().length;
     return (blockCount > 5 && blockCount < 100);
-  } catch (_e) {
+  } catch {
     return false;
   }
 };


### PR DESCRIPTION
## The basics

- [X] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

Fixes #1770.

### Proposed Changes

Omit unused exception arguments from `catch` blocks.

### Reason for Changes

Style better.

### Test Coverage

Passes `npm test`
