### PR TITLE
fix: focus for autohideable flyouts

### DIFF
--- a/core/interfaces/i_autohideable.ts
+++ b/core/interfaces/i_autohideable.ts
@@ -20,3 +20,8 @@ export interface IAutoHideable extends IComponent {
    */
   autoHide(onlyClosePopups: boolean): void;
 }
+
+/** Returns true if the given object is autohideable. */
+export function isAutoHideable(obj: any): obj is IAutoHideable {
+  return obj.autoHide !== undefined;
+}

--- a/core/workspace_svg.ts
+++ b/core/workspace_svg.ts
@@ -41,6 +41,7 @@ import {getFocusManager} from './focus_manager.js';
 import {Gesture} from './gesture.js';
 import {Grid} from './grid.js';
 import type {IASTNodeLocationSvg} from './interfaces/i_ast_node_location_svg.js';
+import {isAutoHideable} from './interfaces/i_autohideable.js';
 import type {IBoundedElement} from './interfaces/i_bounded_element.js';
 import {IContextMenu} from './interfaces/i_contextmenu.js';
 import type {IDragTarget} from './interfaces/i_drag_target.js';
@@ -2765,7 +2766,7 @@ export class WorkspaceSvg
       if (flyout && nextTree === flyout) return;
       if (toolbox && nextTree === toolbox) return;
       if (toolbox) toolbox.clearSelection();
-      if (flyout && flyout instanceof Flyout) flyout.autoHide(false);
+      if (flyout && isAutoHideable(flyout)) flyout.autoHide(false);
     }
   }
 }


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes issue with autohideable flyouts. See https://github.com/google/blockly/pull/8920#discussion_r2059463000

### Proposed Changes

Uses the `IAutoHideable` interface instead of doing an `instanceof Flyout` check. 

### Reason for Changes

- Using our base Flyout class is not required, only using the Flyout interface is required. We still want to hide autohideable flyouts that don't use our base class, so use the interface to check.

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
