### PR TITLE
feat: Add support for retrieving blocks' drag strategies.

### DIFF
--- a/core/block_svg.ts
+++ b/core/block_svg.ts
@@ -1702,6 +1702,16 @@ export class BlockSvg
     );
   }
 
+  /**
+   * Returns the drag strategy currently in use by this block.
+   *
+   * @internal
+   * @returns This block's drag strategy.
+   */
+  getDragStrategy(): IDragStrategy {
+    return this.dragStrategy;
+  }
+
   /** Sets the drag strategy for this block. */
   setDragStrategy(dragStrategy: IDragStrategy) {
     this.dragStrategy = dragStrategy;


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #8850

### Proposed Changes
This PR adds an internal `getDragStrategy()` method to `BlockSvg`.