### PR TITLE
fix: Correctly calculate the bounds of hat blocks.

### DIFF
--- a/core/renderers/common/constants.ts
+++ b/core/renderers/common/constants.ts
@@ -727,7 +727,10 @@ export class ConstantProvider {
       svgPaths.point(70, -height),
       svgPaths.point(width, 0),
     ]);
-    return {height, width, path: mainPath};
+    // Height is actually the Y position of the control points defining the
+    // curve of the hat; the hat's actual rendered height is 3/4 of the control
+    // points' Y position, per https://stackoverflow.com/a/5327329
+    return {height: height * 0.75, width, path: mainPath};
   }
 
   /**

--- a/core/renderers/common/info.ts
+++ b/core/renderers/common/info.ts
@@ -232,7 +232,6 @@ export class RenderInfo {
     if (hasHat) {
       const hat = new Hat(this.constants_);
       this.topRow.elements.push(hat);
-      this.topRow.capline = hat.ascenderHeight;
     } else if (hasPrevious) {
       this.topRow.hasPreviousConnection = true;
       this.topRow.connection = new PreviousConnection(

--- a/core/renderers/zelos/constants.ts
+++ b/core/renderers/zelos/constants.ts
@@ -290,7 +290,10 @@ export class ConstantProvider extends BaseConstantProvider {
       svgPaths.point(71, -height),
       svgPaths.point(width, 0),
     ]);
-    return {height, width, path: mainPath};
+    // Height is actually the Y position of the control points defining the
+    // curve of the hat; the hat's actual rendered height is 3/4 of the control
+    // points' Y position, per https://stackoverflow.com/a/5327329
+    return {height: height * 0.75, width, path: mainPath};
   }
 
   /**


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes https://github.com/gonfunko/scratch-blocks/issues/201

### Proposed Changes
This PR updates the calculation of the height of hats on blocks. Previously, the height of a hat was the value that was used for the Y position of points on an SVG curve. However, this is not the actual Y position of e.g. the apex of the curve, but rather the Y position of the control points used to define the Bézier curve, which is different from the actual max Y value of the curve itself; note the position of the lower control points relative to the bottom of the curve in the graphic here: https://developer.mozilla.org/en-US/docs/Web/SVG/Tutorial/Paths#b%C3%A9zier_curves.

Per https://stackoverflow.com/a/5327329, the height of the curve is 3/4 the Y position of the control points, at least in the simple situation we use for hats. As a result, before this change, the bounds of hat blocks were incorrect:
<img width="251" alt="Screenshot 2024-10-09 at 11 15 27 AM" src="https://github.com/user-attachments/assets/3b231de0-461b-4483-accb-cfd96d2f9687">
<img width="235" alt="Screenshot 2024-10-09 at 11 15 20 AM" src="https://github.com/user-attachments/assets/0d7ee0dc-9296-4a07-ada4-dc5d47645029">
<img width="236" alt="Screenshot 2024-10-09 at 11 15 14 AM" src="https://github.com/user-attachments/assets/c590c331-567b-490f-9821-8fefdc70e083">

With this change, the bounds are as expected across all three built-in renderers:
<img width="217" alt="Screenshot 2024-10-09 at 11 14 23 AM" src="https://github.com/user-attachments/assets/d9107641-3dbd-477c-86f6-16bfe4f1a182">
<img width="241" alt="Screenshot 2024-10-09 at 11 14 30 AM" src="https://github.com/user-attachments/assets/cd16f782-dba4-4131-a6cc-23a559edb68f">
<img width="231" alt="Screenshot 2024-10-09 at 11 14 37 AM" src="https://github.com/user-attachments/assets/1d26d77b-3929-45b8-bc35-32a1f8e40214">

