### PR TITLE
feat: Allow specifying the default size of comments.

### DIFF
--- a/core/comments/comment_view.ts
+++ b/core/comments/comment_view.ts
@@ -52,7 +52,7 @@ export class CommentView implements IRenderedElement {
   private textArea: HTMLTextAreaElement;
 
   /** The current size of the comment in workspace units. */
-  private size: Size = new Size(120, 100);
+  private size: Size;
 
   /** Whether the comment is collapsed or not. */
   private collapsed: boolean = false;
@@ -102,6 +102,9 @@ export class CommentView implements IRenderedElement {
   /** Size of this comment when the resize drag was initiated. */
   private preResizeSize?: Size;
 
+  /** The default size of newly created comments. */
+  static defaultCommentSize = new Size(120, 100);
+
   constructor(private readonly workspace: WorkspaceSvg) {
     this.svgRoot = dom.createSvgElement(Svg.G, {
       'class': 'blocklyComment blocklyEditable blocklyDraggable',
@@ -128,6 +131,7 @@ export class CommentView implements IRenderedElement {
     workspace.getLayerManager()?.append(this, layers.BLOCK);
 
     // Set size to the default size.
+    this.size = CommentView.defaultCommentSize;
     this.setSizeWithoutFiringEvents(this.size);
 
     // Set default transform (including inverted scale for RTL).

--- a/core/comments/workspace_comment.ts
+++ b/core/comments/workspace_comment.ts
@@ -11,6 +11,7 @@ import * as idGenerator from '../utils/idgenerator.js';
 import * as eventUtils from '../events/utils.js';
 import {CommentMove} from '../events/events_comment_move.js';
 import {CommentResize} from '../events/events_comment_resize.js';
+import {CommentView} from './comment_view.js';
 
 export class WorkspaceComment {
   /** The unique identifier for this comment. */
@@ -20,7 +21,7 @@ export class WorkspaceComment {
   private text = '';
 
   /** The size of the comment in workspace units. */
-  private size = new Size(120, 100);
+  private size: Size;
 
   /** Whether the comment is collapsed or not. */
   private collapsed = false;
@@ -55,6 +56,7 @@ export class WorkspaceComment {
     id?: string,
   ) {
     this.id = id && !workspace.getCommentById(id) ? id : idGenerator.genUid();
+    this.size = CommentView.defaultCommentSize;
 
     workspace.addTopComment(this);
 


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
This PR unblocks https://github.com/gonfunko/scratch-blocks/issues/190 by adding an API for specifying the default size of comments.

### Proposed Changes
Users can now set `Blockly.comments.CommentView.defaultCommentSize` (a static property) to the size that newly created workspace comments should default to.

### Reason for Changes
Enables users to customize comment sizes for their application.