### PR TITLE
fix: LineCursor can loop forward, but not back

### DIFF
--- a/core/keyboard_nav/line_cursor.ts
+++ b/core/keyboard_nav/line_cursor.ts
@@ -146,10 +146,12 @@ export class LineCursor extends Marker {
     if (!curNode) {
       return null;
     }
-    const newNode = this.getPreviousNodeImpl(
+    const newNode = this.getPreviousNode(
       curNode,
       this.validLineNode.bind(this),
+      true,
     );
+
     if (newNode) {
       this.setCurNode(newNode);
     }
@@ -168,9 +170,10 @@ export class LineCursor extends Marker {
     if (!curNode) {
       return null;
     }
-    const newNode = this.getPreviousNodeImpl(
+    const newNode = this.getPreviousNode(
       curNode,
       this.validInLineNode.bind(this),
+      true,
     );
 
     if (newNode) {

--- a/tests/mocha/cursor_test.js
+++ b/tests/mocha/cursor_test.js
@@ -125,6 +125,15 @@ suite('Cursor', function () {
       assert.equal(curNode.getLocation(), this.blocks.A.nextConnection);
     });
 
+    test('Prev - From first connection loop to last next connection', function () {
+      const prevConnection = this.blocks.A.previousConnection;
+      const prevConnectionNode = ASTNode.createConnectionNode(prevConnection);
+      this.cursor.setCurNode(prevConnectionNode);
+      this.cursor.prev();
+      const curNode = this.cursor.getCurNode();
+      assert.equal(curNode.getLocation(), this.blocks.D.nextConnection);
+    });
+
     test('Out - From field does not skip over block node', function () {
       const field = this.blocks.E.inputList[0].fieldRow[0];
       const fieldNode = ASTNode.createFieldNode(field);
@@ -132,6 +141,15 @@ suite('Cursor', function () {
       this.cursor.out();
       const curNode = this.cursor.getCurNode();
       assert.equal(curNode.getLocation(), this.blocks.E);
+    });
+
+    test('Out - From first connection loop to last next connection', function () {
+      const prevConnection = this.blocks.A.previousConnection;
+      const prevConnectionNode = ASTNode.createConnectionNode(prevConnection);
+      this.cursor.setCurNode(prevConnectionNode);
+      this.cursor.prev();
+      const curNode = this.cursor.getCurNode();
+      assert.equal(curNode.getLocation(), this.blocks.D.nextConnection);
     });
   });
   suite('Searching', function () {

--- a/tests/mocha/cursor_test.js
+++ b/tests/mocha/cursor_test.js
@@ -147,7 +147,7 @@ suite('Cursor', function () {
       const prevConnection = this.blocks.A.previousConnection;
       const prevConnectionNode = ASTNode.createConnectionNode(prevConnection);
       this.cursor.setCurNode(prevConnectionNode);
-      this.cursor.prev();
+      this.cursor.out();
       const curNode = this.cursor.getCurNode();
       assert.equal(curNode.getLocation(), this.blocks.D.nextConnection);
     });


### PR DESCRIPTION
## The basics

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

Fixes https://github.com/google/blockly/issues/8901 

### Proposed Changes

- Use `getPreviousNode` in `prev` and `out` methods so that the `loop` parameter can be used and set as `true`.
- Add tests for loopback in `prev` and `out` methods.

### Reason for Changes

To fix https://github.com/google/blockly/issues/8901 so that cursor loops when keyboard navigating blocks backwards (up arrow keys, or left arrow keys) as it can forwards.

### Test Coverage

Added loop tests for `prev` and `out` in `cursor_test.ts`.

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
