### PR TITLE
fix: fieldDropdown.getText works in node

### DIFF
--- a/core/field_dropdown.ts
+++ b/core/field_dropdown.ts
@@ -633,7 +633,13 @@ export class FieldDropdown extends Field<string> {
   /**
    * Use the `getText_` developer hook to override the field's text
    * representation.  Get the selected option text.  If the selected option is
-   * an image we return the image alt text.
+   * an image we return the image alt text. If the selected option is
+   * an HTMLElement, return the title, ariaLabel, or innerText of the
+   * element.
+   *
+   * If you use HTMLElement options in node and call this function,
+   * ensure that you are supplying an implementation of HTMLElement,
+   * such as through jsdom-global.
    *
    * @returns Selected option text.
    */
@@ -644,10 +650,21 @@ export class FieldDropdown extends Field<string> {
     const option = this.selectedOption[0];
     if (isImageProperties(option)) {
       return option.alt;
-    } else if (option instanceof HTMLElement) {
+    } else if (
+      typeof HTMLElement !== 'undefined' &&
+      option instanceof HTMLElement
+    ) {
       return option.title ?? option.ariaLabel ?? option.innerText;
+    } else if (typeof option === 'string') {
+      return option;
     }
-    return option;
+
+    console.warn(
+      "Can't get text for existing dropdown option. If " +
+        "you're using HTMLElement dropdown options in node, ensure you're " +
+        'using jsdom-global or similar.',
+    );
+    return null;
   }
 
   /**

--- a/core/field_dropdown.ts
+++ b/core/field_dropdown.ts
@@ -637,7 +637,7 @@ export class FieldDropdown extends Field<string> {
    * an HTMLElement, return the title, ariaLabel, or innerText of the
    * element.
    *
-   * If you use HTMLElement options in node and call this function,
+   * If you use HTMLElement options in Node.js and call this function,
    * ensure that you are supplying an implementation of HTMLElement,
    * such as through jsdom-global.
    *

--- a/tests/node/run_node_test.mjs
+++ b/tests/node/run_node_test.mjs
@@ -181,4 +181,11 @@ suite('Test Node.js', function () {
 
     assert.deepEqual(jsonAfter, json);
   });
+  test('Dropdown getText works with no HTMLElement defined', function () {
+    const field = new Blockly.FieldDropdown([
+      ['firstOption', '1'],
+      ['secondOption', '2'],
+    ]);
+    assert.equal(field.getText(), 'firstOption');
+  });
 });


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #9035 

### Proposed Changes

Checks that `HTMLElement` is defined before trying to use it

### Reason for Changes

Dropdown fields should work in node

### Test Coverage

Added a node test to make sure this change fixes the CI problems we saw in samples

### Documentation

I logged a warning for the case that would hit if:

1. Someone uses a `FieldDropdown` with `HTMLElement` options
2. They use node, haven't supplied an implementation of `HTMLElement`, and call `getText`.

Honestly the chances anyone does this and doesn't run into a number of other issues is relatively small, but hopefully the warning message helps them out if so.

If someone is using node with just regular text options, they don't need to supply an implementation of `HTMLElement` and won't see the warning, so this doesn't affect the usual case (and before v12, the only case, as it wasn't possible to use element options).

### Additional Information

<!-- Anything else we should know? -->
