### PR TITLE
refactor!: Update flyouts to use inflaters.

### DIFF
--- a/core/blockly.ts
+++ b/core/blockly.ts
@@ -96,6 +96,12 @@ import {
 } from './field_variable.js';
 import {Flyout} from './flyout_base.js';
 import {FlyoutButton} from './flyout_button.js';
+import {FlyoutSeparator} from './flyout_separator.js';
+import {IFlyoutInflater} from './interfaces/i_flyout_inflater.js';
+import {BlockFlyoutInflater} from './block_flyout_inflater.js';
+import {ButtonFlyoutInflater} from './button_flyout_inflater.js';
+import {LabelFlyoutInflater} from './label_flyout_inflater.js';
+import {SeparatorFlyoutInflater} from './separator_flyout_inflater.js';
 import {HorizontalFlyout} from './flyout_horizontal.js';
 import {FlyoutMetricsManager} from './flyout_metrics_manager.js';
 import {VerticalFlyout} from './flyout_vertical.js';
@@ -510,6 +516,12 @@ export {
 export {Flyout};
 export {FlyoutButton};
 export {FlyoutMetricsManager};
+export {FlyoutSeparator};
+export {IFlyoutInflater};
+export {BlockFlyoutInflater};
+export {ButtonFlyoutInflater};
+export {LabelFlyoutInflater};
+export {SeparatorFlyoutInflater};
 export {CodeGenerator};
 export {CodeGenerator as Generator}; // Deprecated name, October 2022.
 export {Gesture};

--- a/core/flyout_base.ts
+++ b/core/flyout_base.ts
@@ -216,6 +216,10 @@ export abstract class Flyout
    */
   protected svgGroup_: SVGGElement | null = null;
 
+  /**
+   * Map from flyout content type to the corresponding inflater class
+   * responsible for creating concrete instances of the content type.
+   */
   protected inflaters = new Map<string, IFlyoutInflater>();
 
   /**
@@ -652,7 +656,7 @@ export abstract class Flyout
    *
    * @param parsedContent The array
    *     of objects to show in the flyout.
-   * @returns The list of contents and gaps needed to lay out the flyout.
+   * @returns The list of contents needed to lay out the flyout.
    */
   private createFlyoutInfo(
     parsedContent: toolbox.FlyoutItemInfoArray,
@@ -693,6 +697,17 @@ export abstract class Flyout
     return this.normalizeSeparators(contents);
   }
 
+  /**
+   * Updates and returns the provided list of flyout contents to flatten
+   * separators as needed.
+   *
+   * When multiple separators occur one after another, the value of the last one
+   * takes precedence and the earlier separators in the group are removed.
+   *
+   * @param contents The list of flyout contents to flatten separators in.
+   * @returns An updated list of flyout contents with only one separator between
+   *     each non-separator item.
+   */
   protected normalizeSeparators(contents: FlyoutItem[]): FlyoutItem[] {
     for (let i = contents.length - 1; i > 0; i--) {
       const element = contents[i];
@@ -921,6 +936,13 @@ export abstract class Flyout
     block.moveTo(new Coordinate(finalOffset.x, finalOffset.y));
   }
 
+  /**
+   * Returns the inflater responsible for constructing items of the given type.
+   *
+   * @param type The type of flyout content item to provide an inflater for.
+   * @returns An inflater object for the given type, or undefined if no inflater
+   *     is registered for that type.
+   */
   protected getInflaterForType(type: string): IFlyoutInflater | undefined {
     if (this.inflaters.has(type)) {
       return this.inflaters.get(type);

--- a/core/flyout_base.ts
+++ b/core/flyout_base.ts
@@ -937,12 +937,12 @@ export abstract class Flyout
    * Returns the inflater responsible for constructing items of the given type.
    *
    * @param type The type of flyout content item to provide an inflater for.
-   * @returns An inflater object for the given type, or undefined if no inflater
+   * @returns An inflater object for the given type, or null if no inflater
    *     is registered for that type.
    */
-  protected getInflaterForType(type: string): IFlyoutInflater | undefined {
+  protected getInflaterForType(type: string): IFlyoutInflater | null {
     if (this.inflaters.has(type)) {
-      return this.inflaters.get(type);
+      return this.inflaters.get(type) ?? null;
     }
 
     const InflaterClass = registry.getClass(
@@ -955,7 +955,7 @@ export abstract class Flyout
       return inflater;
     }
 
-    return undefined;
+    return null;
   }
 }
 

--- a/core/flyout_base.ts
+++ b/core/flyout_base.ts
@@ -35,7 +35,6 @@ import * as registry from './registry.js';
 import * as renderManagement from './render_management.js';
 import {IAutoHideable} from './interfaces/i_autohideable.js';
 import {FlyoutSeparator, SeparatorAxis} from './flyout_separator.js';
-import {isRenderedElement} from './interfaces/i_rendered_element.js';
 
 /**
  * Class for a flyout.

--- a/core/flyout_base.ts
+++ b/core/flyout_base.ts
@@ -710,12 +710,9 @@ export abstract class Flyout
    */
   protected normalizeSeparators(contents: FlyoutItem[]): FlyoutItem[] {
     for (let i = contents.length - 1; i > 0; i--) {
-      const element = contents[i];
-      const previousElement = contents[i - 1];
-      if (
-        element.type.toLowerCase() === 'sep' &&
-        previousElement.type.toLowerCase() === 'sep'
-      ) {
+      const elementType = contents[i].type.toLowerCase();
+      const previousElementType = contents[i - 1].type.toLowerCase();
+      if (elementType === 'sep' && previousElementType === 'sep') {
         // Remove previousElement from the array, shifting the current element
         // forward as a result. This preserves the behavior where explicit
         // separator elements override the value of prior implicit (or explicit)
@@ -957,6 +954,8 @@ export abstract class Flyout
       this.inflaters.set(type, inflater);
       return inflater;
     }
+
+    return undefined;
   }
 }
 

--- a/core/flyout_base.ts
+++ b/core/flyout_base.ts
@@ -34,7 +34,7 @@ import {WorkspaceSvg} from './workspace_svg.js';
 import * as registry from './registry.js';
 import * as renderManagement from './render_management.js';
 import {IAutoHideable} from './interfaces/i_autohideable.js';
-import {FlyoutSeparator} from './flyout_separator.js';
+import {FlyoutSeparator, SeparatorAxis} from './flyout_separator.js';
 import {isRenderedElement} from './interfaces/i_rendered_element.js';
 
 /**
@@ -682,7 +682,10 @@ export abstract class Flyout
         if (gap) {
           contents.push({
             type: 'sep',
-            element: new FlyoutSeparator(gap),
+            element: new FlyoutSeparator(
+              gap,
+              this.horizontalLayout ? SeparatorAxis.X : SeparatorAxis.Y,
+            ),
           });
         }
       }

--- a/core/keyboard_nav/ast_node.ts
+++ b/core/keyboard_nav/ast_node.ts
@@ -13,6 +13,7 @@
 // Former goog.module ID: Blockly.ASTNode
 
 import {Block} from '../block.js';
+import {BlockSvg} from '../block_svg.js';
 import type {Connection} from '../connection.js';
 import {ConnectionType} from '../connection_type.js';
 import type {Field} from '../field.js';
@@ -347,10 +348,10 @@ export class ASTNode {
     );
     if (!nextItem) return null;
 
-    if (nextItem.type === 'button' && nextItem.button) {
-      return ASTNode.createButtonNode(nextItem.button);
-    } else if (nextItem.type === 'block' && nextItem.block) {
-      return ASTNode.createStackNode(nextItem.block);
+    if (nextItem.element instanceof FlyoutButton) {
+      return ASTNode.createButtonNode(nextItem.element);
+    } else if (nextItem.element instanceof BlockSvg) {
+      return ASTNode.createStackNode(nextItem.element);
     }
 
     return null;
@@ -370,12 +371,15 @@ export class ASTNode {
     forward: boolean,
   ): FlyoutItem | null {
     const currentIndex = flyoutContents.findIndex((item: FlyoutItem) => {
-      if (currentLocation instanceof Block && item.block === currentLocation) {
+      if (
+        currentLocation instanceof BlockSvg &&
+        item.element === currentLocation
+      ) {
         return true;
       }
       if (
         currentLocation instanceof FlyoutButton &&
-        item.button === currentLocation
+        item.element === currentLocation
       ) {
         return true;
       }

--- a/tests/mocha/flyout_test.js
+++ b/tests/mocha/flyout_test.js
@@ -317,16 +317,12 @@ suite('Flyout', function () {
 
     function checkFlyoutInfo(flyoutSpy) {
       const flyoutInfo = flyoutSpy.returnValues[0];
-      const contents = flyoutInfo.contents;
-      const gaps = flyoutInfo.gaps;
+      const contents = flyoutInfo;
 
-      const expectedGaps = [20, 24, 24];
-      assert.deepEqual(gaps, expectedGaps);
-
-      assert.equal(contents.length, 3, 'Contents');
+      assert.equal(contents.length, 6, 'Contents');
 
       assert.equal(contents[0].type, 'block', 'Contents');
-      const block = contents[0]['block'];
+      const block = contents[0]['element'];
       assert.instanceOf(block, Blockly.BlockSvg);
       assert.equal(block.getFieldValue('OP'), 'NEQ');
       const childA = block.getInputTargetBlock('A');
@@ -336,11 +332,20 @@ suite('Flyout', function () {
       assert.equal(childA.getFieldValue('NUM'), 1);
       assert.equal(childB.getFieldValue('NUM'), 2);
 
-      assert.equal(contents[1].type, 'button', 'Contents');
-      assert.instanceOf(contents[1]['button'], Blockly.FlyoutButton);
+      assert.equal(contents[1].type, 'sep');
+      assert.equal(contents[1].element.getBoundingRectangle().getHeight(), 20);
 
       assert.equal(contents[2].type, 'button', 'Contents');
-      assert.instanceOf(contents[2]['button'], Blockly.FlyoutButton);
+      assert.instanceOf(contents[2]['element'], Blockly.FlyoutButton);
+
+      assert.equal(contents[3].type, 'sep');
+      assert.equal(contents[3].element.getBoundingRectangle().getHeight(), 24);
+
+      assert.equal(contents[4].type, 'label', 'Contents');
+      assert.instanceOf(contents[4]['element'], Blockly.FlyoutButton);
+
+      assert.equal(contents[5].type, 'sep');
+      assert.equal(contents[5].element.getBoundingRectangle().getHeight(), 24);
     }
 
     suite('Direct show', function () {
@@ -628,36 +633,6 @@ suite('Flyout', function () {
       });
       const block = this.flyout.workspace_.getAllBlocks()[0];
       assert.equal(block.getFieldValue('NUM'), 321);
-    });
-
-    test('Recycling enabled', function () {
-      this.flyout.blockIsRecyclable_ = function () {
-        return true;
-      };
-      this.flyout.show({
-        'contents': [
-          {
-            'kind': 'BLOCK',
-            'type': 'math_number',
-            'fields': {
-              'NUM': 123,
-            },
-          },
-        ],
-      });
-      this.flyout.show({
-        'contents': [
-          {
-            'kind': 'BLOCK',
-            'type': 'math_number',
-            'fields': {
-              'NUM': 321,
-            },
-          },
-        ],
-      });
-      const block = this.flyout.workspace_.getAllBlocks()[0];
-      assert.equal(block.getFieldValue('NUM'), 123);
     });
   });
 });


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #8546

### Proposed Changes
This PR updates the base, horizontal and vertical flyout classes to use the newly introduced inflaters rather than hardcoding support for buttons/labels/blocks. As a result, it's now possible to add arbitrary elements of different types to flyouts.

### Breaking Changes
This is a fairly extensive refactor, and makes several changes to the behavior of flyouts. At a high level, support for recycling blocks has been removed. This always required a subclass to enable, and is still achievable through subclassing, but the mostly-inaccessible code that partially supported it has been removed. The continuous toolbox plugin in blockly-samples, which did use recycling, will be updated to implement it using the new API.

Additionally, the backing mats/rects placed behind blocks in the flyout have been removed. These were used to fill in the gaps in C-shaped blocks or empty inputs to allow initiating block drags even when not clicking on the actual block, but instead in one of its voids. This behavior is inconsistent with the main workspace, and was mostly a workaround for not having shadow blocks, which are largely a better solution to this problem.

At an API level, the following have been adjusted:

* The `FlyoutItemType` enum has been removed, since flyout items may now be of arbitrary types.
* The protected method `Flyout.layout_` no longer takes the second `gaps` argument. Flyouts no longer maintain separate lists of gaps and content; instead, there is one list of content, which may include elements representing gaps.
* The protected `Flyout.buttons_` field has been removed, along with the protected `Flyout.initFlyoutButton_()` and `Flyout.addBlockListeners_()` methods. Flyouts are now agnostic as to their contents, so special handling for special types of items is now unneeded.
* The protected `Flyout.rectMap_` field, along with the protected `Flyout.createRect_()` and `Flyout.moveRectToBlock_()` methods have been removed. Flyouts no longer include backing rects for blocks.
* The protected `Flyout.blockIsRecyclable_()` method has been removed, since recycling support has been removed from core.
* The `FlyoutItem` interface has been adjusted to remove the `block` and `button` fields, and replace them with an `element` field of type `IBoundedElement`. The `type` field remains, and may be used to distinguish the types of individual flyout elements.