### PR TITLE
fix: size text with computed styles even when hidden

### DIFF
--- a/core/utils/dom.ts
+++ b/core/utils/dom.ts
@@ -210,7 +210,13 @@ export function getTextWidth(textElement: SVGTextElement): number {
 
   // Attempt to compute fetch the width of the SVG text element.
   try {
-    width = textElement.getComputedTextLength();
+    const style = window.getComputedStyle(textElement);
+    width = getFastTextWidthWithSizeString(
+      textElement,
+      style.fontSize,
+      style.fontWeight,
+      style.fontFamily,
+    );
   } catch (e) {
     // In other cases where we fail to get the computed text. Instead, use an
     // approximation and do not cache the result. At some later point in time

--- a/core/utils/dom.ts
+++ b/core/utils/dom.ts
@@ -208,22 +208,14 @@ export function getTextWidth(textElement: SVGTextElement): number {
     }
   }
 
-  // Attempt to compute fetch the width of the SVG text element.
-  try {
-    const style = window.getComputedStyle(textElement);
-    width = getFastTextWidthWithSizeString(
-      textElement,
-      style.fontSize,
-      style.fontWeight,
-      style.fontFamily,
-    );
-  } catch (e) {
-    // In other cases where we fail to get the computed text. Instead, use an
-    // approximation and do not cache the result. At some later point in time
-    // when the block is inserted into the visible DOM, this method will be
-    // called again and, at that point in time, will not throw an exception.
-    return textElement.textContent!.length * 8;
-  }
+  // Compute the width of the SVG text element.
+  const style = window.getComputedStyle(textElement);
+  width = getFastTextWidthWithSizeString(
+    textElement,
+    style.fontSize,
+    style.fontWeight,
+    style.fontFamily,
+  );
 
   // Cache the computed width and return.
   if (cacheWidths) {


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Re-fixes #8277

### Proposed Changes
Recently, code that was calling `getFastTextWidth()` was updated to call `getTextWidth()` instead, because `getFastTextWidth()` required knowledge of some styling attributes. Historically, these were derived from the theme/renderer, but with recent changes to move towards using CSS for this purpose, it was thought that we needed to use `getTextWidth()` instead, which relied on the `getComputedTextLength()` method of SVG text elements.

Unfortunately, `getComputedTextLength()` has a significant limitation: it doesn't work when the SVG text element (or any of its parents) has `display: none` or similar set. This could result in blocks being incorrectly sized when manipulated while not visible, e.g. https://github.com/gonfunko/scratch-blocks/issues/163.

This PR modifies the implementation of `getTextWidth()` to instead use `getComputedStyle()` to dynamically calculate the CSS styles applied to an SVG text element, whether through Blockly's built-in styles, injected styles, or user agent stylesheets. This method returns a live [CSSStyleDeclaration](https://developer.mozilla.org/en-US/docs/Web/API/CSSStyleDeclaration) object, which allows accessing the currently-applicable value of any CSS property. AIUI, this doesn't calculate anything up front, only determining the value of properties when they are accessed, so performance should be (and appears to be) quite good. Moreover, this appears to return e.g. the font size/weight/face applied to an element even if it is hidden at the moment, and resolves the aforementioned issues.

This PR additionally removes exception handling and size estimation code that was presumably present due to an [IE 10 behavior](https://stackoverflow.com/questions/19122753/getcomputedtextlength-throws-an-error-in-ie10) that caused `getComputedTextLength()` to throw for hidden elements.