### PR TITLE
fix: Fix display of multiline RTL strings in bubbles on Webkit.

### DIFF
--- a/core/bubbles/text_bubble.ts
+++ b/core/bubbles/text_bubble.ts
@@ -16,7 +16,7 @@ import {Bubble} from './bubble.js';
  * A bubble that displays non-editable text. Used by the warning icon.
  */
 export class TextBubble extends Bubble {
-  private paragraph: SVGTextElement;
+  private paragraph: SVGGElement;
 
   constructor(
     private text: string,
@@ -55,35 +55,38 @@ export class TextBubble extends Bubble {
   }
 
   /** Creates the paragraph container for this bubble's view's spans. */
-  private createParagraph(container: SVGGElement): SVGTextElement {
+  private createParagraph(container: SVGGElement): SVGGElement {
     return dom.createSvgElement(
-      Svg.TEXT,
+      Svg.G,
       {
         'class': 'blocklyText blocklyBubbleText blocklyNoPointerEvents',
-        'y': Bubble.BORDER_WIDTH,
+        'transform': `translate(0,${Bubble.BORDER_WIDTH})`,
+        'style': `direction: ${this.workspace.RTL ? 'rtl' : 'ltr'}`,
       },
       container,
     );
   }
 
   /** Creates the spans visualizing the text of this bubble. */
-  private createSpans(parent: SVGTextElement, text: string): SVGTSpanElement[] {
+  private createSpans(parent: SVGGElement, text: string): SVGTextElement[] {
+    let lineNum = 1;
     return text.split('\n').map((line) => {
       const tspan = dom.createSvgElement(
-        Svg.TSPAN,
-        {'dy': '1em', 'x': Bubble.BORDER_WIDTH},
+        Svg.TEXT,
+        {'y': `${lineNum}em`, 'x': Bubble.BORDER_WIDTH},
         parent,
       );
       const textNode = document.createTextNode(line);
       tspan.appendChild(textNode);
+      lineNum += 1;
       return tspan;
     });
   }
 
   /** Right aligns the given spans. */
-  private rightAlignSpans(maxWidth: number, spans: SVGTSpanElement[]) {
+  private rightAlignSpans(maxWidth: number, spans: SVGTextElement[]) {
     for (const span of spans) {
-      span.setAttribute('text-anchor', 'end');
+      span.setAttribute('text-anchor', 'start');
       span.setAttribute('x', `${maxWidth + Bubble.BORDER_WIDTH}`);
     }
   }

--- a/core/bubbles/text_bubble.ts
+++ b/core/bubbles/text_bubble.ts
@@ -48,13 +48,13 @@ export class TextBubble extends Bubble {
    */
   private stringToSvg(text: string, container: SVGGElement) {
     const paragraph = this.createParagraph(container);
-    const spans = this.createSpans(paragraph, text);
+    const fragments = this.createTextFragments(paragraph, text);
     if (this.workspace.RTL)
-      this.rightAlignSpans(paragraph.getBBox().width, spans);
+      this.rightAlignTextFragments(paragraph.getBBox().width, fragments);
     return paragraph;
   }
 
-  /** Creates the paragraph container for this bubble's view's spans. */
+  /** Creates the paragraph container for this bubble's view's text fragments. */
   private createParagraph(container: SVGGElement): SVGGElement {
     return dom.createSvgElement(
       Svg.G,
@@ -67,27 +67,33 @@ export class TextBubble extends Bubble {
     );
   }
 
-  /** Creates the spans visualizing the text of this bubble. */
-  private createSpans(parent: SVGGElement, text: string): SVGTextElement[] {
+  /** Creates the text fragments visualizing the text of this bubble. */
+  private createTextFragments(
+    parent: SVGGElement,
+    text: string,
+  ): SVGTextElement[] {
     let lineNum = 1;
     return text.split('\n').map((line) => {
-      const tspan = dom.createSvgElement(
+      const fragment = dom.createSvgElement(
         Svg.TEXT,
         {'y': `${lineNum}em`, 'x': Bubble.BORDER_WIDTH},
         parent,
       );
       const textNode = document.createTextNode(line);
-      tspan.appendChild(textNode);
+      fragment.appendChild(textNode);
       lineNum += 1;
-      return tspan;
+      return fragment;
     });
   }
 
-  /** Right aligns the given spans. */
-  private rightAlignSpans(maxWidth: number, spans: SVGTextElement[]) {
-    for (const span of spans) {
-      span.setAttribute('text-anchor', 'start');
-      span.setAttribute('x', `${maxWidth + Bubble.BORDER_WIDTH}`);
+  /** Right aligns the given text fragments. */
+  private rightAlignTextFragments(
+    maxWidth: number,
+    fragments: SVGTextElement[],
+  ) {
+    for (const text of fragments) {
+      text.setAttribute('text-anchor', 'start');
+      text.setAttribute('x', `${maxWidth + Bubble.BORDER_WIDTH}`);
     }
   }
 


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #8696

### Proposed Changes
This PR works around a [Webkit rendering issue](https://stackoverflow.com/questions/75595621/safari-rending-svg-text-tspans-in-wrong-positions-when-using-a-rtl-language) that caused RTL text in `tspan`s to be misplaced. It changes the structure of markup in text bubbles to consist of multiple SVG `<text>` tags rather than one `<text>` tag with a series of nested `<tspan>`s. This makes rendering consistent across Chrome/Safari/Firefox. I also updated it to specify the direction, which appears to fix the comma placement issue mentioned in the bug as well.