### PR TITLE
fix: Allow the marker's current node to be null.

### DIFF
--- a/core/keyboard_nav/marker.ts
+++ b/core/keyboard_nav/marker.ts
@@ -24,23 +24,16 @@ export class Marker {
   colour: string | null = null;
 
   /** The current location of the marker. */
-  // AnyDuringMigration because:  Type 'null' is not assignable to type
-  // 'ASTNode'.
-  private curNode: ASTNode = null as AnyDuringMigration;
+  private curNode: ASTNode | null = null;
 
   /**
    * The object in charge of drawing the visual representation of the current
    * node.
    */
-  // AnyDuringMigration because:  Type 'null' is not assignable to type
-  // 'MarkerSvg'.
-  private drawer: MarkerSvg = null as AnyDuringMigration;
+  private drawer: MarkerSvg | null = null;
 
   /** The type of the marker. */
   type = 'marker';
-
-  /** Constructs a new Marker instance. */
-  constructor() {}
 
   /**
    * Sets the object in charge of drawing the marker.
@@ -56,7 +49,7 @@ export class Marker {
    *
    * @returns The object in charge of drawing the marker.
    */
-  getDrawer(): MarkerSvg {
+  getDrawer(): MarkerSvg | null {
     return this.drawer;
   }
 
@@ -65,23 +58,19 @@ export class Marker {
    *
    * @returns The current field, connection, or block the marker is on.
    */
-  getCurNode(): ASTNode {
+  getCurNode(): ASTNode | null {
     return this.curNode;
   }
 
   /**
    * Set the location of the marker and call the update method.
-   * Setting isStack to true will only work if the newLocation is the top most
-   * output or previous connection on a stack.
    *
-   * @param newNode The new location of the marker.
+   * @param newNode The new location of the marker, or null to remove it.
    */
-  setCurNode(newNode: ASTNode) {
+  setCurNode(newNode: ASTNode | null) {
     const oldNode = this.curNode;
     this.curNode = newNode;
-    if (this.drawer) {
-      this.drawer.draw(oldNode, this.curNode);
-    }
+    this.drawer?.draw(oldNode, this.curNode);
   }
 
   /**
@@ -90,22 +79,18 @@ export class Marker {
    * @internal
    */
   draw() {
-    if (this.drawer) {
-      this.drawer.draw(this.curNode, this.curNode);
-    }
+    this.drawer?.draw(this.curNode, this.curNode);
   }
 
   /** Hide the marker SVG. */
   hide() {
-    if (this.drawer) {
-      this.drawer.hide();
-    }
+    this.drawer?.hide();
   }
 
   /** Dispose of this marker. */
   dispose() {
-    if (this.getDrawer()) {
-      this.getDrawer().dispose();
-    }
+    this.drawer?.dispose();
+    this.drawer = null;
+    this.curNode = null;
   }
 }

--- a/core/marker_manager.ts
+++ b/core/marker_manager.ts
@@ -50,10 +50,11 @@ export class MarkerManager {
     if (this.markers.has(id)) {
       this.unregisterMarker(id);
     }
-    marker.setDrawer(
-      this.workspace.getRenderer().makeMarkerDrawer(this.workspace, marker),
-    );
-    this.setMarkerSvg(marker.getDrawer().createDom());
+    const drawer = this.workspace
+      .getRenderer()
+      .makeMarkerDrawer(this.workspace, marker);
+    marker.setDrawer(drawer);
+    this.setMarkerSvg(drawer.createDom());
     this.markers.set(id, marker);
   }
 
@@ -104,16 +105,14 @@ export class MarkerManager {
    * @param cursor The cursor used to move around this workspace.
    */
   setCursor(cursor: Cursor) {
-    if (this.cursor && this.cursor.getDrawer()) {
-      this.cursor.getDrawer().dispose();
-    }
+    this.cursor?.getDrawer()?.dispose();
     this.cursor = cursor;
     if (this.cursor) {
       const drawer = this.workspace
         .getRenderer()
         .makeMarkerDrawer(this.workspace, this.cursor);
       this.cursor.setDrawer(drawer);
-      this.setCursorSvg(this.cursor.getDrawer().createDom());
+      this.setCursorSvg(drawer.createDom());
     }
   }
 

--- a/core/renderers/common/marker_svg.ts
+++ b/core/renderers/common/marker_svg.ts
@@ -156,7 +156,7 @@ export class MarkerSvg {
    * @param oldNode The previous node the marker was on or null.
    * @param curNode The node that we want to draw the marker for.
    */
-  draw(oldNode: ASTNode, curNode: ASTNode) {
+  draw(oldNode: ASTNode | null, curNode: ASTNode | null) {
     if (!curNode) {
       this.hide();
       return;
@@ -620,7 +620,7 @@ export class MarkerSvg {
    * @param oldNode The old node the marker used to be on.
    * @param curNode The new node the marker is currently on.
    */
-  protected fireMarkerEvent(oldNode: ASTNode, curNode: ASTNode) {
+  protected fireMarkerEvent(oldNode: ASTNode | null, curNode: ASTNode) {
     const curBlock = curNode.getSourceBlock();
     const event = new (eventUtils.get(EventType.MARKER_MOVE))(
       curBlock,


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #8794

This PR fixes the typing on `Marker.curNode` to allow for it to be null, and updates types in related methods accordingly.