### PR TITLE
feat(WorkspaceSvg): Add support for tracking keyboard moves

### DIFF
--- a/core/workspace_svg.ts
+++ b/core/workspace_svg.ts
@@ -317,6 +317,9 @@ export class WorkspaceSvg
   /** True if keyboard accessibility mode is on, false otherwise. */
   keyboardAccessibilityMode = false;
 
+  /** True iff a keyboard-initiated move ("drag") is in progress. */
+  keyboardMoveInProgress = false;
+
   /** The list of top-level bounded elements on the workspace. */
   private topBoundedElements: IBoundedElement[] = [];
 
@@ -1505,12 +1508,43 @@ export class WorkspaceSvg
   }
 
   /**
-   * Is the user currently dragging a block or scrolling the flyout/workspace?
+   * Indicate whether a keyboard move is in progress or not.
    *
-   * @returns True if currently dragging or scrolling.
+   * Should be called with true when a keyboard move of an IDraggable
+   * is starts, and false when it finishes or is aborted.
+   *
+   * N.B.: This method is experimental and internal-only.  It is
+   * intended only to called only from the keyboard navigation plugin.
+   * Its signature and behaviour may be modified, or the method
+   * removed, at an time without notice and without being treated
+   * as a breaking change.
+   *
+   * @internal
+   * @param inProgress Is a keyboard-initated move in progress?
+   */
+  setKeyboardMoveInProgress(inProgress: boolean) {
+    this.keyboardMoveInProgress = inProgress;
+  }
+
+  /**
+   * Returns true iff the user is currently engaged in a drag gesture,
+   * or if a keyboard-initated move is in progress.
+   *
+   * Dragging gestures normally entail moving a block or other item on
+   * the workspace, or scrolling the flyout/workspace.
+   *
+   * Keyboard-initated movements are implemnted using the dragging
+   * infrastructure and are intended to emulate (a subset of) drag
+   * gestures and so should typically be treated as if they were a
+   * gesture-based drag.
+   *
+   * @returns True iff a drag gesture or keyboard move is in porgress.
    */
   isDragging(): boolean {
-    return this.currentGesture_ !== null && this.currentGesture_.isDragging();
+    return (
+      this.keyboardMoveInProgress ||
+      (this.currentGesture_ !== null && this.currentGesture_.isDragging())
+    );
   }
 
   /**


### PR DESCRIPTION
## The basics

- [X] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

Fixes #8874.

### Proposed Changes

* Add a private property `.keyboardMoveInProgress` with associated `@internal` set method to `WorkspaceSvg` to allow `Mover` to inform the workspace when a keyboard-initiated move is in progress.
* Modify `Workspace.prototype.isDragging` to return true if `.keyboardMoveInProgress` is true as well as when a drag gesture is in progress.


### Reason for Changes

Make dragging behaviour more consistent regardless of whether initiated by pointer or keyboard.

### Test Coverage

Tested manually by console calls to `.setKeyboardMoveInProgress`.

### Documentation

JSDocs for `.isDragging` updated to describe current behaviour.

### Additional Information

Filed #8960 to implement a less kludgy approach once `Mover` is part of core (or can at least be more easily accessed from core than at present).
