### PR TITLE
fix: Make clickable but non-editable fields navigable.

### DIFF
--- a/core/keyboard_nav/field_navigation_policy.ts
+++ b/core/keyboard_nav/field_navigation_policy.ts
@@ -97,8 +97,7 @@ export class FieldNavigationPolicy implements INavigationPolicy<Field<any>> {
   isNavigable(current: Field<any>): boolean {
     return (
       current.canBeFocused() &&
-      current.isClickable() &&
-      current.isCurrentlyEditable() &&
+      (current.isClickable() || current.isCurrentlyEditable()) &&
       !(
         current.getSourceBlock()?.isSimpleReporter() &&
         current.isFullBlockField()


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves
This PR fixes an issue that prevented fields that were clickable/interactable but not editable from being visited via keyboard navigation.