### PR TITLE
feat!: deprecate scopeType and include focusedNode in context menu options

### DIFF
--- a/core/block_svg.ts
+++ b/core/block_svg.ts
@@ -588,8 +588,7 @@ export class BlockSvg
       return null;
     }
     const menuOptions = ContextMenuRegistry.registry.getContextMenuOptions(
-      ContextMenuRegistry.ScopeType.BLOCK,
-      {block: this},
+      {block: this, focusedNode: this},
       e,
     );
 

--- a/core/comments/rendered_workspace_comment.ts
+++ b/core/comments/rendered_workspace_comment.ts
@@ -286,8 +286,7 @@ export class RenderedWorkspaceComment
   /** Show a context menu for this comment. */
   showContextMenu(e: Event): void {
     const menuOptions = ContextMenuRegistry.registry.getContextMenuOptions(
-      ContextMenuRegistry.ScopeType.COMMENT,
-      {comment: this},
+      {comment: this, focusedNode: this},
       e,
     );
 

--- a/core/contextmenu_registry.ts
+++ b/core/contextmenu_registry.ts
@@ -155,7 +155,8 @@ export namespace ContextMenuRegistry {
     block?: BlockSvg;
     workspace?: WorkspaceSvg;
     comment?: RenderedWorkspaceComment;
-    focusedNode?: IFocusableNode | any; // TODO: Remove any once Block, etc. implement IFocusableNode
+    // TODO(#8839): Remove any once Block, etc. implement IFocusableNode
+    focusedNode?: IFocusableNode | any;
   }
 
   /**

--- a/core/workspace_svg.ts
+++ b/core/workspace_svg.ts
@@ -1711,8 +1711,7 @@ export class WorkspaceSvg
       return;
     }
     const menuOptions = ContextMenuRegistry.registry.getContextMenuOptions(
-      ContextMenuRegistry.ScopeType.WORKSPACE,
-      {workspace: this},
+      {workspace: this, focusedNode: this},
       e,
     );
 


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #8838 and works on #8839 - the latter can be closed once the work on `IFocusableNode` has settled a bit more and we can remove `any` from the type in `Scope` here. Currently it can't be removed because `BlockSvg` and friends don't actually implement that interface yet (Ben has a PR in progress).

### Proposed Changes

- Makes `scopeType` optional in `ContextMenuItem` API
- Changes `getContextMenuOptions` to no longer accept a `scopeType` parameter
- Adds `focusedNode` to `Scope` type

### Reason for Changes

- Makes context menu more flexible by getting rid of the scope type enum and allowing context menu options on any object that can be focused

### Breaking Changes

This is only a breaking change if you call `ContextMenuRegistry.registry.getContextMenuOptions`. The other changes in this PR are backwards-compatible with your existing registered context menu items, though you may wish to read the documentation and update them to the new API.

If you do call `getContextMenuOptions`, update your usage to no longer pass the `scopeType` param, and include the object that is having its menu opened in the `scope.focusedNode` property. See the implementations in this PR for examples.
