### PR TITLE
fix: Improve missing node resiliency

### DIFF
--- a/core/interfaces/i_focusable_tree.ts
+++ b/core/interfaces/i_focusable_tree.ts
@@ -52,6 +52,10 @@ export interface IFocusableTree {
    *    bypass this method.
    * 3. The default behavior (i.e. returning null here) involves either
    *    restoring the previous node (previousNode) or focusing the tree's root.
+   * 4. The provided node may sometimes no longer be valid, such as in the case
+   *    an attempt is made to focus a node that has been recently removed from
+   *    its parent tree. Implementations can check for the validity of the node
+   *    in order to specialize the node to which focus should fall back.
    *
    * This method is largely intended to provide tree implementations with the
    * means of specifying a better default node than their root.

--- a/tests/mocha/focus_manager_test.js
+++ b/tests/mocha/focus_manager_test.js
@@ -72,7 +72,7 @@ class FocusableTreeImpl {
   onTreeBlur() {}
 }
 
-suite.only('FocusManager', function () {
+suite('FocusManager', function () {
   const ACTIVE_FOCUS_NODE_CSS_SELECTOR = `.${FocusManager.ACTIVE_FOCUS_NODE_CSS_CLASS_NAME}`;
   const PASSIVE_FOCUS_NODE_CSS_SELECTOR = `.${FocusManager.PASSIVE_FOCUS_NODE_CSS_CLASS_NAME}`;
 

--- a/tests/mocha/focus_manager_test.js
+++ b/tests/mocha/focus_manager_test.js
@@ -38,6 +38,7 @@ class FocusableTreeImpl {
     this.nestedTrees = nestedTrees;
     this.idToNodeMap = {};
     this.rootNode = this.addNode(rootElement);
+    this.fallbackNode = null;
   }
 
   addNode(element) {
@@ -46,12 +47,16 @@ class FocusableTreeImpl {
     return node;
   }
 
+  removeNode(node) {
+    delete this.idToNodeMap[node.getFocusableElement().id];
+  }
+
   getRootFocusableNode() {
     return this.rootNode;
   }
 
   getRestoredFocusableNode() {
-    return null;
+    return this.fallbackNode;
   }
 
   getNestedTrees() {
@@ -67,7 +72,7 @@ class FocusableTreeImpl {
   onTreeBlur() {}
 }
 
-suite('FocusManager', function () {
+suite.only('FocusManager', function () {
   const ACTIVE_FOCUS_NODE_CSS_SELECTOR = `.${FocusManager.ACTIVE_FOCUS_NODE_CSS_CLASS_NAME}`;
   const PASSIVE_FOCUS_NODE_CSS_SELECTOR = `.${FocusManager.PASSIVE_FOCUS_NODE_CSS_CLASS_NAME}`;
 
@@ -384,6 +389,31 @@ suite('FocusManager', function () {
 
       // There should be exactly 1 focus event fired from focusNode().
       assert.strictEqual(focusCount, 1);
+    });
+
+    test('for orphaned node returns tree root by default', function () {
+      this.focusManager.registerTree(this.testFocusableTree1);
+      this.testFocusableTree1.removeNode(this.testFocusableTree1Node1);
+
+      this.focusManager.focusNode(this.testFocusableTree1Node1);
+
+      // Focusing an invalid node should fall back to the tree root when it has no restoration
+      // fallback node.
+      const currentNode = this.focusManager.getFocusedNode();
+      const treeRoot = this.testFocusableTree1.getRootFocusableNode();
+      assert.strictEqual(currentNode, treeRoot);
+    });
+
+    test('for orphaned node returns specified fallback node', function () {
+      this.focusManager.registerTree(this.testFocusableTree1);
+      this.testFocusableTree1.fallbackNode = this.testFocusableTree1Node2;
+      this.testFocusableTree1.removeNode(this.testFocusableTree1Node1);
+
+      this.focusManager.focusNode(this.testFocusableTree1Node1);
+
+      // Focusing an invalid node should fall back to the restored fallback.
+      const currentNode = this.focusManager.getFocusedNode();
+      assert.strictEqual(currentNode, this.testFocusableTree1Node2);
     });
   });
 


### PR DESCRIPTION
## The basics

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

Fixes #8994

### Proposed Changes

This removes an error that was previously thrown by `FocusManager` when attempting to focus an invalid node (such as one that's been removed from its parent).

### Reason for Changes

https://github.com/google/blockly/issues/8994#issuecomment-2855447539 goes into more detail. While this error did cover legitimately wrong cases to try and focus things (and helped to catch some real problems), fixing this 'properly' may become a leaky boat problem where we have to track down every possible asynchronous scenario that could produce such a case. One class of this is ephemeral focus which had robustness improvements itself in #8981 that, by effect, caused this issue in the first place. Holistically fixing this with enforced API contracts alone isn't simple due to the nature of how these components interact.

This change ensures that there's a sane default to fall back on if an invalid node is passed in. Note that `FocusManager` was designed specifically to disallow defocusing a node (since fallbacks can get messy and introduce unpredictable user experiences), and this sort of allows that now. However, this seems like a reasonable approach as it defaults to the behavior when focusing a tree explicitly which allows the tree to fallback to a more suitable default (such as the first item to select in the toolbox for that particular tree). In many cases this will default back to the tree's root node (such as the workspace root group) since sometimes the removed node is still the "last focused node" of the tree (and is considered valid for the purpose of determining a fallback; tree implementations could further specialize by checking whether that node is still valid).

### Test Coverage

Some new tests were added to cover this case, but more may be useful to add as part of #8910.

### Documentation

No documentation needs to be added or updated as part of this (beyond code documentation changes).

### Additional Information

This original issue was found by @RoboErikG when testing #8995. I also verified this against the keyboard navigation plugin repository.