### PR TITLE
fix: remove black outline on focused items

### DIFF
--- a/core/css.ts
+++ b/core/css.ts
@@ -494,4 +494,13 @@ input[type=number] {
   cursor: grabbing;
 }
 
+.blocklyActiveFocus:is(
+  .blocklyFlyout,
+  .blocklyWorkspace,
+  .blocklyField,
+  .blocklyPath,
+  .blocklyHighlightedConnectionPath
+) {
+  outline-width: 0px;
+}
 `;


### PR DESCRIPTION
## The basics

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves
Fixes an issue found while working on #8950 

The black outline around the selected block should not be visible when the keyboard nav plugin is not involved. Also true for the workspace, flyout, and toolbox.

![439657793-9ce0dfa8-c9a8-4a4a-b412-cfc627a11951](https://github.com/user-attachments/assets/a51ff7a3-4b69-4a66-9cb1-895716a33270)

### Proposed Changes

Add CSS that sets outline width to zero on the focus items.

### Reason for Changes

Fix visual regression.

### Test Coverage
Tested by clicking around in the playground to change focus, including
- field (during edit)
- field (after edit)
- block
- toolbox
- workspace background
- flyout
- blocks in flyout

### Additional Information

CSS provided by @BenHenning 