### PR TITLE
fix: Group field validator changes with field value changes.

### DIFF
--- a/tests/mocha/jso_serialization_test.js
+++ b/tests/mocha/jso_serialization_test.js
@@ -533,7 +533,7 @@ suite('JSO Serialization', function () {
             },
             'block': {
               'type': 'text',
-              'id': 'id3',
+              'id': 'id4',
               'fields': {
                 'TEXT': '',
               },


### PR DESCRIPTION
## The basics

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

Fixes https://github.com/google/blockly/issues/8588

Also fixes https://github.com/google/blockly/issues/6456

### Proposed Changes

Creates a change group before performing any field validation, and uses this group for the field value change event.

### Reason for Changes

There are field validators in the core blockly library that make workspace changes in response to field value changes. For example, the block `list_getIndex` creates or destroys an input connection depending on the value of a dropdown. However, these changes do not get grouped with the field value changes, which causes problems when undoing.

This PR also allows change listeners to retroactively create changes that are grouped with the changes that they are responding to, which is a technique that is already used by some plugins but is incompatible with fields that don't assign any group id to their value changes.

### Test Coverage

All existing tests pass, except for the 4 `WorkspaceSvg cleanUp` test methods that are already currently broken in the 
`develop` branch. (Are these known? I'm testing on a Mac and some coordinates are slightly off.)