### PR TITLE
fix: Fix exception when disposing of a workspace with a variable block obscuring a shadow block.

### DIFF
--- a/core/workspace.ts
+++ b/core/workspace.ts
@@ -371,7 +371,14 @@ export class Workspace implements IASTNodeLocation {
         this.topComments[this.topComments.length - 1].dispose();
       }
       eventUtils.setGroup(existingGroup);
-      this.variableMap.clear();
+      // If this is a flyout workspace, its variable map is shared with the
+      // parent workspace, so we either don't want to disturb it if we're just
+      // disposing the flyout, or if the flyout is being disposed because the
+      // main workspace is being disposed, then the main workspace will handle
+      // cleaning it up.
+      if (!this.isFlyout) {
+        this.variableMap.clear();
+      }
       if (this.potentialVariableMap) {
         this.potentialVariableMap.clear();
       }


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes https://github.com/gonfunko/scratch-blocks/issues/210

### Proposed Changes
This PR fixes a tricky bug related to workspace disposal. When a WorkspaceSvg instance A is disposed:

1. It sets `this.rendered = false`
2. It disposes of its flyout
3. The flyout disposes of its flyout workspace B
4. The flyout workspace B, as part of disposing itself, clears its variable map, which is the same as the variable map of workspace A, because when a flyout is created the parent workspace shares its variable map with the flyout
5. When the variable map clears itself, it calls VariableMap.deleteVariable for each variable it contains
6. `VariableMap.deleteVariable` calls `VariableMap.getVariableUsesById` to identify references to the variable
7. `VariableMap.getVariableUsesById` calls `Variables.getVariableUsesById`, *passing its workspace*, which, because this variable map was shared with the flyout by Workspace A, is Workspace A, which is in the process of being torn down
8. `Variables.getVariableUsesById` retrieves the blocks of Workspace A, which in this (mildly) contrived example includes a variable block obscuring a shadow block
9. `VariableMap.deleteVariable` calls `dispose` on the variable block obscuring a shadow block on Workspace A, in order to clean up references to the being-deleted variable
10. Because the variable block was obscuring a shadow block, the connections attempt to create a new shadow block to restore it
11. When the respawned shadow block gets created on workspace A, which is being disposed, the `BlockSvg` constructor checks to ensure that its workspace is rendered (to prevent creating a `BlockSvg` on a regular `Workspace`), but because the workspace is being disposed, `rendered` is `false`, so it throws
12. @gonfunko spends the better part of two days tracking this down

This PR only clears the variable map when the workspace being disposed is not a flyout workspace, which resolves the issue.