### PR TITLE
fix: Fix bug when referencing HTMLElement in non-browser environments.

### DIFF
--- a/core/field_dropdown.ts
+++ b/core/field_dropdown.ts
@@ -800,7 +800,9 @@ export class FieldDropdown extends Field<string> {
         option[0] &&
         typeof option[0] !== 'string' &&
         !isImageProperties(option[0]) &&
-        !(option[0] instanceof HTMLElement)
+        !(
+          typeof HTMLElement !== 'undefined' && option[0] instanceof HTMLElement
+        )
       ) {
         foundError = true;
         console.error(


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details

### Proposed Changes
This PR fixes an error when calling `validateOptions` in node/non-browser environments. This is the same fix as used in https://github.com/google/blockly/pull/9048, just targeting another place where the root issue occurred in the same file.