### PR TITLE
fix: Use a readonly textarea for non-editable comments.

### DIFF
--- a/core/bubbles/textinput_bubble.ts
+++ b/core/bubbles/textinput_bubble.ts
@@ -62,7 +62,7 @@ export class TextInputBubble extends Bubble {
     45 + Bubble.DOUBLE_BORDER,
     20 + Bubble.DOUBLE_BORDER,
   );
-  
+
   private editable = true;
 
   /**
@@ -107,7 +107,7 @@ export class TextInputBubble extends Bubble {
       this.textArea.setAttribute('readonly', '');
     }
   }
-  
+
   /** Returns whether or not the text in the bubble is editable. */
   isEditable(): boolean {
     return this.editable;

--- a/core/bubbles/textinput_bubble.ts
+++ b/core/bubbles/textinput_bubble.ts
@@ -62,6 +62,8 @@ export class TextInputBubble extends Bubble {
     45 + Bubble.DOUBLE_BORDER,
     20 + Bubble.DOUBLE_BORDER,
   );
+  
+  private editable = true;
 
   /**
    * @param workspace The workspace this bubble belongs to.
@@ -94,6 +96,21 @@ export class TextInputBubble extends Bubble {
     this.text = text;
     this.textArea.value = text;
     this.onTextChange();
+  }
+
+  /** Sets whether or not the text in the bubble is editable. */
+  setEditable(editable: boolean) {
+    this.editable = editable;
+    if (this.editable) {
+      this.textArea.removeAttribute('readonly');
+    } else {
+      this.textArea.setAttribute('readonly', '');
+    }
+  }
+  
+  /** Returns whether or not the text in the bubble is editable. */
+  isEditable(): boolean {
+    return this.editable;
   }
 
   /** Adds a change listener to be notified when this bubble's text changes. */

--- a/core/icons/comment_icon.ts
+++ b/core/icons/comment_icon.ts
@@ -8,7 +8,6 @@
 
 import type {Block} from '../block.js';
 import type {BlockSvg} from '../block_svg.js';
-import {TextBubble} from '../bubbles/text_bubble.js';
 import {TextInputBubble} from '../bubbles/textinput_bubble.js';
 import {EventType} from '../events/type.js';
 import * as eventUtils from '../events/utils.js';
@@ -47,11 +46,8 @@ export class CommentIcon extends Icon implements IHasBubble, ISerializable {
    */
   static readonly WEIGHT = 3;
 
-  /** The bubble used to show editable text to the user. */
+  /** The bubble used to show comment text to the user. */
   private textInputBubble: TextInputBubble | null = null;
-
-  /** The bubble used to show non-editable text to the user. */
-  private textBubble: TextBubble | null = null;
 
   /** The text of this comment. */
   private text = '';
@@ -118,7 +114,6 @@ export class CommentIcon extends Icon implements IHasBubble, ISerializable {
   override dispose() {
     super.dispose();
     this.textInputBubble?.dispose();
-    this.textBubble?.dispose();
   }
 
   override getWeight(): number {
@@ -133,7 +128,6 @@ export class CommentIcon extends Icon implements IHasBubble, ISerializable {
     super.applyColour();
     const colour = (this.sourceBlock as BlockSvg).style.colourPrimary;
     this.textInputBubble?.setColour(colour);
-    this.textBubble?.setColour(colour);
   }
 
   /**
@@ -153,7 +147,6 @@ export class CommentIcon extends Icon implements IHasBubble, ISerializable {
     super.onLocationChange(blockOrigin);
     const anchorLocation = this.getAnchorLocation();
     this.textInputBubble?.setAnchorLocation(anchorLocation);
-    this.textBubble?.setAnchorLocation(anchorLocation);
   }
 
   /** Sets the text of this comment. Updates any bubbles if they are visible. */
@@ -170,7 +163,6 @@ export class CommentIcon extends Icon implements IHasBubble, ISerializable {
     );
     this.text = text;
     this.textInputBubble?.setText(this.text);
-    this.textBubble?.setText(this.text);
   }
 
   /** Returns the text of this comment. */
@@ -302,6 +294,18 @@ export class CommentIcon extends Icon implements IHasBubble, ISerializable {
    * to update the state of this icon in response to changes in the bubble.
    */
   private showEditableBubble() {
+    this.createBubble();
+    this.textInputBubble?.addTextChangeListener(() => this.onTextChange());
+    this.textInputBubble?.addSizeChangeListener(() => this.onSizeChange());
+  }
+
+  /** Shows the non editable text bubble for this comment. */
+  private showNonEditableBubble() {
+    this.createBubble();
+    this.textInputBubble?.setEditable(false);
+  }
+  
+  protected createBubble() {
     this.textInputBubble = new TextInputBubble(
       this.sourceBlock.workspace as WorkspaceSvg,
       this.getAnchorLocation(),
@@ -309,8 +313,6 @@ export class CommentIcon extends Icon implements IHasBubble, ISerializable {
     );
     this.textInputBubble.setText(this.getText());
     this.textInputBubble.setSize(this.bubbleSize, true);
-    this.textInputBubble.addTextChangeListener(() => this.onTextChange());
-    this.textInputBubble.addSizeChangeListener(() => this.onSizeChange());
   }
 
   /** Shows the non editable text bubble for this comment. */
@@ -327,8 +329,6 @@ export class CommentIcon extends Icon implements IHasBubble, ISerializable {
   private hideBubble() {
     this.textInputBubble?.dispose();
     this.textInputBubble = null;
-    this.textBubble?.dispose();
-    this.textBubble = null;
   }
 
   /**

--- a/core/icons/comment_icon.ts
+++ b/core/icons/comment_icon.ts
@@ -315,16 +315,6 @@ export class CommentIcon extends Icon implements IHasBubble, ISerializable {
     this.textInputBubble.setSize(this.bubbleSize, true);
   }
 
-  /** Shows the non editable text bubble for this comment. */
-  private showNonEditableBubble() {
-    this.textBubble = new TextBubble(
-      this.getText(),
-      this.sourceBlock.workspace as WorkspaceSvg,
-      this.getAnchorLocation(),
-      this.getBubbleOwnerRect(),
-    );
-  }
-
   /** Hides any open bubbles owned by this comment. */
   private hideBubble() {
     this.textInputBubble?.dispose();

--- a/core/icons/comment_icon.ts
+++ b/core/icons/comment_icon.ts
@@ -304,7 +304,7 @@ export class CommentIcon extends Icon implements IHasBubble, ISerializable {
     this.createBubble();
     this.textInputBubble?.setEditable(false);
   }
-  
+
   protected createBubble() {
     this.textInputBubble = new TextInputBubble(
       this.sourceBlock.workspace as WorkspaceSvg,

--- a/tests/mocha/comment_test.js
+++ b/tests/mocha/comment_test.js
@@ -41,12 +41,12 @@ suite('Comments', function () {
     });
 
     function assertEditable(comment) {
-      assert.isNotOk(comment.textBubble);
       assert.isOk(comment.textInputBubble);
+      assert.isTrue(comment.textInputBubble.isEditable());
     }
     function assertNotEditable(comment) {
-      assert.isNotOk(comment.textInputBubble);
-      assert.isOk(comment.textBubble);
+      assert.isOk(comment.textInputBubble);
+      assert.isFalse(comment.textInputBubble.isEditable());
     }
     test('Editable', async function () {
       await this.comment.setBubbleVisible(true);


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #2917

### Proposed Changes
This PR uses the regular block comment bubble, but with the textarea's `readonly` attribute set, for displaying block comments in readonly workspaces. This allows the comments to be scrolled (and their text selected/copied) and otherwise interacted with normally, while prohibiting edits.