### PR TITLE
fix: Replace explicit calls to refreshToolboxSelection with a workspace listener

### DIFF
--- a/blocks/variables.ts
+++ b/blocks/variables.ts
@@ -21,7 +21,6 @@ import '../core/field_label.js';
 import {FieldVariable} from '../core/field_variable.js';
 import {Msg} from '../core/msg.js';
 import * as Variables from '../core/variables.js';
-import type {WorkspaceSvg} from '../core/workspace_svg.js';
 
 /**
  * A dictionary of the block definitions provided by this module.

--- a/blocks/variables.ts
+++ b/blocks/variables.ts
@@ -170,7 +170,6 @@ const deleteOptionCallbackFactory = function (
     if (variable) {
       Variables.deleteVariable(variable.getWorkspace(), variable, block);
     }
-    (block.workspace as WorkspaceSvg).refreshToolboxSelection();
   };
 };
 

--- a/blocks/variables_dynamic.ts
+++ b/blocks/variables_dynamic.ts
@@ -22,7 +22,6 @@ import '../core/field_label.js';
 import {FieldVariable} from '../core/field_variable.js';
 import {Msg} from '../core/msg.js';
 import * as Variables from '../core/variables.js';
-import type {WorkspaceSvg} from '../core/workspace_svg.js';
 
 /**
  * A dictionary of the block definitions provided by this module.

--- a/blocks/variables_dynamic.ts
+++ b/blocks/variables_dynamic.ts
@@ -181,7 +181,6 @@ const deleteOptionCallbackFactory = function (block: VariableBlock) {
     if (variable) {
       Variables.deleteVariable(variable.getWorkspace(), variable, block);
     }
-    (block.workspace as WorkspaceSvg).refreshToolboxSelection();
   };
 };
 

--- a/core/field_variable.ts
+++ b/core/field_variable.ts
@@ -523,9 +523,6 @@ export class FieldVariable extends FieldDropdown {
         // Delete variable.
         const workspace = this.variable.getWorkspace();
         Variables.deleteVariable(workspace, this.variable, this.sourceBlock_);
-        if (workspace instanceof WorkspaceSvg) {
-          workspace.refreshToolboxSelection();
-        }
         return;
       }
     }

--- a/core/field_variable.ts
+++ b/core/field_variable.ts
@@ -32,7 +32,6 @@ import * as dom from './utils/dom.js';
 import * as parsing from './utils/parsing.js';
 import {Size} from './utils/size.js';
 import * as Variables from './variables.js';
-import {WorkspaceSvg} from './workspace_svg.js';
 import * as Xml from './xml.js';
 
 /**

--- a/core/variable_map.ts
+++ b/core/variable_map.ts
@@ -93,9 +93,11 @@ export class VariableMap
     } finally {
       eventUtils.setGroup(existingGroup);
     }
-    if (this.workspace instanceof WorkspaceSvg) {
-      this.workspace.refreshToolboxSelection();
-    }
+    setTimeout(() => {
+      if (this.workspace instanceof WorkspaceSvg) {
+        this.workspace.refreshToolboxSelection();
+      }
+    }, 0);
     return variable;
   }
 
@@ -112,9 +114,11 @@ export class VariableMap
     if (!this.variableMap.has(newType)) {
       this.variableMap.set(newType, newTypeVariables);
     }
-    if (this.workspace instanceof WorkspaceSvg) {
-      this.workspace.refreshToolboxSelection();
-    }
+    setTimeout(() => {
+      if (this.workspace instanceof WorkspaceSvg) {
+        this.workspace.refreshToolboxSelection();
+      }
+    }, 0);
     return variable;
   }
 
@@ -161,9 +165,12 @@ export class VariableMap
     for (let i = 0; i < blocks.length; i++) {
       blocks[i].updateVarName(variable);
     }
-    if (this.workspace instanceof WorkspaceSvg) {
-      this.workspace.refreshToolboxSelection();
-    }
+
+    setTimeout(() => {
+      if (this.workspace instanceof WorkspaceSvg) {
+        this.workspace.refreshToolboxSelection();
+      }
+    }, 0);
   }
 
   /**
@@ -259,9 +266,12 @@ export class VariableMap
       this.variableMap.set(type, variables);
     }
     eventUtils.fire(new (eventUtils.get(EventType.VAR_CREATE))(variable));
-    if (this.workspace instanceof WorkspaceSvg) {
-      this.workspace.refreshToolboxSelection();
-    }
+
+    setTimeout(() => {
+      if (this.workspace instanceof WorkspaceSvg) {
+        this.workspace.refreshToolboxSelection();
+      }
+    }, 0);
     return variable;
   }
 
@@ -279,9 +289,12 @@ export class VariableMap
       );
     }
     this.variableMap.get(type)?.set(variable.getId(), variable);
-    if (this.workspace instanceof WorkspaceSvg) {
-      this.workspace.refreshToolboxSelection();
-    }
+
+    setTimeout(() => {
+      if (this.workspace instanceof WorkspaceSvg) {
+        this.workspace.refreshToolboxSelection();
+      }
+    }, 0);
   }
 
   /* Begin functions for variable deletion. */
@@ -310,9 +323,12 @@ export class VariableMap
     } finally {
       eventUtils.setGroup(existingGroup);
     }
-    if (this.workspace instanceof WorkspaceSvg) {
-      this.workspace.refreshToolboxSelection();
-    }
+
+    setTimeout(() => {
+      if (this.workspace instanceof WorkspaceSvg) {
+        this.workspace.refreshToolboxSelection();
+      }
+    }, 0);
   }
 
   /**

--- a/core/variable_map.ts
+++ b/core/variable_map.ts
@@ -27,7 +27,6 @@ import * as deprecation from './utils/deprecation.js';
 import * as idGenerator from './utils/idgenerator.js';
 import {deleteVariable, getVariableUsesById} from './variables.js';
 import type {Workspace} from './workspace.js';
-import {WorkspaceSvg} from './workspace_svg.js';
 
 /**
  * Class for a variable map.  This contains a dictionary data structure with

--- a/core/variable_map.ts
+++ b/core/variable_map.ts
@@ -93,11 +93,6 @@ export class VariableMap
     } finally {
       eventUtils.setGroup(existingGroup);
     }
-    setTimeout(() => {
-      if (this.workspace instanceof WorkspaceSvg) {
-        this.workspace.refreshToolboxSelection();
-      }
-    }, 0);
     return variable;
   }
 
@@ -114,11 +109,6 @@ export class VariableMap
     if (!this.variableMap.has(newType)) {
       this.variableMap.set(newType, newTypeVariables);
     }
-    setTimeout(() => {
-      if (this.workspace instanceof WorkspaceSvg) {
-        this.workspace.refreshToolboxSelection();
-      }
-    }, 0);
     return variable;
   }
 
@@ -165,12 +155,6 @@ export class VariableMap
     for (let i = 0; i < blocks.length; i++) {
       blocks[i].updateVarName(variable);
     }
-
-    setTimeout(() => {
-      if (this.workspace instanceof WorkspaceSvg) {
-        this.workspace.refreshToolboxSelection();
-      }
-    }, 0);
   }
 
   /**
@@ -266,12 +250,6 @@ export class VariableMap
       this.variableMap.set(type, variables);
     }
     eventUtils.fire(new (eventUtils.get(EventType.VAR_CREATE))(variable));
-
-    setTimeout(() => {
-      if (this.workspace instanceof WorkspaceSvg) {
-        this.workspace.refreshToolboxSelection();
-      }
-    }, 0);
     return variable;
   }
 
@@ -289,12 +267,6 @@ export class VariableMap
       );
     }
     this.variableMap.get(type)?.set(variable.getId(), variable);
-
-    setTimeout(() => {
-      if (this.workspace instanceof WorkspaceSvg) {
-        this.workspace.refreshToolboxSelection();
-      }
-    }, 0);
   }
 
   /* Begin functions for variable deletion. */
@@ -323,12 +295,6 @@ export class VariableMap
     } finally {
       eventUtils.setGroup(existingGroup);
     }
-
-    setTimeout(() => {
-      if (this.workspace instanceof WorkspaceSvg) {
-        this.workspace.refreshToolboxSelection();
-      }
-    }, 0);
   }
 
   /**

--- a/core/workspace_svg.ts
+++ b/core/workspace_svg.ts
@@ -33,6 +33,7 @@ import {
   ContextMenuRegistry,
 } from './contextmenu_registry.js';
 import * as dropDownDiv from './dropdowndiv.js';
+import {Abstract as AbstractEvent} from './events/events.js';
 import {EventType} from './events/type.js';
 import * as eventUtils from './events/utils.js';
 import {Flyout} from './flyout_base.js';
@@ -88,7 +89,6 @@ import * as WidgetDiv from './widgetdiv.js';
 import {Workspace} from './workspace.js';
 import {WorkspaceAudio} from './workspace_audio.js';
 import {ZoomControls} from './zoom_controls.js';
-import { Abstract as AbstractEvent } from './events/events.js';
 
 /** Margin around the top/bottom/left/right after a zoomToFit call. */
 const ZOOM_TO_FIT_MARGIN = 20;

--- a/core/workspace_svg.ts
+++ b/core/workspace_svg.ts
@@ -88,6 +88,7 @@ import * as WidgetDiv from './widgetdiv.js';
 import {Workspace} from './workspace.js';
 import {WorkspaceAudio} from './workspace_audio.js';
 import {ZoomControls} from './zoom_controls.js';
+import { Abstract as AbstractEvent } from './events/events.js';
 
 /** Margin around the top/bottom/left/right after a zoomToFit call. */
 const ZOOM_TO_FIT_MARGIN = 20;
@@ -398,6 +399,9 @@ export class WorkspaceSvg
       );
       this.addChangeListener(Procedures.mutatorOpenListener);
     }
+
+    // Set up callbacks to refresh the toolbox when variables change
+    this.addChangeListener(this.variableChangeCallback.bind(this));
 
     /** Object in charge of storing and updating the workspace theme. */
     this.themeManager_ = this.options.parentWorkspace
@@ -1358,6 +1362,24 @@ export class WorkspaceSvg
         this.highlightedBlocks.push(block);
       }
       block.setHighlighted(state);
+    }
+  }
+
+  /**
+   * Handles any necessary updates when a variable changes.
+   *
+   * @internal
+   */
+  variableChangeCallback(event: AbstractEvent) {
+    console.log(this);
+    switch (event.type) {
+      case EventType.VAR_CREATE:
+      case EventType.VAR_DELETE:
+      case EventType.VAR_RENAME:
+      case EventType.VAR_TYPE_CHANGE:
+        this.refreshToolboxSelection();
+        break;
+      default:
     }
   }
 

--- a/core/workspace_svg.ts
+++ b/core/workspace_svg.ts
@@ -1371,7 +1371,6 @@ export class WorkspaceSvg
    * @internal
    */
   variableChangeCallback(event: AbstractEvent) {
-    console.log(this);
     switch (event.type) {
       case EventType.VAR_CREATE:
       case EventType.VAR_DELETE:


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #8975 

### Proposed Changes

Wraps the refreshToolbox calls in a setTimeout so they happen after the changes to variables finish.

### Reason for Changes

We were ending up in an infinite recursion as the toolbox refreshed before the variables were fully created which then tried to create the variables again.

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->
Will need a follow-up PR to add tests for this.

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
