### PR TITLE
chore: Remove obsolete workaround for resize events on iPads.

### DIFF
--- a/core/inject.ts
+++ b/core/inject.ts
@@ -22,7 +22,6 @@ import * as Touch from './touch.js';
 import * as aria from './utils/aria.js';
 import * as dom from './utils/dom.js';
 import {Svg} from './utils/svg.js';
-import * as userAgent from './utils/useragent.js';
 import * as WidgetDiv from './widgetdiv.js';
 import {WorkspaceSvg} from './workspace_svg.js';
 
@@ -337,18 +336,6 @@ function bindDocumentEvents() {
     // should run regardless of what other touch event handlers have run.
     browserEvents.bind(document, 'touchend', null, Touch.longStop);
     browserEvents.bind(document, 'touchcancel', null, Touch.longStop);
-    // Some iPad versions don't fire resize after portrait to landscape change.
-    if (userAgent.IPAD) {
-      browserEvents.conditionalBind(
-        window,
-        'orientationchange',
-        document,
-        function () {
-          // TODO (#397): Fix for multiple Blockly workspaces.
-          common.svgResize(common.getMainWorkspace() as WorkspaceSvg);
-        },
-      );
-    }
   }
   documentEventsBound = true;
 }


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #397

### Proposed Changes
This PR removes a dedicated `orientationchange` listener for iPads, which was apparently added due to iPads not triggering `resize` events in response to rotating the device. This special handler failed to account for multiple workspaces, but I confirmed on an iPad that rotating the device triggers regular `resize` events as expected, so I've removed the workaround entirely.