### PR TITLE
fix: Actually fix the browser tests.

### DIFF
--- a/tests/browser/test/test_setup.mjs
+++ b/tests/browser/test/test_setup.mjs
@@ -38,6 +38,7 @@ export async function driverSetup() {
   const options = {
     capabilities: {
       'browserName': 'chrome',
+      'unhandledPromptBehavior': 'ignore',
       'goog:chromeOptions': {
         args: ['--allow-file-access-from-files'],
       },


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
This PR toggles a config option to make WebDriver not suppress dialogs/alerts, which is needed in addition to the listener added in #8735 to fix the browser tests.