### PR TITLE
fix: Fix bug that caused text to be selected when long-pressing in the workspace on a touch device.

### DIFF
--- a/core/css.ts
+++ b/core/css.ts
@@ -79,6 +79,8 @@ let content = `
   position: relative;
   overflow: hidden;  /* So blocks in drag surface disappear at edges */
   touch-action: none;
+  user-select: none;
+  -webkit-user-select: none;
 }
 
 .blocklyNonSelectable {
@@ -264,17 +266,6 @@ let content = `
 
 .blocklyText text {
   cursor: default;
-}
-
-/*
-  Don't allow users to select text.  It gets annoying when trying to
-  drag a block and selected text moves instead.
-*/
-.blocklySvg text {
-  user-select: none;
-  -ms-user-select: none;
-  -webkit-user-select: none;
-  cursor: inherit;
 }
 
 .blocklyHidden {

--- a/core/toolbox/toolbox.ts
+++ b/core/toolbox/toolbox.ts
@@ -197,7 +197,6 @@ export class Toolbox
     const toolboxContainer = document.createElement('div');
     toolboxContainer.setAttribute('layout', this.isHorizontal() ? 'h' : 'v');
     dom.addClass(toolboxContainer, 'blocklyToolboxDiv');
-    dom.addClass(toolboxContainer, 'blocklyNonSelectable');
     toolboxContainer.setAttribute('dir', this.RTL ? 'RTL' : 'LTR');
     return toolboxContainer;
   }

--- a/tests/mocha/toolbox_test.js
+++ b/tests/mocha/toolbox_test.js
@@ -47,10 +47,7 @@ suite('Toolbox', function () {
     test('Init called -> HtmlDiv is inserted before parent node', function () {
       const toolboxDiv = Blockly.common.getMainWorkspace().getInjectionDiv()
         .childNodes[0];
-      assert.equal(
-        toolboxDiv.className,
-        'blocklyToolboxDiv blocklyNonSelectable',
-      );
+      assert.equal(toolboxDiv.className, 'blocklyToolboxDiv');
     });
     test('Init called -> Toolbox is subscribed to background and foreground colour', function () {
       const themeManager = this.toolbox.workspace_.getThemeManager();


### PR DESCRIPTION

<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
* Fixes #4954
* Fixes #2188

### Proposed Changes
This PR sets `user-select: none;` on the entire injection div, which prevents users from selecting text. We had already had this in place on block text, menus, and toolbox categories, but since e.g. the workspace and blocks themselves did not, long-pressing those items on mobile would also select text (often outside of Blockly) in addition to presenting the context menu. I repro'd this and confirmed the fix on an iPad, but I strongly suspect the two linked issues are the same thing; if folks with an Android and/or ChromeOS touchscreen device could confirm this also resolves the issue there, that would be great, but I'm nearly certain this resolves the problem there as well.

Note that this does not prevent selecting text in text fields, either in blocks or comments. I verified this across Chrome, Safari and Firefox.