### PR TITLE
fix!: deepMerge for arrays, shortcut keycodes returned as array

### DIFF
--- a/core/utils/object.ts
+++ b/core/utils/object.ts
@@ -9,6 +9,9 @@
 /**
  * Complete a deep merge of all members of a source object with a target object.
  *
+ * N.B. This is not a very sophisticated merge algorithm and does not
+ * handle complex cases. Use with caution.
+ *
  * @param target Target.
  * @param source Source.
  * @returns The resulting object.
@@ -18,7 +21,9 @@ export function deepMerge(
   source: AnyDuringMigration,
 ): AnyDuringMigration {
   for (const x in source) {
-    if (source[x] !== null && typeof source[x] === 'object') {
+    if (source[x] !== null && Array.isArray(source[x])) {
+      target[x] = deepMerge(target[x] || [], source[x]);
+    } else if (source[x] !== null && typeof source[x] === 'object') {
       target[x] = deepMerge(target[x] || Object.create(null), source[x]);
     } else {
       target[x] = source[x];

--- a/tests/mocha/shortcut_registry_test.js
+++ b/tests/mocha/shortcut_registry_test.js
@@ -260,13 +260,17 @@ suite('Keyboard Shortcut Registry Test', function () {
       assert.equal(this.registry.getKeyMap()['keyCode'][0], 'a');
     });
     test('Gets a copy of the registry', function () {
-      const shortcut = {'name': 'shortcutName'};
+      const shortcut = {'name': 'shortcutName', 'keyCodes': ['2', '4']};
       this.registry.register(shortcut);
       const registrycopy = this.registry.getRegistry();
       registrycopy['shortcutName']['name'] = 'shortcutName1';
       assert.equal(
         this.registry.getRegistry()['shortcutName']['name'],
         'shortcutName',
+      );
+      assert.deepEqual(
+        this.registry.getRegistry()['shortcutName']['keyCodes'],
+        shortcut['keyCodes'],
       );
     });
     test('Gets keyboard shortcuts from a key code', function () {

--- a/tests/mocha/utils_test.js
+++ b/tests/mocha/utils_test.js
@@ -533,4 +533,25 @@ suite('Utils', function () {
       assert.equal(Blockly.utils.math.toDegrees(5 * quarter), 360 + 90, '450');
     });
   });
+
+  suite('deepMerge', function () {
+    test('Merges two objects', function () {
+      const target = {a: 1, b: '2', shared: 'this should be overwritten'};
+      const source = {c: {deeplyNested: true}, shared: 'I overwrote it'};
+
+      const expected = {...target, ...source};
+      const actual = Blockly.utils.object.deepMerge(target, source);
+
+      assert.deepEqual(expected, actual);
+    });
+    test('Merges objects with arrays', function () {
+      const target = {a: 1};
+      const source = {b: ['orange', 'lime']};
+
+      const expected = {...target, ...source};
+      const actual = Blockly.utils.object.deepMerge(target, source);
+
+      assert.deepEqual(expected, actual);
+    });
+  });
 });


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #9008 

### Proposed Changes

Fixes the `deepMerge` function so that it works correctly for arrays. It still probably does not work correctly for other cases, so I also added a warning to the tsdoc.

### Reason for Changes

This was causing the shortcut registry to return the keycodes as an object instead of as an array.

### Test Coverage

Added tests for the deepMerge function and for the keycodes property of keyboard shortcuts.



### BREAKING CHANGES

- If you are using the `Blockly.utils.object.deepMerge` function, it previously incorrectly converted some arrays to objects. You probably shouldn't be using this version anyway. If you need deep merge functionality we'd recommend you use a separate library that is fully functional and has solid tests.
- If you are getting shortcuts out of the keyboard registry and then re-registering them or reusing the `keyCodes` property, you can now do so without resorting to workarounds to convert the object back into an array. Your workaround may now fail to work as the underlying data is now correctly an array instead of an object, so remove your workaround.
