### PR TITLE
feat: add getSearchRadius to BlockDragStrategy

### DIFF
--- a/core/dragging/block_drag_strategy.ts
+++ b/core/dragging/block_drag_strategy.ts
@@ -315,9 +315,7 @@ export class BlockDragStrategy implements IDragStrategy {
     delta: Coordinate,
   ): ConnectionCandidate | null {
     const localConns = this.getLocalConnections(draggingBlock);
-    let radius = this.connectionCandidate
-      ? config.connectingSnapRadius
-      : config.snapRadius;
+    let radius = this.getSearchRadius();
     let candidate = null;
 
     for (const conn of localConns) {
@@ -333,6 +331,15 @@ export class BlockDragStrategy implements IDragStrategy {
     }
 
     return candidate;
+  }
+
+  /**
+   * Get the radius to use when searching for a nearby valid connection.
+   */
+  protected getSearchRadius() {
+    return this.connectionCandidate
+      ? config.connectingSnapRadius
+      : config.snapRadius;
   }
 
   /**


### PR DESCRIPTION
## The basics

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

Fixes #8869 

### Proposed Changes

Create a protected helper function that can be overridden.

### Reason for Changes

Keyboard drags sometimes search for the nearest compatible block on a workspace, which means an effective radius of Infinity.

### Test Coverage

No current change to functionality.

### Documentation

### Additional Information

I'd like to put this into the next v12 beta release.