### PR TITLE
fix: Fix bug that caused blocks dragged from non-primary flyouts to be misplaced.

### DIFF
--- a/core/block_flyout_inflater.ts
+++ b/core/block_flyout_inflater.ts
@@ -155,9 +155,9 @@ export class BlockFlyoutInflater implements IFlyoutInflater {
   }
 
   /**
-   * Updates this inflater's flyout workspace.
+   * Updates this inflater's flyout.
    *
-   * @param workspace The workspace of the flyout that owns this inflater.
+   * @param flyout The flyout that owns this inflater.
    */
   protected setFlyout(flyout: IFlyout) {
     if (this.flyout === flyout) return;

--- a/core/button_flyout_inflater.ts
+++ b/core/button_flyout_inflater.ts
@@ -6,10 +6,10 @@
 
 import {FlyoutButton} from './flyout_button.js';
 import {FlyoutItem} from './flyout_item.js';
+import type {IFlyout} from './interfaces/i_flyout.js';
 import type {IFlyoutInflater} from './interfaces/i_flyout_inflater.js';
 import * as registry from './registry.js';
 import {ButtonOrLabelInfo} from './utils/toolbox.js';
-import type {WorkspaceSvg} from './workspace_svg.js';
 
 const BUTTON_TYPE = 'button';
 
@@ -21,13 +21,13 @@ export class ButtonFlyoutInflater implements IFlyoutInflater {
    * Inflates a flyout button from the given state and adds it to the flyout.
    *
    * @param state A JSON representation of a flyout button.
-   * @param flyoutWorkspace The workspace to create the button on.
+   * @param flyout The flyout to create the button on.
    * @returns A newly created FlyoutButton.
    */
-  load(state: object, flyoutWorkspace: WorkspaceSvg): FlyoutItem {
+  load(state: object, flyout: IFlyout): FlyoutItem {
     const button = new FlyoutButton(
-      flyoutWorkspace,
-      flyoutWorkspace.targetWorkspace!,
+      flyout.getWorkspace(),
+      flyout.targetWorkspace!,
       state as ButtonOrLabelInfo,
       false,
     );

--- a/core/flyout_base.ts
+++ b/core/flyout_base.ts
@@ -678,7 +678,7 @@ export abstract class Flyout
       const type = info['kind'].toLowerCase();
       const inflater = this.getInflaterForType(type);
       if (inflater) {
-        contents.push(inflater.load(info, this.getWorkspace()));
+        contents.push(inflater.load(info, this));
         const gap = inflater.gapForItem(info, defaultGap);
         if (gap) {
           contents.push(

--- a/core/interfaces/i_flyout_inflater.ts
+++ b/core/interfaces/i_flyout_inflater.ts
@@ -1,5 +1,5 @@
 import type {FlyoutItem} from '../flyout_item.js';
-import type {WorkspaceSvg} from '../workspace_svg.js';
+import type {IFlyout} from './i_flyout.js';
 
 export interface IFlyoutInflater {
   /**
@@ -9,14 +9,14 @@ export interface IFlyoutInflater {
    * allow for code reuse.
    *
    * @param state A JSON representation of an element to inflate on the flyout.
-   * @param flyoutWorkspace The flyout's workspace, where the inflated element
+   * @param flyout The flyout on whose workspace the inflated element
    *    should be created. If the inflated element is an `IRenderedElement` it
    *    itself or the inflater should append it to the workspace; the flyout
    *    will not do so itself. The flyout is responsible for positioning the
    *    element, however.
    * @returns The newly inflated flyout element.
    */
-  load(state: object, flyoutWorkspace: WorkspaceSvg): FlyoutItem;
+  load(state: object, flyout: IFlyout): FlyoutItem;
 
   /**
    * Returns the amount of spacing that should follow the element corresponding

--- a/core/label_flyout_inflater.ts
+++ b/core/label_flyout_inflater.ts
@@ -6,11 +6,10 @@
 
 import {FlyoutButton} from './flyout_button.js';
 import {FlyoutItem} from './flyout_item.js';
+import type {IFlyout} from './interfaces/i_flyout.js';
 import type {IFlyoutInflater} from './interfaces/i_flyout_inflater.js';
 import * as registry from './registry.js';
 import {ButtonOrLabelInfo} from './utils/toolbox.js';
-import type {WorkspaceSvg} from './workspace_svg.js';
-
 const LABEL_TYPE = 'label';
 
 /**
@@ -21,13 +20,13 @@ export class LabelFlyoutInflater implements IFlyoutInflater {
    * Inflates a flyout label from the given state and adds it to the flyout.
    *
    * @param state A JSON representation of a flyout label.
-   * @param flyoutWorkspace The workspace to create the label on.
+   * @param flyout The flyout to create the label on.
    * @returns A FlyoutButton configured as a label.
    */
-  load(state: object, flyoutWorkspace: WorkspaceSvg): FlyoutItem {
+  load(state: object, flyout: IFlyout): FlyoutItem {
     const label = new FlyoutButton(
-      flyoutWorkspace,
-      flyoutWorkspace.targetWorkspace!,
+      flyout.getWorkspace(),
+      flyout.targetWorkspace!,
       state as ButtonOrLabelInfo,
       true,
     );

--- a/core/separator_flyout_inflater.ts
+++ b/core/separator_flyout_inflater.ts
@@ -6,10 +6,10 @@
 
 import {FlyoutItem} from './flyout_item.js';
 import {FlyoutSeparator, SeparatorAxis} from './flyout_separator.js';
+import type {IFlyout} from './interfaces/i_flyout.js';
 import type {IFlyoutInflater} from './interfaces/i_flyout_inflater.js';
 import * as registry from './registry.js';
 import type {SeparatorInfo} from './utils/toolbox.js';
-import type {WorkspaceSvg} from './workspace_svg.js';
 
 /**
  * @internal
@@ -35,12 +35,11 @@ export class SeparatorFlyoutInflater implements IFlyoutInflater {
    * returned by gapForElement, which knows the default gap, unlike this method.
    *
    * @param _state A JSON representation of a flyout separator.
-   * @param flyoutWorkspace The workspace the separator belongs to.
+   * @param flyout The flyout to create the separator for.
    * @returns A newly created FlyoutSeparator.
    */
-  load(_state: object, flyoutWorkspace: WorkspaceSvg): FlyoutItem {
-    const flyoutAxis = flyoutWorkspace.targetWorkspace?.getFlyout()
-      ?.horizontalLayout
+  load(_state: object, flyout: IFlyout): FlyoutItem {
+    const flyoutAxis = flyout.horizontalLayout
       ? SeparatorAxis.X
       : SeparatorAxis.Y;
     const separator = new FlyoutSeparator(0, flyoutAxis);


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Proposed Changes
This PR fixes a bug in v12 that caused blocks dragged from non-primary flyouts (e.g. the trash) to be misaligned relative to the mouse. The block inflater was setting up click handlers with the flyout of the flyout workspace's target workspace (confusing, I know), on the assumption that that was the flyout in which the block was being inflated. This is not true though; the trash's flyout workspace's target workspace is the main workspace, and that workspace's flyout is the main toolbox flyout, not the trash flyout. This indirection was necessary because IFlyout passed in the flyout workspace to inflaters, so the flyout itself had to be derived when needed. This PR changes the interface to instead pass in the flyout itself (which has a getter for its workspace). This would be breaking, but v12 is still in beta.