### PR TITLE
chore: Remove unneeded handling for @suppress and @alias.

### DIFF
--- a/tsdoc.json
+++ b/tsdoc.json
@@ -4,10 +4,6 @@
   "extends": ["@microsoft/api-extractor/extends/tsdoc-base.json"],
   "tagDefinitions": [
     {
-      "tagName": "@alias",
-      "syntaxKind": "block"
-    },
-    {
       "tagName": "@define",
       "syntaxKind": "block"
     },
@@ -18,18 +14,12 @@
     {
       "tagName": "@nocollapse",
       "syntaxKind": "modifier"
-    },
-    {
-      "tagName": "@suppress",
-      "syntaxKind": "modifier"
     }
   ],
 
   "supportForTags": {
-    "@alias": true,
     "@define": true,
     "@license": true,
-    "@nocollapse": true,
-    "@suppress": true
+    "@nocollapse": true
   }
 }


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #6338

### Proposed Changes
This PR removes API Extractor rules for handling `@alias` and `@suppress`, which no longer exist in the codebase.