### PR TITLE
fix: bump connected connections in a different direction

### DIFF
--- a/core/connection.ts
+++ b/core/connection.ts
@@ -214,11 +214,11 @@ export class Connection implements IASTNodeLocationWithBlock {
    * Called when an attempted connection fails. NOP by default (i.e. for
    * headless workspaces).
    *
-   * @param _otherConnection Connection that this connection failed to connect
-   *     to.
+   * @param _superiorConnection Connection that this connection failed to connect
+   *     to. The provided connection should be the superior connection.
    * @internal
    */
-  onFailedConnect(_otherConnection: Connection) {}
+  onFailedConnect(_superiorConnection: Connection) {}
   // NOP
 
   /**


### PR DESCRIPTION
## The basics

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

Fixes https://github.com/google/blockly/issues/8168

### Proposed Changes

When two connections that are compatible but are not connected to each other are close enough to trigger a bump, the choice of which connection to move and in what direction now depends on whether the inferior connection is connected to something else. Previously, if they were both movable, the inferior connection would always be bumped down and right. Now, if the inferior connection is connected, then it will remain in place and the superior connection will be bumped up and right instead.

I also refactored related logic for readability and codified the existing invariant that the parameter to the bump function is the superior connection.

### Reason for Changes

It's possible for two independent groups of connected blocks to have multiple neighboring pairs of connections that can bump each other. Typically, the group with the "inferior" connection is moved, but it's possible that both groups can have an inferior connection that would be bumped by the other group's connection. https://github.com/google/blockly/issues/8168 demonstrates such a scenario, where the `logic_operation` block's inferior output connection is bumped by the outer `controls_if`, which moves it downward and puts its superior input connection near the `logic_compare` block's output connection, resulting in the other group getting bumped. This all happens instantaneously, and results in both groups of blocks moving down and right, lining both them up again to get bumped the next time bumping is triggered.

This can occur when a group contains both an inferior connection and at least one superior connection. However, a group of blocks can only have one unconnected inferior connection, in the top left corner. All other inferior connections must be connected to a parent block in order for associated block to be part of the group. So most of the connections that are in danger of bumping neighboring connections are either superior connections or connected inferior connections. It is important that bumping either of these two kinds of connections does not cancel out the motion of previously bumped connections. 

Thus, I propose we bump them in orthogonal directions: superior up and right, inferior down and right.

A minor downside of this strategy is that it's generally preferable that superior connections end up to the left of inferior connections, to show a gap between the disconnected blocks. However, if the inferior block is already connected to another block, then there won't be any negative space in the gap anyway because it'll be filled by the other block.

### Test Coverage

All existing unit tests pass (except for 4 test methods that were already failing due to coordinates being slightly different when testing on my mac). I manually tested that the linked bug is avoided by this PR.

### Documentation

N/A

### Additional Information

N/A