### PR TITLE
feat: add keyboard navigation controller

### DIFF
--- a/core/blockly.ts
+++ b/core/blockly.ts
@@ -173,6 +173,10 @@ import {IVariableModel, IVariableState} from './interfaces/i_variable_model.js';
 import * as internalConstants from './internal_constants.js';
 import {LineCursor} from './keyboard_nav/line_cursor.js';
 import {Marker} from './keyboard_nav/marker.js';
+import {
+  KeyboardNavigationController,
+  keyboardNavigationController,
+} from './keyboard_navigation_controller.js';
 import type {LayerManager} from './layer_manager.js';
 import * as layers from './layers.js';
 import {MarkerManager} from './marker_manager.js';
@@ -580,6 +584,7 @@ export {
   ImageProperties,
   Input,
   InsertionMarkerPreviewer,
+  KeyboardNavigationController,
   LabelFlyoutInflater,
   LayerManager,
   Marker,
@@ -631,6 +636,7 @@ export {
   isSelectable,
   isSerializable,
   isVariableBackedParameterModel,
+  keyboardNavigationController,
   layers,
   renderManagement,
   serialization,

--- a/core/gesture.ts
+++ b/core/gesture.ts
@@ -31,6 +31,7 @@ import {IDraggable, isDraggable} from './interfaces/i_draggable.js';
 import {IDragger} from './interfaces/i_dragger.js';
 import type {IFlyout} from './interfaces/i_flyout.js';
 import type {IIcon} from './interfaces/i_icon.js';
+import {keyboardNavigationController} from './keyboard_navigation_controller.js';
 import * as registry from './registry.js';
 import * as Tooltip from './tooltip.js';
 import * as Touch from './touch.js';
@@ -541,8 +542,10 @@ export class Gesture {
       // have higher priority than workspaces. The ordering within drags does
       // not matter, because the three types of dragging are exclusive.
       if (this.dragger) {
+        keyboardNavigationController.setIsActive(false);
         this.dragger.onDragEnd(e, this.currentDragDeltaXY);
       } else if (this.workspaceDragger) {
+        keyboardNavigationController.setIsActive(false);
         this.workspaceDragger.endDrag(this.currentDragDeltaXY);
       } else if (this.isBubbleClick()) {
         // Do nothing, bubbles don't currently respond to clicks.
@@ -742,6 +745,8 @@ export class Gesture {
     // TODO: Handle right-click on a bubble.
     e.preventDefault();
     e.stopPropagation();
+
+    keyboardNavigationController.setIsActive(false);
 
     this.dispose();
   }

--- a/core/keyboard_navigation_controller.ts
+++ b/core/keyboard_navigation_controller.ts
@@ -1,0 +1,50 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * The KeyboardNavigationController handles coordinating Blockly-wide
+ * keyboard navigation behavior, such as enabling/disabling full
+ * cursor visualization.
+ */
+export class KeyboardNavigationController {
+  /** Whether the user is actively using keyboard navigation. */
+  private isActive = false;
+  /** Css class name added to body if keyboard nav is active. */
+  private activeClassName = 'blocklyKeyboardNavigation';
+
+  /**
+   * Sets whether we think the user is actively using keyboard navigation.
+   *
+   * If they are, we'll apply a css class to the entire page so that
+   * focused items can apply additional styling for keyboard users.
+   *
+   * @param isUsing
+   */
+  setIsActive(isUsing: boolean = true) {
+    this.isActive = isUsing;
+    this.updateActiveVisualization();
+  }
+
+  /**
+   * @returns true if we think the user is actively using keyboard navigation
+   * (e.g., has recently taken some action that is only relevant to keyboard users)
+   */
+  getIsActive(): boolean {
+    return this.isActive;
+  }
+
+  /** Adds or removes the css class that indicates keyboard navigation is active. */
+  private updateActiveVisualization() {
+    if (this.isActive) {
+      document.body.classList.add(this.activeClassName);
+    } else {
+      document.body.classList.remove(this.activeClassName);
+    }
+  }
+}
+
+/** Singleton instance of the keyboard navigation controller. */
+export const keyboardNavigationController = new KeyboardNavigationController();

--- a/core/keyboard_navigation_controller.ts
+++ b/core/keyboard_navigation_controller.ts
@@ -16,10 +16,23 @@ export class KeyboardNavigationController {
   private activeClassName = 'blocklyKeyboardNavigation';
 
   /**
-   * Sets whether we think the user is actively using keyboard navigation.
+   * Sets whether a user is actively using keyboard navigation.
    *
-   * If they are, we'll apply a css class to the entire page so that
+   * If they are, apply a css class to the entire page so that
    * focused items can apply additional styling for keyboard users.
+   *
+   * Note that since enabling keyboard navigation presents significant UX changes
+   * (such as cursor visualization and move mode), callers should take care to
+   * only set active keyboard navigation when they have a high confidence in that
+   * being the correct state. In general, in any given mouse or key input situation
+   * callers can choose one of three paths:
+   * 1. Do nothing. This should be the choice for neutral actions that don't
+   *    predominantly imply keyboard or mouse usage (such as clicking to select a block).
+   * 2. Disable keyboard navigation. This is the best choice when a user is definitely
+   *    predominantly using the mouse (such as using a right click to open the context menu).
+   * 3. Enable keyboard navigation. This is the best choice when there's high confidence
+   *    a user actually intends to use it (such as attempting to use the arrow keys to move
+   *    around).
    *
    * @param isUsing
    */
@@ -29,7 +42,7 @@ export class KeyboardNavigationController {
   }
 
   /**
-   * @returns true if we think the user is actively using keyboard navigation
+   * @returns true if the user is actively using keyboard navigation
    * (e.g., has recently taken some action that is only relevant to keyboard users)
    */
   getIsActive(): boolean {

--- a/tests/mocha/index.html
+++ b/tests/mocha/index.html
@@ -240,6 +240,7 @@
       import './jso_deserialization_test.js';
       import './jso_serialization_test.js';
       import './json_test.js';
+      import './keyboard_navigation_controller_test.js';
       import './layering_test.js';
       import './blocks/lists_test.js';
       import './blocks/logic_ternary_test.js';

--- a/tests/mocha/keyboard_navigation_controller_test.js
+++ b/tests/mocha/keyboard_navigation_controller_test.js
@@ -1,0 +1,37 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {assert} from '../../node_modules/chai/chai.js';
+import {
+  sharedTestSetup,
+  sharedTestTeardown,
+} from './test_helpers/setup_teardown.js';
+
+suite('Keyboard Navigation Controller', function () {
+  setup(function () {
+    sharedTestSetup.call(this);
+    Blockly.keyboardNavigationController.setIsActive(false);
+  });
+
+  teardown(function () {
+    sharedTestTeardown.call(this);
+    Blockly.keyboardNavigationController.setIsActive(false);
+  });
+
+  test('Setting active keyboard navigation adds css class', function () {
+    Blockly.keyboardNavigationController.setIsActive(true);
+    assert.isTrue(
+      document.body.classList.contains('blocklyKeyboardNavigation'),
+    );
+  });
+
+  test('Disabling active keyboard navigation removes css class', function () {
+    Blockly.keyboardNavigationController.setIsActive(false);
+    assert.isFalse(
+      document.body.classList.contains('blocklyKeyboardNavigation'),
+    );
+  });
+});


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #8852 

### Proposed Changes

- Adds a `KeyboardNavigationController` singleton that has methods for setting keyboard navigation as active or not.

See matching PR in kbe https://github.com/google/blockly-keyboard-experimentation/pull/555

### Additional Information

The idea behind this is explained in #8852 

When a user takes a "mouse action" like dragging blocks or the workspace with the mouse or right-clicking a block, then we decide they're not using keyboard navigation and remove the css class.

When a user takes a "keyboard action" like pressing m for move mode, using the arrow keys to navigate, pressing w to get a workspace cursor, etc. we add the css class, which can be used to show additional styling such as passive focus in certain circumstances. So far these keyboard actions are only present in the keyboard-experiment plugin, so core will never set the value to true, so there's no way for this to affect projects that aren't using the keyboard plugin.

There are some ambiguous actions like using the keyboard to copy/paste that are frequently done by both mouse and keyboard users. Those actions do not update the mode one way or the other.

In this PR I also chose not to change the mode for simple block clicks. The reason is that Ben pointed out that for mixed-mode users, clicking might be simpler with the mouse (or a tap on touch devices) while other actions use keyboard shortcuts. I think the current behavior is good. It starts as false, so a mouse-only user won't ever see the extra styling for keyboard users. Keyboard users will see the extra styling when they take any of several common actions with the keyboard. Mixed mode users will largely always see the extra styling unless they use the mouse to drag blocks. This is an improvement over the current input mode tracking in the plugin which does not handle the ambiguous cases noted above.
