### PR TITLE
fix: improve flyout performance

### DIFF
--- a/core/flyout_base.ts
+++ b/core/flyout_base.ts
@@ -711,9 +711,6 @@ export abstract class Flyout
 
     this.filterForCapacity();
 
-    // Correctly position the flyout's scrollbar when it opens.
-    this.position();
-
     // Listen for block change events, and reflow the flyout in response. This
     // accommodates e.g. resizing a non-autoclosing flyout in response to the
     // user typing long strings into fields on the blocks in the flyout.

--- a/core/flyout_base.ts
+++ b/core/flyout_base.ts
@@ -402,7 +402,14 @@ export abstract class Flyout
         this.wheel_,
       ),
     );
-    this.filterWrapper = this.filterForCapacity.bind(this);
+    this.filterWrapper = (event) => {
+      if (
+        event.type === eventUtils.BLOCK_CREATE ||
+        event.type === eventUtils.BLOCK_DELETE
+      ) {
+        this.filterForCapacity();
+      }
+    };
     this.targetWorkspace.addChangeListener(this.filterWrapper);
 
     // Dragging the flyout up and down.
@@ -707,7 +714,17 @@ export abstract class Flyout
     // Correctly position the flyout's scrollbar when it opens.
     this.position();
 
-    this.reflowWrapper = this.reflow.bind(this);
+    // Listen for block change events, and reflow the flyout in response. This
+    // accommodates e.g. resizing a non-autoclosing flyout in response to the
+    // user typing long strings into fields on the blocks in the flyout.
+    this.reflowWrapper = (event) => {
+      if (
+        event.type === eventUtils.BLOCK_CHANGE ||
+        event.type === eventUtils.BLOCK_FIELD_INTERMEDIATE_CHANGE
+      ) {
+        this.reflow();
+      }
+    };
     this.workspace_.addChangeListener(this.reflowWrapper);
     this.emptyRecycledBlocks();
   }


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
This PR improves performance of flyouts. Previously, flyouts were reflowing/repositioning their contents in response to every event fired by the flyout workspace; this was particularly problematic during populating the flyout, when blocks being added/removed could cause this to happen hundreds of times. Scrolling the flyout also triggered continuous relayouts due to viewport change events. Reflowing is now only triggered in response to block change events, which can legitimately require it when e.g. the user types into a field in a block in the flyout and the flyout needs to resize to accomodate the block's new dimensions.

Additionally, the flyout was also listening to all events from the main/target workspace, and running a handler to check for and disable blocks over the maximum allowed instances threshold. This has been updated to only run on block create/deletes, since these are the only events than can result in a block exceeding/falling back under this threshold.