### PR TITLE
fix: Fixes #8764 by moving the event grouping calls up to dragger.ts

### DIFF
--- a/core/dragging/block_drag_strategy.ts
+++ b/core/dragging/block_drag_strategy.ts
@@ -62,8 +62,8 @@ export class BlockDragStrategy implements IDragStrategy {
    */
   private dragOffset = new Coordinate(0, 0);
 
-  /** Was there already an event group in progress when the drag started? */
-  private inGroup: boolean = false;
+  /** Used to persist an event group when snapping is done async. */
+  private originalEventGroup = '';
 
   constructor(private block: BlockSvg) {
     this.workspace = block.workspace;
@@ -96,10 +96,6 @@ export class BlockDragStrategy implements IDragStrategy {
     }
 
     this.dragging = true;
-    this.inGroup = !!eventUtils.getGroup();
-    if (!this.inGroup) {
-      eventUtils.setGroup(true);
-    }
     this.fireDragStartEvent();
 
     this.startLoc = this.block.getRelativeToSurfaceXY();
@@ -363,6 +359,7 @@ export class BlockDragStrategy implements IDragStrategy {
       this.block.getParent()?.endDrag(e);
       return;
     }
+    this.originalEventGroup = eventUtils.getGroup();
 
     this.fireDragEndEvent();
     this.fireMoveEvent();
@@ -388,20 +385,19 @@ export class BlockDragStrategy implements IDragStrategy {
     } else {
       this.block.queueRender().then(() => this.disposeStep());
     }
-
-    if (!this.inGroup) {
-      eventUtils.setGroup(false);
-    }
   }
 
   /** Disposes of any state at the end of the drag. */
   private disposeStep() {
+    const newGroup = eventUtils.getGroup();
+    eventUtils.setGroup(this.originalEventGroup);
     this.block.snapToGrid();
 
     // Must dispose after connections are applied to not break the dynamic
     // connections plugin. See #7859
     this.connectionPreviewer!.dispose();
     this.workspace.setResizesEnabled(true);
+    eventUtils.setGroup(newGroup);
   }
 
   /** Connects the given candidate connections. */

--- a/core/dragging/bubble_drag_strategy.ts
+++ b/core/dragging/bubble_drag_strategy.ts
@@ -5,16 +5,12 @@
  */
 
 import {IBubble, WorkspaceSvg} from '../blockly.js';
-import * as eventUtils from '../events/utils.js';
 import {IDragStrategy} from '../interfaces/i_draggable.js';
 import * as layers from '../layers.js';
 import {Coordinate} from '../utils.js';
 
 export class BubbleDragStrategy implements IDragStrategy {
   private startLoc: Coordinate | null = null;
-
-  /** Was there already an event group in progress when the drag started? */
-  private inGroup: boolean = false;
 
   constructor(
     private bubble: IBubble,
@@ -26,10 +22,6 @@ export class BubbleDragStrategy implements IDragStrategy {
   }
 
   startDrag(): void {
-    this.inGroup = !!eventUtils.getGroup();
-    if (!this.inGroup) {
-      eventUtils.setGroup(true);
-    }
     this.startLoc = this.bubble.getRelativeToSurfaceXY();
     this.workspace.setResizesEnabled(false);
     this.workspace.getLayerManager()?.moveToDragLayer(this.bubble);
@@ -44,9 +36,6 @@ export class BubbleDragStrategy implements IDragStrategy {
 
   endDrag(): void {
     this.workspace.setResizesEnabled(true);
-    if (!this.inGroup) {
-      eventUtils.setGroup(false);
-    }
 
     this.workspace
       .getLayerManager()

--- a/core/dragging/comment_drag_strategy.ts
+++ b/core/dragging/comment_drag_strategy.ts
@@ -18,9 +18,6 @@ export class CommentDragStrategy implements IDragStrategy {
 
   private workspace: WorkspaceSvg;
 
-  /** Was there already an event group in progress when the drag started? */
-  private inGroup: boolean = false;
-
   constructor(private comment: RenderedWorkspaceComment) {
     this.workspace = comment.workspace;
   }
@@ -34,10 +31,6 @@ export class CommentDragStrategy implements IDragStrategy {
   }
 
   startDrag(): void {
-    this.inGroup = !!eventUtils.getGroup();
-    if (!this.inGroup) {
-      eventUtils.setGroup(true);
-    }
     this.fireDragStartEvent();
     this.startLoc = this.comment.getRelativeToSurfaceXY();
     this.workspace.setResizesEnabled(false);
@@ -61,9 +54,6 @@ export class CommentDragStrategy implements IDragStrategy {
     this.comment.snapToGrid();
 
     this.workspace.setResizesEnabled(true);
-    if (!this.inGroup) {
-      eventUtils.setGroup(false);
-    }
   }
 
   /** Fire a UI event at the start of a comment drag. */

--- a/core/dragging/dragger.ts
+++ b/core/dragging/dragger.ts
@@ -31,6 +31,9 @@ export class Dragger implements IDragger {
 
   /** Handles any drag startup. */
   onDragStart(e: PointerEvent) {
+    if (!eventUtils.getGroup()) {
+      eventUtils.setGroup(true);
+    }
     this.draggable.startDrag(e);
   }
 
@@ -119,13 +122,13 @@ export class Dragger implements IDragger {
     this.draggable.endDrag(e);
 
     if (wouldDelete && isDeletable(root)) {
-      // We want to make sure the delete gets grouped with any possible
-      // move event.
-      const newGroup = eventUtils.getGroup();
+      // We want to make sure the delete gets grouped with any possible move
+      // event. In core Blockly this shouldn't happen, but due to a change
+      // in behavior older custom draggables might still clear the group.
       eventUtils.setGroup(origGroup);
       root.dispose();
-      eventUtils.setGroup(newGroup);
     }
+    eventUtils.setGroup(false);
   }
 
   // We need to special case blocks for now so that we look at the root block


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #8764 

### Proposed Changes

Moves the event group management up to dragger.ts instead of being handled in the various *_drag_strategy.ts files. Conceptually, this makes it the responsibility of the top level dragger to manage event groups and ensures that the group wraps all side effects of the drag.

In vanilla Blockly this shouldn't have any effect, but is necessary for the multi-select plugin used by AppInventor.

Also fixes a bug where snapping to the grid adds a move event that isn't part of the group.

### Reason for Changes

AppInventor has a multi-select plugin that creates multiple BlockDragStrategy instances. This requires that endDrag be called on each one, which was causing the event group to be reset after the first one. Moving it up a level ensures all of the block drags finish before the event group is reset.

### Test Coverage

[Video of manual testing](https://github.com/user-attachments/assets/6091a93b-26f3-41d6-9918-a55f4791525d)


### Documentation

No documentation changes, but we should include it in the release notes that the behavior has changed and anyone overriding dragger.ts should make this change if they aren't calling through to the super.

### Additional Information

<!-- Anything else we should know? -->
