### PR TITLE
fix: Disable newly created function call blocks when the corresponding definition is disabled.

### DIFF
--- a/blocks/procedures.ts
+++ b/blocks/procedures.ts
@@ -1099,6 +1099,14 @@ const PROCEDURE_CALL_COMMON = {
         xml.appendChild(block);
         Xml.domToWorkspace(xml, this.workspace);
         Events.setGroup(false);
+      } else if (!def.isEnabled()) {
+        this.setDisabledReason(
+          true,
+          DISABLED_PROCEDURE_DEFINITION_DISABLED_REASON,
+        );
+        this.setWarningText(
+          Msg['PROCEDURES_CALL_DISABLED_DEF_WARNING'].replace('%1', name),
+        );
       }
     } else if (event.type === Events.BLOCK_DELETE) {
       // Look for the case where a procedure definition has been deleted,


### PR DESCRIPTION

<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #8661

### Proposed Changes
This PR fixes a bug that allow enabled function caller blocks to be created on the workspace after their corresponding definition block was disabled.