### PR TITLE
Fix #8194 by using a stepped animation for the wiggle

### DIFF
--- a/core/block_animations.ts
+++ b/core/block_animations.ts
@@ -187,15 +187,27 @@ export function disconnectUiEffect(block: BlockSvg) {
  * @param start Date of animation's start for deciding when to stop.
  * @param step Which step of the animation we're on.
  */
-function disconnectUiStep(block: BlockSvg, magnitude: number, start: Date, step: number) {
+function disconnectUiStep(
+  block: BlockSvg,
+  magnitude: number,
+  start: Date,
+  step: number,
+) {
   const DURATION = 200; // Milliseconds.
-  const WIGGLES = [.66, 1, .66, 0, -.66, -1, -.66, 0]; // Single cycle
+  const WIGGLES = [0.66, 1, 0.66, 0, -0.66, -1, -0.66, 0]; // Single cycle
 
   let skew = '';
   if (start.getTime() + DURATION > new Date().getTime()) {
     const val = Math.round(WIGGLES[step % WIGGLES.length] * magnitude);
     skew = `skewX(${val})`;
-    disconnectPid = setTimeout(disconnectUiStep, 15, block, magnitude, start, step + 1);
+    disconnectPid = setTimeout(
+      disconnectUiStep,
+      15,
+      block,
+      magnitude,
+      start,
+      step + 1,
+    );
   }
 
   block

--- a/core/block_animations.ts
+++ b/core/block_animations.ts
@@ -176,7 +176,7 @@ export function disconnectUiEffect(block: BlockSvg) {
   }
   // Start the animation.
   wobblingBlock = block;
-  disconnectUiStep(block, magnitude, new Date());
+  disconnectUiStep(block, magnitude, new Date(), 0);
 }
 
 /**
@@ -184,22 +184,18 @@ export function disconnectUiEffect(block: BlockSvg) {
  *
  * @param block Block to animate.
  * @param magnitude Maximum degrees skew (reversed for RTL).
- * @param start Date of animation's start.
+ * @param start Date of animation's start for deciding when to stop.
+ * @param step Which step of the animation we're on.
  */
-function disconnectUiStep(block: BlockSvg, magnitude: number, start: Date) {
+function disconnectUiStep(block: BlockSvg, magnitude: number, start: Date, step: number) {
   const DURATION = 200; // Milliseconds.
-  const WIGGLES = 3; // Half oscillations.
-
-  const ms = new Date().getTime() - start.getTime();
-  const percent = ms / DURATION;
+  const WIGGLES = [.66, 1, .66, 0, -.66, -1, -.66, 0]; // Single cycle
 
   let skew = '';
-  if (percent <= 1) {
-    const val = Math.round(
-      Math.sin(percent * Math.PI * WIGGLES) * (1 - percent) * magnitude,
-    );
+  if (start.getTime() + DURATION > new Date().getTime()) {
+    const val = Math.round(WIGGLES[step % WIGGLES.length] * magnitude);
     skew = `skewX(${val})`;
-    disconnectPid = setTimeout(disconnectUiStep, 10, block, magnitude, start);
+    disconnectPid = setTimeout(disconnectUiStep, 15, block, magnitude, start, step + 1);
   }
 
   block


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

Fixes #8194 

### Proposed Changes

Instead of calculating a skew from the elapsed time, step through an array of animation values
and change the update period to 15ms. This creates a more consistent animation even if frames
are misses.

### Reason for Changes

The wiggle animation could end up calculating a skew of 0 a lot of the time. If there were also
some skipped render frames this could lead to the wiggle being much smaller than intended.
By stepping through pre-calculated animation steps we can guarantee more frames will include
a non-zero value making it much less likely to have no apparent wiggle.

Updating every 15ms better aligns with the 60 fps limit (16.67ms/frame) making it unlikely we'll
double update between frames.

### Test Coverage

N/A

### Documentation

No

### Additional Information

