### PR TITLE
feat!: Use CSS to specify field cursors.

### DIFF
--- a/core/css.ts
+++ b/core/css.ts
@@ -478,4 +478,17 @@ input[type=number] {
   z-index: 80;
   pointer-events: none;
 }
+
+.blocklyField {
+  cursor: default;
+}
+
+.blocklyInputField {
+  cursor: text;
+}
+
+.blocklyDragging .blocklyField,
+.blocklyDragging .blocklyIconGroup {
+  cursor: grabbing;
+}
 `;

--- a/core/field.ts
+++ b/core/field.ts
@@ -193,9 +193,6 @@ export abstract class Field<T = any>
    */
   SERIALIZABLE = false;
 
-  /** Mouse cursor style when over the hotspot that initiates the editor. */
-  CURSOR = '';
-
   /**
    * @param value The initial value of the field.
    *     Also accepts Field.SKIP_SETUP if you wish to skip setup (only used by
@@ -536,11 +533,9 @@ export abstract class Field<T = any>
     if (this.enabled_ && block.isEditable()) {
       dom.addClass(group, 'blocklyEditableField');
       dom.removeClass(group, 'blocklyNonEditableField');
-      group.style.cursor = this.CURSOR;
     } else {
       dom.addClass(group, 'blocklyNonEditableField');
       dom.removeClass(group, 'blocklyEditableField');
-      group.style.cursor = '';
     }
   }
 

--- a/core/field_checkbox.ts
+++ b/core/field_checkbox.ts
@@ -36,11 +36,6 @@ export class FieldCheckbox extends Field<CheckboxBool> {
   override SERIALIZABLE = true;
 
   /**
-   * Mouse cursor style when over the hotspot that initiates editability.
-   */
-  override CURSOR = 'default';
-
-  /**
    * NOTE: The default value is set in `Field`, so maintain that value instead
    * of overwriting it here or in the constructor.
    */

--- a/core/field_dropdown.ts
+++ b/core/field_dropdown.ts
@@ -70,9 +70,6 @@ export class FieldDropdown extends Field<string> {
    */
   override SERIALIZABLE = true;
 
-  /** Mouse cursor style when over the hotspot that initiates the editor. */
-  override CURSOR = 'default';
-
   protected menuGenerator_?: MenuGenerator;
 
   /** A cache of the most recently generated options. */
@@ -203,6 +200,11 @@ export class FieldDropdown extends Field<string> {
 
     if (this.borderRect_) {
       dom.addClass(this.borderRect_, 'blocklyDropdownRect');
+    }
+
+    if (this.fieldGroup_) {
+      dom.addClass(this.fieldGroup_, 'blocklyField');
+      dom.addClass(this.fieldGroup_, 'blocklyDropdownField');
     }
   }
 

--- a/core/field_input.ts
+++ b/core/field_input.ts
@@ -99,9 +99,6 @@ export abstract class FieldInput<T extends InputTypes> extends Field<
    */
   override SERIALIZABLE = true;
 
-  /** Mouse cursor style when over the hotspot that initiates the editor. */
-  override CURSOR = 'text';
-
   /**
    * @param value The initial value of the field. Should cast to a string.
    *     Defaults to an empty string if null or undefined. Also accepts
@@ -147,6 +144,10 @@ export abstract class FieldInput<T extends InputTypes> extends Field<
 
     if (this.isFullBlockField()) {
       this.clickTarget_ = (this.sourceBlock_ as BlockSvg).getSvgRoot();
+    }
+
+    if (this.fieldGroup_) {
+      dom.addClass(this.fieldGroup_, 'blocklyInputField');
     }
   }
 


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
* Fixes #8319
* Fixes #2885
* Fixes #2884
* Fixes #995

### Proposed Changes
This PR removes the `CURSOR` field from fields, and instead uses CSS to specify which cursor should be used for which fields. This directly fixes #8319. #2885 and #2884 are old bugs proposing adding options to inject classes into fields and refactoring the `CURSOR` field, which I believe are obsolete in light of the move to CSS. All core fields now add a class specifying the type of field, and custom field subclasses can also easily do this. As a result, users should be able to use CSS to customize the appearance of fields in general and their cursors in particular.

#995 was incidentally fixed here, since now that we're using CSS to specify cursors, it's trivial to specify the grabby cursor for fields when their parent block is being dragged.