### PR TITLE
feat: support menuOpenEvent, menuSelectEvent, location for context menu items

### DIFF
--- a/core/block_svg.ts
+++ b/core/block_svg.ts
@@ -581,15 +581,16 @@ export class BlockSvg
    *
    * @returns Context menu options or null if no menu.
    */
-  protected generateContextMenu(): Array<
-    ContextMenuOption | LegacyContextMenuOption
-  > | null {
+  protected generateContextMenu(
+    e: Event,
+  ): Array<ContextMenuOption | LegacyContextMenuOption> | null {
     if (this.workspace.isReadOnly() || !this.contextMenu) {
       return null;
     }
     const menuOptions = ContextMenuRegistry.registry.getContextMenuOptions(
       ContextMenuRegistry.ScopeType.BLOCK,
       {block: this},
+      e,
     );
 
     // Allow the block to add or modify menuOptions.
@@ -607,7 +608,7 @@ export class BlockSvg
    * @internal
    */
   showContextMenu(e: PointerEvent) {
-    const menuOptions = this.generateContextMenu();
+    const menuOptions = this.generateContextMenu(e);
 
     if (menuOptions && menuOptions.length) {
       ContextMenu.show(e, menuOptions, this.RTL, this.workspace);

--- a/core/block_svg.ts
+++ b/core/block_svg.ts
@@ -602,16 +602,53 @@ export class BlockSvg
   }
 
   /**
+   * Gets the location in which to show the context menu for this block.
+   * Use the location of a click if the block was clicked, or a location
+   * based on the block's fields otherwise.
+   */
+  protected calculateContextMenuLocation(e: Event): Coordinate {
+    // Open the menu where the user clicked, if they clicked
+    if (e instanceof PointerEvent) {
+      return new Coordinate(e.clientX, e.clientY);
+    }
+
+    // Otherwise, calculate a location.
+    // Get the location of the top-left corner of the block in
+    // screen coordinates.
+    const blockCoords = svgMath.wsToScreenCoordinates(
+      this.workspace,
+      this.getRelativeToSurfaceXY(),
+    );
+
+    // Prefer a y position below the first field in the block.
+    const fieldBoundingClientRect = this.inputList
+      .filter((input) => input.isVisible())
+      .flatMap((input) => input.fieldRow)
+      .filter((f) => f.isVisible())[0]
+      ?.getSvgRoot()
+      ?.getBoundingClientRect();
+
+    const y =
+      fieldBoundingClientRect && fieldBoundingClientRect.height
+        ? fieldBoundingClientRect.y + fieldBoundingClientRect.height
+        : blockCoords.y + this.height;
+
+    return new Coordinate(blockCoords.x + 5, y + 5);
+  }
+
+  /**
    * Show the context menu for this block.
    *
    * @param e Mouse event.
    * @internal
    */
-  showContextMenu(e: PointerEvent) {
+  showContextMenu(e: Event) {
     const menuOptions = this.generateContextMenu(e);
 
+    const location = this.calculateContextMenuLocation(e);
+
     if (menuOptions && menuOptions.length) {
-      ContextMenu.show(e, menuOptions, this.RTL, this.workspace);
+      ContextMenu.show(e, menuOptions, this.RTL, this.workspace, location);
       ContextMenu.setCurrentBlock(this);
     }
   }

--- a/core/block_svg.ts
+++ b/core/block_svg.ts
@@ -624,7 +624,7 @@ export class BlockSvg
     const fieldBoundingClientRect = this.inputList
       .filter((input) => input.isVisible())
       .flatMap((input) => input.fieldRow)
-      .filter((f) => f.isVisible())[0]
+      .find((f) => f.isVisible())
       ?.getSvgRoot()
       ?.getBoundingClientRect();
 
@@ -633,7 +633,10 @@ export class BlockSvg
         ? fieldBoundingClientRect.y + fieldBoundingClientRect.height
         : blockCoords.y + this.height;
 
-    return new Coordinate(blockCoords.x + 5, y + 5);
+    return new Coordinate(
+      this.RTL ? blockCoords.x - 5 : blockCoords.x + 5,
+      y + 5,
+    );
   }
 
   /**

--- a/core/comments/rendered_workspace_comment.ts
+++ b/core/comments/rendered_workspace_comment.ts
@@ -287,6 +287,7 @@ export class RenderedWorkspaceComment
     const menuOptions = ContextMenuRegistry.registry.getContextMenuOptions(
       ContextMenuRegistry.ScopeType.COMMENT,
       {comment: this},
+      e,
     );
     contextMenu.show(e, menuOptions, this.workspace.RTL, this.workspace);
   }

--- a/core/comments/rendered_workspace_comment.ts
+++ b/core/comments/rendered_workspace_comment.ts
@@ -22,6 +22,7 @@ import {IRenderedElement} from '../interfaces/i_rendered_element.js';
 import {ISelectable} from '../interfaces/i_selectable.js';
 import * as layers from '../layers.js';
 import * as commentSerialization from '../serialization/workspace_comments.js';
+import {svgMath} from '../utils.js';
 import {Coordinate} from '../utils/coordinate.js';
 import * as dom from '../utils/dom.js';
 import {Rect} from '../utils/rect.js';
@@ -283,13 +284,32 @@ export class RenderedWorkspaceComment
   }
 
   /** Show a context menu for this comment. */
-  showContextMenu(e: PointerEvent): void {
+  showContextMenu(e: Event): void {
     const menuOptions = ContextMenuRegistry.registry.getContextMenuOptions(
       ContextMenuRegistry.ScopeType.COMMENT,
       {comment: this},
       e,
     );
-    contextMenu.show(e, menuOptions, this.workspace.RTL, this.workspace);
+
+    let location: Coordinate;
+    if (e instanceof PointerEvent) {
+      location = new Coordinate(e.clientX, e.clientY);
+    } else {
+      // Show the menu based on the location of the comment
+      const xy = svgMath.wsToScreenCoordinates(
+        this.workspace,
+        this.getRelativeToSurfaceXY(),
+      );
+      location = xy.translate(10, 10);
+    }
+
+    contextMenu.show(
+      e,
+      menuOptions,
+      this.workspace.RTL,
+      this.workspace,
+      location,
+    );
   }
 
   /** Snap this comment to the nearest grid point. */

--- a/core/contextmenu.ts
+++ b/core/contextmenu.ts
@@ -21,6 +21,7 @@ import {Menu} from './menu.js';
 import {MenuSeparator} from './menu_separator.js';
 import {MenuItem} from './menuitem.js';
 import * as serializationBlocks from './serialization/blocks.js';
+import {Coordinate} from './utils.js';
 import * as aria from './utils/aria.js';
 import * as dom from './utils/dom.js';
 import {Rect} from './utils/rect.js';
@@ -38,6 +39,8 @@ const dummyOwner = {};
 
 /**
  * Gets the block the context menu is currently attached to.
+ * It is not recommended that you use this function; instead,
+ * use the scope object passed to the context menu callback.
  *
  * @returns The block the context menu is attached to.
  */
@@ -62,26 +65,39 @@ let menu_: Menu | null = null;
 /**
  * Construct the menu based on the list of options and show the menu.
  *
- * @param e Mouse event.
+ * @param menuOpenEvent Event that caused the menu to open.
  * @param options Array of menu options.
  * @param rtl True if RTL, false if LTR.
  * @param workspace The workspace associated with the context menu, if any.
+ * @param location The screen coordinates at which to show the menu.
+ * @param location
  */
 export function show(
-  e: PointerEvent,
+  menuOpenEvent: Event,
   options: (ContextMenuOption | LegacyContextMenuOption)[],
   rtl: boolean,
   workspace?: WorkspaceSvg,
+  location?: Coordinate,
 ) {
   WidgetDiv.show(dummyOwner, rtl, dispose, workspace);
   if (!options.length) {
     hide();
     return;
   }
-  const menu = populate_(options, rtl, e);
+
+  if (!location) {
+    if (menuOpenEvent instanceof PointerEvent) {
+      location = new Coordinate(menuOpenEvent.clientX, menuOpenEvent.clientY);
+    } else {
+      // We got a keyboard event that didn't tell us where to open the menu, so just guess
+      console.warn('Context menu opened with keyboard but no location given');
+      location = new Coordinate(0, 0);
+    }
+  }
+  const menu = populate_(options, rtl, menuOpenEvent, location);
   menu_ = menu;
 
-  position_(menu, e, rtl);
+  position_(menu, rtl, location);
   // 1ms delay is required for focusing on context menus because some other
   // mouse event is still waiting in the queue and clears focus.
   setTimeout(function () {
@@ -95,13 +111,15 @@ export function show(
  *
  * @param options Array of menu options.
  * @param rtl True if RTL, false if LTR.
- * @param e The event that triggered the context menu to open.
+ * @param menuOpenEvent The event that triggered the context menu to open.
+ * @param location The screen coordinates at which to show the menu.
  * @returns The menu that will be shown on right click.
  */
 function populate_(
   options: (ContextMenuOption | LegacyContextMenuOption)[],
   rtl: boolean,
-  e: PointerEvent,
+  menuOpenEvent: Event,
+  location: Coordinate,
 ): Menu {
   /* Here's what one option object looks like:
       {text: 'Make It So',
@@ -123,7 +141,7 @@ function populate_(
     menu.addChild(menuItem);
     menuItem.setEnabled(option.enabled);
     if (option.enabled) {
-      const actionHandler = function () {
+      const actionHandler = function (p1: MenuItem, menuSelectEvent: Event) {
         hide();
         requestAnimationFrame(() => {
           setTimeout(() => {
@@ -131,7 +149,12 @@ function populate_(
             // will not be expecting a scope parameter, so there should be
             // no problems. Just assume it is a ContextMenuOption and we'll
             // pass undefined if it's not.
-            option.callback((option as ContextMenuOption).scope, e);
+            option.callback(
+              (option as ContextMenuOption).scope,
+              menuOpenEvent,
+              menuSelectEvent,
+              location,
+            );
           }, 0);
         });
       };
@@ -145,21 +168,19 @@ function populate_(
  * Add the menu to the page and position it correctly.
  *
  * @param menu The menu to add and position.
- * @param e Mouse event for the right click that is making the context
- *     menu appear.
  * @param rtl True if RTL, false if LTR.
+ * @param location The location at which to anchor the menu.
  */
-function position_(menu: Menu, e: Event, rtl: boolean) {
+function position_(menu: Menu, rtl: boolean, location: Coordinate) {
   // Record windowSize and scrollOffset before adding menu.
   const viewportBBox = svgMath.getViewportBBox();
-  const mouseEvent = e as MouseEvent;
   // This one is just a point, but we'll pretend that it's a rect so we can use
   // some helper functions.
   const anchorBBox = new Rect(
-    mouseEvent.clientY + viewportBBox.top,
-    mouseEvent.clientY + viewportBBox.top,
-    mouseEvent.clientX + viewportBBox.left,
-    mouseEvent.clientX + viewportBBox.left,
+    location.y + viewportBBox.top,
+    location.y + viewportBBox.top,
+    location.x + viewportBBox.left,
+    location.x + viewportBBox.left,
   );
 
   createWidget_(menu);

--- a/core/contextmenu.ts
+++ b/core/contextmenu.ts
@@ -70,7 +70,6 @@ let menu_: Menu | null = null;
  * @param rtl True if RTL, false if LTR.
  * @param workspace The workspace associated with the context menu, if any.
  * @param location The screen coordinates at which to show the menu.
- * @param location
  */
 export function show(
   menuOpenEvent: Event,

--- a/core/contextmenu_items.ts
+++ b/core/contextmenu_items.ts
@@ -614,7 +614,12 @@ export function registerCommentCreate() {
     preconditionFn: (scope: Scope) => {
       return scope.workspace?.isMutator ? 'hidden' : 'enabled';
     },
-    callback: (scope: Scope, e: PointerEvent) => {
+    callback: (
+      scope: Scope,
+      menuOpenEvent: Event,
+      menuSelectEvent: Event,
+      location: Coordinate,
+    ) => {
       const workspace = scope.workspace;
       if (!workspace) return;
       eventUtils.setGroup(true);
@@ -622,7 +627,7 @@ export function registerCommentCreate() {
       comment.setPlaceholderText(Msg['WORKSPACE_COMMENT_DEFAULT_TEXT']);
       comment.moveTo(
         pixelsToWorkspaceCoords(
-          new Coordinate(e.clientX, e.clientY),
+          new Coordinate(location.x, location.y),
           workspace,
         ),
       );

--- a/core/contextmenu_registry.ts
+++ b/core/contextmenu_registry.ts
@@ -13,6 +13,7 @@
 
 import type {BlockSvg} from './block_svg.js';
 import {RenderedWorkspaceComment} from './comments/rendered_workspace_comment.js';
+import {Coordinate} from './utils.js';
 import type {WorkspaceSvg} from './workspace_svg.js';
 
 /**
@@ -83,6 +84,7 @@ export class ContextMenuRegistry {
   getContextMenuOptions(
     scopeType: ScopeType,
     scope: Scope,
+    menuOpenEvent: Event,
   ): ContextMenuOption[] {
     const menuOptions: ContextMenuOption[] = [];
     for (const item of this.registeredItems.values()) {
@@ -102,7 +104,7 @@ export class ContextMenuRegistry {
             separator: true,
           };
         } else {
-          const precondition = item.preconditionFn(scope);
+          const precondition = item.preconditionFn(scope, menuOpenEvent);
           if (precondition === 'hidden') continue;
 
           const displayText =
@@ -165,12 +167,18 @@ export namespace ContextMenuRegistry {
     /**
      * @param scope Object that provides a reference to the thing that had its
      *     context menu opened.
-     * @param e The original event that triggered the context menu to open. Not
-     *     the event that triggered the click on the option.
+     * @param menuOpenEvent The original event that triggered the context menu to open.
+     * @param menuSelectEvent The event that triggered the option being selected.
+     * @param location The location in screen coordinates where the menu was opened.
      */
-    callback: (scope: Scope, e: PointerEvent) => void;
+    callback: (
+      scope: Scope,
+      menuOpenEvent: Event,
+      menuSelectEvent: Event,
+      location: Coordinate,
+    ) => void;
     displayText: ((p1: Scope) => string | HTMLElement) | string | HTMLElement;
-    preconditionFn: (p1: Scope) => string;
+    preconditionFn: (p1: Scope, menuOpenEvent: Event) => string;
     separator?: never;
   }
 
@@ -206,10 +214,16 @@ export namespace ContextMenuRegistry {
     /**
      * @param scope Object that provides a reference to the thing that had its
      *     context menu opened.
-     * @param e The original event that triggered the context menu to open. Not
-     *     the event that triggered the click on the option.
+     * @param menuOpenEvent The original event that triggered the context menu to open.
+     * @param menuSelectEvent The event that triggered the option being selected.
+     * @param location The location in screen coordinates where the menu was opened.
      */
-    callback: (scope: Scope, e: PointerEvent) => void;
+    callback: (
+      scope: Scope,
+      menuOpenEvent: Event,
+      menuSelectEvent: Event,
+      location: Coordinate,
+    ) => void;
     separator?: never;
   }
 

--- a/core/menu.ts
+++ b/core/menu.ts
@@ -379,7 +379,7 @@ export class Menu {
 
     const menuItem = this.getMenuItem(e.target as Element);
     if (menuItem) {
-      menuItem.performAction();
+      menuItem.performAction(e);
     }
   }
 
@@ -431,7 +431,7 @@ export class Menu {
       case 'Enter':
       case ' ':
         if (highlighted) {
-          highlighted.performAction();
+          highlighted.performAction(e);
         }
         break;
 

--- a/core/menuitem.ts
+++ b/core/menuitem.ts
@@ -41,7 +41,8 @@ export class MenuItem {
   private highlight = false;
 
   /** Bound function to call when this menu item is clicked. */
-  private actionHandler: ((obj: this) => void) | null = null;
+  private actionHandler: ((obj: this, menuSelectEvent: Event) => void) | null =
+    null;
 
   /**
    * @param content Text caption to display as the content of the item, or a
@@ -220,11 +221,14 @@ export class MenuItem {
    * Performs the appropriate action when the menu item is activated
    * by the user.
    *
+   * @param menuSelectEvent the event that triggered the selection
+   * of the menu item.
+   *
    * @internal
    */
-  performAction() {
+  performAction(menuSelectEvent: Event) {
     if (this.isEnabled() && this.actionHandler) {
-      this.actionHandler(this);
+      this.actionHandler(this, menuSelectEvent);
     }
   }
 
@@ -236,7 +240,7 @@ export class MenuItem {
    * @param obj Used as the 'this' object in fn when called.
    * @internal
    */
-  onAction(fn: (p1: MenuItem) => void, obj: object) {
+  onAction(fn: (p1: MenuItem, menuSelectEvent: Event) => void, obj: object) {
     this.actionHandler = fn.bind(obj);
   }
 }

--- a/core/workspace_svg.ts
+++ b/core/workspace_svg.ts
@@ -1713,6 +1713,7 @@ export class WorkspaceSvg
     const menuOptions = ContextMenuRegistry.registry.getContextMenuOptions(
       ContextMenuRegistry.ScopeType.WORKSPACE,
       {workspace: this},
+      e,
     );
 
     // Allow the developer to add or modify menuOptions.

--- a/core/workspace_svg.ts
+++ b/core/workspace_svg.ts
@@ -1706,7 +1706,7 @@ export class WorkspaceSvg
    * @param e Mouse event.
    * @internal
    */
-  showContextMenu(e: PointerEvent) {
+  showContextMenu(e: Event) {
     if (this.isReadOnly() || this.isFlyout) {
       return;
     }
@@ -1721,7 +1721,15 @@ export class WorkspaceSvg
       this.configureContextMenu(menuOptions, e);
     }
 
-    ContextMenu.show(e, menuOptions, this.RTL, this);
+    let location;
+    if (e instanceof PointerEvent) {
+      location = new Coordinate(e.clientX, e.clientY);
+    } else {
+      // TODO: Get the location based on the workspace cursor location
+      location = svgMath.wsToScreenCoordinates(this, new Coordinate(5, 5));
+    }
+
+    ContextMenu.show(e, menuOptions, this.RTL, this, location);
   }
 
   /**


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #8844 and fixes #8843 

### Proposed Changes

- Updates many of the context menu-related functions to take `Event` and not just `PointerEvent`
- Passes the events that opened a menu and selected an option down to the option callbacks
- Calculates a location correctly for the existing uses of the context menu (on blocks, comments, and workspaces). The logic for the block location comes from the keyboard experiment (`fakeEventForBlock`) while for the comments it comes from the location of the comment. For workspace it is not currently implemented. It needs to be implemented based on the cursor location on the workspace, but since that's a bit in flux I just left it out for now.
- Should be backwards compatible as in the `contextmenu.show` method, if no location is passed, I calculate one based off the `PointerEvent` that would have to be passed in if there wasn't a location.

### Reason for Changes

- It should be possible for the context menu to be opened via keyboard, so the opening event will not always be a `PointerEvent`.
- Since the location of the menu if opened via keyboard event is determined by the thing that owns the menu, the menu itself can't calculate its location anymore. The owner of the menu is responsible for calculating its location, and the logic for doing so varies based on type of thing, as you can see from the logic here.
- Some context menu events need to behave differently based on how the menu was opened.

### Test Coverage

Manually tested by invoking `showContextMenu` on blocks, workspaces, and comments and made sure the menu opened even when not passed a pointer event, and that the location was expected. Also ensured the events were passed down to the callback correctly.

### Documentation

Yes, but there's another issue for that.

### Additional Information

<!-- Anything else we should know? -->
