### PR TITLE
fix!: change css class for disabled block pattern

### DIFF
--- a/core/css.ts
+++ b/core/css.ts
@@ -198,7 +198,7 @@ let content = `
   display: none;
 }
 
-.blocklyDisabled>.blocklyPath {
+.blocklyDisabledPattern>.blocklyPath {
   fill: var(--blocklyDisabledPattern);
   fill-opacity: .5;
   stroke-opacity: .5;

--- a/core/renderers/common/path_object.ts
+++ b/core/renderers/common/path_object.ts
@@ -200,6 +200,7 @@ export class PathObject implements IPathObject {
    */
   protected updateDisabled_(disabled: boolean) {
     this.setClass_('blocklyDisabled', disabled);
+    this.setClass_('blocklyDisabledPattern', disabled);
   }
 
   /**

--- a/core/renderers/zelos/constants.ts
+++ b/core/renderers/zelos/constants.ts
@@ -890,7 +890,7 @@ export class ConstantProvider extends BaseConstantProvider {
       `}`,
 
       // Disabled outline paths.
-      `${selector} .blocklyDisabled > .blocklyOutlinePath {`,
+      `${selector} .blocklyDisabledPattern > .blocklyOutlinePath {`,
       `fill: var(--blocklyDisabledPattern)`,
       `}`,
 


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #8857 

### Proposed Changes

Moves the disabled pattern css into a separate class. The `blocklyDisabled` class doesn't contain any styling now by default.

### Reason for Changes

Not everyone wants to use the disabled pattern for their disabled blocks. They can't just skip adding the `blocklyDisabled` class because we use that for other things like adding other styles or not during a drag for example. Now if they don't want it, they can override `updateDisabled_` in their custom path object and apply `blocklyDisabled` but not `blocklyDisabledPattern`.

### Breaking Changes

If you do not override `PathObject` in a custom renderer, this change does not affect you and you do not need to take any action. This change only affects you if you override `PathObject.updateDisabled_` and you do not call `super`.

If you want the appearance of disabled blocks to remain the default, and you override this method, either call `super` or be sure to add/remove the `blocklyDisabledPattern` as needed.

If you do not want the appearance of blocks to remain the default, and you had previously overridden `updateDisabled_` to ensure this, then you can continue to do so and be sure not to apply the `blocklyDisabledPattern` class. Do apply the `blocklyDisabled` class to continue getting other effects for disabled blocks like not showing the outline on when you hover a field on a disabled block.
