### PR TITLE
fix: Fix menu scrolling.

### DIFF
--- a/core/field_dropdown.ts
+++ b/core/field_dropdown.ts
@@ -29,6 +29,7 @@ import {Coordinate} from './utils/coordinate.js';
 import * as dom from './utils/dom.js';
 import * as parsing from './utils/parsing.js';
 import * as utilsString from './utils/string.js';
+import * as style from './utils/style.js';
 import {Svg} from './utils/svg.js';
 
 /**
@@ -303,6 +304,11 @@ export class FieldDropdown extends Field<string> {
 
     if (this.selectedMenuItem) {
       this.menu_!.setHighlighted(this.selectedMenuItem);
+      style.scrollIntoContainerView(
+        this.selectedMenuItem.getElement()!,
+        dropDownDiv.getContentDiv(),
+        true,
+      );
     }
 
     this.applyColour();

--- a/core/menu.ts
+++ b/core/menu.ts
@@ -260,14 +260,10 @@ export class Menu {
       this.highlightedItem = item;
       // Bring the highlighted item into view. This has no effect if the menu is
       // not scrollable.
-      const el = this.getElement();
-      if (el) {
-        aria.setState(el, aria.State.ACTIVEDESCENDANT, item.getId());
-      }
-      item.getElement()?.scrollIntoView({
-        block: 'nearest',
-        inline: 'start',
-      });
+      const el = this.getElement() as Element;
+      style.scrollIntoContainerView(item.getElement() as Element, el);
+
+      aria.setState(el, aria.State.ACTIVEDESCENDANT, item.getId());
     }
   }
 

--- a/core/menu.ts
+++ b/core/menu.ts
@@ -260,10 +260,13 @@ export class Menu {
       this.highlightedItem = item;
       // Bring the highlighted item into view. This has no effect if the menu is
       // not scrollable.
-      const el = this.getElement() as Element;
-      style.scrollIntoContainerView(item.getElement() as Element, el);
+      const menuElement = this.getElement();
+      const scrollingParent = menuElement?.parentElement;
+      const menuItemElement = item.getElement();
+      if (!scrollingParent || !menuItemElement) return;
 
-      aria.setState(el, aria.State.ACTIVEDESCENDANT, item.getId());
+      style.scrollIntoContainerView(menuItemElement, scrollingParent);
+      aria.setState(menuElement, aria.State.ACTIVEDESCENDANT, item.getId());
     }
   }
 

--- a/core/utils/style.ts
+++ b/core/utils/style.ts
@@ -7,7 +7,6 @@
 // Former goog.module ID: Blockly.utils.style
 
 import {Coordinate} from './coordinate.js';
-import * as deprecation from './deprecation.js';
 import {Rect} from './rect.js';
 import {Size} from './size.js';
 
@@ -59,7 +58,6 @@ function getSizeInternal(element: Element): Size {
  * @returns Object with width/height properties.
  */
 function getSizeWithDisplay(element: Element): Size {
-  deprecation.warn(`Blockly.utils.style.getSizeWithDisplay()`, 'v11.2', 'v13');
   const offsetWidth = (element as HTMLElement).offsetWidth;
   const offsetHeight = (element as HTMLElement).offsetHeight;
   return new Size(offsetWidth, offsetHeight);
@@ -132,7 +130,6 @@ export function getViewportPageOffset(): Coordinate {
  * @returns The computed border widths.
  */
 export function getBorderBox(element: Element): Rect {
-  deprecation.warn(`Blockly.utils.style.getBorderBox()`, 'v11.2', 'v13');
   const left = parseFloat(getComputedStyle(element, 'borderLeftWidth'));
   const right = parseFloat(getComputedStyle(element, 'borderRightWidth'));
   const top = parseFloat(getComputedStyle(element, 'borderTopWidth'));
@@ -159,12 +156,6 @@ export function scrollIntoContainerView(
   container: Element,
   opt_center?: boolean,
 ) {
-  deprecation.warn(
-    `Blockly.utils.style.scrollIntoContainerView()`,
-    'v11.2',
-    'v13',
-    'the native Element.scrollIntoView()',
-  );
   const offset = getContainerOffsetToScrollInto(element, container, opt_center);
   container.scrollLeft = offset.x;
   container.scrollTop = offset.y;
@@ -189,11 +180,6 @@ export function getContainerOffsetToScrollInto(
   container: Element,
   opt_center?: boolean,
 ): Coordinate {
-  deprecation.warn(
-    `Blockly.utils.style.getContainerOffsetToScrollInto()`,
-    'v11.2',
-    'v13',
-  );
   // Absolute position of the element's border's top left corner.
   const elementPos = getPageOffset(element);
   // Absolute position of the container's border's top left corner.


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #8762

### Proposed Changes
This PR reverts #8726, which attempted to fix menu scrolling by using `scrollIntoView()`. Instead, the original scrolling utility function is reintroduced and used; the original issue was apparently that an intermediate div got introduced, so the parent element that was passed to the scrolling utility function wasn't actually the scrollable element.