### PR TITLE
Fix: Remove the collapsed block warning when expanding a block

### DIFF
--- a/core/block_svg.ts
+++ b/core/block_svg.ts
@@ -508,6 +508,23 @@ export class BlockSvg
   }
 
   /**
+   * Traverses child blocks to see if any of them have a warning.
+   *
+   * @returns true if any child has a warning, false otherwise.
+   */
+  private childHasWarning(): boolean {
+    const children = this.getChildren(false);
+    for (const child of children) {
+      if (child.getIcon(WarningIcon.TYPE)) {
+        return true;
+      } else if (child.childHasWarning()) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /**
    * Makes sure that when the block is collapsed, it is rendered correctly
    * for that state.
    */
@@ -531,6 +548,13 @@ export class BlockSvg
       this.removeInput(collapsedInputName);
       this.setWarningText(null, BlockSvg.COLLAPSED_WARNING_ID);
       return;
+    }
+
+    if (this.childHasWarning()) {
+      this.setWarningText(
+        Msg['COLLAPSED_WARNINGS_WARNING'],
+        BlockSvg.COLLAPSED_WARNING_ID,
+      );
     }
 
     const text = this.toString(internalConstants.COLLAPSE_CHARS);

--- a/core/block_svg.ts
+++ b/core/block_svg.ts
@@ -515,9 +515,7 @@ export class BlockSvg
   private childHasWarning(): boolean {
     const children = this.getChildren(false);
     for (const child of children) {
-      if (child.getIcon(WarningIcon.TYPE)) {
-        return true;
-      } else if (child.childHasWarning()) {
+      if (child.getIcon(WarningIcon.TYPE) || child.childHasWarning()) {
         return true;
       }
     }

--- a/core/block_svg.ts
+++ b/core/block_svg.ts
@@ -529,6 +529,7 @@ export class BlockSvg
     if (!collapsed) {
       this.updateDisabled();
       this.removeInput(collapsedInputName);
+      this.setWarningText(null, BlockSvg.COLLAPSED_WARNING_ID);
       return;
     }
 

--- a/tests/mocha/block_test.js
+++ b/tests/mocha/block_test.js
@@ -1840,6 +1840,62 @@ suite('Blocks', function () {
       });
     });
 
+    suite('Warning icons and collapsing', function () {
+      setup(function () {
+        this.workspace = Blockly.inject('blocklyDiv');
+        this.parentBlock = Blockly.serialization.blocks.append(
+          {
+            'type': 'statement_block',
+            'inputs': {
+              'STATEMENT': {
+                'block': {
+                  'type': 'statement_block',
+                },
+              },
+            },
+          },
+          this.workspace,
+        );
+        this.parentBlock.initSvg();
+        this.parentBlock.render();
+
+        this.childBlock = this.parentBlock.getInputTargetBlock('STATEMENT');
+        this.childBlock.initSvg();
+        this.childBlock.render();
+      });
+
+      teardown(function () {
+        workspaceTeardown.call(this, this.workspace);
+      });
+
+      test('Adding a warning to a child block does not affect the parent', function () {
+        const text = 'Warning Text';
+        this.childBlock.setWarningText(text);
+        const icon = this.parentBlock.getIcon(Blockly.icons.WarningIcon.TYPE);
+        assert.isUndefined(
+          icon,
+          "Setting a child block's warning should not add a warning to the parent",
+        );
+      });
+
+      test('Warnings are added and removed when collapsing a stack with warnings', function () {
+        const text = 'Warning Text';
+
+        this.childBlock.setWarningText(text);
+
+        this.parentBlock.setCollapsed(true);
+        let icon = this.parentBlock.getIcon(Blockly.icons.WarningIcon.TYPE);
+        assert.exists(icon?.getText(), 'Expected warning icon text to be set');
+
+        this.parentBlock.setCollapsed(false);
+        icon = this.parentBlock.getIcon(Blockly.icons.WarningIcon.TYPE);
+        assert.isUndefined(
+          icon,
+          'Warning should be removed from parent after expanding',
+        );
+      });
+    });
+
     suite('Bubbles and collapsing', function () {
       setup(function () {
         this.workspace = Blockly.inject('blocklyDiv');


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #6020 

### Proposed Changes

- Clears the collapsed block warning message when a block is expanded.
- When collapsing, checks if any children have a warning and if so adds the collapsed warnings warning.

### Reason for Changes

The collapsed block warning message was set if any block in a collapsed stack added a warning, but wasn't added if there already was a warning and was never removed making it sticky on the parent even after expanding and deleting the block with the warning.

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
