### PR TITLE
refactor: Reenable workspace resizing after reflowing flyouts.

### DIFF
--- a/core/flyout_base.ts
+++ b/core/flyout_base.ts
@@ -633,8 +633,8 @@ export abstract class Flyout
     } else {
       this.width_ = 0;
     }
-    this.workspace_.setResizesEnabled(true);
     this.reflow();
+    this.workspace_.setResizesEnabled(true);
 
     // Listen for block change events, and reflow the flyout in response. This
     // accommodates e.g. resizing a non-autoclosing flyout in response to the


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #785

### Proposed Changes
This PR moves the call to `setResizesEnabled(true)` to after the call to `reflow()` in flyouts. The multiplayground environment with both simple and category toolboxes showed no behavioral differences with this change. I'm making this change against v12 since there are significant flyout refactors there already.