### PR TITLE
fix: include potential variables in variable dropdowns in the flyout

### DIFF
--- a/core/field_variable.ts
+++ b/core/field_variable.ts
@@ -572,15 +572,23 @@ export class FieldVariable extends FieldDropdown {
     }
     const name = this.getText();
     let variableModelList: IVariableModel<IVariableState>[] = [];
-    if (this.sourceBlock_ && !this.sourceBlock_.isDeadOrDying()) {
+    const sourceBlock = this.getSourceBlock();
+    if (sourceBlock && !sourceBlock.isDeadOrDying()) {
+      const workspace = sourceBlock.workspace;
       const variableTypes = this.getVariableTypes();
       // Get a copy of the list, so that adding rename and new variable options
       // doesn't modify the workspace's list.
       for (let i = 0; i < variableTypes.length; i++) {
         const variableType = variableTypes[i];
-        const variables =
-          this.sourceBlock_.workspace.getVariablesOfType(variableType);
+        const variables = workspace.getVariablesOfType(variableType);
         variableModelList = variableModelList.concat(variables);
+        if (workspace.isFlyout) {
+          variableModelList = variableModelList.concat(
+            workspace
+              .getPotentialVariableMap()
+              ?.getVariablesOfType(variableType) ?? [],
+          );
+        }
       }
     }
     variableModelList.sort(Variables.compareByName);


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
Blockly has two sets of variables: those in the main workspace, and those that exist solely in the flyout. The latter were not included in the dropdown list of variables shown by FieldVariable however; this PR resolves that. This fixes https://github.com/gonfunko/scratch-blocks/issues/149.