### PR TITLE
chore: update assignment workflow permissions for v12

### DIFF
--- a/.github/workflows/assign_reviewers.yml
+++ b/.github/workflows/assign_reviewers.yml
@@ -15,6 +15,8 @@ on:
 jobs:
   requested-reviewer:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     steps:
       - name: Assign requested reviewer
         uses: actions/github-script@v7


### PR DESCRIPTION
_This is a cherry-pick of #8811 into the v12 release branch._

## The basics

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

(ish--largely relying on the original testing for this PR since it's actions-related)

## The details
### Resolves

This fixes the same issue as #8811 but on the v12 branch.

### Proposed Changes

See #8811.

### Reason for Changes

The failing assignee workflow will continue on v12 so the cherry-pick makes the next couple of PRs for this branch a bit nicer, but it's not a strong must-have since we'll eventually merge `develop` into `v12` which would then include #8811.

### Test Coverage

N/A -- There's no strong benefit from automated tests for this workflow, and it was manually tested as part of #8811 (see https://github.com/google/blockly/pull/8811#issuecomment-2822741434).

### Documentation

N/A -- No documentation changes are needed for this.

### Additional Information

None.