### PR TITLE
fix: Fix bug that allowed some invisible fields/inputs to be navigate…

### DIFF
--- a/core/keyboard_nav/ast_node.ts
+++ b/core/keyboard_nav/ast_node.ts
@@ -461,6 +461,8 @@ export class ASTNode {
     const inputs = block.inputList;
     for (let i = 0; i < inputs.length; i++) {
       const input = inputs[i];
+      if (!input.isVisible()) continue;
+
       const fieldRow = input.fieldRow;
       for (let j = 0; j < fieldRow.length; j++) {
         const field = fieldRow[j];
@@ -468,7 +470,7 @@ export class ASTNode {
           return ASTNode.createFieldNode(field);
         }
       }
-      if (input.connection && input.isVisible()) {
+      if (input.connection) {
         return ASTNode.createInputNode(input);
       }
     }


### PR DESCRIPTION
…d to.

<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes https://github.com/google/blockly-keyboard-experimentation/issues/269

### Proposed Changes
This PR updates ASTNode to skip invisible inputs when searching for an input or field to navigate to. Previously, it was only disregarding hidden inputs themselves, but would still navigate to fields attached to a hidden input.