### PR TITLE
chore!: Fix warnings when generating docs.

### DIFF
--- a/api-extractor.json
+++ b/api-extractor.json
@@ -352,6 +352,11 @@
       // Needs investigation.
       "ae-forgotten-export": {
         "logLevel": "none"
+      },
+
+      // We don't prefix our internal APIs with underscores.
+      "ae-internal-missing-underscore": {
+        "logLevel": "none"
       }
     },
 

--- a/core/block.ts
+++ b/core/block.ts
@@ -1406,7 +1406,7 @@ export class Block implements IASTNodeLocation {
     return this.disabledReasons.size === 0;
   }
 
-  /** @deprecated v11 - Get whether the block is manually disabled. */
+  /** @deprecated v11 - Get or sets whether the block is manually disabled. */
   private get disabled(): boolean {
     deprecation.warn(
       'disabled',
@@ -1417,7 +1417,6 @@ export class Block implements IASTNodeLocation {
     return this.hasDisabledReason(constants.MANUALLY_DISABLED);
   }
 
-  /** @deprecated v11 - Set whether the block is manually disabled. */
   private set disabled(value: boolean) {
     deprecation.warn(
       'disabled',
@@ -2499,7 +2498,7 @@ export class Block implements IASTNodeLocation {
    *
    * Intended to on be used in console logs and errors. If you need a string
    * that uses the user's native language (including block text, field values,
-   * and child blocks), use [toString()]{@link Block#toString}.
+   * and child blocks), use {@link (Block:class).toString | toString()}.
    *
    * @returns The description.
    */

--- a/core/connection.ts
+++ b/core/connection.ts
@@ -484,7 +484,7 @@ export class Connection implements IASTNodeLocationWithBlock {
    *
    * Headless configurations (the default) do not have neighboring connection,
    * and always return an empty list (the default).
-   * {@link RenderedConnection#neighbours} overrides this behavior with a list
+   * {@link (RenderedConnection:class).neighbours} overrides this behavior with a list
    * computed from the rendered positioning.
    *
    * @param _maxLimit The maximum radius to another connection.

--- a/core/events/events_var_delete.ts
+++ b/core/events/events_var_delete.ts
@@ -18,8 +18,6 @@ import type {Workspace} from '../workspace.js';
 
 /**
  * Notifies listeners that a variable model has been deleted.
- *
- * @class
  */
 export class VarDelete extends VarBase {
   override type = eventUtils.VAR_DELETE;

--- a/core/events/events_var_rename.ts
+++ b/core/events/events_var_rename.ts
@@ -18,8 +18,6 @@ import type {Workspace} from '../workspace.js';
 
 /**
  * Notifies listeners that a variable model was renamed.
- *
- * @class
  */
 export class VarRename extends VarBase {
   override type = eventUtils.VAR_RENAME;

--- a/core/interfaces/i_metrics_manager.ts
+++ b/core/interfaces/i_metrics_manager.ts
@@ -62,7 +62,7 @@ export interface IMetricsManager {
    * Gets the width, height and position of the toolbox on the workspace in
    * pixel coordinates. Returns 0 for the width and height if the workspace has
    * a simple toolbox instead of a category toolbox. To get the width and height
-   * of a simple toolbox, see {@link IMetricsManager#getFlyoutMetrics}.
+   * of a simple toolbox, see {@link IMetricsManager.getFlyoutMetrics}.
    *
    * @returns The object with the width, height and position of the toolbox.
    */

--- a/core/interfaces/i_rendered_element.ts
+++ b/core/interfaces/i_rendered_element.ts
@@ -4,18 +4,15 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/** @internal */
 export interface IRenderedElement {
   /**
-   * @returns The root SVG element of htis rendered element.
+   * @returns The root SVG element of this rendered element.
    */
   getSvgRoot(): SVGElement;
 }
 
 /**
  * @returns True if the given object is an IRenderedElement.
- *
- * @internal
  */
 export function isRenderedElement(obj: any): obj is IRenderedElement {
   return obj['getSvgRoot'] !== undefined;

--- a/core/menu.ts
+++ b/core/menu.ts
@@ -389,9 +389,7 @@ export class Menu {
   // Keyboard events.
 
   /**
-   * Attempts to handle a keyboard event, if the menu item is enabled, by
-   * calling
-   * {@link Menu#handleKeyEventInternal_}.
+   * Attempts to handle a keyboard event.
    *
    * @param e Key event to handle.
    */

--- a/core/metrics_manager.ts
+++ b/core/metrics_manager.ts
@@ -76,7 +76,7 @@ export class MetricsManager implements IMetricsManager {
    * Gets the width, height and position of the toolbox on the workspace in
    * pixel coordinates. Returns 0 for the width and height if the workspace has
    * a simple toolbox instead of a category toolbox. To get the width and height
-   * of a simple toolbox, see {@link MetricsManager#getFlyoutMetrics}.
+   * of a simple toolbox, see {@link (MetricsManager:class).getFlyoutMetrics}.
    *
    * @returns The object with the width, height and position of the toolbox.
    */

--- a/core/renderers/common/renderer.ts
+++ b/core/renderers/common/renderer.ts
@@ -74,7 +74,7 @@ export class Renderer implements IRegistrable {
   /**
    * Create any DOM elements that this renderer needs.
    * If you need to create additional DOM elements, override the
-   * {@link ConstantProvider#createDom} method instead.
+   * {@link blockRendering#ConstantProvider.createDom} method instead.
    *
    * @param svg The root of the workspace's SVG.
    * @param theme The workspace theme object.

--- a/core/workspace_svg.ts
+++ b/core/workspace_svg.ts
@@ -1092,6 +1092,7 @@ export class WorkspaceSvg extends Workspace implements IASTNodeLocationSvg {
 
   /**
    * @returns The layer manager for this workspace.
+   * @internal
    */
   getLayerManager(): LayerManager | null {
     return this.layerManager;


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #6936

### Proposed Changes
This PR resolves various warnings when generating documentation. It fixes the @link syntax in various docstrings to either be valid or disambiguate the symbol being referenced, removes @class on docstrings attached to a class, unifies docs for setters/getters to be on the getter, and updates the API Extractor config to not require leading underscores on internal symbols.

### Breaking Change
`WorkspaceSvg.getLayerManager()` is now marked `@internal`; API Extractor was complaining that the class itself was internal but had a public getter. The PR that introduced the layer manager and this method (#7619) stated that "The new system should be entirely internal.", so I believe this being public was an oversight.

The `IRenderedElement` interface is made public by this change.