### PR TITLE
fix: Fix serialization of the lists_split block.

### DIFF
--- a/blocks/lists.ts
+++ b/blocks/lists.ts
@@ -1046,22 +1046,19 @@ blocks['lists_split'] = {
 
   /**
    * Returns the state of this block as a JSON serializable object.
-   * This block does not need to serialize any specific state as it is already
-   * encoded in the dropdown values, but must have an implementation to avoid
-   * the backward compatible XML mutations being serialized.
    *
    * @returns The state of this block.
    */
-  saveExtraState: function (this: SplitBlock): null {
-    return null;
+  saveExtraState: function (this: SplitBlock): {mode: string} {
+    return {'mode': this.getFieldValue('MODE')};
   },
 
   /**
    * Applies the given state to this block.
-   * No extra state is needed or expected as it is already encoded in the
-   * dropdown values.
    */
-  loadExtraState: function (this: SplitBlock) {},
+  loadExtraState: function (this: SplitBlock, state: {mode: string}) {
+    this.updateType_(state['mode']);
+  },
 };
 
 // Register provided blocks.

--- a/tests/mocha/blocks/lists_test.js
+++ b/tests/mocha/blocks/lists_test.js
@@ -181,16 +181,58 @@ suite('Lists', function () {
      * Test cases for serialization tests.
      * @type {Array<SerializationTestCase>}
      */
-    const testCases = makeTestCasesForBlockNotNeedingExtraState_(
+    const testCases = [
       {
-        'type': 'lists_split',
-        'id': '1',
-        'fields': {
-          'MODE': 'SPLIT',
+        title: 'JSON for splitting',
+        json: {
+          type: 'lists_split',
+          id: '1',
+          extraState: {mode: 'SPLIT'},
+          fields: {MODE: 'SPLIT'},
+          inputs: {
+            DELIM: {
+              shadow: {
+                type: 'text',
+                id: '2',
+                fields: {
+                  TEXT: ',',
+                },
+              },
+            },
+          },
+        },
+        assertBlockStructure: (block) => {
+          assert.equal(block.type, 'lists_split');
+          assert.deepEqual(block.outputConnection.getCheck(), ['Array']);
+          assert.isTrue(block.getField('MODE').getValue() === 'SPLIT');
         },
       },
-      '<mutation mode="SPLIT"></mutation>',
-    );
+      {
+        title: 'JSON for joining',
+        json: {
+          type: 'lists_split',
+          id: '1',
+          extraState: {mode: 'JOIN'},
+          fields: {MODE: 'JOIN'},
+          inputs: {
+            DELIM: {
+              shadow: {
+                type: 'text',
+                id: '2',
+                fields: {
+                  TEXT: ',',
+                },
+              },
+            },
+          },
+        },
+        assertBlockStructure: (block) => {
+          assert.equal(block.type, 'lists_split');
+          assert.deepEqual(block.outputConnection.getCheck(), ['String']);
+          assert.isTrue(block.getField('MODE').getValue() === 'JOIN');
+        },
+      },
+    ];
     runSerializationTestSuite(testCases);
   });
 });


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #8692

### Proposed Changes
This PR updates the `lists_split` block's implementation to serialize the state of the mode (join vs split) field. While as the old comment notes the field validator does update this, during block serialization blocks are connected to their parents before having their field values set, so at the time of connection the field validator has not yet run to set the appropriate connection check, so the block and its parent become separated due to the connection check failing. Now, the extra state will be deserialized early, update the connection checks, and allow the block to be connected to its parent during deserialization. Note that this will not resolve already-saved projects with this issue, but it will fix it going forward.