### PR TITLE
fix: Skip hidden fields when navigating

### DIFF
--- a/core/keyboard_nav/field_navigation_policy.ts
+++ b/core/keyboard_nav/field_navigation_policy.ts
@@ -97,6 +97,7 @@ export class FieldNavigationPolicy implements INavigationPolicy<Field<any>> {
   isNavigable(current: Field<any>): boolean {
     return (
       current.canBeFocused() &&
+      current.isVisible() &&
       (current.isClickable() || current.isCurrentlyEditable()) &&
       !(
         current.getSourceBlock()?.isSimpleReporter() &&

--- a/tests/mocha/navigation_test.js
+++ b/tests/mocha/navigation_test.js
@@ -165,6 +165,30 @@ suite('Navigation', function () {
           'helpUrl': '',
         },
         {
+          'type': 'hidden_field',
+          'message0': '%1 %2 %3',
+          'args0': [
+            {
+              'type': 'field_input',
+              'name': 'ONE',
+              'text': 'default',
+            },
+            {
+              'type': 'field_input',
+              'name': 'TWO',
+              'text': 'default',
+            },
+            {
+              'type': 'field_input',
+              'name': 'THREE',
+              'text': 'default',
+            },
+          ],
+          'colour': 230,
+          'tooltip': '',
+          'helpUrl': '',
+        },
+        {
           'type': 'fields_and_input2',
           'message0': '%1 %2 %3 %4 bye',
           'args0': [
@@ -222,17 +246,61 @@ suite('Navigation', function () {
           'helpUrl': '',
           'nextStatement': null,
         },
+        {
+          'type': 'hidden_input',
+          'message0': '%1 hi %2 %3 %4 %5 %6',
+          'args0': [
+            {
+              'type': 'field_input',
+              'name': 'ONE',
+              'text': 'default',
+            },
+            {
+              'type': 'input_dummy',
+            },
+            {
+              'type': 'field_input',
+              'name': 'TWO',
+              'text': 'default',
+            },
+            {
+              'type': 'input_value',
+              'name': 'SECOND',
+            },
+            {
+              'type': 'field_input',
+              'name': 'THREE',
+              'text': 'default',
+            },
+            {
+              'type': 'input_value',
+              'name': 'THIRD',
+            },
+          ],
+          'previousStatement': null,
+          'nextStatement': null,
+          'colour': 230,
+          'tooltip': '',
+          'helpUrl': '',
+        },
       ]);
       const noNextConnection = this.workspace.newBlock('top_connection');
       const fieldAndInputs = this.workspace.newBlock('fields_and_input');
       const twoFields = this.workspace.newBlock('two_fields');
       const fieldAndInputs2 = this.workspace.newBlock('fields_and_input2');
       const noPrevConnection = this.workspace.newBlock('start_block');
+      const hiddenField = this.workspace.newBlock('hidden_field');
+      const hiddenInput = this.workspace.newBlock('hidden_input');
       this.blocks.noNextConnection = noNextConnection;
       this.blocks.fieldAndInputs = fieldAndInputs;
       this.blocks.twoFields = twoFields;
       this.blocks.fieldAndInputs2 = fieldAndInputs2;
       this.blocks.noPrevConnection = noPrevConnection;
+      this.blocks.hiddenField = hiddenField;
+      this.blocks.hiddenInput = hiddenInput;
+
+      hiddenField.inputList[0].fieldRow[1].setVisible(false);
+      hiddenInput.inputList[1].setVisible(false);
 
       const dummyInput = this.workspace.newBlock('dummy_input');
       const dummyInputValue = this.workspace.newBlock('dummy_inputValue');
@@ -322,6 +390,20 @@ suite('Navigation', function () {
         const nextNode = this.navigator.getNextSibling(field);
         assert.isNull(nextNode);
       });
+      test('skipsHiddenField', function () {
+        const field = this.blocks.hiddenField.inputList[0].fieldRow[0];
+        const field2 = this.blocks.hiddenField.inputList[0].fieldRow[2];
+        const nextNode = this.navigator.getNextSibling(field);
+        assert.equal(nextNode.name, field2.name);
+      });
+      test('skipsHiddenInput', function () {
+        const field = this.blocks.hiddenInput.inputList[0].fieldRow[0];
+        const nextNode = this.navigator.getNextSibling(field);
+        assert.equal(
+          nextNode,
+          this.blocks.hiddenInput.inputList[2].fieldRow[0],
+        );
+      });
     });
 
     suite('Previous', function () {
@@ -399,6 +481,20 @@ suite('Navigation', function () {
         const field2 = this.blocks.fieldAndInputs.inputList[0].fieldRow[0];
         const prevNode = this.navigator.getPreviousSibling(field);
         assert.equal(prevNode, field2);
+      });
+      test('skipsHiddenField', function () {
+        const field = this.blocks.hiddenField.inputList[0].fieldRow[2];
+        const field2 = this.blocks.hiddenField.inputList[0].fieldRow[0];
+        const prevNode = this.navigator.getPreviousSibling(field);
+        assert.equal(prevNode.name, field2.name);
+      });
+      test('skipsHiddenInput', function () {
+        const field = this.blocks.hiddenInput.inputList[2].fieldRow[0];
+        const nextNode = this.navigator.getPreviousSibling(field);
+        assert.equal(
+          nextNode,
+          this.blocks.hiddenInput.inputList[0].fieldRow[0],
+        );
       });
     });
 


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes https://github.com/google/blockly-keyboard-experimentation/issues/524

### Proposed Changes

Skip over hidden fields when navigating.

### Reason for Changes

We were already skipping hidden inputs, but there are also cases where just a field is hidden and needs to be skipped over.

### Test Coverage

Added unit tests for hidden inputs and fields.

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
