### PR TITLE
feat: show context menu for connections

### DIFF
--- a/core/rendered_connection.ts
+++ b/core/rendered_connection.ts
@@ -603,10 +603,11 @@ export class RenderedConnection extends Connection implements IContextMenu {
    */
   showContextMenu(e: Event): void {
     const menuOptions = ContextMenuRegistry.registry.getContextMenuOptions(
-      ContextMenuRegistry.ScopeType.WORKSPACE,
       {focusedNode: this},
       e,
     );
+
+    if (!menuOptions.length) return;
 
     const block = this.getSourceBlock();
     const workspace = block.workspace;

--- a/core/rendered_connection.ts
+++ b/core/rendered_connection.ts
@@ -18,10 +18,14 @@ import {config} from './config.js';
 import {Connection} from './connection.js';
 import type {ConnectionDB} from './connection_db.js';
 import {ConnectionType} from './connection_type.js';
+import * as ContextMenu from './contextmenu.js';
+import {ContextMenuRegistry} from './contextmenu_registry.js';
 import * as eventUtils from './events/utils.js';
+import {IContextMenu} from './interfaces/i_contextmenu.js';
 import {hasBubble} from './interfaces/i_has_bubble.js';
 import * as internalConstants from './internal_constants.js';
 import {Coordinate} from './utils/coordinate.js';
+import * as svgMath from './utils/svg_math.js';
 
 /** Maximum randomness in workspace units for bumping a block. */
 const BUMP_RANDOMNESS = 10;
@@ -29,7 +33,7 @@ const BUMP_RANDOMNESS = 10;
 /**
  * Class for a connection between blocks that may be rendered on screen.
  */
-export class RenderedConnection extends Connection {
+export class RenderedConnection extends Connection implements IContextMenu {
   // TODO(b/109816955): remove '!', see go/strict-prop-init-fix.
   sourceBlock_!: BlockSvg;
   private readonly db: ConnectionDB;
@@ -587,6 +591,39 @@ export class RenderedConnection extends Connection {
     super.setCheck(check);
     this.sourceBlock_.queueRender();
     return this;
+  }
+
+  /**
+   * Handles showing the context menu when it is opened on a connection.
+   * Note that typically the context menu can't be opened with the mouse
+   * on a connection, because you can't select a connection. But keyboard
+   * users may open the context menu with a keyboard shortcut.
+   *
+   * @param e Event that triggered the opening of the context menu.
+   */
+  showContextMenu(e: Event): void {
+    const menuOptions = ContextMenuRegistry.registry.getContextMenuOptions(
+      ContextMenuRegistry.ScopeType.WORKSPACE,
+      {focusedNode: this},
+      e,
+    );
+
+    const block = this.getSourceBlock();
+    const workspace = block.workspace;
+
+    let location;
+    if (e instanceof PointerEvent) {
+      location = new Coordinate(e.clientX, e.clientY);
+    } else {
+      const connectionWSCoords = new Coordinate(this.x, this.y);
+      const connectionScreenCoords = svgMath.wsToScreenCoordinates(
+        workspace,
+        connectionWSCoords,
+      );
+      location = connectionScreenCoords.translate(block.RTL ? -5 : 5, 5);
+    }
+
+    ContextMenu.show(e, menuOptions, block.RTL, workspace, location);
   }
 }
 


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #8846 

### Proposed Changes

Makes `RenderedConnection` implement `IContextMenu`

The logic for where to show the menu comes from the keyboard experiment which is currently manually triggering the menu.

### Reason for Changes

Connections can have context menu items now (if opened via keyboard).

### Test Coverage

Core doesn't have any context menu items on connections, so tested with linking to the keyboard experiment.

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
