### PR TITLE
fix: Listen for keyboard shortcuts when the widget or dropdown divs have focus.

### DIFF
--- a/core/inject.ts
+++ b/core/inject.ts
@@ -77,6 +77,16 @@ export function inject(
   });
 
   browserEvents.conditionalBind(subContainer, 'keydown', null, onKeyDown);
+  browserEvents.conditionalBind(
+    dropDownDiv.getContentDiv(),
+    'keydown',
+    null,
+    onKeyDown,
+  );
+  const widgetContainer = WidgetDiv.getDiv();
+  if (widgetContainer) {
+    browserEvents.conditionalBind(widgetContainer, 'keydown', null, onKeyDown);
+  }
 
   return workspace;
 }


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #8725

### Proposed Changes
This PR adds keydown listeners for the widget and dropdown divs and runs those events through the shortcut infrastructure. This allows keyboard shortcuts (e.g. esc, delete, copy/paste) to operate when a menu/dropdown is focused.