### PR TITLE
fix: Ensure flyout remains open after creating a variable with mouse

### DIFF
--- a/core/workspace_svg.ts
+++ b/core/workspace_svg.ts
@@ -2728,8 +2728,9 @@ export class WorkspaceSvg
 
   /** See IFocusableTree.onTreeBlur. */
   onTreeBlur(nextTree: IFocusableTree | null): void {
-    // If the flyout loses focus, make sure to close it.
-    if (this.isFlyout && this.targetWorkspace) {
+    // If the flyout loses focus, make sure to close it unless focus is being
+    // lost to a different element on the page.
+    if (nextTree && this.isFlyout && this.targetWorkspace) {
       // Only hide the flyout if the flyout's workspace is losing focus and that
       // focus isn't returning to the flyout itself or the toolbox.
       const flyout = this.targetWorkspace.getFlyout();


### PR DESCRIPTION
## The basics

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

Fixes #8976

### Proposed Changes

Only auto-close the flyout if focus is being lost to a known tree.

### Reason for Changes

I noticed from testing that the system does attempt to restore focus back to the flyout after creating a variable but the auto-closing logic was kicking in due to focus being lost with the variable creation prompt open. Even though an attempt was made to restore focus, this doesn't automatically reopen the flyout (since it is primarily governed by the toolbox selection state).

One alternative might be to try and save the previously selected toolbox category and restore it, but that's tricky. This seems simpler, and also seems to largely maintain parity with pre-focus manager Blockly. Clicking outside of the toolbox with the flyout open only closes it if the click is within the toolbox itself or within the workspace.

### Test Coverage

No new tests were added. However, it may be worth considering this specific case for future tests added with #8915.

### Documentation

No new documentation seems necessary here.

### Additional Information

None.