### PR TITLE
chore: Remove CSS targeting multiline input field.

### DIFF
--- a/core/css.ts
+++ b/core/css.ts
@@ -251,10 +251,6 @@ let content = `
   stroke: none;
 }
 
-.blocklyMultilineText {
-  font-family: monospace;
-}
-
 .blocklyNonEditableText>text {
   pointer-events: none;
 }


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes https://github.com/google/blockly-samples/issues/2418

### Proposed Changes
This PR removes CSS targeting the multiline input field, which has now been moved out of core into a plugin. The only rule attempted to apply monospace styling to it; I didn't migrate this to samples, because, while that field has historically been used for code, it's perfectly reasonable to use it for regular multiline text as well, and we shouldn't make an assumption either way. Developers that wish to can easily apply that style themselves.