### PR TITLE
refactor!: Use JSON instead of XML for defining dynamic toolbox categories.

### DIFF
--- a/core/procedures.ts
+++ b/core/procedures.ts
@@ -42,6 +42,7 @@ import {IProcedureModel} from './interfaces/i_procedure_model.js';
 import {Msg} from './msg.js';
 import {Names} from './names.js';
 import {ObservableProcedureMap} from './observable_procedure_map.js';
+import * as deprecation from './utils/deprecation.js';
 import type {FlyoutItemInfo} from './utils/toolbox.js';
 import * as utilsXml from './utils/xml.js';
 import * as Variables from './variables.js';
@@ -355,6 +356,12 @@ export function flyoutCategory(
   useXml = true,
 ): Element[] | FlyoutItemInfo[] {
   if (useXml) {
+    deprecation.warn(
+      'The XML return value of Blockly.Procedures.flyoutCategory()',
+      'v12',
+      'v13',
+      'the same method, but handle a return type of FlyoutItemInfo[] (JSON) instead.',
+    );
     return xmlFlyoutCategory(workspace);
   }
   const blocks = [];

--- a/core/procedures.ts
+++ b/core/procedures.ts
@@ -274,7 +274,7 @@ export function flyoutCategory(workspace: WorkspaceSvg): FlyoutItemInfo[] {
   }
 
   /**
-   * Add items to xmlList for each listed procedure.
+   * Creates JSON block definitions for each of the given procedures.
    *
    * @param procedureList A list of procedures, each of which is defined by a
    *     three-element list of name, parameter list, and return value boolean.

--- a/core/variables.ts
+++ b/core/variables.ts
@@ -113,9 +113,28 @@ export function flyoutCategory(workspace: WorkspaceSvg): FlyoutItemInfo[] {
 }
 
 /**
+ * Returns the JSON definition for a variable field.
+ *
+ * @param variable The variable the field should reference.
+ * @returns JSON for a variable field.
+ */
+function generateVariableFieldJson(variable: IVariableModel<IVariableState>) {
+  return {
+    'VAR': {
+      'name': variable.getName(),
+      'type': variable.getType(),
+    },
+  };
+}
+
+/**
  * Construct the blocks required by the flyout for the variable category.
  *
  * @param workspace The workspace containing variables.
+ * @param variables List of variables to create blocks for.
+ * @param includeChangeBlocks True to include `change x by _` blocks.
+ * @param getterType The type of the variable getter block to generate.
+ * @param setterType The type of the variable setter block to generate.
  * @returns JSON list of blocks.
  */
 export function flyoutCategoryBlocks(
@@ -127,20 +146,10 @@ export function flyoutCategoryBlocks(
 ): BlockInfo[] {
   includeChangeBlocks &&= Blocks['math_change'];
 
-  const generateVariableFieldJson = (
-    variable: IVariableModel<IVariableState>,
-  ) => {
-    return {
-      'VAR': {
-        'name': variable.getName(),
-        'type': variable.getType(),
-      },
-    };
-  };
-
   const blocks = [];
   const mostRecentVariable = variables.slice(-1)[0];
   if (mostRecentVariable) {
+    // Show one setter block, with the name of the most recently created variable.
     if (Blocks[setterType]) {
       blocks.push({
         kind: 'block',
@@ -171,6 +180,7 @@ export function flyoutCategoryBlocks(
   }
 
   if (Blocks[getterType]) {
+    // Show one getter block for each variable, sorted in alphabetical order.
     blocks.push(
       ...variables.sort(compareByName).map((variable) => {
         return {

--- a/core/variables.ts
+++ b/core/variables.ts
@@ -13,6 +13,7 @@ import {isLegacyProcedureDefBlock} from './interfaces/i_legacy_procedure_blocks.
 import {isVariableBackedParameterModel} from './interfaces/i_variable_backed_parameter_model.js';
 import {IVariableModel, IVariableState} from './interfaces/i_variable_model.js';
 import {Msg} from './msg.js';
+import * as deprecation from './utils/deprecation.js';
 import type {BlockInfo, FlyoutItemInfo} from './utils/toolbox.js';
 import * as utilsXml from './utils/xml.js';
 import type {Workspace} from './workspace.js';
@@ -124,6 +125,12 @@ export function flyoutCategory(
   }
 
   if (useXml) {
+    deprecation.warn(
+      'The XML return value of Blockly.Variables.flyoutCategory()',
+      'v12',
+      'v13',
+      'the same method, but handle a return type of FlyoutItemInfo[] (JSON) instead.',
+    );
     return xmlFlyoutCategory(workspace);
   }
 

--- a/core/variables_dynamic.ts
+++ b/core/variables_dynamic.ts
@@ -9,9 +9,8 @@
 import {Blocks} from './blocks.js';
 import type {FlyoutButton} from './flyout_button.js';
 import {Msg} from './msg.js';
-import * as xml from './utils/xml.js';
+import type {FlyoutItemInfo} from './utils/toolbox.js';
 import * as Variables from './variables.js';
-import type {Workspace} from './workspace.js';
 import type {WorkspaceSvg} from './workspace_svg.js';
 
 /**
@@ -73,27 +72,14 @@ export const onCreateVariableButtonClick_Colour = colourButtonClickHandler;
  * variable category.
  *
  * @param workspace The workspace containing variables.
- * @returns Array of XML elements.
+ * @returns JSON list of flyout contents.
  */
-export function flyoutCategory(workspace: WorkspaceSvg): Element[] {
+export function flyoutCategory(workspace: WorkspaceSvg): FlyoutItemInfo[] {
   if (!Blocks['variables_set_dynamic'] && !Blocks['variables_get_dynamic']) {
     console.warn(
       'There are no dynamic variable blocks, but there is a dynamic variable category.',
     );
   }
-  let xmlList = new Array<Element>();
-  let button = document.createElement('button');
-  button.setAttribute('text', Msg['NEW_STRING_VARIABLE']);
-  button.setAttribute('callbackKey', 'CREATE_VARIABLE_STRING');
-  xmlList.push(button);
-  button = document.createElement('button');
-  button.setAttribute('text', Msg['NEW_NUMBER_VARIABLE']);
-  button.setAttribute('callbackKey', 'CREATE_VARIABLE_NUMBER');
-  xmlList.push(button);
-  button = document.createElement('button');
-  button.setAttribute('text', Msg['NEW_COLOUR_VARIABLE']);
-  button.setAttribute('callbackKey', 'CREATE_VARIABLE_COLOUR');
-  xmlList.push(button);
 
   workspace.registerButtonCallback(
     'CREATE_VARIABLE_STRING',
@@ -108,40 +94,28 @@ export function flyoutCategory(workspace: WorkspaceSvg): Element[] {
     colourButtonClickHandler,
   );
 
-  const blockList = flyoutCategoryBlocks(workspace);
-  xmlList = xmlList.concat(blockList);
-  return xmlList;
-}
-
-/**
- * Construct the blocks required by the flyout for the variable category.
- *
- * @param workspace The workspace containing variables.
- * @returns Array of XML block elements.
- */
-export function flyoutCategoryBlocks(workspace: Workspace): Element[] {
-  const variableModelList = workspace.getAllVariables();
-
-  const xmlList = [];
-  if (variableModelList.length > 0) {
-    if (Blocks['variables_set_dynamic']) {
-      const firstVariable = variableModelList[variableModelList.length - 1];
-      const block = xml.createElement('block');
-      block.setAttribute('type', 'variables_set_dynamic');
-      block.setAttribute('gap', '24');
-      block.appendChild(Variables.generateVariableFieldDom(firstVariable));
-      xmlList.push(block);
-    }
-    if (Blocks['variables_get_dynamic']) {
-      variableModelList.sort(Variables.compareByName);
-      for (let i = 0, variable; (variable = variableModelList[i]); i++) {
-        const block = xml.createElement('block');
-        block.setAttribute('type', 'variables_get_dynamic');
-        block.setAttribute('gap', '8');
-        block.appendChild(Variables.generateVariableFieldDom(variable));
-        xmlList.push(block);
-      }
-    }
-  }
-  return xmlList;
+  return [
+    {
+      'kind': 'button',
+      'text': Msg['NEW_STRING_VARIABLE'],
+      'callbackkey': 'CREATE_VARIABLE_STRING',
+    },
+    {
+      'kind': 'button',
+      'text': Msg['NEW_NUMBER_VARIABLE'],
+      'callbackkey': 'CREATE_VARIABLE_NUMBER',
+    },
+    {
+      'kind': 'button',
+      'text': Msg['NEW_COLOUR_VARIABLE'],
+      'callbackkey': 'CREATE_VARIABLE_COLOUR',
+    },
+    ...Variables.flyoutCategoryBlocks(
+      workspace,
+      workspace.getAllVariables(),
+      false,
+      'variables_get_dynamic',
+      'variables_set_dynamic',
+    ),
+  ];
 }

--- a/core/variables_dynamic.ts
+++ b/core/variables_dynamic.ts
@@ -9,6 +9,7 @@
 import {Blocks} from './blocks.js';
 import type {FlyoutButton} from './flyout_button.js';
 import {Msg} from './msg.js';
+import * as deprecation from './utils/deprecation.js';
 import type {FlyoutItemInfo} from './utils/toolbox.js';
 import * as xml from './utils/xml.js';
 import * as Variables from './variables.js';
@@ -107,6 +108,12 @@ export function flyoutCategory(
   }
 
   if (useXml) {
+    deprecation.warn(
+      'The XML return value of Blockly.VariablesDynamic.flyoutCategory()',
+      'v12',
+      'v13',
+      'the same method, but handle a return type of FlyoutItemInfo[] (JSON) instead.',
+    );
     return xmlFlyoutCategory(workspace);
   }
 

--- a/core/workspace_svg.ts
+++ b/core/workspace_svg.ts
@@ -365,24 +365,24 @@ export class WorkspaceSvg extends Workspace implements IASTNodeLocationSvg {
     /** Manager in charge of markers and cursors. */
     this.markerManager = new MarkerManager(this);
 
-    if (Variables && Variables.flyoutCategory) {
+    if (Variables && Variables.internalFlyoutCategory) {
       this.registerToolboxCategoryCallback(
         Variables.CATEGORY_NAME,
-        Variables.flyoutCategory,
+        Variables.internalFlyoutCategory,
       );
     }
 
-    if (VariablesDynamic && VariablesDynamic.flyoutCategory) {
+    if (VariablesDynamic && VariablesDynamic.internalFlyoutCategory) {
       this.registerToolboxCategoryCallback(
         VariablesDynamic.CATEGORY_NAME,
-        VariablesDynamic.flyoutCategory,
+        VariablesDynamic.internalFlyoutCategory,
       );
     }
 
-    if (Procedures && Procedures.flyoutCategory) {
+    if (Procedures && Procedures.internalFlyoutCategory) {
       this.registerToolboxCategoryCallback(
         Procedures.CATEGORY_NAME,
-        Procedures.flyoutCategory,
+        Procedures.internalFlyoutCategory,
       );
       this.addChangeListener(Procedures.mutatorOpenListener);
     }

--- a/tests/mocha/contextmenu_test.js
+++ b/tests/mocha/contextmenu_test.js
@@ -32,9 +32,13 @@ suite('Context Menu', function () {
     });
 
     test('callback with xml state creates block', function () {
-      const xmlField = Variables.generateVariableFieldDom(
-        this.forLoopBlock.getField('VAR').getVariable(),
-      );
+      const variable = this.forLoopBlock.getField('VAR').getVariable();
+      const xmlField = document.createElement('field');
+      xmlField.setAttribute('name', 'VAR');
+      xmlField.setAttribute('id', variable.getId());
+      xmlField.setAttribute('variabletype', variable.getType());
+      xmlField.textContent = variable.getName();
+
       const xmlBlock = xmlUtils.createElement('block');
       xmlBlock.setAttribute('type', 'variables_get');
       xmlBlock.appendChild(xmlField);

--- a/tests/mocha/contextmenu_test.js
+++ b/tests/mocha/contextmenu_test.js
@@ -6,7 +6,6 @@
 
 import {callbackFactory} from '../../build/src/core/contextmenu.js';
 import * as xmlUtils from '../../build/src/core/utils/xml.js';
-import * as Variables from '../../build/src/core/variables.js';
 import {assert} from '../../node_modules/chai/chai.js';
 import {
   sharedTestSetup,

--- a/tests/mocha/xml_test.js
+++ b/tests/mocha/xml_test.js
@@ -888,42 +888,4 @@ suite('XML', function () {
       });
     });
   });
-  suite('generateVariableFieldDom', function () {
-    test('Case Sensitive', function () {
-      const varId = 'testId';
-      const type = 'testType';
-      const name = 'testName';
-
-      const mockVariableModel = {
-        type: type,
-        name: name,
-        getId: function () {
-          return varId;
-        },
-        getName: function () {
-          return name;
-        },
-        getType: function () {
-          return type;
-        },
-      };
-
-      const generatedXml = Blockly.Xml.domToText(
-        Blockly.Variables.generateVariableFieldDom(mockVariableModel),
-      );
-      const expectedXml =
-        '<field xmlns="https://developers.google.com/blockly/xml"' +
-        ' name="VAR"' +
-        ' id="' +
-        varId +
-        '"' +
-        ' variabletype="' +
-        type +
-        '"' +
-        '>' +
-        name +
-        '</field>';
-      assert.equal(generatedXml, expectedXml);
-    });
-  });
 });

--- a/tests/mocha/xml_test.js
+++ b/tests/mocha/xml_test.js
@@ -531,28 +531,6 @@ suite('XML', function () {
     teardown(function () {
       workspaceTeardown.call(this, this.workspace);
     });
-    suite('Dynamic Category Blocks', function () {
-      test('Untyped Variables', function () {
-        this.workspace.createVariable('name1', '', 'id1');
-        const blocksArray = Blockly.Variables.flyoutCategoryBlocks(
-          this.workspace,
-        );
-        for (let i = 0, xml; (xml = blocksArray[i]); i++) {
-          Blockly.Xml.domToBlock(xml, this.workspace);
-        }
-      });
-      test('Typed Variables', function () {
-        this.workspace.createVariable('name1', 'String', 'id1');
-        this.workspace.createVariable('name2', 'Number', 'id2');
-        this.workspace.createVariable('name3', 'Colour', 'id3');
-        const blocksArray = Blockly.VariablesDynamic.flyoutCategoryBlocks(
-          this.workspace,
-        );
-        for (let i = 0, xml; (xml = blocksArray[i]); i++) {
-          Blockly.Xml.domToBlock(xml, this.workspace);
-        }
-      });
-    });
     suite('Comments', function () {
       suite('Headless', function () {
         test('Text', function () {


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #5580

### Proposed Changes
This PR updates the variable, dynamic variable, and procedure toolbox category definitions to use the newer JSON schema in place of the older XML-based format.

### Reason for Changes
Support for XML will eventually be removed, and this serves as both eating our own dogfood and a practical example of implementing a dynamic category definition with JSON which third party developers may benefit from as a reference.

### Deprecations
* The `Element[]` return type of the `flyoutCategory()` method for each category is now deprecated. Users can opt-in to the new `FlyoutItemInfo[]` (JSON) return type by passing a second argument of `false` to the method. We expect to switch the default return type in v13.