### PR TITLE
feat: Add support for toggling readonly mode.

### DIFF
--- a/core/block.ts
+++ b/core/block.ts
@@ -795,7 +795,7 @@ export class Block implements IASTNodeLocation {
       this.deletable &&
       !this.shadow &&
       !this.isDeadOrDying() &&
-      !this.workspace.options.readOnly
+      !this.workspace.isReadOnly()
     );
   }
 
@@ -828,7 +828,7 @@ export class Block implements IASTNodeLocation {
       this.movable &&
       !this.shadow &&
       !this.isDeadOrDying() &&
-      !this.workspace.options.readOnly
+      !this.workspace.isReadOnly()
     );
   }
 
@@ -917,7 +917,7 @@ export class Block implements IASTNodeLocation {
    */
   isEditable(): boolean {
     return (
-      this.editable && !this.isDeadOrDying() && !this.workspace.options.readOnly
+      this.editable && !this.isDeadOrDying() && !this.workspace.isReadOnly()
     );
   }
 

--- a/core/block_svg.ts
+++ b/core/block_svg.ts
@@ -231,7 +231,7 @@ export class BlockSvg
     this.applyColour();
     this.pathObject.updateMovable(this.isMovable() || this.isInFlyout);
     const svg = this.getSvgRoot();
-    if (!this.workspace.options.readOnly && svg) {
+    if (svg) {
       browserEvents.conditionalBind(svg, 'pointerdown', this, this.onMouseDown);
     }
 
@@ -585,6 +585,8 @@ export class BlockSvg
    * @param e Pointer down event.
    */
   private onMouseDown(e: PointerEvent) {
+    if (this.workspace.isReadOnly()) return;
+
     const gesture = this.workspace.getGesture(e);
     if (gesture) {
       gesture.handleBlockStart(e, this);
@@ -612,7 +614,7 @@ export class BlockSvg
   protected generateContextMenu(): Array<
     ContextMenuOption | LegacyContextMenuOption
   > | null {
-    if (this.workspace.options.readOnly || !this.contextMenu) {
+    if (this.workspace.isReadOnly() || !this.contextMenu) {
       return null;
     }
     const menuOptions = ContextMenuRegistry.registry.getContextMenuOptions(

--- a/core/comments/workspace_comment.ts
+++ b/core/comments/workspace_comment.ts
@@ -144,7 +144,7 @@ export class WorkspaceComment {
    * workspace is read-only.
    */
   isEditable(): boolean {
-    return this.isOwnEditable() && !this.workspace.options.readOnly;
+    return this.isOwnEditable() && !this.workspace.isReadOnly();
   }
 
   /**
@@ -165,7 +165,7 @@ export class WorkspaceComment {
    * workspace is read-only.
    */
   isMovable() {
-    return this.isOwnMovable() && !this.workspace.options.readOnly;
+    return this.isOwnMovable() && !this.workspace.isReadOnly();
   }
 
   /**
@@ -189,7 +189,7 @@ export class WorkspaceComment {
     return (
       this.isOwnDeletable() &&
       !this.isDeadOrDying() &&
-      !this.workspace.options.readOnly
+      !this.workspace.isReadOnly()
     );
   }
 

--- a/core/dragging/block_drag_strategy.ts
+++ b/core/dragging/block_drag_strategy.ts
@@ -78,7 +78,7 @@ export class BlockDragStrategy implements IDragStrategy {
     return (
       this.block.isOwnMovable() &&
       !this.block.isDeadOrDying() &&
-      !this.workspace.options.readOnly &&
+      !this.workspace.isReadOnly() &&
       // We never drag blocks in the flyout, only create new blocks that are
       // dragged.
       !this.block.isInFlyout

--- a/core/dragging/comment_drag_strategy.ts
+++ b/core/dragging/comment_drag_strategy.ts
@@ -29,7 +29,7 @@ export class CommentDragStrategy implements IDragStrategy {
     return (
       this.comment.isOwnMovable() &&
       !this.comment.isDeadOrDying() &&
-      !this.workspace.options.readOnly
+      !this.workspace.isReadOnly()
     );
   }
 

--- a/core/flyout_base.ts
+++ b/core/flyout_base.ts
@@ -786,7 +786,7 @@ export abstract class Flyout
    * @internal
    */
   isBlockCreatable(block: BlockSvg): boolean {
-    return block.isEnabled();
+    return block.isEnabled() && !this.getTargetWorkspace().isReadOnly();
   }
 
   /**

--- a/core/gesture.ts
+++ b/core/gesture.ts
@@ -894,7 +894,7 @@ export class Gesture {
           'Cannot do a block click because the target block is ' + 'undefined',
         );
       }
-      if (this.targetBlock.isEnabled()) {
+      if (this.flyout.isBlockCreatable(this.targetBlock)) {
         if (!eventUtils.getGroup()) {
           eventUtils.setGroup(true);
         }

--- a/core/shortcut_items.ts
+++ b/core/shortcut_items.ts
@@ -40,7 +40,7 @@ export function registerEscape() {
   const escapeAction: KeyboardShortcut = {
     name: names.ESCAPE,
     preconditionFn(workspace) {
-      return !workspace.options.readOnly;
+      return !workspace.isReadOnly();
     },
     callback(workspace) {
       // AnyDuringMigration because:  Property 'hideChaff' does not exist on
@@ -62,7 +62,7 @@ export function registerDelete() {
     preconditionFn(workspace) {
       const selected = common.getSelected();
       return (
-        !workspace.options.readOnly &&
+        !workspace.isReadOnly() &&
         selected != null &&
         isDeletable(selected) &&
         selected.isDeletable() &&
@@ -113,7 +113,7 @@ export function registerCopy() {
     preconditionFn(workspace) {
       const selected = common.getSelected();
       return (
-        !workspace.options.readOnly &&
+        !workspace.isReadOnly() &&
         !Gesture.inProgress() &&
         selected != null &&
         isDeletable(selected) &&
@@ -164,7 +164,7 @@ export function registerCut() {
     preconditionFn(workspace) {
       const selected = common.getSelected();
       return (
-        !workspace.options.readOnly &&
+        !workspace.isReadOnly() &&
         !Gesture.inProgress() &&
         selected != null &&
         isDeletable(selected) &&
@@ -221,7 +221,7 @@ export function registerPaste() {
   const pasteShortcut: KeyboardShortcut = {
     name: names.PASTE,
     preconditionFn(workspace) {
-      return !workspace.options.readOnly && !Gesture.inProgress();
+      return !workspace.isReadOnly() && !Gesture.inProgress();
     },
     callback() {
       if (!copyData || !copyWorkspace) return false;
@@ -269,7 +269,7 @@ export function registerUndo() {
   const undoShortcut: KeyboardShortcut = {
     name: names.UNDO,
     preconditionFn(workspace) {
-      return !workspace.options.readOnly && !Gesture.inProgress();
+      return !workspace.isReadOnly() && !Gesture.inProgress();
     },
     callback(workspace, e) {
       // 'z' for undo 'Z' is for redo.
@@ -308,7 +308,7 @@ export function registerRedo() {
   const redoShortcut: KeyboardShortcut = {
     name: names.REDO,
     preconditionFn(workspace) {
-      return !Gesture.inProgress() && !workspace.options.readOnly;
+      return !Gesture.inProgress() && !workspace.isReadOnly();
     },
     callback(workspace, e) {
       // 'z' for undo 'Z' is for redo.

--- a/core/workspace.ts
+++ b/core/workspace.ts
@@ -114,7 +114,7 @@ export class Workspace implements IASTNodeLocation {
   private readonly typedBlocksDB = new Map<string, Block[]>();
   private variableMap: IVariableMap<IVariableModel<IVariableState>>;
   private procedureMap: IProcedureMap = new ObservableProcedureMap();
-  private readOnly: boolean;
+  private readOnly = false;
 
   /**
    * Blocks in the flyout can refer to variables that don't exist in the main
@@ -155,7 +155,7 @@ export class Workspace implements IASTNodeLocation {
     const VariableMap = this.getVariableMapClass();
     this.variableMap = new VariableMap(this);
 
-    this.readOnly = this.options.readOnly;
+    this.setIsReadOnly(this.options.readOnly);
   }
 
   /**

--- a/core/workspace.ts
+++ b/core/workspace.ts
@@ -114,6 +114,7 @@ export class Workspace implements IASTNodeLocation {
   private readonly typedBlocksDB = new Map<string, Block[]>();
   private variableMap: IVariableMap<IVariableModel<IVariableState>>;
   private procedureMap: IProcedureMap = new ObservableProcedureMap();
+  private readOnly: boolean;
 
   /**
    * Blocks in the flyout can refer to variables that don't exist in the main
@@ -153,6 +154,8 @@ export class Workspace implements IASTNodeLocation {
      */
     const VariableMap = this.getVariableMapClass();
     this.variableMap = new VariableMap(this);
+
+    this.readOnly = this.options.readOnly;
   }
 
   /**
@@ -946,5 +949,24 @@ export class Workspace implements IASTNodeLocation {
       throw new Error('No variable map is registered.');
     }
     return VariableMap;
+  }
+
+  /**
+   * Returns whether or not this workspace is in readonly mode.
+   *
+   * @returns True if the workspace is readonly, otherwise false.
+   */
+  isReadOnly(): boolean {
+    return this.readOnly;
+  }
+
+  /**
+   * Sets whether or not this workspace is in readonly mode.
+   *
+   * @param readOnly True to make the workspace readonly, otherwise false.
+   */
+  setIsReadOnly(readOnly: boolean) {
+    this.readOnly = readOnly;
+    this.options.readOnly = readOnly;
   }
 }

--- a/core/workspace_svg.ts
+++ b/core/workspace_svg.ts
@@ -2535,7 +2535,7 @@ export class WorkspaceSvg extends Workspace implements IASTNodeLocationSvg {
 
   override setIsReadOnly(readOnly: boolean) {
     super.setIsReadOnly(readOnly);
-    if (readonly) {
+    if (readOnly) {
       this.addClass('blocklyReadOnly');
     } else {
       this.removeClass('blocklyReadOnly');

--- a/core/workspace_svg.ts
+++ b/core/workspace_svg.ts
@@ -2532,6 +2532,13 @@ export class WorkspaceSvg extends Workspace implements IASTNodeLocationSvg {
       dom.removeClass(this.injectionDiv, className);
     }
   }
+
+  override setIsReadOnly(readOnly: boolean) {
+    super.setIsReadOnly(readOnly);
+    readOnly
+      ? this.addClass('blocklyReadOnly')
+      : this.removeClass('blocklyReadOnly');
+  }
 }
 
 /**

--- a/core/workspace_svg.ts
+++ b/core/workspace_svg.ts
@@ -1703,7 +1703,7 @@ export class WorkspaceSvg extends Workspace implements IASTNodeLocationSvg {
    * @internal
    */
   showContextMenu(e: PointerEvent) {
-    if (this.options.readOnly || this.isFlyout) {
+    if (this.isReadOnly() || this.isFlyout) {
       return;
     }
     const menuOptions = ContextMenuRegistry.registry.getContextMenuOptions(

--- a/core/workspace_svg.ts
+++ b/core/workspace_svg.ts
@@ -2535,9 +2535,11 @@ export class WorkspaceSvg extends Workspace implements IASTNodeLocationSvg {
 
   override setIsReadOnly(readOnly: boolean) {
     super.setIsReadOnly(readOnly);
-    readOnly
-      ? this.addClass('blocklyReadOnly')
-      : this.removeClass('blocklyReadOnly');
+    if (readonly) {
+      this.addClass('blocklyReadOnly');
+    } else {
+      this.removeClass('blocklyReadOnly');
+    }
   }
 }
 

--- a/tests/mocha/keydown_test.js
+++ b/tests/mocha/keydown_test.js
@@ -42,7 +42,7 @@ suite('Key Down', function () {
   function runReadOnlyTest(keyEvent, opt_name) {
     const name = opt_name ? opt_name : 'Not called when readOnly is true';
     test(name, function () {
-      this.workspace.options.readOnly = true;
+      this.workspace.setIsReadOnly(true);
       this.injectionDiv.dispatchEvent(keyEvent);
       sinon.assert.notCalled(this.hideChaffSpy);
     });


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #8732

### Proposed Changes
This PR adds a `setIsReadOnly()` method to `Workspace` that allows dynamically toggling readonly status at runtime. Previously, the readonly option could only be set at injection time, and thus required reinjecting the workspace to modify.

For backwards compatibility, the `readOnly` field in the `options` dictionary is updated when the state is changed, since this was previously the only way to observe the readonly status. A getter, `isReadOnly()`, has also been introduced, and core has been refactored to use it.

### Reason for Changes
This unblocks #8732, but also has potential instructional usecases.