### PR TITLE
fix: Fix conventional auto labeling

### DIFF
--- a/.github/workflows/conventional-label.yml
+++ b/.github/workflows/conventional-label.yml
@@ -8,7 +8,7 @@ jobs:
   label:
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      issues: write
       pull-requests: write
     steps:
       - uses: bcoe/conventional-release-labels@v1


### PR DESCRIPTION
## The basics

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

This fixes the ongoing CI failure for the conventional auto-labeling.

### Proposed Changes

This fixes the permissions in a way that should work. It may be the case that 'issues' only needs to be 'read' but I'm basically just copying what's done in https://github.com/GoogleCloudPlatform/developer-journey-app/blob/main/.github/workflows/auto-label.yml since it's working for them.

### Reason for Changes

We want this workflow working--it's preferable to avoid getting used to a failing CI workflow (ideally every PR has zero CI failures).

As for the specific changes, note that the check will still fail in this PR. Similar to #8811, it's not expected that the CI workflow will pass in this PR until the change is checked in since the workflow uses 'pull_request_target'. While I haven't verified this change directly, I'm fairly confident it will work given the project linked above and our successes with fixing the auto assigner workflow.

Finally, the 'contents: read' bit is unnecessary since that's the default permission for `GITHUB_TOKEN` per https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication#permissions-for-the-github_token.

Edit: It seems that the check actually is passing with these changes--that's a bit surprising to me.

### Test Coverage

N/A

### Documentation

N/A

### Additional Information

None.