### PR TITLE
fix: Fixed the advanced toolbox, so it does not zoom with the workspace.

### DIFF
--- a/core/toolbox/toolbox.ts
+++ b/core/toolbox/toolbox.ts
@@ -1093,7 +1093,7 @@ Css.register(`
   overflow-y: auto;
   padding: 4px 0 4px 0;
   position: absolute;
-  z-index: 70;  /* so blocks go under toolbox when dragging */
+  z-index: 100;  /* so blocks go under toolbox when dragging */
   -webkit-tap-highlight-color: transparent;  /* issue #1345 */
 }
 


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [ ] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes the toolbox in advanced page, which was able to zoom while zooming into the workspace. A small contribution to start with, will continue to look for bugs and fixing them.

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
It bumps the z-index correctly.

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
I was able to zoom in the toolbox while zooming the taskbar, if i have clicked on the right black box/bar, and hover on the workspace and then zoom it. So, easy fix was to bump the z-index of it.

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->
I have tested it in total of 7 times, as that's my lucky charm, even restarted the server twice to make sure things were okay!

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->
No documentation needs to be updated. 

### Additional Information

<!-- Anything else we should know? -->
