### PR TITLE
fix: Fix regressions in `Field`.

### DIFF
--- a/core/field.ts
+++ b/core/field.ts
@@ -88,6 +88,9 @@ export abstract class Field<T = any>
    */
   DEFAULT_VALUE: T | null = null;
 
+  /** Non-breaking space. */
+  static readonly NBSP = '\u00A0';
+
   /**
    * A value used to signal when a field's constructor should *not* set the
    * field's value or run configure_, and should allow a subclass to do that
@@ -110,7 +113,28 @@ export abstract class Field<T = any>
    * field is not yet initialized. Is *not* guaranteed to be accurate.
    */
   private tooltip: Tooltip.TipInfo | null = null;
-  protected size_: Size;
+
+  /** This field's dimensions. */
+  private size: Size = new Size(0, 0);
+
+  /**
+   * Gets the size of this field. Because getSize() and updateSize() have side
+   * effects, this acts as a shim for subclasses which wish to adjust field
+   * bounds when setting/getting the size without triggering unwanted rendering
+   * or other side effects. Note that subclasses must override *both* get and
+   * set if either is overridden; the implementation may just call directly
+   * through to super, but it must exist per the JS spec.
+   */
+  protected get size_(): Size {
+    return this.size;
+  }
+
+  /**
+   * Sets the size of this field.
+   */
+  protected set size_(newValue: Size) {
+    this.size = newValue;
+  }
 
   /** The rendered field's SVG group element. */
   protected fieldGroup_: SVGGElement | null = null;
@@ -973,6 +997,8 @@ export abstract class Field<T = any>
       // Truncate displayed string and add an ellipsis ('...').
       text = text.substring(0, this.maxDisplayLength - 2) + '…';
     }
+    // Replace whitespace with non-breaking spaces so the text doesn't collapse.
+    text = text.replace(/\s/g, Field.NBSP);
     if (this.sourceBlock_ && this.sourceBlock_.RTL) {
       // The SVG is LTR, force text to be RTL by adding an RLM.
       text += '\u200F';

--- a/core/field_image.ts
+++ b/core/field_image.ts
@@ -27,7 +27,6 @@ export class FieldImage extends Field<string> {
    * of the field.
    */
   private static readonly Y_PADDING = 1;
-  protected override size_: Size;
   protected readonly imageHeight: number;
 
   /** The function to be called when this field is clicked. */

--- a/core/field_input.ts
+++ b/core/field_input.ts
@@ -101,6 +101,26 @@ export abstract class FieldInput<T extends InputTypes> extends Field<
   override SERIALIZABLE = true;
 
   /**
+   * Sets the size of this field. Although this appears to be a no-op, it must
+   * exist since the getter is overridden below.
+   */
+  protected override set size_(newValue: Size) {
+    super.size_ = newValue;
+  }
+
+  /**
+   * Returns the size of this field, with a minimum width of 14.
+   */
+  protected override get size_() {
+    const s = super.size_;
+    if (s.width < 14) {
+      s.width = 14;
+    }
+
+    return s;
+  }
+
+  /**
    * @param value The initial value of the field. Should cast to a string.
    *     Defaults to an empty string if null or undefined. Also accepts
    *     Field.SKIP_SETUP if you wish to skip setup (only used by subclasses

--- a/core/field_variable.ts
+++ b/core/field_variable.ts
@@ -49,7 +49,6 @@ export class FieldVariable extends FieldDropdown {
    * dropdown.
    */
   variableTypes: string[] | null = [];
-  protected override size_: Size;
 
   /** The variable model associated with this field. */
   private variable: IVariableModel<IVariableState> | null = null;


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #9005

### Proposed Changes
This PR fixes several regressions in `Field` introduced by an earlier change:
* It restores the `Field.NBSP` constant, which was in fact in use
* It makes empty input fields have a reasonable minimum width
* It prevents sequential spaces from collapsing when rendering a field