### PR TITLE
fix: Fix bug in IF block generators.

### DIFF
--- a/generators/dart/logic.ts
+++ b/generators/dart/logic.ts
@@ -46,7 +46,9 @@ export function controls_if(block: Block, generator: DartGenerator) {
   } while (block.getInput('IF' + n));
 
   if (block.getInput('ELSE') || generator.STATEMENT_SUFFIX) {
-    branchCode = generator.statementToCode(block, 'ELSE');
+    branchCode = block.getInput('ELSE')
+      ? generator.statementToCode(block, 'ELSE')
+      : '';
     if (generator.STATEMENT_SUFFIX) {
       branchCode =
         generator.prefixLines(

--- a/generators/javascript/logic.ts
+++ b/generators/javascript/logic.ts
@@ -44,7 +44,9 @@ export function controls_if(block: Block, generator: JavascriptGenerator) {
   } while (block.getInput('IF' + n));
 
   if (block.getInput('ELSE') || generator.STATEMENT_SUFFIX) {
-    let branchCode = generator.statementToCode(block, 'ELSE');
+    let branchCode = block.getInput('ELSE')
+      ? generator.statementToCode(block, 'ELSE')
+      : '';
     if (generator.STATEMENT_SUFFIX) {
       branchCode =
         generator.prefixLines(

--- a/generators/lua/logic.ts
+++ b/generators/lua/logic.ts
@@ -39,7 +39,9 @@ export function controls_if(block: Block, generator: LuaGenerator): string {
   } while (block.getInput('IF' + n));
 
   if (block.getInput('ELSE') || generator.STATEMENT_SUFFIX) {
-    let branchCode = generator.statementToCode(block, 'ELSE');
+    let branchCode = block.getInput('ELSE')
+      ? generator.statementToCode(block, 'ELSE')
+      : '';
     if (generator.STATEMENT_SUFFIX) {
       branchCode =
         generator.prefixLines(

--- a/generators/php/logic.ts
+++ b/generators/php/logic.ts
@@ -46,7 +46,9 @@ export function controls_if(block: Block, generator: PhpGenerator) {
   } while (block.getInput('IF' + n));
 
   if (block.getInput('ELSE') || generator.STATEMENT_SUFFIX) {
-    branchCode = generator.statementToCode(block, 'ELSE');
+    branchCode = block.getInput('ELSE')
+      ? generator.statementToCode(block, 'ELSE')
+      : '';
     if (generator.STATEMENT_SUFFIX) {
       branchCode =
         generator.prefixLines(

--- a/generators/python/logic.ts
+++ b/generators/python/logic.ts
@@ -40,7 +40,11 @@ export function controls_if(block: Block, generator: PythonGenerator) {
   } while (block.getInput('IF' + n));
 
   if (block.getInput('ELSE') || generator.STATEMENT_SUFFIX) {
-    branchCode = generator.statementToCode(block, 'ELSE') || generator.PASS;
+    if (block.getInput('ELSE')) {
+      branchCode = generator.statementToCode(block, 'ELSE') || generator.PASS;
+    } else {
+      branchCode = generator.PASS;
+    }
     if (generator.STATEMENT_SUFFIX) {
       branchCode =
         generator.prefixLines(


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes https://github.com/google/blockly/issues/8778 .

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
Check if 'ELSE' input exists before trying to generate code, since `generator.statementToCode` now throws instead of returning empty string.

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
When `STATEMENT_SUFFIX` is defined and no 'ELSE' is present, the IF block generator adds an empty 'ELSE' branch anyway - this way e.g. highlighting works correctly. So there is a code path that wants to generate code for the else branch even when the input doesn't exist.

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->
I tested manually in playground by adding suffixes for all languages and generating code for various IF block configurations.

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
