### PR TITLE
chore: Try another workflow permission.

### DIFF
--- a/.github/workflows/assign_reviewers.yml
+++ b/.github/workflows/assign_reviewers.yml
@@ -9,14 +9,14 @@ name: Assign requested reviewers
 # N.B.: Runs with a read-write repo token.  Do not check out the
 # submitted branch!
 on:
-  pull_request:
+  pull_request_target:
     types: [review_requested]
-
-permissions: write-all
 
 jobs:
   requested-reviewer:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     steps:
       - name: Assign requested reviewer
         uses: actions/github-script@v7

--- a/.github/workflows/assign_reviewers.yml
+++ b/.github/workflows/assign_reviewers.yml
@@ -16,14 +16,12 @@ jobs:
   requested-reviewer:
     runs-on: ubuntu-latest
     permissions:
-      contents: read
-      issues: write
+      contents: write
       pull-requests: write
     steps:
       - name: Assign requested reviewer
         uses: actions/github-script@v7
         with:
-          github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
             try {
               if (context.payload.pull_request === undefined) {

--- a/.github/workflows/assign_reviewers.yml
+++ b/.github/workflows/assign_reviewers.yml
@@ -12,12 +12,11 @@ on:
   pull_request_target:
     types: [review_requested]
 
+permissions: write-all
+
 jobs:
   requested-reviewer:
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      pull-requests: write
     steps:
       - name: Assign requested reviewer
         uses: actions/github-script@v7

--- a/.github/workflows/assign_reviewers.yml
+++ b/.github/workflows/assign_reviewers.yml
@@ -23,6 +23,7 @@ jobs:
       - name: Assign requested reviewer
         uses: actions/github-script@v7
         with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
             try {
               if (context.payload.pull_request === undefined) {

--- a/.github/workflows/assign_reviewers.yml
+++ b/.github/workflows/assign_reviewers.yml
@@ -9,7 +9,7 @@ name: Assign requested reviewers
 # N.B.: Runs with a read-write repo token.  Do not check out the
 # submitted branch!
 on:
-  pull_request_target:
+  pull_request:
     types: [review_requested]
 
 permissions: write-all

--- a/.github/workflows/assign_reviewers.yml
+++ b/.github/workflows/assign_reviewers.yml
@@ -18,6 +18,7 @@ jobs:
     permissions:
       contents: read
       issues: write
+      pull-requests: write
     steps:
       - name: Assign requested reviewer
         uses: actions/github-script@v7


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics
This PR adds the `pull-requests: write` permission to assign_reviewers.yml. The docs say it needs this or `issues: write`, but I'm suspicious it may need both.