### PR TITLE
fix: Fix bug that caused comments to be incorrectly positioned.

### DIFF
--- a/core/icons/comment_icon.ts
+++ b/core/icons/comment_icon.ts
@@ -338,8 +338,7 @@ export class CommentIcon extends Icon implements IHasBubble, ISerializable {
    *     I.E. the block that owns this icon.
    */
   private getBubbleOwnerRect(): Rect {
-    const bbox = (this.sourceBlock as BlockSvg).getSvgRoot().getBBox();
-    return new Rect(bbox.y, bbox.y + bbox.height, bbox.x, bbox.x + bbox.width);
+    return (this.sourceBlock as BlockSvg).getBoundingRectangleWithoutChildren();
   }
 }
 


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #7855

### Proposed Changes
This PR fixes a bug that caused block comments to be incorrectly positioned/overlapping their parent block when loaded into a hidden workspace that was subsequently shown.