### PR TITLE
feat: add keyboard shortcut to open context menu

### DIFF
--- a/core/contextmenu.ts
+++ b/core/contextmenu.ts
@@ -220,6 +220,8 @@ function createWidget_(menu: Menu) {
   );
   // Focus only after the initial render to avoid issue #1329.
   menu.focus();
+  // Highlight the first thing in the menu
+  menu.highlightNext();
 }
 /**
  * Halts the propagation of the event without doing anything else.

--- a/core/interfaces/i_contextmenu.ts
+++ b/core/interfaces/i_contextmenu.ts
@@ -14,3 +14,8 @@ export interface IContextMenu {
    */
   showContextMenu(e: Event): void;
 }
+
+/** Type guard for objects that implement IContextMenu. */
+export function hasContextMenu(obj: object): obj is IContextMenu {
+  return (obj as any).showContextMenu !== undefined;
+}

--- a/core/shortcut_items.ts
+++ b/core/shortcut_items.ts
@@ -8,12 +8,12 @@
 
 import {BlockSvg} from './block_svg.js';
 import * as clipboard from './clipboard.js';
-import * as common from './common.js';
 import * as eventUtils from './events/utils.js';
 import {Gesture} from './gesture.js';
 import {ICopyData, isCopyable} from './interfaces/i_copyable.js';
 import {isDeletable} from './interfaces/i_deletable.js';
 import {isDraggable} from './interfaces/i_draggable.js';
+import {isSelectable} from './interfaces/i_selectable.js';
 import {KeyboardShortcut, ShortcutRegistry} from './shortcut_registry.js';
 import {Coordinate} from './utils/coordinate.js';
 import {KeyCodes} from './utils/keycodes.js';
@@ -43,9 +43,7 @@ export function registerEscape() {
       return !workspace.isReadOnly();
     },
     callback(workspace) {
-      // AnyDuringMigration because:  Property 'hideChaff' does not exist on
-      // type 'Workspace'.
-      (workspace as AnyDuringMigration).hideChaff();
+      workspace.hideChaff();
       return true;
     },
     keyCodes: [KeyCodes.ESC],
@@ -59,28 +57,28 @@ export function registerEscape() {
 export function registerDelete() {
   const deleteShortcut: KeyboardShortcut = {
     name: names.DELETE,
-    preconditionFn(workspace) {
-      const selected = common.getSelected();
+    preconditionFn(workspace, scope) {
+      const focused = scope.focusedNode;
       return (
         !workspace.isReadOnly() &&
-        selected != null &&
-        isDeletable(selected) &&
-        selected.isDeletable() &&
+        focused != null &&
+        isDeletable(focused) &&
+        focused.isDeletable() &&
         !Gesture.inProgress()
       );
     },
-    callback(workspace, e) {
+    callback(workspace, e, shortcut, scope) {
       // Delete or backspace.
       // Stop the browser from going back to the previous page.
       // Do this first to prevent an error in the delete code from resulting in
       // data loss.
       e.preventDefault();
-      const selected = common.getSelected();
-      if (selected instanceof BlockSvg) {
-        selected.checkAndDelete();
-      } else if (isDeletable(selected) && selected.isDeletable()) {
+      const focused = scope.focusedNode;
+      if (focused instanceof BlockSvg) {
+        focused.checkAndDelete();
+      } else if (isDeletable(focused) && focused.isDeletable()) {
         eventUtils.setGroup(true);
-        selected.dispose();
+        focused.dispose();
         eventUtils.setGroup(false);
       }
       return true;
@@ -110,33 +108,33 @@ export function registerCopy() {
 
   const copyShortcut: KeyboardShortcut = {
     name: names.COPY,
-    preconditionFn(workspace) {
-      const selected = common.getSelected();
+    preconditionFn(workspace, scope) {
+      const focused = scope.focusedNode;
       return (
         !workspace.isReadOnly() &&
         !Gesture.inProgress() &&
-        selected != null &&
-        isDeletable(selected) &&
-        selected.isDeletable() &&
-        isDraggable(selected) &&
-        selected.isMovable() &&
-        isCopyable(selected)
+        focused != null &&
+        isDeletable(focused) &&
+        focused.isDeletable() &&
+        isDraggable(focused) &&
+        focused.isMovable() &&
+        isCopyable(focused)
       );
     },
-    callback(workspace, e) {
+    callback(workspace, e, shortcut, scope) {
       // Prevent the default copy behavior, which may beep or otherwise indicate
       // an error due to the lack of a selection.
       e.preventDefault();
       workspace.hideChaff();
-      const selected = common.getSelected();
-      if (!selected || !isCopyable(selected)) return false;
-      copyData = selected.toCopyData();
+      const focused = scope.focusedNode;
+      if (!focused || !isCopyable(focused)) return false;
+      copyData = focused.toCopyData();
       copyWorkspace =
-        selected.workspace instanceof WorkspaceSvg
-          ? selected.workspace
+        focused.workspace instanceof WorkspaceSvg
+          ? focused.workspace
           : workspace;
-      copyCoords = isDraggable(selected)
-        ? selected.getRelativeToSurfaceXY()
+      copyCoords = isDraggable(focused)
+        ? focused.getRelativeToSurfaceXY()
         : null;
       return !!copyData;
     },
@@ -161,39 +159,40 @@ export function registerCut() {
 
   const cutShortcut: KeyboardShortcut = {
     name: names.CUT,
-    preconditionFn(workspace) {
-      const selected = common.getSelected();
+    preconditionFn(workspace, scope) {
+      const focused = scope.focusedNode;
       return (
         !workspace.isReadOnly() &&
         !Gesture.inProgress() &&
-        selected != null &&
-        isDeletable(selected) &&
-        selected.isDeletable() &&
-        isDraggable(selected) &&
-        selected.isMovable() &&
-        !selected.workspace!.isFlyout
+        focused != null &&
+        isDeletable(focused) &&
+        focused.isDeletable() &&
+        isDraggable(focused) &&
+        focused.isMovable() &&
+        isSelectable(focused) &&
+        !focused.workspace.isFlyout
       );
     },
-    callback(workspace) {
-      const selected = common.getSelected();
+    callback(workspace, e, shortcut, scope) {
+      const focused = scope.focusedNode;
 
-      if (selected instanceof BlockSvg) {
-        copyData = selected.toCopyData();
+      if (focused instanceof BlockSvg) {
+        copyData = focused.toCopyData();
         copyWorkspace = workspace;
-        copyCoords = selected.getRelativeToSurfaceXY();
-        selected.checkAndDelete();
+        copyCoords = focused.getRelativeToSurfaceXY();
+        focused.checkAndDelete();
         return true;
       } else if (
-        isDeletable(selected) &&
-        selected.isDeletable() &&
-        isCopyable(selected)
+        isDeletable(focused) &&
+        focused.isDeletable() &&
+        isCopyable(focused)
       ) {
-        copyData = selected.toCopyData();
+        copyData = focused.toCopyData();
         copyWorkspace = workspace;
-        copyCoords = isDraggable(selected)
-          ? selected.getRelativeToSurfaceXY()
+        copyCoords = isDraggable(focused)
+          ? focused.getRelativeToSurfaceXY()
           : null;
-        selected.dispose();
+        focused.dispose();
         return true;
       }
       return false;

--- a/core/shortcut_items.ts
+++ b/core/shortcut_items.ts
@@ -10,6 +10,7 @@ import {BlockSvg} from './block_svg.js';
 import * as clipboard from './clipboard.js';
 import * as eventUtils from './events/utils.js';
 import {Gesture} from './gesture.js';
+import {hasContextMenu} from './interfaces/i_contextmenu.js';
 import {ICopyData, isCopyable} from './interfaces/i_copyable.js';
 import {isDeletable} from './interfaces/i_deletable.js';
 import {isDraggable} from './interfaces/i_draggable.js';
@@ -31,6 +32,7 @@ export enum names {
   PASTE = 'paste',
   UNDO = 'undo',
   REDO = 'redo',
+  MENU = 'menu',
 }
 
 /**
@@ -322,6 +324,33 @@ export function registerRedo() {
 }
 
 /**
+ * Keyboard shortcut to open the context menu on ctrl/cmd+Enter.
+ */
+export function registerMenu() {
+  const ctrlEnter = ShortcutRegistry.registry.createSerializedKey(
+    KeyCodes.ENTER,
+    [KeyCodes.CTRL],
+  );
+  const cmdEnter = ShortcutRegistry.registry.createSerializedKey(
+    KeyCodes.ENTER,
+    [KeyCodes.META],
+  );
+  const menuShortcut: KeyboardShortcut = {
+    name: names.MENU,
+    preconditionFn: (workspace, scope) => {
+      return hasContextMenu(scope.focusedNode);
+    },
+    callback: (workspace, e, shortcut, scope) => {
+      if (!hasContextMenu(scope.focusedNode)) return false;
+      scope.focusedNode.showContextMenu(e);
+      return true;
+    },
+    keyCodes: [ctrlEnter, cmdEnter],
+  };
+  ShortcutRegistry.registry.register(menuShortcut);
+}
+
+/**
  * Registers all default keyboard shortcut item. This should be called once per
  * instance of KeyboardShortcutRegistry.
  *
@@ -335,6 +364,7 @@ export function registerDefaultShortcuts() {
   registerPaste();
   registerUndo();
   registerRedo();
+  registerMenu();
 }
 
 registerDefaultShortcuts();

--- a/core/shortcut_registry.ts
+++ b/core/shortcut_registry.ts
@@ -12,7 +12,8 @@
  */
 // Former goog.module ID: Blockly.ShortcutRegistry
 
-import { Scope } from './contextmenu_registry.js';
+import {Scope} from './contextmenu_registry.js';
+import {getFocusManager} from './focus_manager.js';
 import {KeyCodes} from './utils/keycodes.js';
 import * as object from './utils/object.js';
 import {WorkspaceSvg} from './workspace_svg.js';
@@ -250,12 +251,20 @@ export class ShortcutRegistry {
       const shortcut = this.shortcuts.get(shortcutName);
       if (
         !shortcut ||
-        (shortcut.preconditionFn && !shortcut.preconditionFn(workspace, {}))
+        (shortcut.preconditionFn &&
+          !shortcut.preconditionFn(workspace, {
+            focusedNode: getFocusManager().getFocusedNode(),
+          }))
       ) {
         continue;
       }
       // If the key has been handled, stop processing shortcuts.
-      if (shortcut.callback?.(workspace, e, shortcut, {})) return true;
+      if (
+        shortcut.callback?.(workspace, e, shortcut, {
+          focusedNode: getFocusManager().getFocusedNode(),
+        })
+      )
+        return true;
     }
     return false;
   }

--- a/core/shortcut_registry.ts
+++ b/core/shortcut_registry.ts
@@ -12,6 +12,7 @@
  */
 // Former goog.module ID: Blockly.ShortcutRegistry
 
+import { Scope } from './contextmenu_registry.js';
 import {KeyCodes} from './utils/keycodes.js';
 import * as object from './utils/object.js';
 import {WorkspaceSvg} from './workspace_svg.js';
@@ -249,12 +250,12 @@ export class ShortcutRegistry {
       const shortcut = this.shortcuts.get(shortcutName);
       if (
         !shortcut ||
-        (shortcut.preconditionFn && !shortcut.preconditionFn(workspace))
+        (shortcut.preconditionFn && !shortcut.preconditionFn(workspace, {}))
       ) {
         continue;
       }
       // If the key has been handled, stop processing shortcuts.
-      if (shortcut.callback?.(workspace, e, shortcut)) return true;
+      if (shortcut.callback?.(workspace, e, shortcut, {})) return true;
     }
     return false;
   }
@@ -372,6 +373,8 @@ export namespace ShortcutRegistry {
      * @param e The event that caused the shortcut to be activated.
      * @param shortcut The `KeyboardShortcut` that was activated
      *     (i.e., the one this callback is attached to).
+     * @param scope Information about the focused item when the
+     * shortcut was invoked.
      * @returns Returning true ends processing of the invoked keycode.
      *     Returning false causes processing to continue with the
      *     next-most-recently registered shortcut for the invoked
@@ -381,6 +384,7 @@ export namespace ShortcutRegistry {
       workspace: WorkspaceSvg,
       e: Event,
       shortcut: KeyboardShortcut,
+      scope: Scope,
     ) => boolean;
 
     /** The name of the shortcut.  Should be unique. */
@@ -393,9 +397,11 @@ export namespace ShortcutRegistry {
      *
      * @param workspace The `WorkspaceSvg` where the shortcut was
      *     invoked.
+     * @param scope Information about the focused item when the
+     * shortcut would be invoked.
      * @returns True iff `callback` function should be called.
      */
-    preconditionFn?: (workspace: WorkspaceSvg) => boolean;
+    preconditionFn?: (workspace: WorkspaceSvg, scope: Scope) => boolean;
 
     /** Optional arbitray extra data attached to the shortcut. */
     metadata?: object;

--- a/tests/mocha/keydown_test.js
+++ b/tests/mocha/keydown_test.js
@@ -31,6 +31,7 @@ suite('Key Down', function () {
     defineStackBlock();
     const block = workspace.newBlock('stack_block');
     Blockly.common.setSelected(block);
+    sinon.stub(Blockly.getFocusManager(), 'getFocusedNode').returns(block);
     return block;
   }
 


### PR DESCRIPTION
## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #8847 

### Proposed Changes

- Adds a keyboard shortcut to open the context menu
- Highlights the first item in the context menu automatically when shown

### Reason for Changes

- Context menus should be navigable by keyboard users.

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

This change depends on #8917 which depends on changes to FocusManager to return the correct thing from `getFocusedNode`. I manually made `getFocusedNode` return the selected block, and the context menu behaved as expected when opened with `cmd+enter`, so I think this should "just work" when the prerequisites are done, at which point it should be rebased onto the v12 branch.
