### PR TITLE
fix: clear touch identifier on comment icon down

### DIFF
--- a/core/comments/comment_view.ts
+++ b/core/comments/comment_view.ts
@@ -623,6 +623,7 @@ export class CommentView implements IRenderedElement {
    * event on the foldout icon.
    */
   private onFoldoutDown(e: PointerEvent) {
+    touch.clearTouchIdentifier();
     this.bringToFront();
     if (browserEvents.isRightButton(e)) {
       e.stopPropagation();
@@ -738,6 +739,7 @@ export class CommentView implements IRenderedElement {
    * delete icon.
    */
   private onDeleteDown(e: PointerEvent) {
+    touch.clearTouchIdentifier();
     if (browserEvents.isRightButton(e)) {
       e.stopPropagation();
       return;


### PR DESCRIPTION
## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

Fixes https://github.com/google/blockly/issues/8626

### Proposed Changes

Calls `clearTouchIdentifier()` inside the two pointerdown events for the workspace comment icons inside the CommentView class.

### Reason for Changes

The two icon pointerdown event handlers inside the workspace CommentView don't ever clear the touch identifier. Click events should always call that function when bound with conditionalBind or else they leave behind an orphaned touchIdentifier that prevents all further events from firing.

### Test Coverage

N/A

### Documentation

N/A

### Additional Information

Tested on the iPad simulator using ios 18.0
