### PR TITLE
fix: Fix bug that caused fields in the flyout to use the main workspace's scale.

### DIFF
--- a/core/field_input.ts
+++ b/core/field_input.ts
@@ -415,7 +415,7 @@ export abstract class FieldInput<T extends InputTypes> extends Field<
       'spellcheck',
       this.spellcheck_ as AnyDuringMigration,
     );
-    const scale = this.workspace_!.getScale();
+    const scale = this.workspace_!.getAbsoluteScale();
     const fontSize = this.getConstants()!.FIELD_TEXT_FONTSIZE * scale + 'pt';
     div!.style.fontSize = fontSize;
     htmlInput.style.fontSize = fontSize;

--- a/core/workspace_svg.ts
+++ b/core/workspace_svg.ts
@@ -2044,7 +2044,6 @@ export class WorkspaceSvg extends Workspace implements IASTNodeLocationSvg {
    * workspace, the absolute/effective scale may be needed to render
    * appropriately.
    *
-   * @param workspace The workspace to determine the absolute/effective scale of.
    * @returns The absolute/effective scale of the given workspace.
    */
   getAbsoluteScale() {

--- a/tests/mocha/field_textinput_test.js
+++ b/tests/mocha/field_textinput_test.js
@@ -192,7 +192,7 @@ suite('Text Input Fields', function () {
       setup(function () {
         this.prepField = function (field) {
           const workspace = {
-            getScale: function () {
+            getAbsoluteScale: function () {
               return 1;
             },
             getRenderer: function () {


### PR DESCRIPTION

<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #8596

### Proposed Changes
This PR introduces a new `WorkspaceSvg.getAbsoluteScale()` method that returns the absolute scale of a workspace, taking into account whether it is in a flyout, nested in one or more parent workspaces, mutator editors, etc. Workspace scaling is somewhat counterintuitive in that workspaces that are children of one another have multiplicative scaling, because scaling is achieved through transforms and those apply to child elements and compound. 

The PR also updates field editors, which are visually associated with a particular workspace but live at the top of the DOM, to use the absolute scale of their visually-associated workspace.