### PR TITLE
fix: Allow dragging blocks from the far lower right corner.

### DIFF
--- a/core/css.ts
+++ b/core/css.ts
@@ -353,6 +353,7 @@ input[type=number] {
 
 .blocklyScrollbarBackground {
   opacity: 0;
+  pointer-events: none;
 }
 
 .blocklyScrollbarHandle {


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #842

### Proposed Changes
This PR sets `pointer-events: none` on the scrollbar background, which is a small square element in the corner where a pair of scrollbars join. Previously, if a block was located in this 15x15px square, clicking and dragging on it would pan the workspace, since the click event never reached the block to focus it because it was intercepted by the scrollbar background. Now, the click will pass through to the block, which will become selected, and the subsequent drag will move the block rather than the workspace.