### PR TITLE
fix: Reposition the trashcan's flyout in response to workspace changes.

### DIFF
--- a/core/trashcan.ts
+++ b/core/trashcan.ts
@@ -395,6 +395,8 @@ export class Trashcan
       'transform',
       'translate(' + this.left + ',' + this.top + ')',
     );
+
+    this.flyout?.position();
   }
 
   /**


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #5799

### Proposed Changes
This PR repositions the trashcan's flyout when the trashcan itself is repositioned, e.g. in response to workspace resize events. This fixes a bug that could cause the flyout to be detached when changing the browser zoom level or rotating a mobile device.