### PR TITLE
fix: Simplify list and text WHERE validation

### DIFF
--- a/blocks/lists.ts
+++ b/blocks/lists.ts
@@ -417,10 +417,7 @@ const LISTS_GETINDEX = {
       options: this.WHERE_OPTIONS,
     }) as FieldDropdown;
     menu.setValidator(
-      /**
-       * @param value The input value.
-       * @returns Null if the field has been replaced; otherwise undefined.
-       */
+      /** @param value The input value. */
       function (this: FieldDropdown, value: string) {
         const oldValue: string | null = this.getValue();
         const oldAt = oldValue === 'FROM_START' || oldValue === 'FROM_END';
@@ -645,10 +642,7 @@ const LISTS_SETINDEX = {
       options: this.WHERE_OPTIONS,
     }) as FieldDropdown;
     menu.setValidator(
-      /**
-       * @param value The input value.
-       * @returns Null if the field has been replaced; otherwise undefined.
-       */
+      /** @param value The input value. */
       function (this: FieldDropdown, value: string) {
         const oldValue: string | null = this.getValue();
         const oldAt = oldValue === 'FROM_START' || oldValue === 'FROM_END';
@@ -816,10 +810,7 @@ const LISTS_GETSUBLIST = {
           this[('WHERE_OPTIONS_' + n) as 'WHERE_OPTIONS_1' | 'WHERE_OPTIONS_2'],
       }) as FieldDropdown;
       menu.setValidator(
-        /**
-         * @param value The input value.
-         * @returns Null if the field has been replaced; otherwise undefined.
-         */
+        /** @param value The input value. */
         function (this: FieldDropdown, value: string) {
           const oldValue: string | null = this.getValue();
           const oldAt = oldValue === 'FROM_START' || oldValue === 'FROM_END';

--- a/blocks/text.ts
+++ b/blocks/text.ts
@@ -216,7 +216,33 @@ const GET_SUBSTRING_BLOCK = {
     this.appendValueInput('STRING')
       .setCheck('String')
       .appendField(Msg['TEXT_GET_SUBSTRING_INPUT_IN_TEXT']);
+    const createMenu = (n: 1 | 2): FieldDropdown => {
+      const menu = fieldRegistry.fromJson({
+        type: 'field_dropdown',
+        options:
+          this[('WHERE_OPTIONS_' + n) as 'WHERE_OPTIONS_1' | 'WHERE_OPTIONS_2'],
+      }) as FieldDropdown;
+      menu.setValidator(
+        /**
+         * @param value The input value.
+         * @returns Null if the field has been replaced; otherwise undefined.
+         */
+        function (this: FieldDropdown, value: any): null | undefined {
+          const oldValue: string | null = this.getValue();
+          const oldAt = oldValue === 'FROM_START' || oldValue === 'FROM_END';
+          const newAt = value === 'FROM_START' || value === 'FROM_END';
+          if (newAt !== oldAt) {
+            const block = this.getSourceBlock() as GetSubstringBlock;
+            block.updateAt_(n, newAt);
+          }
+          return undefined;
+        },
+      );
+      return menu;
+    };
+    this.appendDummyInput('WHERE1_INPUT').appendField(createMenu(1), 'WHERE1');
     this.appendDummyInput('AT1');
+    this.appendDummyInput('WHERE2_INPUT').appendField(createMenu(2), 'WHERE2');
     this.appendDummyInput('AT2');
     if (Msg['TEXT_GET_SUBSTRING_TAIL']) {
       this.appendDummyInput('TAIL').appendField(Msg['TEXT_GET_SUBSTRING_TAIL']);
@@ -288,37 +314,10 @@ const GET_SUBSTRING_BLOCK = {
       this.removeInput('TAIL', true);
       this.appendDummyInput('TAIL').appendField(Msg['TEXT_GET_SUBSTRING_TAIL']);
     }
-    const menu = fieldRegistry.fromJson({
-      type: 'field_dropdown',
-      options:
-        this[('WHERE_OPTIONS_' + n) as 'WHERE_OPTIONS_1' | 'WHERE_OPTIONS_2'],
-    }) as FieldDropdown;
-    menu.setValidator(
-      /**
-       * @param value The input value.
-       * @returns Null if the field has been replaced; otherwise undefined.
-       */
-      function (this: FieldDropdown, value: any): null | undefined {
-        const newAt = value === 'FROM_START' || value === 'FROM_END';
-        // The 'isAt' variable is available due to this function being a
-        // closure.
-        if (newAt !== isAt) {
-          const block = this.getSourceBlock() as GetSubstringBlock;
-          block.updateAt_(n, newAt);
-          // This menu has been destroyed and replaced.
-          // Update the replacement.
-          block.setFieldValue(value, 'WHERE' + n);
-          return null;
-        }
-        return undefined;
-      },
-    );
-
-    this.getInput('AT' + n)!.appendField(menu, 'WHERE' + n);
     if (n === 1) {
-      this.moveInputBefore('AT1', 'AT2');
+      this.moveInputBefore('AT1', 'WHERE2_INPUT');
       if (this.getInput('ORDINAL1')) {
-        this.moveInputBefore('ORDINAL1', 'AT2');
+        this.moveInputBefore('ORDINAL1', 'WHERE2_INPUT');
       }
     }
   },

--- a/blocks/text.ts
+++ b/blocks/text.ts
@@ -223,10 +223,7 @@ const GET_SUBSTRING_BLOCK = {
           this[('WHERE_OPTIONS_' + n) as 'WHERE_OPTIONS_1' | 'WHERE_OPTIONS_2'],
       }) as FieldDropdown;
       menu.setValidator(
-        /**
-         * @param value The input value.
-         * @returns Null if the field has been replaced; otherwise undefined.
-         */
+        /** @param value The input value. */
         function (this: FieldDropdown, value: any): null | undefined {
           const oldValue: string | null = this.getValue();
           const oldAt = oldValue === 'FROM_START' || oldValue === 'FROM_END';


### PR DESCRIPTION
## The basics

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

Fixes https://github.com/google/blockly/issues/8556

### Proposed Changes

I modified the following block type definitions:
- `lists_getIndex`
- `lists_setIndex`
- `lists_getSublist`
- `text_getSubstring`

Each of these had an input called `AT` with an attached field called `WHERE`. The input and its attached field were sometimes removed and recreated in response to the field's validator. This PR instead attaches the field to a separate dummy input, such that the field does not need to be recreated every time the input is recreated.

### Reason for Changes

Edits to the field did not always fire a BlockChange event. In particular, if the user is trying to change the field's value to its default value, but the field gets recreated, then the recreated field will already have the default value and thus no change is detected.

### Test Coverage

All existing tests pass. Manual testing confirms that BlockChange events are fired as expected.

### Additional Information

I can't prove that nobody is depending on the specific hierarchy of inputs and fields in these blocks, although I preserved the existing names of the inputs and fields. I also added new names for new dummy inputs in some cases (so that other inputs could be moved adjacent to them). Should this be considered a breaking change?

Also, there's a bug when undoing/redoing edits to the `WHERE` field while a child block is already attached to the `AT` input. Changing the field's value can replace the `AT` input with a dummy input, which forcibly detaches the child block, but this is not properly recorded in undo history. In particular, if you edited the field and then made additional changes, then undid all those changes and tried to redo them, the additional changes are lost. A similar bug existed before this PR, but I don't think this PR makes the bug any worse, and I suspect this PR is a prerequisite to properly fixing the bug. Possibly related to: https://github.com/google/blockly/issues/7950