### PR TITLE
fix: Take the flyout into account when positioning the workspace after a toolbox change.

### DIFF
--- a/core/toolbox/toolbox.ts
+++ b/core/toolbox/toolbox.ts
@@ -743,7 +743,9 @@ export class Toolbox
         : workspace.scrollX;
     const newY =
       this.toolboxPosition === toolbox.Position.TOP
-        ? workspace.scrollY + rect.height
+        ? workspace.scrollY +
+          rect.height +
+          (flyout?.isVisible() ? flyout.getHeight() : 0)
         : workspace.scrollY;
     workspace.translate(newX, newY);
 

--- a/core/toolbox/toolbox.ts
+++ b/core/toolbox/toolbox.ts
@@ -734,9 +734,12 @@ export class Toolbox
     // relative to the new absolute edge (ie toolbox edge).
     const workspace = this.workspace_;
     const rect = this.HtmlDiv!.getBoundingClientRect();
+    const flyout = this.getFlyout();
     const newX =
       this.toolboxPosition === toolbox.Position.LEFT
-        ? workspace.scrollX + rect.width
+        ? workspace.scrollX +
+          rect.width +
+          (flyout?.isVisible() ? flyout.getWidth() : 0)
         : workspace.scrollX;
     const newY =
       this.toolboxPosition === toolbox.Position.TOP


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes https://github.com/gonfunko/scratch-blocks/issues/199 and https://github.com/gonfunko/scratch-blocks/issues/187

### Proposed Changes
This PR updates the code that handles repositioning the workspace in response to a toolbox item size change. It seems to have been written taking into account the normal auto-closing flyouts, but in Scratch, where the flyout is visible by default, the workspace was positioned as if the flyout wasn't present. This caused the first block dropped on the workspace to shift by the width of the flyout, and also caused blocks to be mispositioned when restoring the state of the workspace.