### PR TITLE
chore: Try adding additional permissions.

### DIFF
--- a/.github/workflows/assign_reviewers.yml
+++ b/.github/workflows/assign_reviewers.yml
@@ -16,6 +16,7 @@ jobs:
   requested-reviewer:
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       issues: write
     steps:
       - name: Assign requested reviewer

--- a/.github/workflows/conventional-label.yml
+++ b/.github/workflows/conventional-label.yml
@@ -8,6 +8,7 @@ jobs:
   label:
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       pull-requests: write
     steps:
       - uses: bcoe/conventional-release-labels@v1


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics
This PR attempts to fix the CI breakage by adding `contents: read` permissions. The docs indicate this is granted by default, but also suggest that if you manually specify any permission then all others are set to none.