### PR TITLE
fix: Disallow and ignore x and y attributes for blocks in toolbox definitions.

### DIFF
--- a/core/block_flyout_inflater.ts
+++ b/core/block_flyout_inflater.ts
@@ -101,8 +101,9 @@ export class BlockFlyoutInflater implements IFlyoutInflater {
       ) {
         blockDefinition['disabledReasons'] = [MANUALLY_DISABLED];
       }
-      // These fields used to be allowed and may still be present, but should
-      // now be ignored.
+      // These fields used to be allowed and may still be present, but are
+      // ignored here since everything in the flyout should always be laid out
+      // linearly.
       if ('x' in blockDefinition) {
         delete blockDefinition['x'];
       }

--- a/core/block_flyout_inflater.ts
+++ b/core/block_flyout_inflater.ts
@@ -101,6 +101,14 @@ export class BlockFlyoutInflater implements IFlyoutInflater {
       ) {
         blockDefinition['disabledReasons'] = [MANUALLY_DISABLED];
       }
+      // These fields used to be allowed and may still be present, but should
+      // now be ignored.
+      if ('x' in blockDefinition) {
+        delete blockDefinition['x'];
+      }
+      if ('y' in blockDefinition) {
+        delete blockDefinition['y'];
+      }
       block = blocks.appendInternal(blockDefinition as blocks.State, workspace);
     }
 

--- a/core/utils/toolbox.ts
+++ b/core/utils/toolbox.ts
@@ -24,8 +24,6 @@ export interface BlockInfo {
   disabledReasons?: string[];
   enabled?: boolean;
   id?: string;
-  x?: number;
-  y?: number;
   collapsed?: boolean;
   inline?: boolean;
   data?: string;


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #6280

### Proposed Changes
This PR removes `x` and `y` from `BlockInfo`, and removes them if set before loading and laying out blocks in a flyout. Previously, these would cause blocks to be positioned incorrectly in the flyout, since the flyout repositions its contents relative to one another but assumes their initial origin is (0, 0). The XML codepath was not subject to this issue.