### PR TITLE
refactor!: Finish refactor of `WorkspaceSvg` `VariableMap` methods

### DIFF
--- a/core/block_svg.ts
+++ b/core/block_svg.ts
@@ -1079,13 +1079,15 @@ export class BlockSvg
   }
 
   /**
-   * @deprecated v11 - Set whether the block is manually enabled or disabled.
+   * Set whether the block is manually enabled or disabled.
+   *
    * The user can toggle whether a block is disabled from a context menu
    * option. A block may still be disabled for other reasons even if the user
    * attempts to manually enable it, such as when the block is in an invalid
    * location. This method is deprecated and setDisabledReason should be used
    * instead.
    *
+   * @deprecated v11: use setDisabledReason.
    * @param enabled True if enabled.
    */
   override setEnabled(enabled: boolean) {

--- a/core/events/events_var_create.ts
+++ b/core/events/events_var_create.ts
@@ -113,10 +113,12 @@ export class VarCreate extends VarBase {
           'the constructor, or call fromJson',
       );
     }
+    const variableMap = workspace.getVariableMap();
     if (forward) {
-      workspace.createVariable(this.varName, this.varType, this.varId);
+      variableMap.createVariable(this.varName, this.varType, this.varId);
     } else {
-      workspace.deleteVariableById(this.varId);
+      const variable = variableMap.getVariableById(this.varId);
+      if (variable) variableMap.deleteVariable(variable);
     }
   }
 }

--- a/core/events/events_var_delete.ts
+++ b/core/events/events_var_delete.ts
@@ -106,10 +106,12 @@ export class VarDelete extends VarBase {
           'the constructor, or call fromJson',
       );
     }
+    const variableMap = workspace.getVariableMap();
     if (forward) {
-      workspace.deleteVariableById(this.varId);
+      const variable = variableMap.getVariableById(this.varId);
+      if (variable) variableMap.deleteVariable(variable);
     } else {
-      workspace.createVariable(this.varName, this.varType, this.varId);
+      variableMap.createVariable(this.varName, this.varType, this.varId);
     }
   }
 }

--- a/core/events/events_var_rename.ts
+++ b/core/events/events_var_rename.ts
@@ -115,10 +115,12 @@ export class VarRename extends VarBase {
           'the constructor, or call fromJson',
       );
     }
+    const variableMap = workspace.getVariableMap();
+    const variable = variableMap.getVariableById(this.varId);
     if (forward) {
-      workspace.renameVariableById(this.varId, this.newName);
+      if (variable) variableMap.renameVariable(variable, this.newName);
     } else {
-      workspace.renameVariableById(this.varId, this.oldName);
+      if (variable) variableMap.renameVariable(variable, this.oldName);
     }
   }
 }

--- a/core/field_variable.ts
+++ b/core/field_variable.ts
@@ -586,7 +586,9 @@ export class FieldVariable extends FieldDropdown {
       // doesn't modify the workspace's list.
       for (let i = 0; i < variableTypes.length; i++) {
         const variableType = variableTypes[i];
-        const variables = workspace.getVariablesOfType(variableType);
+        const variables = workspace
+          .getVariableMap()
+          .getVariablesOfType(variableType);
         variableModelList = variableModelList.concat(variables);
         if (workspace.isFlyout) {
           variableModelList = variableModelList.concat(

--- a/core/variable_map.ts
+++ b/core/variable_map.ts
@@ -27,6 +27,7 @@ import * as deprecation from './utils/deprecation.js';
 import * as idGenerator from './utils/idgenerator.js';
 import * as Variables from './variables.js';
 import type {Workspace} from './workspace.js';
+import {WorkspaceSvg} from './workspace_svg.js';
 
 /**
  * Class for a variable map.  This contains a dictionary data structure with
@@ -92,6 +93,9 @@ export class VariableMap
     } finally {
       eventUtils.setGroup(existingGroup);
     }
+    if (this.workspace instanceof WorkspaceSvg) {
+      this.workspace.refreshToolboxSelection();
+    }
     return variable;
   }
 
@@ -108,7 +112,9 @@ export class VariableMap
     if (!this.variableMap.has(newType)) {
       this.variableMap.set(newType, newTypeVariables);
     }
-
+    if (this.workspace instanceof WorkspaceSvg) {
+      this.workspace.refreshToolboxSelection();
+    }
     return variable;
   }
 
@@ -154,6 +160,9 @@ export class VariableMap
     variable.setName(newName);
     for (let i = 0; i < blocks.length; i++) {
       blocks[i].updateVarName(variable);
+    }
+    if (this.workspace instanceof WorkspaceSvg) {
+      this.workspace.refreshToolboxSelection();
     }
   }
 
@@ -250,6 +259,9 @@ export class VariableMap
       this.variableMap.set(type, variables);
     }
     eventUtils.fire(new (eventUtils.get(EventType.VAR_CREATE))(variable));
+    if (this.workspace instanceof WorkspaceSvg) {
+      this.workspace.refreshToolboxSelection();
+    }
     return variable;
   }
 
@@ -267,6 +279,9 @@ export class VariableMap
       );
     }
     this.variableMap.get(type)?.set(variable.getId(), variable);
+    if (this.workspace instanceof WorkspaceSvg) {
+      this.workspace.refreshToolboxSelection();
+    }
   }
 
   /* Begin functions for variable deletion. */
@@ -294,6 +309,9 @@ export class VariableMap
       }
     } finally {
       eventUtils.setGroup(existingGroup);
+    }
+    if (this.workspace instanceof WorkspaceSvg) {
+      this.workspace.refreshToolboxSelection();
     }
   }
 

--- a/core/variable_map.ts
+++ b/core/variable_map.ts
@@ -25,7 +25,7 @@ import {Names} from './names.js';
 import * as registry from './registry.js';
 import * as deprecation from './utils/deprecation.js';
 import * as idGenerator from './utils/idgenerator.js';
-import * as Variables from './variables.js';
+import {deleteVariable, getVariableUsesById} from './variables.js';
 import type {Workspace} from './workspace.js';
 import {WorkspaceSvg} from './workspace_svg.js';
 
@@ -291,7 +291,7 @@ export class VariableMap
    * @param variable Variable to delete.
    */
   deleteVariable(variable: IVariableModel<IVariableState>) {
-    const uses = this.getVariableUsesById(variable.getId());
+    const uses = getVariableUsesById(this.workspace, variable.getId());
     const existingGroup = eventUtils.getGroup();
     if (!existingGroup) {
       eventUtils.setGroup(true);
@@ -331,7 +331,7 @@ export class VariableMap
     );
     const variable = this.getVariableById(id);
     if (variable) {
-      Variables.deleteVariable(this.workspace, variable);
+      deleteVariable(this.workspace, variable);
     }
   }
 
@@ -449,7 +449,7 @@ export class VariableMap
       'v13',
       'Blockly.Variables.getVariableUsesById',
     );
-    return Variables.getVariableUsesById(this.workspace, id);
+    return getVariableUsesById(this.workspace, id);
   }
 }
 

--- a/core/variable_map.ts
+++ b/core/variable_map.ts
@@ -116,7 +116,7 @@ export class VariableMap
    * Rename a variable by updating its name in the variable map. Identify the
    * variable to rename with the given ID.
    *
-   * @deprecated v12, use VariableMap.renameVariable.
+   * @deprecated v12: use VariableMap.renameVariable.
    * @param id ID of the variable to rename.
    * @param newName New variable name.
    */
@@ -301,7 +301,7 @@ export class VariableMap
    * Delete a variables by the passed in ID and all of its uses from this
    * workspace. May prompt the user for confirmation.
    *
-   * @deprecated v12, use Blockly.Variables.deleteVariable.
+   * @deprecated v12: use Blockly.Variables.deleteVariable.
    * @param id ID of variable to delete.
    */
   deleteVariableById(id: string) {
@@ -398,7 +398,7 @@ export class VariableMap
   /**
    * Returns all of the variable names of all types.
    *
-   * @deprecated v12, use Blockly.Variables.getAllVariables.
+   * @deprecated v12: use Blockly.Variables.getAllVariables.
    * @returns All of the variable names of all types.
    */
   getAllVariableNames(): string[] {
@@ -420,7 +420,7 @@ export class VariableMap
   /**
    * Find all the uses of a named variable.
    *
-   * @deprecated v12, use Blockly.Variables.getVariableUsesById.
+   * @deprecated v12: use Blockly.Variables.getVariableUsesById.
    * @param id ID of the variable to find.
    * @returns Array of block usages.
    */

--- a/core/variables.ts
+++ b/core/variables.ts
@@ -31,8 +31,9 @@ export const CATEGORY_NAME = 'VARIABLE';
 /**
  * Find all user-created variables that are in use in the workspace.
  * For use by generators.
+ *
  * To get a list of all variables on a workspace, including unused variables,
- * call Workspace.getAllVariables.
+ * call getAllVariables.
  *
  * @param ws The workspace to search for variables.
  * @returns Array of variable models.
@@ -61,6 +62,7 @@ export function allUsedVarModels(
 
 /**
  * Find all developer variables used by blocks in the workspace.
+ *
  * Developer variables are never shown to the user, but are declared as global
  * variables in the generated code.
  * To declare developer variables, define the getDeveloperVariables function on
@@ -146,7 +148,7 @@ export function flyoutCategory(
     },
     ...jsonFlyoutCategoryBlocks(
       workspace,
-      workspace.getVariablesOfType(''),
+      workspace.getVariableMap().getVariablesOfType(''),
       true,
     ),
   ];
@@ -268,7 +270,7 @@ function xmlFlyoutCategory(workspace: WorkspaceSvg): Element[] {
  * @returns Array of XML block elements.
  */
 export function flyoutCategoryBlocks(workspace: Workspace): Element[] {
-  const variableModelList = workspace.getVariablesOfType('');
+  const variableModelList = workspace.getVariableMap().getVariablesOfType('');
 
   const xmlList = [];
   if (variableModelList.length > 0) {
@@ -332,7 +334,10 @@ export function generateUniqueName(workspace: Workspace): string {
 function generateUniqueNameInternal(workspace: Workspace): string {
   return generateUniqueNameFromOptions(
     VAR_LETTER_OPTIONS.charAt(0),
-    workspace.getAllVariableNames(),
+    workspace
+      .getVariableMap()
+      .getAllVariables()
+      .map((v) => v.getName()),
   );
 }
 
@@ -415,7 +420,7 @@ export function createVariableButtonHandler(
       const existing = nameUsedWithAnyType(text, workspace);
       if (!existing) {
         // No conflict
-        workspace.createVariable(text, type);
+        workspace.getVariableMap().createVariable(text, type);
         if (opt_callback) opt_callback(text);
         return;
       }
@@ -478,7 +483,7 @@ export function renameVariable(
       );
       if (!existing && !procedure) {
         // No conflict.
-        workspace.renameVariableById(variable.getId(), newName);
+        workspace.getVariableMap().renameVariable(variable, newName);
         if (opt_callback) opt_callback(newName);
         return;
       }
@@ -762,6 +767,7 @@ function createVariable(
   opt_name?: string,
   opt_type?: string,
 ): IVariableModel<IVariableState> {
+  const variableMap = workspace.getVariableMap();
   const potentialVariableMap = workspace.getPotentialVariableMap();
   // Variables without names get uniquely named for this workspace.
   if (!opt_name) {
@@ -781,7 +787,7 @@ function createVariable(
     );
   } else {
     // In the main workspace, create a real variable.
-    variable = workspace.createVariable(opt_name, opt_type, id);
+    variable = variableMap.createVariable(opt_name, opt_type, id);
   }
   return variable;
 }

--- a/core/variables_dynamic.ts
+++ b/core/variables_dynamic.ts
@@ -148,7 +148,7 @@ export function flyoutCategory(
     },
     ...Variables.jsonFlyoutCategoryBlocks(
       workspace,
-      workspace.getAllVariables(),
+      workspace.getVariableMap().getAllVariables(),
       false,
       'variables_get_dynamic',
       'variables_set_dynamic',
@@ -203,7 +203,7 @@ function xmlFlyoutCategory(workspace: WorkspaceSvg): Element[] {
  * @returns Array of XML block elements.
  */
 export function flyoutCategoryBlocks(workspace: Workspace): Element[] {
-  const variableModelList = workspace.getAllVariables();
+  const variableModelList = workspace.getVariableMap().getAllVariables();
 
   const xmlList = [];
   if (variableModelList.length > 0) {

--- a/core/workspace.ts
+++ b/core/workspace.ts
@@ -37,7 +37,7 @@ import * as deprecation from './utils/deprecation.js';
 import * as idGenerator from './utils/idgenerator.js';
 import * as math from './utils/math.js';
 import type * as toolbox from './utils/toolbox.js';
-import * as Variables from './variables.js';
+import {deleteVariable, getVariableUsesById} from './variables.js';
 
 /**
  * Class for a workspace.  This is a data structure that contains blocks.
@@ -449,7 +449,7 @@ export class Workspace implements IASTNodeLocation {
       'v13',
       'Blockly.Workspace.getVariableMap().getVariableUsesById',
     );
-    return Variables.getVariableUsesById(this, id);
+    return getVariableUsesById(this, id);
   }
 
   /**
@@ -471,7 +471,7 @@ export class Workspace implements IASTNodeLocation {
       console.warn(`Can't delete non-existent variable: ${id}`);
       return;
     }
-    Variables.deleteVariable(this, variable);
+    deleteVariable(this, variable);
   }
 
   /**

--- a/core/workspace.ts
+++ b/core/workspace.ts
@@ -386,9 +386,10 @@ export class Workspace implements IASTNodeLocation {
 
   /* Begin functions that are just pass-throughs to the variable map. */
   /**
-   * @deprecated v12 - Rename a variable by updating its name in the variable
+   * Rename a variable by updating its name in the variable
    * map. Identify the variable to rename with the given ID.
    *
+   * @deprecated v12: use Blockly.Workspace.getVariableMap().renameVariable
    * @param id ID of the variable to rename.
    * @param newName New variable name.
    */
@@ -407,7 +408,7 @@ export class Workspace implements IASTNodeLocation {
   /**
    * Create a variable with a given name, optional type, and optional ID.
    *
-   * @deprecated v12, use Blockly.Workspace.getVariableMap().createVariable.
+   * @deprecated v12: use Blockly.Workspace.getVariableMap().createVariable.
    * @param name The name of the variable. This must be unique across variables
    *     and procedures.
    * @param opt_type The type of the variable like 'int' or 'string'.
@@ -437,7 +438,7 @@ export class Workspace implements IASTNodeLocation {
   /**
    * Find all the uses of the given variable, which is identified by ID.
    *
-   * @deprecated v12, use Blockly.Workspace.getVariableMap().getVariableUsesById
+   * @deprecated v12: use Blockly.Workspace.getVariableMap().getVariableUsesById
    * @param id ID of the variable to find.
    * @returns Array of block usages.
    */
@@ -455,7 +456,7 @@ export class Workspace implements IASTNodeLocation {
    * Delete a variables by the passed in ID and all of its uses from this
    * workspace. May prompt the user for confirmation.
    *
-   * @deprecated v12, use Blockly.Workspace.getVariableMap().deleteVariable.
+   * @deprecated v12: use Blockly.Workspace.getVariableMap().deleteVariable.
    * @param id ID of variable to delete.
    */
   deleteVariableById(id: string) {
@@ -477,7 +478,7 @@ export class Workspace implements IASTNodeLocation {
    * Find the variable by the given name and return it. Return null if not
    * found.
    *
-   * @deprecated v12, use Blockly.Workspace.getVariableMap().getVariable.
+   * @deprecated v12: use Blockly.Workspace.getVariableMap().getVariable.
    * @param name The name to check for.
    * @param opt_type The type of the variable.  If not provided it defaults to
    *     the empty string, which is a specific type.
@@ -500,7 +501,7 @@ export class Workspace implements IASTNodeLocation {
   /**
    * Find the variable by the given ID and return it. Return null if not found.
    *
-   * @deprecated v12, use Blockly.Workspace.getVariableMap().getVariableById.
+   * @deprecated v12: use Blockly.Workspace.getVariableMap().getVariableById.
    * @param id The ID to check for.
    * @returns The variable with the given ID.
    */
@@ -518,7 +519,7 @@ export class Workspace implements IASTNodeLocation {
    * Find the variable with the specified type. If type is null, return list of
    *     variables with empty string type.
    *
-   * @deprecated v12, use Blockly.Workspace.getVariableMap().getVariablesOfType.
+   * @deprecated v12: use Blockly.Workspace.getVariableMap().getVariablesOfType.
    * @param type Type of the variables to find.
    * @returns The sought after variables of the passed in type. An empty array
    *     if none are found.
@@ -536,7 +537,7 @@ export class Workspace implements IASTNodeLocation {
   /**
    * Return all variables of all types.
    *
-   * @deprecated v12, use Blockly.Workspace.getVariableMap().getAllVariables.
+   * @deprecated v12: use Blockly.Workspace.getVariableMap().getAllVariables.
    * @returns List of variable models.
    */
   getAllVariables(): IVariableModel<IVariableState>[] {
@@ -552,7 +553,7 @@ export class Workspace implements IASTNodeLocation {
   /**
    * Returns all variable names of all types.
    *
-   * @deprecated v12, use Blockly.Workspace.getVariableMap().getAllVariables.
+   * @deprecated v12: use Blockly.Workspace.getVariableMap().getAllVariables.
    * @returns List of all variable names of all types.
    */
   getAllVariableNames(): string[] {

--- a/core/workspace_svg.ts
+++ b/core/workspace_svg.ts
@@ -46,10 +46,6 @@ import type {IDragTarget} from './interfaces/i_drag_target.js';
 import type {IFlyout} from './interfaces/i_flyout.js';
 import type {IMetricsManager} from './interfaces/i_metrics_manager.js';
 import type {IToolbox} from './interfaces/i_toolbox.js';
-import type {
-  IVariableModel,
-  IVariableState,
-} from './interfaces/i_variable_model.js';
 import type {LineCursor} from './keyboard_nav/line_cursor.js';
 import type {Marker} from './keyboard_nav/marker.js';
 import {LayerManager} from './layer_manager.js';
@@ -1332,50 +1328,6 @@ export class WorkspaceSvg
     if (ws && !ws.currentGesture_ && ws.toolbox && ws.toolbox.getFlyout()) {
       ws.toolbox.refreshSelection();
     }
-  }
-
-  /**
-   * Rename a variable by updating its name in the variable map.  Update the
-   *     flyout to show the renamed variable immediately.
-   *
-   * @param id ID of the variable to rename.
-   * @param newName New variable name.
-   */
-  override renameVariableById(id: string, newName: string) {
-    super.renameVariableById(id, newName);
-    this.refreshToolboxSelection();
-  }
-
-  /**
-   * Delete a variable by the passed in ID.   Update the flyout to show
-   *     immediately that the variable is deleted.
-   *
-   * @param id ID of variable to delete.
-   */
-  override deleteVariableById(id: string) {
-    super.deleteVariableById(id);
-    this.refreshToolboxSelection();
-  }
-
-  /**
-   * Create a new variable with the given name.  Update the flyout to show the
-   *     new variable immediately.
-   *
-   * @param name The new variable's name.
-   * @param opt_type The type of the variable like 'int' or 'string'.
-   *     Does not need to be unique. Field_variable can filter variables based
-   * on their type. This will default to '' which is a specific type.
-   * @param opt_id The unique ID of the variable. This will default to a UUID.
-   * @returns The newly created variable.
-   */
-  override createVariable(
-    name: string,
-    opt_type?: string | null,
-    opt_id?: string | null,
-  ): IVariableModel<IVariableState> {
-    const newVar = super.createVariable(name, opt_type, opt_id);
-    this.refreshToolboxSelection();
-    return newVar;
   }
 
   /** Make a list of all the delete areas for this workspace. */

--- a/core/xml.ts
+++ b/core/xml.ts
@@ -703,7 +703,7 @@ export function domToVariables(xmlVariables: Element, workspace: Workspace) {
     const name = xmlChild.textContent;
 
     if (!name) return;
-    workspace.createVariable(name, type, id);
+    workspace.getVariableMap().createVariable(name, type ?? undefined, id);
   }
 }
 


### PR DESCRIPTION
## The basics

- [X] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

Fixes closure compiler warnings for calls to deprecated methods.

Part of #8945.

### Proposed Changes

Delete the following methods from `WorkspaceSvg`:

- `renameVariableById`
- `deleteVariableById`
- `createVariable`

Modify the following methods on `VariableMap` to call `this.workspace.refreshToolboxSelection()` if this.workspace is a `WorkspaceSvg`, replicating the behaviour of the aforementioned deleted methods and additionally ensuring that that method is called following any change to the variable map:

- `renameVariable`
- `changeVariableType`
- `renameVariableAndUses`
- `createVariable`
- `addVariable`
- `deleteVariable`

Additionally, refactor remaining calls to deprecated `Workspace` variable methods in `core/`, and improve consistency of use of `@deprecated` JSDoc tag.

### Reason for Changes

PR #8401 deprecated certain `…ById` methods on `VariableMap`, and PR #8415 subsequently deprecated related wrapper methods on `Workspace`, but the versions of these methods on `WorkspaceSvg` were not deprecated despite continuing to call the deprecated superclass versions.

### Test Coverage

Passes `npm test` and some manual sanity checking of variable field behaviour.

### Documentation

Deprecation of variable-related methods on `Workspace` worth calling out in release notes.

### Additional Information

Opened #8945 to track remaining (non-`core/`) cleanup from this series of refactors/deprecations.

**BREAKING CHANGE:**

This change ensures that the toolbox will be refreshed regardless of what route the `VaribleMap` was updated, rather than only being refreshed when it is updated via calls to methods on `WorkspaceSvg`.

Overall this is much more likely to fix a bug (where the toolbox wasn't being refreshed when it should have been) than cause one (by refreshing the toolbox when it shouldn't be), but this is still a behaviour change which could _conceivably_ result an
unexpected regression.
