### PR TITLE
refactor!: Add setSelectedItem() to IToolbox.

### DIFF
--- a/core/interfaces/i_toolbox.ts
+++ b/core/interfaces/i_toolbox.ts
@@ -94,7 +94,7 @@ export interface IToolbox extends IRegistrable {
   setVisible(isVisible: boolean): void;
 
   /**
-   * Selects the toolbox item by it's position in the list of toolbox items.
+   * Selects the toolbox item by its position in the list of toolbox items.
    *
    * @param position The position of the item to select.
    */
@@ -106,6 +106,14 @@ export interface IToolbox extends IRegistrable {
    * @returns The selected item, or null if no item is currently selected.
    */
   getSelectedItem(): IToolboxItem | null;
+
+  /**
+   * Sets the selected item.
+   *
+   * @param item The toolbox item to select, or null to remove the current
+   *     selection.
+   */
+  setSelectedItem(item: IToolboxItem | null): void;
 
   /** Disposes of this toolbox. */
   dispose(): void;


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #7273

### Proposed Changes
This PR updates the IToolbox interface by adding `setSelectedItem()`, to pair with the existing `getSelectedItem()`. This is a breaking change; implementers of this interface will need to add this method. Blockly's core Toolbox class already does implement this method, so subclasses of that will get it for free. The linked issue requested a method to select an item by ID, but since this (a) adds a setter to an existing getter (b) is already implemented in the core Toolbox class and (c) you'd need to have an item to get its ID anyway, I think this addresses the root need and is a bit cleaner.