### PR TITLE
fix: focus something after deleting a block

### DIFF
--- a/core/block_svg.ts
+++ b/core/block_svg.ts
@@ -849,6 +849,17 @@ export class BlockSvg
     Tooltip.dispose();
     ContextMenu.hide();
 
+    // If this block was focused, focus its parent or workspace instead.
+    const focusManager = getFocusManager();
+    if (focusManager.getFocusedNode() === this) {
+      const parent = this.getParent();
+      if (parent) {
+        focusManager.focusNode(parent);
+      } else {
+        focusManager.focusTree(this.workspace);
+      }
+    }
+
     if (animate) {
       this.unplug(healStack);
       blockAnimations.disposeUiEffect(this);


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #8793 

### Proposed Changes

Focuses the parent of a block or the workspace after deleting a block

### Reason for Changes

Keyboard shortcuts stopped working if you deleted a block, because blockly wasn't focused anymore. Unblocks some testing issues in the kb experiment

### Test Coverage

There are some tests in the keyboard-experiment that test this

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
