### PR TITLE
fix: check potential variables for flyout variable fields

### DIFF
--- a/core/field_variable.ts
+++ b/core/field_variable.ts
@@ -428,13 +428,13 @@ export class FieldVariable extends FieldDropdown {
   private getVariableTypes(): string[] {
     if (this.variableTypes) return this.variableTypes;
 
-    // If variableTypes is null, return all variable types in the workspace.
     if (!this.sourceBlock_ || this.sourceBlock_.isDeadOrDying()) {
       // We should include all types in the block's workspace,
       // but the block is dead so just give up.
       return [''];
     }
 
+    // If variableTypes is null, return all variable types in the workspace.
     let allTypes = this.sourceBlock_.workspace.getVariableMap().getTypes();
     if (this.sourceBlock_.isInFlyout) {
       // If this block is in a flyout, we also need to check the potential variables

--- a/core/field_variable.ts
+++ b/core/field_variable.ts
@@ -71,7 +71,8 @@ export class FieldVariable extends FieldDropdown {
    *     field's value. Takes in a variable ID  & returns a validated variable
    *     ID, or null to abort the change.
    * @param variableTypes A list of the types of variables to include in the
-   *     dropdown. Will only be used if config is not provided.
+   *     dropdown. Pass `null` to include all types that exist on the
+   *     workspace. Will only be used if config is not provided.
    * @param defaultType The type of variable to create if this field's value
    *     is not explicitly set.  Defaults to ''. Will only be used if config
    *     is not provided.
@@ -83,7 +84,7 @@ export class FieldVariable extends FieldDropdown {
   constructor(
     varName: string | null | typeof Field.SKIP_SETUP,
     validator?: FieldVariableValidator,
-    variableTypes?: string[],
+    variableTypes?: string[] | null,
     defaultType?: string,
     config?: FieldVariableConfig,
   ) {
@@ -423,25 +424,29 @@ export class FieldVariable extends FieldDropdown {
    * Return a list of variable types to include in the dropdown.
    *
    * @returns Array of variable types.
-   * @throws {Error} if variableTypes is an empty array.
    */
   private getVariableTypes(): string[] {
     let variableTypes = this.variableTypes;
-    if (variableTypes === null) {
-      // If variableTypes is null, return all variable types.
-      if (this.sourceBlock_ && !this.sourceBlock_.isDeadOrDying()) {
-        return this.sourceBlock_.workspace.getVariableMap().getTypes();
-      }
+
+    if (variableTypes) return variableTypes;
+
+    // If variableTypes is null, return all variable types in the workspace.
+    if (!this.sourceBlock_ || this.sourceBlock_.isDeadOrDying()) {
+      // We should include all types in the block's workspace,
+      // but the block is dead so just give up.
+      return [''];
     }
-    variableTypes = variableTypes || [''];
-    if (variableTypes.length === 0) {
-      // Throw an error if variableTypes is an empty list.
-      const name = this.getText();
-      throw Error(
-        "'variableTypes' of field variable " + name + ' was an empty list',
-      );
+
+    let allTypes = this.sourceBlock_.workspace.getVariableMap().getTypes();
+    if (this.sourceBlock_.isInFlyout) {
+      // If this block is in a flyout, we also need to check the potential variables
+      const potentialMap =
+        this.sourceBlock_.workspace.getPotentialVariableMap();
+      if (!potentialMap) return allTypes;
+      allTypes = Array.from(new Set([...allTypes, ...potentialMap.getTypes()]));
     }
-    return variableTypes;
+
+    return allTypes;
   }
 
   /**
@@ -455,11 +460,15 @@ export class FieldVariable extends FieldDropdown {
    *     value is not explicitly set.  Defaults to ''.
    */
   private setTypes(variableTypes: string[] | null = null, defaultType = '') {
-    // If you expected that the default type would be the same as the only entry
-    // in the variable types array, tell the Blockly team by commenting on
-    // #1499.
-    // Set the allowable variable types.  Null means all types on the workspace.
+    const name = this.getText();
     if (Array.isArray(variableTypes)) {
+      if (variableTypes.length === 0) {
+        // Throw an error if variableTypes is an empty list.
+        throw Error(
+          `'variableTypes' of field variable ${name} was an empty list. If you want to include all variable types, pass 'null' instead.`,
+        );
+      }
+
       // Make sure the default type is valid.
       let isInArray = false;
       for (let i = 0; i < variableTypes.length; i++) {
@@ -477,8 +486,7 @@ export class FieldVariable extends FieldDropdown {
       }
     } else if (variableTypes !== null) {
       throw Error(
-        "'variableTypes' was not an array in the definition of " +
-          'a FieldVariable',
+        `'variableTypes' was not an array or null in the definition of FieldVariable ${name}`,
       );
     }
     // Only update the field once all checks pass.

--- a/core/field_variable.ts
+++ b/core/field_variable.ts
@@ -426,9 +426,7 @@ export class FieldVariable extends FieldDropdown {
    * @returns Array of variable types.
    */
   private getVariableTypes(): string[] {
-    let variableTypes = this.variableTypes;
-
-    if (variableTypes) return variableTypes;
+    if (this.variableTypes) return this.variableTypes;
 
     // If variableTypes is null, return all variable types in the workspace.
     if (!this.sourceBlock_ || this.sourceBlock_.isDeadOrDying()) {

--- a/core/workspace.ts
+++ b/core/workspace.ts
@@ -854,7 +854,6 @@ export class Workspace implements IASTNodeLocation {
    * These exist in the flyout but not in the workspace.
    *
    * @returns The potential variable map.
-   * @internal
    */
   getPotentialVariableMap(): IVariableMap<
     IVariableModel<IVariableState>


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #8863 

### Proposed Changes

- Fixes the bug where variable fields in flyouts weren't allowing setting their types correctly
- Adds test for the above case
- Fixes a test for the case where `variableTypes` was `undefined` in the constructor. The old test comments were incorrect and the test only passed because the test case block did not have a `sourceBlock` property. The correct behavior is that passing `undefined` behaves the same as passing `null`.
- Updated the type signature and tsdoc to explictly allow passing `null` since that's what we say to do if you want to see all the variable types.
- Moved the code checking that you don't set an empty array to the `setTypes` method with the rest of the validation instead of the `getTypes` method.
- Removes `@internal` from `workspace.getPotentialVariableMap` since it is called from `FieldVariable` which may be subclassed.

### Reason for Changes

- Fixing bugs and improving tests

### Test Coverage

Added tests and tested manually using the test block from the issue description

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
