### PR TITLE
refactor: make CommentView more amenable to subclassing.

### DIFF
--- a/core/comments/comment_view.ts
+++ b/core/comments/comment_view.ts
@@ -95,10 +95,10 @@ export class CommentView implements IRenderedElement {
   private resizePointerMoveListener: browserEvents.Data | null = null;
 
   /** Whether this comment view is currently being disposed or not. */
-  private disposing = false;
+  protected disposing = false;
 
   /** Whether this comment view has been disposed or not. */
-  private disposed = false;
+  protected disposed = false;
 
   /** Size of this comment when the resize drag was initiated. */
   private preResizeSize?: Size;
@@ -106,7 +106,7 @@ export class CommentView implements IRenderedElement {
   /** The default size of newly created comments. */
   static defaultCommentSize = new Size(120, 100);
 
-  constructor(private readonly workspace: WorkspaceSvg) {
+  constructor(readonly workspace: WorkspaceSvg) {
     this.svgRoot = dom.createSvgElement(Svg.G, {
       'class': 'blocklyComment blocklyEditable blocklyDraggable',
     });


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics
This PR makes `CommentView` more compatible with subclassing. Scratch has a subclass, which it uses to provide a bubble-based comment view attached by a line to its parent block. This PR allows that subclass to implement `ISelectable`, which requires `this.workspace` to be public, and allows for it to correctly update its disposal state around additional disposal logic.