### PR TITLE
feat!: add scope to keyboard shortcuts and use it

### DIFF
--- a/core/shortcut_items.ts
+++ b/core/shortcut_items.ts
@@ -8,12 +8,12 @@
 
 import {BlockSvg} from './block_svg.js';
 import * as clipboard from './clipboard.js';
-import * as common from './common.js';
 import * as eventUtils from './events/utils.js';
 import {Gesture} from './gesture.js';
 import {ICopyData, isCopyable} from './interfaces/i_copyable.js';
 import {isDeletable} from './interfaces/i_deletable.js';
 import {isDraggable} from './interfaces/i_draggable.js';
+import {isSelectable} from './interfaces/i_selectable.js';
 import {KeyboardShortcut, ShortcutRegistry} from './shortcut_registry.js';
 import {Coordinate} from './utils/coordinate.js';
 import {KeyCodes} from './utils/keycodes.js';
@@ -43,9 +43,7 @@ export function registerEscape() {
       return !workspace.isReadOnly();
     },
     callback(workspace) {
-      // AnyDuringMigration because:  Property 'hideChaff' does not exist on
-      // type 'Workspace'.
-      (workspace as AnyDuringMigration).hideChaff();
+      workspace.hideChaff();
       return true;
     },
     keyCodes: [KeyCodes.ESC],
@@ -59,28 +57,28 @@ export function registerEscape() {
 export function registerDelete() {
   const deleteShortcut: KeyboardShortcut = {
     name: names.DELETE,
-    preconditionFn(workspace) {
-      const selected = common.getSelected();
+    preconditionFn(workspace, scope) {
+      const focused = scope.focusedNode;
       return (
         !workspace.isReadOnly() &&
-        selected != null &&
-        isDeletable(selected) &&
-        selected.isDeletable() &&
+        focused != null &&
+        isDeletable(focused) &&
+        focused.isDeletable() &&
         !Gesture.inProgress()
       );
     },
-    callback(workspace, e) {
+    callback(workspace, e, shortcut, scope) {
       // Delete or backspace.
       // Stop the browser from going back to the previous page.
       // Do this first to prevent an error in the delete code from resulting in
       // data loss.
       e.preventDefault();
-      const selected = common.getSelected();
-      if (selected instanceof BlockSvg) {
-        selected.checkAndDelete();
-      } else if (isDeletable(selected) && selected.isDeletable()) {
+      const focused = scope.focusedNode;
+      if (focused instanceof BlockSvg) {
+        focused.checkAndDelete();
+      } else if (isDeletable(focused) && focused.isDeletable()) {
         eventUtils.setGroup(true);
-        selected.dispose();
+        focused.dispose();
         eventUtils.setGroup(false);
       }
       return true;
@@ -110,33 +108,33 @@ export function registerCopy() {
 
   const copyShortcut: KeyboardShortcut = {
     name: names.COPY,
-    preconditionFn(workspace) {
-      const selected = common.getSelected();
+    preconditionFn(workspace, scope) {
+      const focused = scope.focusedNode;
       return (
         !workspace.isReadOnly() &&
         !Gesture.inProgress() &&
-        selected != null &&
-        isDeletable(selected) &&
-        selected.isDeletable() &&
-        isDraggable(selected) &&
-        selected.isMovable() &&
-        isCopyable(selected)
+        focused != null &&
+        isDeletable(focused) &&
+        focused.isDeletable() &&
+        isDraggable(focused) &&
+        focused.isMovable() &&
+        isCopyable(focused)
       );
     },
-    callback(workspace, e) {
+    callback(workspace, e, shortcut, scope) {
       // Prevent the default copy behavior, which may beep or otherwise indicate
       // an error due to the lack of a selection.
       e.preventDefault();
       workspace.hideChaff();
-      const selected = common.getSelected();
-      if (!selected || !isCopyable(selected)) return false;
-      copyData = selected.toCopyData();
+      const focused = scope.focusedNode;
+      if (!focused || !isCopyable(focused)) return false;
+      copyData = focused.toCopyData();
       copyWorkspace =
-        selected.workspace instanceof WorkspaceSvg
-          ? selected.workspace
+        focused.workspace instanceof WorkspaceSvg
+          ? focused.workspace
           : workspace;
-      copyCoords = isDraggable(selected)
-        ? selected.getRelativeToSurfaceXY()
+      copyCoords = isDraggable(focused)
+        ? focused.getRelativeToSurfaceXY()
         : null;
       return !!copyData;
     },
@@ -161,39 +159,40 @@ export function registerCut() {
 
   const cutShortcut: KeyboardShortcut = {
     name: names.CUT,
-    preconditionFn(workspace) {
-      const selected = common.getSelected();
+    preconditionFn(workspace, scope) {
+      const focused = scope.focusedNode;
       return (
         !workspace.isReadOnly() &&
         !Gesture.inProgress() &&
-        selected != null &&
-        isDeletable(selected) &&
-        selected.isDeletable() &&
-        isDraggable(selected) &&
-        selected.isMovable() &&
-        !selected.workspace!.isFlyout
+        focused != null &&
+        isDeletable(focused) &&
+        focused.isDeletable() &&
+        isDraggable(focused) &&
+        focused.isMovable() &&
+        isSelectable(focused) &&
+        !focused.workspace.isFlyout
       );
     },
-    callback(workspace) {
-      const selected = common.getSelected();
+    callback(workspace, e, shortcut, scope) {
+      const focused = scope.focusedNode;
 
-      if (selected instanceof BlockSvg) {
-        copyData = selected.toCopyData();
+      if (focused instanceof BlockSvg) {
+        copyData = focused.toCopyData();
         copyWorkspace = workspace;
-        copyCoords = selected.getRelativeToSurfaceXY();
-        selected.checkAndDelete();
+        copyCoords = focused.getRelativeToSurfaceXY();
+        focused.checkAndDelete();
         return true;
       } else if (
-        isDeletable(selected) &&
-        selected.isDeletable() &&
-        isCopyable(selected)
+        isDeletable(focused) &&
+        focused.isDeletable() &&
+        isCopyable(focused)
       ) {
-        copyData = selected.toCopyData();
+        copyData = focused.toCopyData();
         copyWorkspace = workspace;
-        copyCoords = isDraggable(selected)
-          ? selected.getRelativeToSurfaceXY()
+        copyCoords = isDraggable(focused)
+          ? focused.getRelativeToSurfaceXY()
           : null;
-        selected.dispose();
+        focused.dispose();
         return true;
       }
       return false;

--- a/core/shortcut_registry.ts
+++ b/core/shortcut_registry.ts
@@ -12,7 +12,8 @@
  */
 // Former goog.module ID: Blockly.ShortcutRegistry
 
-import { Scope } from './contextmenu_registry.js';
+import {Scope} from './contextmenu_registry.js';
+import {getFocusManager} from './focus_manager.js';
 import {KeyCodes} from './utils/keycodes.js';
 import * as object from './utils/object.js';
 import {WorkspaceSvg} from './workspace_svg.js';
@@ -250,12 +251,20 @@ export class ShortcutRegistry {
       const shortcut = this.shortcuts.get(shortcutName);
       if (
         !shortcut ||
-        (shortcut.preconditionFn && !shortcut.preconditionFn(workspace, {}))
+        (shortcut.preconditionFn &&
+          !shortcut.preconditionFn(workspace, {
+            focusedNode: getFocusManager().getFocusedNode(),
+          }))
       ) {
         continue;
       }
       // If the key has been handled, stop processing shortcuts.
-      if (shortcut.callback?.(workspace, e, shortcut, {})) return true;
+      if (
+        shortcut.callback?.(workspace, e, shortcut, {
+          focusedNode: getFocusManager().getFocusedNode(),
+        })
+      )
+        return true;
     }
     return false;
   }

--- a/core/shortcut_registry.ts
+++ b/core/shortcut_registry.ts
@@ -12,6 +12,7 @@
  */
 // Former goog.module ID: Blockly.ShortcutRegistry
 
+import { Scope } from './contextmenu_registry.js';
 import {KeyCodes} from './utils/keycodes.js';
 import * as object from './utils/object.js';
 import {WorkspaceSvg} from './workspace_svg.js';
@@ -249,12 +250,12 @@ export class ShortcutRegistry {
       const shortcut = this.shortcuts.get(shortcutName);
       if (
         !shortcut ||
-        (shortcut.preconditionFn && !shortcut.preconditionFn(workspace))
+        (shortcut.preconditionFn && !shortcut.preconditionFn(workspace, {}))
       ) {
         continue;
       }
       // If the key has been handled, stop processing shortcuts.
-      if (shortcut.callback?.(workspace, e, shortcut)) return true;
+      if (shortcut.callback?.(workspace, e, shortcut, {})) return true;
     }
     return false;
   }
@@ -372,6 +373,8 @@ export namespace ShortcutRegistry {
      * @param e The event that caused the shortcut to be activated.
      * @param shortcut The `KeyboardShortcut` that was activated
      *     (i.e., the one this callback is attached to).
+     * @param scope Information about the focused item when the
+     * shortcut was invoked.
      * @returns Returning true ends processing of the invoked keycode.
      *     Returning false causes processing to continue with the
      *     next-most-recently registered shortcut for the invoked
@@ -381,6 +384,7 @@ export namespace ShortcutRegistry {
       workspace: WorkspaceSvg,
       e: Event,
       shortcut: KeyboardShortcut,
+      scope: Scope,
     ) => boolean;
 
     /** The name of the shortcut.  Should be unique. */
@@ -393,9 +397,11 @@ export namespace ShortcutRegistry {
      *
      * @param workspace The `WorkspaceSvg` where the shortcut was
      *     invoked.
+     * @param scope Information about the focused item when the
+     * shortcut would be invoked.
      * @returns True iff `callback` function should be called.
      */
-    preconditionFn?: (workspace: WorkspaceSvg) => boolean;
+    preconditionFn?: (workspace: WorkspaceSvg, scope: Scope) => boolean;
 
     /** Optional arbitray extra data attached to the shortcut. */
     metadata?: object;

--- a/tests/mocha/keydown_test.js
+++ b/tests/mocha/keydown_test.js
@@ -31,6 +31,7 @@ suite('Key Down', function () {
     defineStackBlock();
     const block = workspace.newBlock('stack_block');
     Blockly.common.setSelected(block);
+    sinon.stub(Blockly.getFocusManager(), 'getFocusedNode').returns(block);
     return block;
   }
 


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #8845 

### Proposed Changes

- Adds scope to keyboard shortcut callback and precondition
- Updates existing keyboard shortcuts to use that scope
- Adds tests for the new arguments and updates existing tests
- Fixes an unrelated problem with the existing tests where it was stubbing out `precondition` instead of `preconditionFn` making the tests not behave as expected, and added the obvious missing test for the precondition returning false

### Reason for Changes

Works on #8862 

### Test Coverage

Updated and added tests for some cases

We need to manually test and probably want written tests for what happens when things like connections or fields are actively focused

### Documentation

There is not currently any documentation about keyboard shortcuts.

### Additional Information

The keyboard shortcuts don't actually work right now because `Blockly.getFocusManager.getFocusedNode()` doesn't return anything.

The keyboard shortcuts in the plugin need to be updated as well.

**BREAKING CHANGE:**

This PR is only a breaking change if you:
1) Get keyboard shortcut methods out of the registry and
2) call or modify those methods.

This PR is *not* a breaking change if you don't use keyboard shortcuts at all, or you simply register custom keyboard shortcuts. In that case, while this PR is not breaking, you may wish to update your functions to take advantage of the new parameter to act on the focused object.

This PR modifies the signatures of `preconditionFn` and `callback` methods of registered shortcuts, specifically by adding additional non-optional parameters.  Code that obtains these shortcut objects from the shortcut registry and calls those methods will need to be updated to supply the additional requires arguments.
