### PR TITLE
fix: fix bug that modalInputs option is not working in toolbox area

### DIFF
--- a/core/toolbox/toolbox.ts
+++ b/core/toolbox/toolbox.ts
@@ -333,6 +333,7 @@ export class Toolbox
       'horizontalLayout': workspace.horizontalLayout,
       'renderer': workspace.options.renderer,
       'rendererOverrides': workspace.options.rendererOverrides,
+      'modalInputs': workspace.options.modalInputs,
       'move': {
         'scrollbars': true,
       },

--- a/core/trashcan.ts
+++ b/core/trashcan.ts
@@ -110,6 +110,7 @@ export class Trashcan
       'oneBasedIndex': this.workspace.options.oneBasedIndex,
       'renderer': this.workspace.options.renderer,
       'rendererOverrides': this.workspace.options.rendererOverrides,
+      'modalInputs': this.workspace.options.modalInputs,
       'move': {
         'scrollbars': true,
       },

--- a/core/workspace_svg.ts
+++ b/core/workspace_svg.ts
@@ -953,6 +953,7 @@ export class WorkspaceSvg extends Workspace implements IASTNodeLocationSvg {
       'horizontalLayout': this.horizontalLayout,
       'renderer': this.options.renderer,
       'rendererOverrides': this.options.rendererOverrides,
+      'modalInputs': this.options.modalInputs,
       'move': {
         'scrollbars': true,
       },


### PR DESCRIPTION
## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #8816

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->

Pass the modalInputs option when creating the toolbox.

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

The modalInputs is missing when creating toolbox, therefore, the specified modalInputs option has never been fully effective.
