### PR TITLE
refactor!: Use one map for toolbox contents.

### DIFF
--- a/tests/mocha/test_helpers/toolbox_definitions.js
+++ b/tests/mocha/test_helpers/toolbox_definitions.js
@@ -243,9 +243,8 @@ export function getBasicToolbox() {
 }
 
 export function getCollapsibleItem(toolbox) {
-  const contents = toolbox.contents_;
-  for (let i = 0; i < contents.length; i++) {
-    const item = contents[i];
+  const contents = toolbox.contents.values();
+  for (const item of contents) {
     if (item.isCollapsible()) {
       return item;
     }
@@ -253,9 +252,8 @@ export function getCollapsibleItem(toolbox) {
 }
 
 export function getNonCollapsibleItem(toolbox) {
-  const contents = toolbox.contents_;
-  for (let i = 0; i < contents.length; i++) {
-    const item = contents[i];
+  const contents = toolbox.contents.values();
+  for (const item of contents) {
     if (!item.isCollapsible()) {
       return item;
     }

--- a/tests/mocha/toolbox_test.js
+++ b/tests/mocha/toolbox_test.js
@@ -98,7 +98,7 @@ suite('Toolbox', function () {
           {'kind': 'category', 'contents': []},
         ],
       });
-      assert.lengthOf(this.toolbox.contents_, 2);
+      assert.equal(this.toolbox.contents.size, 2);
       sinon.assert.called(positionStub);
     });
     // TODO: Uncomment once implemented.
@@ -153,7 +153,7 @@ suite('Toolbox', function () {
         ],
       };
       this.toolbox.render(jsonDef);
-      assert.lengthOf(this.toolbox.contents_, 1);
+      assert.equal(this.toolbox.contents.size, 1);
     });
     test('multiple icon classes can be applied', function () {
       const jsonDef = {
@@ -176,7 +176,7 @@ suite('Toolbox', function () {
       assert.doesNotThrow(() => {
         this.toolbox.render(jsonDef);
       });
-      assert.lengthOf(this.toolbox.contents_, 1);
+      assert.equal(this.toolbox.contents.size, 1);
     });
   });
 
@@ -204,7 +204,7 @@ suite('Toolbox', function () {
       const evt = {
         'target': categoryXml,
       };
-      const item = this.toolbox.contentMap_[categoryXml.getAttribute('id')];
+      const item = this.toolbox.contents.get(categoryXml.getAttribute('id'));
       const setSelectedSpy = sinon.spy(this.toolbox, 'setSelectedItem');
       const onClickSpy = sinon.spy(item, 'onClick');
       this.toolbox.onClick_(evt);
@@ -356,14 +356,16 @@ suite('Toolbox', function () {
         assert.isFalse(handled);
       });
       test('Next item is selectable -> Should select next item', function () {
-        const item = this.toolbox.contents_[0];
+        const items = [...this.toolbox.contents.values()];
+        const item = items[0];
         this.toolbox.selectedItem_ = item;
         const handled = this.toolbox.selectNext_();
         assert.isTrue(handled);
-        assert.equal(this.toolbox.selectedItem_, this.toolbox.contents_[1]);
+        assert.equal(this.toolbox.selectedItem_, items[1]);
       });
       test('Selected item is last item -> Should not handle event', function () {
-        const item = this.toolbox.contents_[this.toolbox.contents_.length - 1];
+        const items = [...this.toolbox.contents.values()];
+        const item = items.at(-1);
         this.toolbox.selectedItem_ = item;
         const handled = this.toolbox.selectNext_();
         assert.isFalse(handled);
@@ -387,15 +389,16 @@ suite('Toolbox', function () {
         assert.isFalse(handled);
       });
       test('Selected item is first item -> Should not handle event', function () {
-        const item = this.toolbox.contents_[0];
+        const item = [...this.toolbox.contents.values()][0];
         this.toolbox.selectedItem_ = item;
         const handled = this.toolbox.selectPrevious_();
         assert.isFalse(handled);
         assert.equal(this.toolbox.selectedItem_, item);
       });
       test('Previous item is selectable -> Should select previous item', function () {
-        const item = this.toolbox.contents_[1];
-        const prevItem = this.toolbox.contents_[0];
+        const items = [...this.toolbox.contents.values()];
+        const item = items[1];
+        const prevItem = items[0];
         this.toolbox.selectedItem_ = item;
         const handled = this.toolbox.selectPrevious_();
         assert.isTrue(handled);
@@ -404,9 +407,10 @@ suite('Toolbox', function () {
       test('Previous item is collapsed -> Should skip over children of the previous item', function () {
         const childItem = getChildItem(this.toolbox);
         const parentItem = childItem.getParent();
-        const parentIdx = this.toolbox.contents_.indexOf(parentItem);
+        const items = [...this.toolbox.contents.values()];
+        const parentIdx = items.indexOf(parentItem);
         // Gets the item after the parent.
-        const item = this.toolbox.contents_[parentIdx + 1];
+        const item = items[parentIdx + 1];
         this.toolbox.selectedItem_ = item;
         const handled = this.toolbox.selectPrevious_();
         assert.isTrue(handled);
@@ -728,9 +732,10 @@ suite('Toolbox', function () {
     });
     test('Child categories visible if all ancestors expanded', function () {
       this.toolbox.render(getDeeplyNestedJSON());
-      const outerCategory = this.toolbox.contents_[0];
-      const middleCategory = this.toolbox.contents_[1];
-      const innerCategory = this.toolbox.contents_[2];
+      const items = [...this.toolbox.contents.values()];
+      const outerCategory = items[0];
+      const middleCategory = items[1];
+      const innerCategory = items[2];
 
       outerCategory.toggleExpanded();
       middleCategory.toggleExpanded();
@@ -743,8 +748,9 @@ suite('Toolbox', function () {
     });
     test('Child categories not visible if any ancestor not expanded', function () {
       this.toolbox.render(getDeeplyNestedJSON());
-      const middleCategory = this.toolbox.contents_[1];
-      const innerCategory = this.toolbox.contents_[2];
+      const items = [...this.toolbox.contents.values()];
+      const middleCategory = items[1];
+      const innerCategory = items[2];
 
       // Don't expand the outermost category
       // Even though the direct parent of inner is expanded, it shouldn't be visible


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details

### Proposed Changes
This PR updates the toolbox to use a single `Map` for keeping track of its contents, in place of an array and an object keyed by ID. Previously, these two sources of truth needed to be kept in sync, which was error prone, and also minorly memory inefficient. Now, there is a single source of truth. This is a breaking changed because the `protected` fields `contents_` and `contentMap_` have been removed and replaced by the single `protected` field `contents`.