### PR TITLE
fix: Fix bug in `BlockSvg.prototype.setParent`

### DIFF
--- a/core/block_svg.ts
+++ b/core/block_svg.ts
@@ -305,14 +305,22 @@ export class BlockSvg
       (newParent as BlockSvg).getSvgRoot().appendChild(svgRoot);
     } else if (oldParent) {
       // If we are losing a parent, we want to move our DOM element to the
-      // root of the workspace.
-      const draggingBlock = this.workspace
+      // root of the workspace.  Try to insert it before any top-level
+      // block being dragged, but note that blocks can have the
+      // blocklyDragging class even if they're not top blocks (especially
+      // at start and end of a drag).
+      const draggingBlockElement = this.workspace
         .getCanvas()
         .querySelector('.blocklyDragging');
-      if (draggingBlock) {
-        this.workspace.getCanvas().insertBefore(svgRoot, draggingBlock);
+      const draggingParentElement = draggingBlockElement?.parentElement as
+        | SVGElement
+        | null
+        | undefined;
+      const canvass = this.workspace.getCanvas();
+      if (draggingParentElement === canvass) {
+        canvass.insertBefore(svgRoot, draggingBlockElement);
       } else {
-        this.workspace.getCanvas().appendChild(svgRoot);
+        canvass.appendChild(svgRoot);
       }
       this.translate(oldXY.x, oldXY.y);
     }

--- a/core/dragging/block_drag_strategy.ts
+++ b/core/dragging/block_drag_strategy.ts
@@ -445,6 +445,9 @@ export class BlockDragStrategy implements IDragStrategy {
       return;
     }
 
+    this.connectionPreviewer!.hidePreview();
+    this.connectionCandidate = null;
+
     this.startChildConn?.connect(this.block.nextConnection);
     if (this.startParentConn) {
       switch (this.startParentConn.type) {
@@ -470,9 +473,6 @@ export class BlockDragStrategy implements IDragStrategy {
 
     this.startChildConn = null;
     this.startParentConn = null;
-
-    this.connectionPreviewer!.hidePreview();
-    this.connectionCandidate = null;
 
     this.block.setDragging(false);
     this.dragging = false;

--- a/tests/mocha/block_test.js
+++ b/tests/mocha/block_test.js
@@ -1105,6 +1105,18 @@ suite('Blocks', function () {
         );
         this.textJoinBlock = this.printBlock.getInputTargetBlock('TEXT');
         this.textBlock = this.textJoinBlock.getInputTargetBlock('ADD0');
+        this.extraTopBlock = Blockly.Xml.domToBlock(
+          Blockly.utils.xml.textToDom(`
+            <block type="text_print">
+              <value name="TEXT">
+                <block type="text">
+                  <field name="TEXT">drag me</field>
+                </block>
+              </value>
+            </block>`),
+          this.workspace,
+        );
+        this.extraNestedBlock = this.extraTopBlock.getInputTargetBlock('TEXT');
       });
 
       function assertBlockIsOnlyChild(parent, child, inputName) {
@@ -1116,6 +1128,10 @@ suite('Blocks', function () {
         assert.equal(nonParent.getChildren().length, 0);
         assert.isNull(nonParent.getInputTargetBlock('TEXT'));
         assert.isNull(orphan.getParent());
+        assert.equal(
+          orphan.getSvgRoot().parentElement,
+          orphan.workspace.getCanvas(),
+        );
       }
       function assertOriginalSetup() {
         assertBlockIsOnlyChild(this.printBlock, this.textJoinBlock, 'TEXT');
@@ -1186,6 +1202,27 @@ suite('Blocks', function () {
           this.textBlock.setParent.bind(this.textBlock, null),
         );
         assertNonParentAndOrphan(this.textJoinBlock, this.textBlock, 'ADD0');
+      });
+      test('Setting parent to null with dragging block', function () {
+        this.extraTopBlock.setDragging(true);
+        this.textBlock.outputConnection.disconnect();
+        assert.doesNotThrow(
+          this.textBlock.setParent.bind(this.textBlock, null),
+        );
+        assertNonParentAndOrphan(this.textJoinBlock, this.textBlock, 'ADD0');
+        assert.equal(
+          this.textBlock.getSvgRoot().nextSibling,
+          this.extraTopBlock.getSvgRoot(),
+        );
+      });
+      test('Setting parent to null with non-top dragging block', function () {
+        this.extraNestedBlock.setDragging(true);
+        this.textBlock.outputConnection.disconnect();
+        assert.doesNotThrow(
+          this.textBlock.setParent.bind(this.textBlock, null),
+        );
+        assertNonParentAndOrphan(this.textJoinBlock, this.textBlock, 'ADD0');
+        assert.equal(this.textBlock.getSvgRoot().nextSibling, null);
       });
       test('Setting parent to null without disconnecting', function () {
         assert.throws(this.textBlock.setParent.bind(this.textBlock, null));


### PR DESCRIPTION
## The basics

- [X] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

Fix an incorrect assumption in `setParent` when handling `.setParent(null)` calls.

Fixes #8853.

(But see comments on that bug for detail.)

### Proposed Changes

* In `BlockSvg.prototype.setParent`, when setting parent to `null`, check to see if the top-most `blocklyDragging` element is in fact a direct child of the canvass before attempting to insert the new top-level block ahead of it in the canvass's contents.
* In `BlockDragStragegy.prototype.revertDrag`, call `connectionPreviewer.hidePreview()` earlier, before attempting to reconnect the dragged block to its original parent.  Not strictly necessary but makes more sense.

### Reason for Changes

The topmost block whose root SVG element has the `blocklyDragging` class may not actually be a top-level block on the workspace, but the existing implementation assumed that was true and would throw an error if it wasn't.  This resulted in problems when reverting a drag if an insertion marker was displayed.

### Test Coverage

Adds two new tests for `setParent` (one of which actually caught a bug that existed in an earlier version of the fix in this PR!)

