### PR TITLE
fix: Fix crash when resizing page while editing a field.

### DIFF
--- a/core/field_input.ts
+++ b/core/field_input.ts
@@ -28,6 +28,7 @@ import {
   UnattachedFieldError,
 } from './field.js';
 import {Msg} from './msg.js';
+import * as renderManagement from './render_management.js';
 import * as aria from './utils/aria.js';
 import {Coordinate} from './utils/coordinate.js';
 import * as dom from './utils/dom.js';
@@ -630,22 +631,24 @@ export abstract class FieldInput<T extends InputTypes> extends Field<
 
   /** Resize the editor to fit the text. */
   protected resizeEditor_() {
-    const block = this.getSourceBlock();
-    if (!block) {
-      throw new UnattachedFieldError();
-    }
-    const div = WidgetDiv.getDiv();
-    const bBox = this.getScaledBBox();
-    div!.style.width = bBox.right - bBox.left + 'px';
-    div!.style.height = bBox.bottom - bBox.top + 'px';
+    renderManagement.finishQueuedRenders().then(() => {
+      const block = this.getSourceBlock();
+      if (!block) {
+        throw new UnattachedFieldError();
+      }
+      const div = WidgetDiv.getDiv();
+      const bBox = this.getScaledBBox();
+      div!.style.width = bBox.right - bBox.left + 'px';
+      div!.style.height = bBox.bottom - bBox.top + 'px';
 
-    // In RTL mode block fields and LTR input fields the left edge moves,
-    // whereas the right edge is fixed.  Reposition the editor.
-    const x = block.RTL ? bBox.right - div!.offsetWidth : bBox.left;
-    const xy = new Coordinate(x, bBox.top);
+      // In RTL mode block fields and LTR input fields the left edge moves,
+      // whereas the right edge is fixed.  Reposition the editor.
+      const x = block.RTL ? bBox.right - div!.offsetWidth : bBox.left;
+      const xy = new Coordinate(x, bBox.top);
 
-    div!.style.left = xy.x + 'px';
-    div!.style.top = xy.y + 'px';
+      div!.style.left = xy.x + 'px';
+      div!.style.top = xy.y + 'px';
+    });
   }
 
   /**
@@ -657,7 +660,7 @@ export abstract class FieldInput<T extends InputTypes> extends Field<
    *     div.
    */
   override repositionForWindowResize(): boolean {
-    const block = this.getSourceBlock();
+    const block = this.getSourceBlock()?.getRootBlock();
     // This shouldn't be possible. We should never have a WidgetDiv if not using
     // rendered blocks.
     if (!(block instanceof BlockSvg)) return false;

--- a/core/field_input.ts
+++ b/core/field_input.ts
@@ -30,7 +30,6 @@ import {
 import {Msg} from './msg.js';
 import * as renderManagement from './render_management.js';
 import * as aria from './utils/aria.js';
-import {Coordinate} from './utils/coordinate.js';
 import * as dom from './utils/dom.js';
 import {Size} from './utils/size.js';
 import * as userAgent from './utils/useragent.js';
@@ -633,9 +632,7 @@ export abstract class FieldInput<T extends InputTypes> extends Field<
   protected resizeEditor_() {
     renderManagement.finishQueuedRenders().then(() => {
       const block = this.getSourceBlock();
-      if (!block) {
-        throw new UnattachedFieldError();
-      }
+      if (!block) throw new UnattachedFieldError();
       const div = WidgetDiv.getDiv();
       const bBox = this.getScaledBBox();
       div!.style.width = bBox.right - bBox.left + 'px';
@@ -644,10 +641,10 @@ export abstract class FieldInput<T extends InputTypes> extends Field<
       // In RTL mode block fields and LTR input fields the left edge moves,
       // whereas the right edge is fixed.  Reposition the editor.
       const x = block.RTL ? bBox.right - div!.offsetWidth : bBox.left;
-      const xy = new Coordinate(x, bBox.top);
+      const y = bBox.top;
 
-      div!.style.left = xy.x + 'px';
-      div!.style.top = xy.y + 'px';
+      div!.style.left = `${x}px`;
+      div!.style.top = `${y}px`;
     });
   }
 


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #7809

### Proposed Changes
This PR fixes a crash that could occur when the window was resized while a field has focus/is being edited. Calling `moveBy` on a child block is invalid, but because FieldInput was bumping its parent block (potentially nested) during resizes, that invalid code path could be triggered. Instead, the root block of the FieldInput will be bumped into bounds if needed, which is safe. `resizeEditor_()` was also updated to wait for the active render to complete, since it needs to know the bounds of its parent block, which was causing rendering glitches.