### PR TITLE
fix: Fix unsafe cast in Input.setVisible().

### DIFF
--- a/core/inputs/input.ts
+++ b/core/inputs/input.ts
@@ -20,7 +20,7 @@ import type {Connection} from '../connection.js';
 import type {ConnectionType} from '../connection_type.js';
 import type {Field} from '../field.js';
 import * as fieldRegistry from '../field_registry.js';
-import type {RenderedConnection} from '../rendered_connection.js';
+import {RenderedConnection} from '../rendered_connection.js';
 import {Align} from './align.js';
 import {inputTypes} from './input_types.js';
 
@@ -181,15 +181,14 @@ export class Input {
     for (let y = 0, field; (field = this.fieldRow[y]); y++) {
       field.setVisible(visible);
     }
-    if (this.connection) {
-      const renderedConnection = this.connection as RenderedConnection;
+    if (this.connection && this.connection instanceof RenderedConnection) {
       // Has a connection.
       if (visible) {
-        renderList = renderedConnection.startTrackingAll();
+        renderList = this.connection.startTrackingAll();
       } else {
-        renderedConnection.stopTrackingAll();
+        this.connection.stopTrackingAll();
       }
-      const child = renderedConnection.targetBlock();
+      const child = this.connection.targetBlock();
       if (child) {
         child.getSvgRoot().style.display = visible ? 'block' : 'none';
       }


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #8694

### Proposed Changes
This PR checks if the connection in Input.setVisible() is actually a rendered connection before assuming it is. If `setVisible()` was called while initing a block, connections may not have been fully set up and this would throw.  