### PR TITLE
Fix: Fix dropdown text color in Zelos

### DIFF
--- a/core/renderers/zelos/constants.ts
+++ b/core/renderers/zelos/constants.ts
@@ -844,11 +844,11 @@ export class ConstantProvider extends BaseConstantProvider {
       `}`,
 
       // Widget and Dropdown Div
-      `${selector}.blocklyWidgetDiv .goog-menuitem,`,
-      `${selector}.blocklyDropDownDiv .goog-menuitem {`,
+      `${selector}.blocklyWidgetDiv .blocklyMenuItem,`,
+      `${selector}.blocklyDropDownDiv .blocklyMenuItem {`,
       `font-family: ${this.FIELD_TEXT_FONTFAMILY};`,
       `}`,
-      `${selector}.blocklyDropDownDiv .goog-menuitem-content {`,
+      `${selector}.blocklyDropDownDiv .blocklyMenuItemContent {`,
       `color: #fff;`,
       `}`,
 


### PR DESCRIPTION
## The basics

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details

### Resolves

Fixes https://github.com/google/blockly/issues/8740

### Proposed Changes

Update CSS class

### Reason for Changes

CSS classes have changed to remove goog-x, but it was not updated here.

### Test Coverage

Tested in advanced playground.

### Documentation

### Additional Information
