### PR TITLE
fix: Fix bug that prevented keyboard navigation in flyouts.

### DIFF
--- a/core/blockly.ts
+++ b/core/blockly.ts
@@ -99,9 +99,10 @@ import {
   FieldVariableFromJsonConfig,
   FieldVariableValidator,
 } from './field_variable.js';
-import {Flyout, FlyoutItem} from './flyout_base.js';
+import {Flyout} from './flyout_base.js';
 import {FlyoutButton} from './flyout_button.js';
 import {HorizontalFlyout} from './flyout_horizontal.js';
+import {FlyoutItem} from './flyout_item.js';
 import {FlyoutMetricsManager} from './flyout_metrics_manager.js';
 import {FlyoutSeparator} from './flyout_separator.js';
 import {VerticalFlyout} from './flyout_vertical.js';

--- a/core/button_flyout_inflater.ts
+++ b/core/button_flyout_inflater.ts
@@ -5,11 +5,13 @@
  */
 
 import {FlyoutButton} from './flyout_button.js';
-import type {IBoundedElement} from './interfaces/i_bounded_element.js';
+import {FlyoutItem} from './flyout_item.js';
 import type {IFlyoutInflater} from './interfaces/i_flyout_inflater.js';
 import * as registry from './registry.js';
 import {ButtonOrLabelInfo} from './utils/toolbox.js';
 import type {WorkspaceSvg} from './workspace_svg.js';
+
+const BUTTON_TYPE = 'button';
 
 /**
  * Class responsible for creating buttons for flyouts.
@@ -22,7 +24,7 @@ export class ButtonFlyoutInflater implements IFlyoutInflater {
    * @param flyoutWorkspace The workspace to create the button on.
    * @returns A newly created FlyoutButton.
    */
-  load(state: object, flyoutWorkspace: WorkspaceSvg): IBoundedElement {
+  load(state: object, flyoutWorkspace: WorkspaceSvg): FlyoutItem {
     const button = new FlyoutButton(
       flyoutWorkspace,
       flyoutWorkspace.targetWorkspace!,
@@ -30,7 +32,8 @@ export class ButtonFlyoutInflater implements IFlyoutInflater {
       false,
     );
     button.show();
-    return button;
+
+    return new FlyoutItem(button, BUTTON_TYPE, true);
   }
 
   /**
@@ -40,24 +43,34 @@ export class ButtonFlyoutInflater implements IFlyoutInflater {
    * @param defaultGap The default spacing for flyout items.
    * @returns The amount of space that should follow this button.
    */
-  gapForElement(state: object, defaultGap: number): number {
+  gapForItem(state: object, defaultGap: number): number {
     return defaultGap;
   }
 
   /**
    * Disposes of the given button.
    *
-   * @param element The flyout button to dispose of.
+   * @param item The flyout button to dispose of.
    */
-  disposeElement(element: IBoundedElement): void {
+  disposeItem(item: FlyoutItem): void {
+    const element = item.getElement();
     if (element instanceof FlyoutButton) {
       element.dispose();
     }
+  }
+
+  /**
+   * Returns the type of items this inflater is responsible for creating.
+   *
+   * @returns An identifier for the type of items this inflater creates.
+   */
+  getType() {
+    return BUTTON_TYPE;
   }
 }
 
 registry.register(
   registry.Type.FLYOUT_INFLATER,
-  'button',
+  BUTTON_TYPE,
   ButtonFlyoutInflater,
 );

--- a/core/flyout_horizontal.ts
+++ b/core/flyout_horizontal.ts
@@ -13,7 +13,8 @@
 
 import * as browserEvents from './browser_events.js';
 import * as dropDownDiv from './dropdowndiv.js';
-import {Flyout, FlyoutItem} from './flyout_base.js';
+import {Flyout} from './flyout_base.js';
+import type {FlyoutItem} from './flyout_item.js';
 import type {Options} from './options.js';
 import * as registry from './registry.js';
 import {Scrollbar} from './scrollbar.js';
@@ -263,10 +264,10 @@ export class HorizontalFlyout extends Flyout {
     }
 
     for (const item of contents) {
-      const rect = item.element.getBoundingRectangle();
+      const rect = item.getElement().getBoundingRectangle();
       const moveX = this.RTL ? cursorX + rect.getWidth() : cursorX;
-      item.element.moveBy(moveX, cursorY);
-      cursorX += item.element.getBoundingRectangle().getWidth();
+      item.getElement().moveBy(moveX, cursorY);
+      cursorX += item.getElement().getBoundingRectangle().getWidth();
     }
   }
 
@@ -336,7 +337,7 @@ export class HorizontalFlyout extends Flyout {
     let flyoutHeight = this.getContents().reduce((maxHeightSoFar, item) => {
       return Math.max(
         maxHeightSoFar,
-        item.element.getBoundingRectangle().getHeight(),
+        item.getElement().getBoundingRectangle().getHeight(),
       );
     }, 0);
     flyoutHeight += this.MARGIN * 1.5;

--- a/core/flyout_item.ts
+++ b/core/flyout_item.ts
@@ -1,0 +1,42 @@
+import type {IBoundedElement} from './interfaces/i_bounded_element.js';
+
+/**
+ * Representation of an item displayed in a flyout.
+ */
+export class FlyoutItem {
+  /**
+   * Creates a new FlyoutItem.
+   *
+   * @param element The element that will be displayed in the flyout.
+   * @param type The type of element. Should correspond to the type of the
+   *     flyout inflater that created this object.
+   * @param focusable True if the element should be allowed to be focused by
+   *     e.g. keyboard navigation in the flyout.
+   */
+  constructor(
+    private element: IBoundedElement,
+    private type: string,
+    private focusable: boolean,
+  ) {}
+
+  /**
+   * Returns the element displayed in the flyout.
+   */
+  getElement() {
+    return this.element;
+  }
+
+  /**
+   * Returns the type of flyout element this item represents.
+   */
+  getType() {
+    return this.type;
+  }
+
+  /**
+   * Returns whether or not the flyout element can receive focus.
+   */
+  isFocusable() {
+    return this.focusable;
+  }
+}

--- a/core/flyout_vertical.ts
+++ b/core/flyout_vertical.ts
@@ -13,7 +13,8 @@
 
 import * as browserEvents from './browser_events.js';
 import * as dropDownDiv from './dropdowndiv.js';
-import {Flyout, FlyoutItem} from './flyout_base.js';
+import {Flyout} from './flyout_base.js';
+import type {FlyoutItem} from './flyout_item.js';
 import type {Options} from './options.js';
 import * as registry from './registry.js';
 import {Scrollbar} from './scrollbar.js';
@@ -229,8 +230,8 @@ export class VerticalFlyout extends Flyout {
     let cursorY = margin;
 
     for (const item of contents) {
-      item.element.moveBy(cursorX, cursorY);
-      cursorY += item.element.getBoundingRectangle().getHeight();
+      item.getElement().moveBy(cursorX, cursorY);
+      cursorY += item.getElement().getBoundingRectangle().getHeight();
     }
   }
 
@@ -301,7 +302,7 @@ export class VerticalFlyout extends Flyout {
     let flyoutWidth = this.getContents().reduce((maxWidthSoFar, item) => {
       return Math.max(
         maxWidthSoFar,
-        item.element.getBoundingRectangle().getWidth(),
+        item.getElement().getBoundingRectangle().getWidth(),
       );
     }, 0);
     flyoutWidth += this.MARGIN * 1.5 + this.tabWidth_;
@@ -312,13 +313,13 @@ export class VerticalFlyout extends Flyout {
       if (this.RTL) {
         // With the flyoutWidth known, right-align the flyout contents.
         for (const item of this.getContents()) {
-          const oldX = item.element.getBoundingRectangle().left;
+          const oldX = item.getElement().getBoundingRectangle().left;
           const newX =
             flyoutWidth / this.workspace_.scale -
-            item.element.getBoundingRectangle().getWidth() -
+            item.getElement().getBoundingRectangle().getWidth() -
             this.MARGIN -
             this.tabWidth_;
-          item.element.moveBy(newX - oldX, 0);
+          item.getElement().moveBy(newX - oldX, 0);
         }
       }
 

--- a/core/interfaces/i_flyout.ts
+++ b/core/interfaces/i_flyout.ts
@@ -7,7 +7,7 @@
 // Former goog.module ID: Blockly.IFlyout
 
 import type {BlockSvg} from '../block_svg.js';
-import {FlyoutItem} from '../flyout_base.js';
+import type {FlyoutItem} from '../flyout_item.js';
 import type {Coordinate} from '../utils/coordinate.js';
 import type {Svg} from '../utils/svg.js';
 import type {FlyoutDefinition} from '../utils/toolbox.js';

--- a/core/interfaces/i_flyout_inflater.ts
+++ b/core/interfaces/i_flyout_inflater.ts
@@ -1,5 +1,5 @@
+import type {FlyoutItem} from '../flyout_item.js';
 import type {WorkspaceSvg} from '../workspace_svg.js';
-import type {IBoundedElement} from './i_bounded_element.js';
 
 export interface IFlyoutInflater {
   /**
@@ -16,7 +16,7 @@ export interface IFlyoutInflater {
    *    element, however.
    * @returns The newly inflated flyout element.
    */
-  load(state: object, flyoutWorkspace: WorkspaceSvg): IBoundedElement;
+  load(state: object, flyoutWorkspace: WorkspaceSvg): FlyoutItem;
 
   /**
    * Returns the amount of spacing that should follow the element corresponding
@@ -26,7 +26,7 @@ export interface IFlyoutInflater {
    * @param defaultGap The default gap for elements in this flyout.
    * @returns The gap that should follow the given element.
    */
-  gapForElement(state: object, defaultGap: number): number;
+  gapForItem(state: object, defaultGap: number): number;
 
   /**
    * Disposes of the given element.
@@ -37,5 +37,15 @@ export interface IFlyoutInflater {
    *
    * @param element The flyout element to dispose of.
    */
-  disposeElement(element: IBoundedElement): void;
+  disposeItem(item: FlyoutItem): void;
+
+  /**
+   * Returns the type of items that this inflater is responsible for inflating.
+   * This should be the same as the name under which this inflater registers
+   * itself, as well as the value returned by `getType()` on the `FlyoutItem`
+   * objects returned by `load()`.
+   *
+   * @returns The type of items this inflater creates.
+   */
+  getType(): string;
 }

--- a/core/keyboard_nav/ast_node.ts
+++ b/core/keyboard_nav/ast_node.ts
@@ -388,7 +388,20 @@ export class ASTNode {
 
     if (currentIndex < 0) return null;
 
-    const resultIndex = forward ? currentIndex + 1 : currentIndex - 1;
+    let resultIndex = forward ? currentIndex + 1 : currentIndex - 1;
+    // The flyout may contain non-navigable elements like spacers or custom
+    // items. If the next/previous element is one of those, keep looking until a
+    // block or button is encountered.
+    while (
+      resultIndex >= 0 &&
+      resultIndex < flyoutContents.length &&
+      !(
+        flyoutContents[resultIndex].element instanceof BlockSvg ||
+        flyoutContents[resultIndex].element instanceof FlyoutButton
+      )
+    ) {
+      resultIndex += forward ? 1 : -1;
+    }
     if (resultIndex === -1 || resultIndex === flyoutContents.length) {
       return null;
     }

--- a/core/label_flyout_inflater.ts
+++ b/core/label_flyout_inflater.ts
@@ -5,11 +5,13 @@
  */
 
 import {FlyoutButton} from './flyout_button.js';
-import type {IBoundedElement} from './interfaces/i_bounded_element.js';
+import {FlyoutItem} from './flyout_item.js';
 import type {IFlyoutInflater} from './interfaces/i_flyout_inflater.js';
 import * as registry from './registry.js';
 import {ButtonOrLabelInfo} from './utils/toolbox.js';
 import type {WorkspaceSvg} from './workspace_svg.js';
+
+const LABEL_TYPE = 'label';
 
 /**
  * Class responsible for creating labels for flyouts.
@@ -22,7 +24,7 @@ export class LabelFlyoutInflater implements IFlyoutInflater {
    * @param flyoutWorkspace The workspace to create the label on.
    * @returns A FlyoutButton configured as a label.
    */
-  load(state: object, flyoutWorkspace: WorkspaceSvg): IBoundedElement {
+  load(state: object, flyoutWorkspace: WorkspaceSvg): FlyoutItem {
     const label = new FlyoutButton(
       flyoutWorkspace,
       flyoutWorkspace.targetWorkspace!,
@@ -30,7 +32,8 @@ export class LabelFlyoutInflater implements IFlyoutInflater {
       true,
     );
     label.show();
-    return label;
+
+    return new FlyoutItem(label, LABEL_TYPE, true);
   }
 
   /**
@@ -40,20 +43,34 @@ export class LabelFlyoutInflater implements IFlyoutInflater {
    * @param defaultGap The default spacing for flyout items.
    * @returns The amount of space that should follow this label.
    */
-  gapForElement(state: object, defaultGap: number): number {
+  gapForItem(state: object, defaultGap: number): number {
     return defaultGap;
   }
 
   /**
    * Disposes of the given label.
    *
-   * @param element The flyout label to dispose of.
+   * @param item The flyout label to dispose of.
    */
-  disposeElement(element: IBoundedElement): void {
+  disposeItem(item: FlyoutItem): void {
+    const element = item.getElement();
     if (element instanceof FlyoutButton) {
       element.dispose();
     }
   }
+
+  /**
+   * Returns the type of items this inflater is responsible for creating.
+   *
+   * @returns An identifier for the type of items this inflater creates.
+   */
+  getType() {
+    return LABEL_TYPE;
+  }
 }
 
-registry.register(registry.Type.FLYOUT_INFLATER, 'label', LabelFlyoutInflater);
+registry.register(
+  registry.Type.FLYOUT_INFLATER,
+  LABEL_TYPE,
+  LabelFlyoutInflater,
+);

--- a/core/separator_flyout_inflater.ts
+++ b/core/separator_flyout_inflater.ts
@@ -4,12 +4,17 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import {FlyoutItem} from './flyout_item.js';
 import {FlyoutSeparator, SeparatorAxis} from './flyout_separator.js';
-import type {IBoundedElement} from './interfaces/i_bounded_element.js';
 import type {IFlyoutInflater} from './interfaces/i_flyout_inflater.js';
 import * as registry from './registry.js';
 import type {SeparatorInfo} from './utils/toolbox.js';
 import type {WorkspaceSvg} from './workspace_svg.js';
+
+/**
+ * @internal
+ */
+export const SEPARATOR_TYPE = 'sep';
 
 /**
  * Class responsible for creating separators for flyouts.
@@ -33,12 +38,13 @@ export class SeparatorFlyoutInflater implements IFlyoutInflater {
    * @param flyoutWorkspace The workspace the separator belongs to.
    * @returns A newly created FlyoutSeparator.
    */
-  load(_state: object, flyoutWorkspace: WorkspaceSvg): IBoundedElement {
+  load(_state: object, flyoutWorkspace: WorkspaceSvg): FlyoutItem {
     const flyoutAxis = flyoutWorkspace.targetWorkspace?.getFlyout()
       ?.horizontalLayout
       ? SeparatorAxis.X
       : SeparatorAxis.Y;
-    return new FlyoutSeparator(0, flyoutAxis);
+    const separator = new FlyoutSeparator(0, flyoutAxis);
+    return new FlyoutItem(separator, SEPARATOR_TYPE, false);
   }
 
   /**
@@ -48,7 +54,7 @@ export class SeparatorFlyoutInflater implements IFlyoutInflater {
    * @param defaultGap The default spacing for flyout items.
    * @returns The desired size of the separator.
    */
-  gapForElement(state: object, defaultGap: number): number {
+  gapForItem(state: object, defaultGap: number): number {
     const separatorState = state as SeparatorInfo;
     const newGap = parseInt(String(separatorState['gap']));
     return newGap ?? defaultGap;
@@ -57,13 +63,22 @@ export class SeparatorFlyoutInflater implements IFlyoutInflater {
   /**
    * Disposes of the given separator. Intentional no-op.
    *
-   * @param _element The flyout separator to dispose of.
+   * @param _item The flyout separator to dispose of.
    */
-  disposeElement(_element: IBoundedElement): void {}
+  disposeItem(_item: FlyoutItem): void {}
+
+  /**
+   * Returns the type of items this inflater is responsible for creating.
+   *
+   * @returns An identifier for the type of items this inflater creates.
+   */
+  getType() {
+    return SEPARATOR_TYPE;
+  }
 }
 
 registry.register(
   registry.Type.FLYOUT_INFLATER,
-  'sep',
+  SEPARATOR_TYPE,
   SeparatorFlyoutInflater,
 );


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
This PR fixes an issue that caused `findNextLocationInFlyout()` to return invalid items. With the flyout changes in v12, spacers (and potentially custom user-defined items) are included in the list of flyout contents, but are not valid keyboard navigation locations. As such, simply taking the next/previous item relative to the current one is insufficient; that item may be inspected, but if it is of a non-navigable type, the subsequent item needs to be checked until a valid navigation location is found.