### PR TITLE
fix: treat media files as binary while packaging them

### DIFF
--- a/scripts/gulpfiles/package_tasks.js
+++ b/scripts/gulpfiles/package_tasks.js
@@ -159,7 +159,7 @@ module.exports = require('./${bundle}');
  * This task copies all the media/* files into the release directory.
  */
 function packageMedia() {
-  return gulp.src('media/*')
+  return gulp.src('media/*', {encoding: false})
     .pipe(gulp.dest(`${RELEASE_DIR}/media`));
 };
 


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [ ] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #8705

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->

Adds `encoding: false` option to `gulp.src()` in `packageMedia()` to treat files as binary.

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

Without this the files are interpreted as UTF-8, which corrupts binaries like MP3s etc. This was a breaking change in gulp 5.0.0.

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->

Manually tested with:
```
npm run package
diff -r media dist/media
```