### PR TITLE
fix!: remove deprecated setEnabled and backwards event filtering

### DIFF
--- a/core/block.ts
+++ b/core/block.ts
@@ -50,7 +50,6 @@ import * as registry from './registry.js';
 import * as Tooltip from './tooltip.js';
 import * as arrayUtils from './utils/array.js';
 import {Coordinate} from './utils/coordinate.js';
-import * as deprecation from './utils/deprecation.js';
 import * as idGenerator from './utils/idgenerator.js';
 import * as parsing from './utils/parsing.js';
 import {Size} from './utils/size.js';
@@ -1408,47 +1407,6 @@ export class Block {
    */
   isEnabled(): boolean {
     return this.disabledReasons.size === 0;
-  }
-
-  /** @deprecated v11 - Get or sets whether the block is manually disabled. */
-  private get disabled(): boolean {
-    deprecation.warn(
-      'disabled',
-      'v11',
-      'v12',
-      'the isEnabled or hasDisabledReason methods of Block',
-    );
-    return this.hasDisabledReason(constants.MANUALLY_DISABLED);
-  }
-
-  private set disabled(value: boolean) {
-    deprecation.warn(
-      'disabled',
-      'v11',
-      'v12',
-      'the setDisabledReason method of Block',
-    );
-    this.setDisabledReason(value, constants.MANUALLY_DISABLED);
-  }
-
-  /**
-   * @deprecated v11 - Set whether the block is manually enabled or disabled.
-   * The user can toggle whether a block is disabled from a context menu
-   * option. A block may still be disabled for other reasons even if the user
-   * attempts to manually enable it, such as when the block is in an invalid
-   * location. This method is deprecated and setDisabledReason should be used
-   * instead.
-   *
-   * @param enabled True if enabled.
-   */
-  setEnabled(enabled: boolean) {
-    deprecation.warn(
-      'setEnabled',
-      'v11',
-      'v12',
-      'the setDisabledReason method of Block',
-    );
-    this.setDisabledReason(!enabled, constants.MANUALLY_DISABLED);
   }
 
   /**

--- a/core/block_svg.ts
+++ b/core/block_svg.ts
@@ -57,7 +57,6 @@ import * as blocks from './serialization/blocks.js';
 import type {BlockStyle} from './theme.js';
 import * as Tooltip from './tooltip.js';
 import {Coordinate} from './utils/coordinate.js';
-import * as deprecation from './utils/deprecation.js';
 import * as dom from './utils/dom.js';
 import {Rect} from './utils/rect.js';
 import {Svg} from './utils/svg.js';
@@ -1076,32 +1075,6 @@ export class BlockSvg
     this.queueRender();
 
     return removed;
-  }
-
-  /**
-   * Set whether the block is manually enabled or disabled.
-   *
-   * The user can toggle whether a block is disabled from a context menu
-   * option. A block may still be disabled for other reasons even if the user
-   * attempts to manually enable it, such as when the block is in an invalid
-   * location. This method is deprecated and setDisabledReason should be used
-   * instead.
-   *
-   * @deprecated v11: use setDisabledReason.
-   * @param enabled True if enabled.
-   */
-  override setEnabled(enabled: boolean) {
-    deprecation.warn(
-      'setEnabled',
-      'v11',
-      'v12',
-      'the setDisabledReason method of BlockSvg',
-    );
-    const wasEnabled = this.isEnabled();
-    super.setEnabled(enabled);
-    if (this.isEnabled() !== wasEnabled && !this.getInheritedDisabled()) {
-      this.updateDisabled();
-    }
   }
 
   /**

--- a/core/events/utils.ts
+++ b/core/events/utils.ts
@@ -9,7 +9,6 @@
 import type {Block} from '../block.js';
 import * as common from '../common.js';
 import * as registry from '../registry.js';
-import * as deprecation from '../utils/deprecation.js';
 import * as idGenerator from '../utils/idgenerator.js';
 import type {Workspace} from '../workspace.js';
 import type {WorkspaceSvg} from '../workspace_svg.js';
@@ -124,7 +123,7 @@ function fireInternal(event: Abstract) {
 
 /** Dispatch all queued events. */
 function fireNow() {
-  const queue = filter(FIRE_QUEUE, true);
+  const queue = filter(FIRE_QUEUE);
   FIRE_QUEUE.length = 0;
   for (const event of queue) {
     if (!event.workspaceId) continue;
@@ -227,18 +226,9 @@ function enqueueEvent(event: Abstract) {
  * cause them to be reordered.
  *
  * @param queue Array of events.
- * @param forward True if forward (redo), false if backward (undo).
- *     This parameter is deprecated: true is now the default and
- *     calling filter with it set to false will in future not be
- *     supported.
  * @returns Array of filtered events.
  */
-export function filter(queue: Abstract[], forward = true): Abstract[] {
-  if (!forward) {
-    deprecation.warn('filter(queue, /*forward=*/false)', 'v11.2', 'v12');
-    // Undo was merged in reverse order.
-    queue = queue.slice().reverse(); // Copy before reversing in place.
-  }
+export function filter(queue: Abstract[]): Abstract[] {
   const mergedQueue: Abstract[] = [];
   // Merge duplicates.
   for (const event of queue) {
@@ -290,10 +280,6 @@ export function filter(queue: Abstract[], forward = true): Abstract[] {
   }
   // Filter out any events that have become null due to merging.
   queue = mergedQueue.filter((e) => !e.isNull());
-  if (!forward) {
-    // Restore undo order.
-    queue.reverse();
-  }
   return queue;
 }
 

--- a/tests/mocha/event_test.js
+++ b/tests/mocha/event_test.js
@@ -1222,7 +1222,7 @@ suite('Events', function () {
         new Blockly.Events.BlockChange(block, 'field', 'VAR', 'id1', 'id2'),
         new Blockly.Events.Click(block),
       ];
-      const filteredEvents = eventUtils.filter(events, true);
+      const filteredEvents = eventUtils.filter(events);
       assert.equal(filteredEvents.length, 4); // no event should have been removed.
       // test that the order hasn't changed
       assert.isTrue(filteredEvents[0] instanceof Blockly.Events.BlockCreate);
@@ -1240,7 +1240,7 @@ suite('Events', function () {
         new Blockly.Events.BlockCreate(block2),
         new Blockly.Events.BlockMove(block2),
       ];
-      const filteredEvents = eventUtils.filter(events, true);
+      const filteredEvents = eventUtils.filter(events);
       assert.equal(filteredEvents.length, 4); // no event should have been removed.
     });
 
@@ -1250,7 +1250,7 @@ suite('Events', function () {
       addMoveEvent(events, block, 1, 1);
       addMoveEvent(events, block, 2, 2);
       addMoveEvent(events, block, 3, 3);
-      const filteredEvents = eventUtils.filter(events, true);
+      const filteredEvents = eventUtils.filter(events);
       assert.equal(filteredEvents.length, 2); // duplicate moves should have been removed.
       // test that the order hasn't changed
       assert.isTrue(filteredEvents[0] instanceof Blockly.Events.BlockCreate);
@@ -1259,27 +1259,12 @@ suite('Events', function () {
       assert.equal(filteredEvents[1].newCoordinate.y, 3);
     });
 
-    test('Backward', function () {
-      const block = this.workspace.newBlock('field_variable_test_block', '1');
-      const events = [new Blockly.Events.BlockCreate(block)];
-      addMoveEvent(events, block, 1, 1);
-      addMoveEvent(events, block, 2, 2);
-      addMoveEvent(events, block, 3, 3);
-      const filteredEvents = eventUtils.filter(events, false);
-      assert.equal(filteredEvents.length, 2); // duplicate event should have been removed.
-      // test that the order hasn't changed
-      assert.isTrue(filteredEvents[0] instanceof Blockly.Events.BlockCreate);
-      assert.isTrue(filteredEvents[1] instanceof Blockly.Events.BlockMove);
-      assert.equal(filteredEvents[1].newCoordinate.x, 1);
-      assert.equal(filteredEvents[1].newCoordinate.y, 1);
-    });
-
     test('Merge block move events', function () {
       const block = this.workspace.newBlock('field_variable_test_block', '1');
       const events = [];
       addMoveEvent(events, block, 0, 0);
       addMoveEvent(events, block, 1, 1);
-      const filteredEvents = eventUtils.filter(events, true);
+      const filteredEvents = eventUtils.filter(events);
       assert.equal(filteredEvents.length, 1); // second move event merged into first
       assert.equal(filteredEvents[0].newCoordinate.x, 1);
       assert.equal(filteredEvents[0].newCoordinate.y, 1);
@@ -1297,7 +1282,7 @@ suite('Events', function () {
           'item2',
         ),
       ];
-      const filteredEvents = eventUtils.filter(events, true);
+      const filteredEvents = eventUtils.filter(events);
       assert.equal(filteredEvents.length, 1); // second change event merged into first
       assert.equal(filteredEvents[0].oldValue, 'item');
       assert.equal(filteredEvents[0].newValue, 'item2');
@@ -1308,7 +1293,7 @@ suite('Events', function () {
         new Blockly.Events.ViewportChange(1, 2, 3, this.workspace, 4),
         new Blockly.Events.ViewportChange(5, 6, 7, this.workspace, 8),
       ];
-      const filteredEvents = eventUtils.filter(events, true);
+      const filteredEvents = eventUtils.filter(events);
       assert.equal(filteredEvents.length, 1); // second change event merged into first
       assert.equal(filteredEvents[0].viewTop, 5);
       assert.equal(filteredEvents[0].viewLeft, 6);
@@ -1328,7 +1313,7 @@ suite('Events', function () {
         new Blockly.Events.BubbleOpen(block3, true, 'warning'),
         new Blockly.Events.Click(block3),
       ];
-      const filteredEvents = eventUtils.filter(events, true);
+      const filteredEvents = eventUtils.filter(events);
       // click event merged into corresponding *Open event
       assert.equal(filteredEvents.length, 3);
       assert.isTrue(filteredEvents[0] instanceof Blockly.Events.BubbleOpen);
@@ -1347,7 +1332,7 @@ suite('Events', function () {
         new Blockly.Events.Click(block),
         new Blockly.Events.BlockDrag(block, true),
       ];
-      const filteredEvents = eventUtils.filter(events, true);
+      const filteredEvents = eventUtils.filter(events);
       // click and stackclick should both exist
       assert.equal(filteredEvents.length, 2);
       assert.isTrue(filteredEvents[0] instanceof Blockly.Events.Click);
@@ -1367,7 +1352,7 @@ suite('Events', function () {
       const events = [];
       addMoveEventParent(events, block, null);
       addMoveEventParent(events, block, null);
-      const filteredEvents = eventUtils.filter(events, true);
+      const filteredEvents = eventUtils.filter(events);
       // The two events should be merged, but because nothing has changed
       // they will be filtered out.
       assert.equal(filteredEvents.length, 0);
@@ -1388,7 +1373,7 @@ suite('Events', function () {
       events.push(new Blockly.Events.BlockDelete(block2));
       addMoveEvent(events, block1, 2, 2);
 
-      const filteredEvents = eventUtils.filter(events, true);
+      const filteredEvents = eventUtils.filter(events);
       // Nothing should have merged.
       assert.equal(filteredEvents.length, 4);
       // test that the order hasn't changed


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #9038 

### Proposed Changes

- Removes the deprecated `setEnabled` functions from `Block` and `BlockSvg`.
- Removes the `forward` parameter from `Blockly.Events.filter` and updates usages.

### BREAKING CHANGES

**If you call `block.setEnabled`, update to call [`block.setDisabledReason`](https://developers.google.com/blockly/reference/js/blockly.blocksvg_class.setdisabledreason_1_method.md) instead.** A block could be disabled for multiple reasons, and calling `setDisabledReason` multiple times for each of these reasons is supported and encouraged. A block will only appear enabled if there are no disabled reasons remaining. Blockly will now manage this state for you.


**Calling [`Blockly.Events.filter()`](https://developers.google.com/blockly/reference/js/blockly.events_namespace.filter_variable.md) with the `forward` parameter set to false is no longer supported.** If you only call this function with the second parameter set to `true` you can simply remove the parameter. If you are ever calling this function with the second parameter set to `false`, you are doing something complex and error-prone. Please get in touch on the forum, or see [this PR](https://github.com/google/blockly/pull/8539) and the linked issues for context.