### PR TITLE
fix: Fix bug that prevented editing workspace comments on Firefox.

### DIFF
--- a/core/comments/comment_view.ts
+++ b/core/comments/comment_view.ts
@@ -783,6 +783,12 @@ export class CommentView implements IRenderedElement {
     this.disposeListeners.splice(this.disposeListeners.indexOf(listener), 1);
   }
 
+  /**
+   * Returns the textarea used to display and edit comment text.
+   *
+   * @internal
+   * @returns The textarea associated with this comment.
+   */
   getTextArea() {
     return this.textArea;
   }

--- a/core/comments/comment_view.ts
+++ b/core/comments/comment_view.ts
@@ -782,16 +782,6 @@ export class CommentView implements IRenderedElement {
   removeDisposeListener(listener: () => void) {
     this.disposeListeners.splice(this.disposeListeners.indexOf(listener), 1);
   }
-
-  /**
-   * Returns the textarea used to display and edit comment text.
-   *
-   * @internal
-   * @returns The textarea associated with this comment.
-   */
-  getTextArea() {
-    return this.textArea;
-  }
 }
 
 css.register(`

--- a/core/comments/comment_view.ts
+++ b/core/comments/comment_view.ts
@@ -782,6 +782,10 @@ export class CommentView implements IRenderedElement {
   removeDisposeListener(listener: () => void) {
     this.disposeListeners.splice(this.disposeListeners.indexOf(listener), 1);
   }
+
+  getTextArea() {
+    return this.textArea;
+  }
 }
 
 css.register(`

--- a/core/comments/rendered_workspace_comment.ts
+++ b/core/comments/rendered_workspace_comment.ts
@@ -208,8 +208,15 @@ export class RenderedWorkspaceComment
   private startGesture(e: PointerEvent) {
     const gesture = this.workspace.getGesture(e);
     if (gesture) {
-      gesture.handleCommentStart(e, this);
-      this.workspace.getLayerManager()?.append(this, layers.BLOCK);
+      const textArea = this.view.getTextArea();
+      if (e.target === textArea) {
+        // If the text area was the focus, don't allow this event to bubble up
+        // and steal focus away from the editor/comment.
+        e.stopPropagation();
+      } else {
+        gesture.handleCommentStart(e, this);
+        this.workspace.getLayerManager()?.append(this, layers.BLOCK);
+      }
       common.setSelected(this);
     }
   }

--- a/core/comments/rendered_workspace_comment.ts
+++ b/core/comments/rendered_workspace_comment.ts
@@ -208,8 +208,7 @@ export class RenderedWorkspaceComment
   private startGesture(e: PointerEvent) {
     const gesture = this.workspace.getGesture(e);
     if (gesture) {
-      const textArea = this.view.getTextArea();
-      if (e.target === textArea) {
+      if (browserEvents.isTargetInput(e)) {
         // If the text area was the focus, don't allow this event to bubble up
         // and steal focus away from the editor/comment.
         e.stopPropagation();


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #8768

### Proposed Changes
This PR fixes a bug that prevented editing the text of workspace comments on Firefox.