### PR TITLE
refactor: remove redundant flyout positioning.

### DIFF
--- a/core/workspace_svg.ts
+++ b/core/workspace_svg.ts
@@ -1050,9 +1050,6 @@ export class WorkspaceSvg extends Workspace implements IASTNodeLocationSvg {
     if (this.toolbox_) {
       this.toolbox_.position();
     }
-    if (this.flyout) {
-      this.flyout.position();
-    }
 
     const positionables = this.componentManager.getComponents(
       ComponentManager.Capability.POSITIONABLE,

--- a/core/workspace_svg.ts
+++ b/core/workspace_svg.ts
@@ -1049,6 +1049,8 @@ export class WorkspaceSvg extends Workspace implements IASTNodeLocationSvg {
   resize() {
     if (this.toolbox_) {
       this.toolbox_.position();
+    } else if (this.flyout) {
+      this.flyout.position();
     }
 
     const positionables = this.componentManager.getComponents(


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
This PR removes a redundant call to `Flyout.position()` in `WorkspaceSvg`. The code calls `Toolbox.position()` on the previous line, which [in turn calls `Flyout.position()`](https://github.com/google/blockly/blob/develop/core/toolbox/toolbox.ts#L723), so the flyout was needlessly being positioned twice.