### PR TITLE
fix: Address remaining invisible input positions

### DIFF
--- a/core/keyboard_nav/ast_node.ts
+++ b/core/keyboard_nav/ast_node.ts
@@ -131,6 +131,10 @@ export class ASTNode {
     return this.isConnectionLocation;
   }
 
+  private getVisibleInputs(block: Block): Input[] {
+    return block.inputList.filter((input) => input.isVisible());
+  }
+
   /**
    * Given an input find the next editable field or an input with a non null
    * connection in the same block. The current location must be an input
@@ -145,9 +149,10 @@ export class ASTNode {
     const block = parentInput?.getSourceBlock();
     if (!block || !parentInput) return null;
 
-    const curIdx = block.inputList.indexOf(parentInput);
-    for (let i = curIdx + 1; i < block.inputList.length; i++) {
-      const input = block.inputList[i];
+    const visibleInputs = this.getVisibleInputs(block);
+    const curIdx = visibleInputs.indexOf(parentInput);
+    for (let i = curIdx + 1; i < visibleInputs.length; i++) {
+      const input = visibleInputs[i];
       const fieldRow = input.fieldRow;
       for (let j = 0; j < fieldRow.length; j++) {
         const field = fieldRow[j];
@@ -178,10 +183,11 @@ export class ASTNode {
         'The current AST location is not associated with a block',
       );
     }
-    const curIdx = block.inputList.indexOf(input);
+    const visibleInputs = this.getVisibleInputs(block);
+    const curIdx = visibleInputs.indexOf(input);
     let fieldIdx = input.fieldRow.indexOf(location) + 1;
-    for (let i = curIdx; i < block.inputList.length; i++) {
-      const newInput = block.inputList[i];
+    for (let i = curIdx; i < visibleInputs.length; i++) {
+      const newInput = visibleInputs[i];
       const fieldRow = newInput.fieldRow;
       while (fieldIdx < fieldRow.length) {
         if (fieldRow[fieldIdx].isClickable() || ASTNode.NAVIGATE_ALL_FIELDS) {
@@ -210,9 +216,10 @@ export class ASTNode {
     const block = parentInput?.getSourceBlock();
     if (!block || !parentInput) return null;
 
-    const curIdx = block.inputList.indexOf(parentInput);
+    const visibleInputs = this.getVisibleInputs(block);
+    const curIdx = visibleInputs.indexOf(parentInput);
     for (let i = curIdx; i >= 0; i--) {
-      const input = block.inputList[i];
+      const input = visibleInputs[i];
       if (input.connection && input !== parentInput) {
         return ASTNode.createInputNode(input);
       }
@@ -242,10 +249,11 @@ export class ASTNode {
         'The current AST location is not associated with a block',
       );
     }
-    const curIdx = block.inputList.indexOf(parentInput);
+    const visibleInputs = this.getVisibleInputs(block);
+    const curIdx = visibleInputs.indexOf(parentInput);
     let fieldIdx = parentInput.fieldRow.indexOf(location) - 1;
     for (let i = curIdx; i >= 0; i--) {
-      const input = block.inputList[i];
+      const input = visibleInputs[i];
       if (input.connection && input !== parentInput) {
         return ASTNode.createInputNode(input);
       }
@@ -259,7 +267,7 @@ export class ASTNode {
       // Reset the fieldIdx to the length of the field row of the previous
       // input.
       if (i - 1 >= 0) {
-        fieldIdx = block.inputList[i - 1].fieldRow.length - 1;
+        fieldIdx = visibleInputs[i - 1].fieldRow.length - 1;
       }
     }
     return null;
@@ -458,10 +466,9 @@ export class ASTNode {
    * block.
    */
   private findFirstFieldOrInput(block: Block): ASTNode | null {
-    const inputs = block.inputList;
-    for (let i = 0; i < inputs.length; i++) {
-      const input = inputs[i];
-      if (!input.isVisible()) continue;
+    const visibleInputs = this.getVisibleInputs(block);
+    for (let i = 0; i < visibleInputs.length; i++) {
+      const input = visibleInputs[i];
 
       const fieldRow = input.fieldRow;
       for (let j = 0; j < fieldRow.length; j++) {


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

Fixes https://github.com/google/blockly-keyboard-experimentation/issues/269

### Proposed Changes

This PR updates ASTNode to operate only on visible inputs that are filtered by a new private method when searching for an input or field to navigate to. Previous work didn't fully address the problem as noted on https://github.com/google/blockly-keyboard-experimentation/issues/269

### Reason for Changes

As above.

### Test Coverage

There are no existing unit tests to my knowledge. We have run this version of Blockly and the latest keyboard experimentation plugin in MakeCode and manually verified that the invisible navigation positions have been removed.

### Documentation

N/A

### Additional Information

N/A
