### PR TITLE
fix: Fix bug that prevented dismissing the widgetdiv in a mutator workspace.

### DIFF
--- a/core/widgetdiv.ts
+++ b/core/widgetdiv.ts
@@ -169,7 +169,7 @@ export function hideIfOwner(oldOwner: unknown) {
  * @param workspace The workspace that was using this container.
  */
 export function hideIfOwnerIsInWorkspace(workspace: WorkspaceSvg) {
-  let ownerIsInWorkspace = workspace === null;
+  let ownerIsInWorkspace = this.ownerWorkspace === null;
   // Check if the given workspace is a parent workspace of the one containing
   // our owner.
   let currentWorkspace: WorkspaceSvg | null = workspace;

--- a/core/widgetdiv.ts
+++ b/core/widgetdiv.ts
@@ -166,10 +166,22 @@ export function hideIfOwner(oldOwner: unknown) {
  * Destroy the widget and hide the div if it is being used by an object in the
  * specified workspace, or if it is used by an unknown workspace.
  *
- * @param oldOwnerWorkspace The workspace that was using this container.
+ * @param workspace The workspace that was using this container.
  */
-export function hideIfOwnerIsInWorkspace(oldOwnerWorkspace: WorkspaceSvg) {
-  if (ownerWorkspace === null || ownerWorkspace === oldOwnerWorkspace) {
+export function hideIfOwnerIsInWorkspace(workspace: WorkspaceSvg) {
+  let ownerIsInWorkspace = workspace === null;
+  // Check if the given workspace is a parent workspace of the one containing
+  // our owner.
+  let currentWorkspace: WorkspaceSvg | null = workspace;
+  while (!ownerIsInWorkspace && currentWorkspace) {
+    if (currentWorkspace === workspace) {
+      ownerIsInWorkspace = true;
+      break;
+    }
+    currentWorkspace = workspace.options.parentWorkspace;
+  }
+
+  if (ownerIsInWorkspace) {
     hide();
   }
 }

--- a/core/widgetdiv.ts
+++ b/core/widgetdiv.ts
@@ -169,7 +169,7 @@ export function hideIfOwner(oldOwner: unknown) {
  * @param workspace The workspace that was using this container.
  */
 export function hideIfOwnerIsInWorkspace(workspace: WorkspaceSvg) {
-  let ownerIsInWorkspace = this.ownerWorkspace === null;
+  let ownerIsInWorkspace = ownerWorkspace === null;
   // Check if the given workspace is a parent workspace of the one containing
   // our owner.
   let currentWorkspace: WorkspaceSvg | null = workspace;


### PR DESCRIPTION

<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #8599

### Proposed Changes
This PR updates `WidgetDiv.hideIfOwnerIsInWorkspace()` to hide the widget div if its owner is an indirect child of the given workspace, e.g. the given workspace is the root workspace but the widget div is owned by a child of a mutator workspace. AFAIK workspaces are only ever nested one level deep in practice, but I'm not aware of anything that enforces that, so it attempts to walk up an arbitrarily deep workspace hierarchy.