### PR TITLE
feat: make getNextNode and getPreviousNode public

### DIFF
--- a/core/keyboard_nav/line_cursor.ts
+++ b/core/keyboard_nav/line_cursor.ts
@@ -299,7 +299,7 @@ export class LineCursor extends Marker {
    *     should be traversed.
    * @returns The next node in the traversal.
    */
-  private getNextNode(
+  getNextNode(
     node: ASTNode | null,
     isValid: (p1: ASTNode | null) => boolean,
   ): ASTNode | null {
@@ -332,7 +332,7 @@ export class LineCursor extends Marker {
    * @returns The previous node in the traversal or null if no previous node
    *     exists.
    */
-  private getPreviousNode(
+  getPreviousNode(
     node: ASTNode | null,
     isValid: (p1: ASTNode | null) => boolean,
   ): ASTNode | null {


### PR DESCRIPTION
## The basics

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves
Fixes https://github.com/google/blockly/issues/8851

### Proposed Changes
Make two methods public for use by keyboard dragging code.

### Reason for Changes

See https://github.com/google/blockly/issues/8851

### Test Coverage

### Documentation


### Additional Information

