### PR TITLE
fix: Let old block factory overwrite user defined blocks.

### DIFF
--- a/demos/blockfactory/block_library_controller.js
+++ b/demos/blockfactory/block_library_controller.js
@@ -109,9 +109,9 @@ BlockLibraryController.prototype.clearBlockLibrary = function() {
 BlockLibraryController.prototype.saveToBlockLibrary = function() {
   var blockType = this.getCurrentBlockType();
   // If user has not changed the name of the starter block.
-  if (blockType === 'block_type') {
+  if (reservedBlockFactoryBlocks.has(blockType) || blockType === 'block_type') {
     // Do not save block if it has the default type, 'block_type'.
-    var msg = 'You cannot save a block under the name "block_type". Try ' +
+    var msg = `You cannot save a block under the name "${blockType}". Try ` +
         'changing the name before saving. Then, click on the "Block Library"' +
         ' button to view your saved blocks.';
     alert(msg);

--- a/demos/blockfactory/block_library_view.js
+++ b/demos/blockfactory/block_library_view.js
@@ -104,36 +104,36 @@ BlockLibraryView.prototype.updateButtons =
     // User is editing a block.
 
     if (!isInLibrary) {
-      // Block type has not been saved to library yet. Disable the delete button
-      // and allow user to save.
+      // Block type has not been saved to the library yet.
+      // Disable the delete button.
       this.saveButton.textContent = 'Save "' + blockType + '"';
-      this.saveButton.disabled = false;
       this.deleteButton.disabled = true;
     } else {
-      // Block type has already been saved. Disable the save button unless the
-      // there are unsaved changes (checked below).
+      // A version of the block type has already been saved.
+      // Enable the delete button.
       this.saveButton.textContent = 'Update "' + blockType + '"';
-      this.saveButton.disabled = true;
       this.deleteButton.disabled = false;
     }
     this.deleteButton.textContent = 'Delete "' + blockType + '"';
 
-    // If changes to block have been made and are not saved, make button
-    // green to encourage user to save the block.
+    this.saveButton.classList.remove('button_alert', 'button_warn');
     if (!savedChanges) {
-      var buttonFormatClass = 'button_warn';
+      var buttonFormatClass;
 
-      // If block type is the default, 'block_type', make button red to alert
-      // user.
-      if (blockType === 'block_type') {
+      var isReserved = reservedBlockFactoryBlocks.has(blockType);
+      if (isReserved || blockType === 'block_type') {
+        // Make button red to alert user that the block type can't be saved.
         buttonFormatClass = 'button_alert';
+      } else {
+        // Block type has not been saved to library yet or has unsaved changes.
+        // Make the button green to encourage the user to save the block.
+        buttonFormatClass = 'button_warn';
       }
       this.saveButton.classList.add(buttonFormatClass);
       this.saveButton.disabled = false;
 
     } else {
       // No changes to save.
-      this.saveButton.classList.remove('button_alert', 'button_warn');
       this.saveButton.disabled = true;
     }
 

--- a/demos/blockfactory/blocks.js
+++ b/demos/blockfactory/blocks.js
@@ -914,3 +914,7 @@ function inputNameCheck(referenceBlock) {
       'There are ' + count + ' input blocks\n with this name.' : null;
   referenceBlock.setWarningText(msg);
 }
+
+// Make a set of all of block types that are required for the block factory.
+var reservedBlockFactoryBlocks =
+    new Set(Object.getOwnPropertyNames(Blockly.Blocks));

--- a/demos/blockfactory/factory.js
+++ b/demos/blockfactory/factory.js
@@ -187,8 +187,9 @@ BlockFactory.updatePreview = function() {
   // Don't let the user create a block type that already exists,
   // because it doesn't work.
   var warnExistingBlock = function(blockType) {
-    if (blockType in Blockly.Blocks) {
-      var text = `You can't make a block called ${blockType} in this tool because that name already exists.`;
+    if (reservedBlockFactoryBlocks.has(blockType)) {
+      var text = `You can't make a block called ${blockType} in this tool ` +
+          `because that name is reserved.`;
       FactoryUtils.getRootBlock(BlockFactory.mainWorkspace).setWarningText(text);
       console.error(text);
       return true;


### PR DESCRIPTION
## The basics

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

Fixes https://github.com/google/blockly/issues/6820

### Proposed Changes

Makes a record of all of the reserved block type names that are required by the old block factory workspace on startup, and uses that to determine whether a user-defined block type has a conflicting name, instead of assuming the current definitions in `Blockly.Blocks` is an authoritative proxy for the reserved types.

### Reason for Changes

The desired behavior is to prevent replacing critical blocks that are used by the block factory, like core Blockly blocks or even block-factory-specific blocks like `factory_base`. The existing strategy is to refuse to overwrite any block type that is currently recognized by the definitions in `Blockly.Blocks`, and to support this strategy, whenever the factory defines a user-defined block in this mapping, it always [removes the block immediately after adding it](https://github.com/google/blockly/blob/f7a2c4dcd06c1a84a251f7f94b788ddfcced922b/demos/blockfactory/factory.js#L264) so that user-defined block types become available again while critical block types remain reserved. However, there are ways that user-defined block types can "leak" into `Blockly.Blocks` permanently, after which point the block factory will mistake it for a critical block that shouldn't be replaced. For example, if there are already user-defined blocks saved in the block library when the block factory is reloaded or you switch between the factory/exporter tabs, [all user-defined will be added to `Blockly.Blocks` without being removed](https://github.com/google/blockly/blob/f7a2c4dcd06c1a84a251f7f94b788ddfcced922b/demos/blockfactory/block_exporter_tools.js#L187), so you're not allowed to make edits to saved blocks after reloading or switching tabs.

### Test Coverage

There are no tests for the old block factory. It seems to work in my manual testing.

### Documentation

N/A

### Additional Information

There are at least two publicly hosted copies of the old block factory that ought to be updated:
https://blockly-demo.appspot.com/static/demos/blockfactory/index.html
https://google.github.io/blockly/demos/blockfactory/index.html
