### PR TITLE
fix: Reenable support for tabbing between fields.

### DIFF
--- a/core/field_input.ts
+++ b/core/field_input.ts
@@ -582,6 +582,38 @@ export abstract class FieldInput<T extends InputTypes> extends Field<
       );
       WidgetDiv.hideIfOwner(this);
       dropDownDiv.hideWithoutAnimation();
+    } else if (e.key === 'Tab') {
+      e.preventDefault();
+      const cursor = this.workspace_?.getCursor();
+      const target = e.shiftKey
+        ? cursor?.getPreviousNode(
+            this,
+            (node) =>
+              (node instanceof FieldInput ||
+                (node instanceof BlockSvg && node.isSimpleReporter())) &&
+              node !== this.getSourceBlock(),
+            false,
+          )
+        : cursor?.getNextNode(
+            this,
+            (node) =>
+              (node instanceof FieldInput ||
+                (node instanceof BlockSvg && node.isSimpleReporter())) &&
+              node !== this.getSourceBlock(),
+            false,
+          );
+      if (target && target instanceof FieldInput) {
+        WidgetDiv.hideIfOwner(this);
+        dropDownDiv.hideWithoutAnimation();
+        target.showEditor();
+      } else if (target instanceof BlockSvg && target.isSimpleReporter()) {
+        WidgetDiv.hideIfOwner(this);
+        dropDownDiv.hideWithoutAnimation();
+        const field = target.getFields().next().value;
+        if (field instanceof FieldInput) {
+          field.showEditor();
+        }
+      }
     }
   }
 


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes  https://github.com/google/blockly/issues/8821

### Proposed Changes
This PR re-adds support for tabbing between editable fields to correct a regression. This is a bit complicated because, in Zelos, navigation is to blocks rather than fields for simple reporters, but it appears to work correctly in both Zelos and non-Zelos renderers.