### PR TITLE
Revert "fix!: Remove the blocklyMenuItemHighlight CSS class and use the hover"

### DIFF
--- a/core/css.ts
+++ b/core/css.ts
@@ -438,7 +438,8 @@ input[type=number] {
   cursor: inherit;
 }
 
-.blocklyMenuItem:hover {
+/* State: hover. */
+.blocklyMenuItemHighlight {
   background-color: rgba(0,0,0,.1);
 }
 

--- a/core/menu.ts
+++ b/core/menu.ts
@@ -249,9 +249,11 @@ export class Menu {
   setHighlighted(item: MenuItem | null) {
     const currentHighlighted = this.highlightedItem;
     if (currentHighlighted) {
+      currentHighlighted.setHighlighted(false);
       this.highlightedItem = null;
     }
     if (item) {
+      item.setHighlighted(true);
       this.highlightedItem = item;
       // Bring the highlighted item into view. This has no effect if the menu is
       // not scrollable.

--- a/core/menuitem.ts
+++ b/core/menuitem.ts
@@ -12,6 +12,7 @@
 // Former goog.module ID: Blockly.MenuItem
 
 import * as aria from './utils/aria.js';
+import * as dom from './utils/dom.js';
 import * as idGenerator from './utils/idgenerator.js';
 
 /**
@@ -67,6 +68,7 @@ export class MenuItem {
       'blocklyMenuItem ' +
       (this.enabled ? '' : 'blocklyMenuItemDisabled ') +
       (this.checked ? 'blocklyMenuItemSelected ' : '') +
+      (this.highlight ? 'blocklyMenuItemHighlight ' : '') +
       (this.rightToLeft ? 'blocklyMenuItemRtl ' : '');
 
     const content = document.createElement('div');
@@ -173,6 +175,25 @@ export class MenuItem {
    */
   setChecked(checked: boolean) {
     this.checked = checked;
+  }
+
+  /**
+   * Highlights or unhighlights the component.
+   *
+   * @param highlight Whether to highlight or unhighlight the component.
+   * @internal
+   */
+  setHighlighted(highlight: boolean) {
+    this.highlight = highlight;
+    const el = this.getElement();
+    if (el && this.isEnabled()) {
+      const name = 'blocklyMenuItemHighlight';
+      if (highlight) {
+        dom.addClass(el, name);
+      } else {
+        dom.removeClass(el, name);
+      }
+    }
   }
 
   /**


### PR DESCRIPTION
Reverts google/blockly#8536

Using :hover is not sufficient, because menu items can also be focused by keyboard navigation, but need to be able to be targeted by a selector in order to be styled.