### PR TITLE
feat: Allow specifying the placeholder text of workspace comments.

### DIFF
--- a/core/comments/comment_view.ts
+++ b/core/comments/comment_view.ts
@@ -684,6 +684,11 @@ export class CommentView implements IRenderedElement {
     this.onTextChange();
   }
 
+  /** Sets the placeholder text displayed for an empty comment. */
+  setPlaceholderText(text: string) {
+    this.textArea.placeholder = text;
+  }
+
   /** Registers a callback that listens for text changes. */
   addTextChangeListener(listener: (oldText: string, newText: string) => void) {
     this.textChangeListeners.push(listener);

--- a/core/comments/rendered_workspace_comment.ts
+++ b/core/comments/rendered_workspace_comment.ts
@@ -104,6 +104,11 @@ export class RenderedWorkspaceComment
     this.view.setText(text);
   }
 
+  /** Sets the placeholder text displayed if the comment is empty. */
+  setPlaceholderText(text: string): void {
+    this.view.setPlaceholderText(text);
+  }
+
   /** Sets the size of the comment. */
   override setSize(size: Size) {
     // setSize will trigger the change listener that updates

--- a/core/contextmenu_items.ts
+++ b/core/contextmenu_items.ts
@@ -617,7 +617,7 @@ export function registerCommentCreate() {
       if (!workspace) return;
       eventUtils.setGroup(true);
       const comment = new RenderedWorkspaceComment(workspace);
-      comment.setText(Msg['WORKSPACE_COMMENT_DEFAULT_TEXT']);
+      comment.setPlaceholderText(Msg['WORKSPACE_COMMENT_DEFAULT_TEXT']);
       comment.moveTo(
         pixelsToWorkspaceCoords(
           new Coordinate(e.clientX, e.clientY),


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
This PR adds a `setPlaceholderText()` method to `CommentView` and `RenderedWorkspaceComment` that allows specifying the placeholder text for a comment. It also updates the workspace comment creation contextual menu item to set the default text as a placeholder instead of literal text so that users don't have to manually delete/type over it to write their comment.