### PR TITLE
chore: bump version to 12.0.0-beta.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blockly",
-  "version": "12.0.0-beta.4",
+  "version": "12.0.0-beta.5",
   "description": "Blockly is a library for building visual programming editors.",
   "keywords": [
     "blockly"


### PR DESCRIPTION
Version bump to cut a beta release.