### PR TITLE
fix: focus after drag and deleting comments

### DIFF
--- a/core/block_svg.ts
+++ b/core/block_svg.ts
@@ -856,7 +856,7 @@ export class BlockSvg
       if (parent) {
         focusManager.focusNode(parent);
       } else {
-        focusManager.focusTree(this.workspace);
+        setTimeout(() => focusManager.focusTree(this.workspace), 0);
       }
     }
 

--- a/core/comments/rendered_workspace_comment.ts
+++ b/core/comments/rendered_workspace_comment.ts
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {IFocusableNode} from '../blockly.js';
 import * as browserEvents from '../browser_events.js';
 import {
   WorkspaceCommentCopyData,
@@ -20,6 +19,7 @@ import {IContextMenu} from '../interfaces/i_contextmenu.js';
 import {ICopyable} from '../interfaces/i_copyable.js';
 import {IDeletable} from '../interfaces/i_deletable.js';
 import {IDraggable} from '../interfaces/i_draggable.js';
+import {IFocusableNode} from '../interfaces/i_focusable_node.js';
 import type {IFocusableTree} from '../interfaces/i_focusable_tree.js';
 import {IRenderedElement} from '../interfaces/i_rendered_element.js';
 import {ISelectable} from '../interfaces/i_selectable.js';

--- a/core/comments/rendered_workspace_comment.ts
+++ b/core/comments/rendered_workspace_comment.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import {IFocusableNode} from '../blockly.js';
 import * as browserEvents from '../browser_events.js';
 import {
   WorkspaceCommentCopyData,
@@ -42,7 +43,8 @@ export class RenderedWorkspaceComment
     ISelectable,
     IDeletable,
     ICopyable<WorkspaceCommentCopyData>,
-    IContextMenu
+    IContextMenu,
+    IFocusableNode
 {
   /** The class encompassing the svg elements making up the workspace comment. */
   private view: CommentView;
@@ -207,7 +209,12 @@ export class RenderedWorkspaceComment
   /** Disposes of the view. */
   override dispose() {
     this.disposing = true;
+    const focusManager = getFocusManager();
+    if (focusManager.getFocusedNode() === this) {
+      setTimeout(() => focusManager.focusTree(this.workspace), 0);
+    }
     if (!this.view.isDeadOrDying()) this.view.dispose();
+
     super.dispose();
   }
 


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #8825 

### Proposed Changes

- has `RenderedWorkspaceComment` declare that it implements `IFocusableNode`, it already did this so idk why it didn't say it did
- adds a timeout when focusing the workspace after disposing a block. the reason this is needed is in case of deleting a block via dragging it to the workspace, we need to wait for the timeout otherwise when focusing the workspace, the block we're about to delete is still focused
- focuses the workspace when a comment is deleted

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage

There are tests for this in keyboard-nav which I'll update when I remove the extra delete handling code there. It's a whole can of worms to move those tests into core, so for now, they'll live in keyboard-nav but will move into core with many of the other keyboard nav tests post-launch

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
