### PR TITLE
feat: Allow customizing GRID_UNIT for the Zelos renderer.

### DIFF
--- a/core/renderers/zelos/constants.ts
+++ b/core/renderers/zelos/constants.ts
@@ -151,8 +151,18 @@ export class ConstantProvider extends BaseConstantProvider {
    */
   SQUARED: Shape | null = null;
 
-  constructor() {
+  /**
+   * Creates a new ConstantProvider.
+   *
+   * @param gridUnit If set, defines the base unit used to calculate other
+   *     constants.
+   */
+  constructor(gridUnit?: number) {
     super();
+
+    if (gridUnit) {
+      this.GRID_UNIT = gridUnit;
+    }
 
     this.SMALL_PADDING = this.GRID_UNIT;
 


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #6928

### Proposed Changes
This PR updates the Zelos constant provider's constructor to take an optional `gridUnit` arg that defines the base unit which all other constants are calculated relative to. This allows subclasses to more easily control the rendering without duplicating substantial code from the base class.