### PR TITLE
fix: Fix bug that caused flyout items under the mouse to be selected without movement.

### DIFF
--- a/core/block_flyout_inflater.ts
+++ b/core/block_flyout_inflater.ts
@@ -222,7 +222,7 @@ export class BlockFlyoutInflater implements IFlyoutInflater {
     );
 
     blockListeners.push(
-      browserEvents.bind(block.getSvgRoot(), 'pointerenter', null, () => {
+      browserEvents.bind(block.getSvgRoot(), 'pointermove', null, () => {
         if (!this.flyout?.targetWorkspace?.isDragging()) {
           block.addSelect();
         }


### PR DESCRIPTION

<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes https://github.com/google/blockly-keyboard-experimentation/issues/216

### Proposed Changes
This PR updates the flyouts to select items on `pointermove` rather than `pointerenter`. This resolves an issue where, when using keyboard navigation, flyout items that happened to appear under the mouse when the flyout was opened via the keyboard would appear selected. This resulted in a confusing behavior where there could be two selections: the cursor, and the block incidentally under the mouse. Now, blocks will not be selected/highlighted unless the mouse is actually moved.