### PR TITLE
feat: add loopback in cursor navigation, and add tests

### DIFF
--- a/core/keyboard_nav/line_cursor.ts
+++ b/core/keyboard_nav/line_cursor.ts
@@ -328,7 +328,7 @@ export class LineCursor extends Marker {
    * @param node The current position in the AST.
    * @param isValid A function true/false depending on whether the given node
    *     should be traversed.
-   * @param boolean Whether to loop around to the beginning of the workspace if
+   * @param loop Whether to loop around to the beginning of the workspace if
    *     novalid node was found.
    * @returns The next node in the traversal.
    */
@@ -382,7 +382,7 @@ export class LineCursor extends Marker {
    * @param node The current position in the AST.
    * @param isValid A function true/false depending on whether the given node
    *     should be traversed.
-   * @param boolean Whether to loop around to the end of the workspace if no
+   * @param loop Whether to loop around to the end of the workspace if no
    *     valid node was found.
    * @returns The previous node in the traversal or null if no previous node
    *     exists.

--- a/core/keyboard_nav/line_cursor.ts
+++ b/core/keyboard_nav/line_cursor.ts
@@ -311,21 +311,14 @@ export class LineCursor extends Marker {
     node: ASTNode | null,
     isValid: (p1: ASTNode | null) => boolean,
   ): ASTNode | null {
-    if (!node) {
-      return null;
-    }
-    const newNode = node.in() || node.next();
-    if (isValid(newNode)) {
-      return newNode;
-    } else if (newNode) {
-      return this.getNextNodeImpl(newNode, isValid);
-    }
-    const siblingOrParentSibling = this.findSiblingOrParentSibling(node.out());
-    if (isValid(siblingOrParentSibling)) {
-      return siblingOrParentSibling;
-    } else if (siblingOrParentSibling) {
-      return this.getNextNodeImpl(siblingOrParentSibling, isValid);
-    }
+    if (!node) return null;
+    let newNode = node.in() || node.next();
+    if (isValid(newNode)) return newNode;
+    if (newNode) return this.getNextNodeImpl(newNode, isValid);
+
+    newNode = this.findSiblingOrParentSibling(node.out());
+    if (isValid(newNode)) return newNode;
+    if (newNode) return this.getNextNodeImpl(newNode, isValid);
     return null;
   }
 
@@ -344,9 +337,7 @@ export class LineCursor extends Marker {
     isValid: (p1: ASTNode | null) => boolean,
     loop: boolean,
   ): ASTNode | null {
-    if (!node) {
-      return null;
-    }
+    if (!node) return null;
 
     const potential = this.getNextNodeImpl(node, isValid);
     if (potential || !loop) return potential;
@@ -371,9 +362,7 @@ export class LineCursor extends Marker {
     node: ASTNode | null,
     isValid: (p1: ASTNode | null) => boolean,
   ): ASTNode | null {
-    if (!node) {
-      return null;
-    }
+    if (!node) return null;
     let newNode: ASTNode | null = node.prev();
 
     if (newNode) {
@@ -381,13 +370,12 @@ export class LineCursor extends Marker {
     } else {
       newNode = node.out();
     }
-    if (isValid(newNode)) {
-      return newNode;
-    } else if (newNode) {
-      return this.getPreviousNodeImpl(newNode, isValid);
-    }
+
+    if (isValid(newNode)) return newNode;
+    if (newNode) return this.getPreviousNodeImpl(newNode, isValid);
     return null;
   }
+
   /**
    * Get the previous node in the AST, optionally allowing for loopback.
    *
@@ -404,9 +392,7 @@ export class LineCursor extends Marker {
     isValid: (p1: ASTNode | null) => boolean,
     loop: boolean,
   ): ASTNode | null {
-    if (!node) {
-      return null;
-    }
+    if (!node) return null;
 
     const potential = this.getPreviousNodeImpl(node, isValid);
     if (potential || !loop) return potential;
@@ -415,6 +401,7 @@ export class LineCursor extends Marker {
     if (isValid(lastNode)) return lastNode;
     return this.getPreviousNodeImpl(lastNode, isValid);
   }
+
   /**
    * From the given node find either the next valid sibling or the parent's
    * next sibling.
@@ -423,13 +410,9 @@ export class LineCursor extends Marker {
    * @returns The next sibling node, the parent's next sibling, or null.
    */
   private findSiblingOrParentSibling(node: ASTNode | null): ASTNode | null {
-    if (!node) {
-      return null;
-    }
+    if (!node) return null;
     const nextNode = node.next();
-    if (nextNode) {
-      return nextNode;
-    }
+    if (nextNode) return nextNode;
     return this.findSiblingOrParentSibling(node.out());
   }
 
@@ -442,9 +425,7 @@ export class LineCursor extends Marker {
    */
   private getRightMostChild(node: ASTNode): ASTNode | null {
     let newNode = node.in();
-    if (!newNode) {
-      return node;
-    }
+    if (!newNode) return node;
     for (
       let nextNode: ASTNode | null = newNode;
       nextNode;

--- a/tests/mocha/cursor_test.js
+++ b/tests/mocha/cursor_test.js
@@ -385,7 +385,7 @@ suite('Cursor', function () {
       });
     });
   });
-  suite.only('Get next node', function () {
+  suite('Get next node', function () {
     setup(function () {
       sharedTestSetup.call(this);
       Blockly.defineBlocksWithJsonArray([
@@ -601,7 +601,7 @@ suite('Cursor', function () {
     });
   });
 
-  suite.only('Get previous node', function () {
+  suite('Get previous node', function () {
     setup(function () {
       sharedTestSetup.call(this);
       Blockly.defineBlocksWithJsonArray([
@@ -726,7 +726,6 @@ suite('Cursor', function () {
           this.alwaysValid,
           false,
         );
-        //assert.equal(previousNode.getLocation(), this.blockA);
         assert.isNotNull(previousNode);
       });
       test('Always valid - start in middle', function () {
@@ -736,8 +735,10 @@ suite('Cursor', function () {
           this.alwaysValid,
           false,
         );
-        assert.equal(previousNode.getLocation(), this.blockB.previousConnection);
-        //assert.isNotNull(previousNode);
+        assert.equal(
+          previousNode.getLocation(),
+          this.blockB.previousConnection,
+        );
       });
       test('Always valid - start at end', function () {
         const startNode = ASTNode.createConnectionNode(
@@ -769,9 +770,10 @@ suite('Cursor', function () {
           this.isConnection,
           false,
         );
-        assert.equal(previousNode.getLocation(), this.blockB.previousConnection);
-        //assert.equal(previousNode.getLocation(), this.blockB.nextConnection);
-        //assert.isNotNull(previousNode);
+        assert.equal(
+          previousNode.getLocation(),
+          this.blockB.previousConnection,
+        );
       });
       test('Valid if connection - start at end', function () {
         const startNode = ASTNode.createConnectionNode(
@@ -782,8 +784,10 @@ suite('Cursor', function () {
           this.isConnection,
           false,
         );
-        assert.equal(previousNode.getLocation(), this.blockC.previousConnection);
-        //assert.isNull(previousNode);
+        assert.equal(
+          previousNode.getLocation(),
+          this.blockC.previousConnection,
+        );
       });
       test('Never valid - start at top - with loopback', function () {
         const startNode = ASTNode.createConnectionNode(
@@ -796,7 +800,7 @@ suite('Cursor', function () {
         );
         assert.isNull(previousNode);
       });
-      test('Always valid - start at top - with loopback', function () {
+      test.skip('Always valid - start at top - with loopback', function () {
         const startNode = ASTNode.createConnectionNode(
           this.blockA.previousConnection,
         );

--- a/tests/mocha/cursor_test.js
+++ b/tests/mocha/cursor_test.js
@@ -800,7 +800,7 @@ suite('Cursor', function () {
         );
         assert.isNull(previousNode);
       });
-      test.skip('Always valid - start at top - with loopback', function () {
+      test('Always valid - start at top - with loopback', function () {
         const startNode = ASTNode.createConnectionNode(
           this.blockA.previousConnection,
         );
@@ -809,9 +809,9 @@ suite('Cursor', function () {
           this.alwaysValid,
           true,
         );
-        assert.equal(previousNode.getLocation(), this.blockC.nextConnection);
+        // Previous node will be a stack node in this case.
+        assert.equal(previousNode.getLocation(), this.blockA);
       });
-
       test('Valid if connection - start at top - with loopback', function () {
         const startNode = ASTNode.createConnectionNode(
           this.blockA.previousConnection,


### PR DESCRIPTION
## The basics

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

Progress on https://github.com/google/blockly-keyboard-experimentation/pull/409

### Proposed Changes

- Add a `loop` parameter to `getPreviousNode` and `getNextNode` in cursor.
- Add tests for loopback and non loopback cases.

### Reason for Changes

Both navigation and keyboard drags will use this to smoothly roll from the end of the workspace to the beginning and vice versa, matching standard approaches to searching.

### Test Coverage
Added tests in `cursor_test.ts`.

### Documentation


### Additional Information
I got some unexpected (to me) behaviour in `getPreviousNode` but they turned out to be unexpected stack nodes. Getting rid of stack nodes is being considered already, and will require updates to these tests.

The fourth commit inlines some logic in functions in `line_cursor.ts`, but I can revert it if necessary.
