### PR TITLE
fix: Fix a bug where selection outlines could be cut off when connecting blocks.

### DIFF
--- a/core/rendered_connection.ts
+++ b/core/rendered_connection.ts
@@ -533,6 +533,21 @@ export class RenderedConnection extends Connection {
     childBlock.updateDisabled();
     childBlock.queueRender();
 
+    // If either block being connected was selected, visually un- and reselect
+    // it. This has the effect of moving the selection path to the end of the
+    // list of child nodes in the DOM. Since SVG z-order is determined by node
+    // order in the DOM, this works around an issue where the selection outline
+    // path could be partially obscured by a new block inserted after it in the
+    // DOM.
+    const selection = common.getSelected();
+    const selectedBlock =
+      (selection === parentBlock && parentBlock) ||
+      (selection === childBlock && childBlock);
+    if (selectedBlock) {
+      selectedBlock.removeSelect();
+      selectedBlock.addSelect();
+    }
+
     // The input the child block is connected to (if any).
     const parentInput = parentBlock.getInputWithBlock(childBlock);
     if (parentInput) {


### PR DESCRIPTION


<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #8787

### Proposed Changes
This PR un- and re-selects selected blocks when they are connected to another block. This fixes the z-ordering of the selection highlight path relative to other blocks, which prevents it from becoming partially obscured.