### PR TITLE
fix: Remove un-typesafe cast.

### DIFF
--- a/core/utils/dom.ts
+++ b/core/utils/dom.ts
@@ -289,13 +289,13 @@ export function getFastTextWidthWithSizeString(
     // Initialize the HTML canvas context and set the font.
     // The context font must match blocklyText's fontsize and font-family
     // set in CSS.
-    canvasContext = computeCanvas.getContext('2d') as CanvasRenderingContext2D;
+    canvasContext = computeCanvas.getContext('2d');
   }
-  // Set the desired font size and family.
-  canvasContext.font = fontWeight + ' ' + fontSize + ' ' + fontFamily;
 
   // Measure the text width using the helper canvas context.
-  if (text) {
+  if (text && canvasContext) {
+    // Set the desired font size and family.
+    canvasContext.font = fontWeight + ' ' + fontSize + ' ' + fontFamily;
     width = canvasContext.measureText(text).width;
   } else {
     width = 0;


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves
This PR removes a cast that could cause errors at runtime on environments without Canvas support, such as JSDom.