### PR TITLE
fix: Skip invisible inputs in the field navigation policy

### DIFF
--- a/core/keyboard_nav/field_navigation_policy.ts
+++ b/core/keyboard_nav/field_navigation_policy.ts
@@ -48,15 +48,14 @@ export class FieldNavigationPolicy implements INavigationPolicy<Field<any>> {
     let fieldIdx = input.fieldRow.indexOf(current) + 1;
     for (let i = curIdx; i < block.inputList.length; i++) {
       const newInput = block.inputList[i];
-      if (!newInput.isVisible()) {
-        continue;
+      if (newInput.isVisible()) {
+        const fieldRow = newInput.fieldRow;
+        if (fieldIdx < fieldRow.length) return fieldRow[fieldIdx];
+        if (newInput.connection?.targetBlock()) {
+          return newInput.connection.targetBlock() as BlockSvg;
+        }
       }
-      const fieldRow = newInput.fieldRow;
-      if (fieldIdx < fieldRow.length) return fieldRow[fieldIdx];
       fieldIdx = 0;
-      if (newInput.connection?.targetBlock()) {
-        return newInput.connection.targetBlock() as BlockSvg;
-      }
     }
     return null;
   }
@@ -76,15 +75,13 @@ export class FieldNavigationPolicy implements INavigationPolicy<Field<any>> {
     let fieldIdx = parentInput.fieldRow.indexOf(current) - 1;
     for (let i = curIdx; i >= 0; i--) {
       const input = block.inputList[i];
-      if (!input.isVisible()) {
-        continue;
+      if (input.isVisible()) {
+        if (input.connection?.targetBlock() && input !== parentInput) {
+          return input.connection.targetBlock() as BlockSvg;
+        }
+        const fieldRow = input.fieldRow;
+        if (fieldIdx > -1) return fieldRow[fieldIdx];
       }
-      if (input.connection?.targetBlock() && input !== parentInput) {
-        return input.connection.targetBlock() as BlockSvg;
-      }
-      const fieldRow = input.fieldRow;
-      if (fieldIdx > -1) return fieldRow[fieldIdx];
-
       // Reset the fieldIdx to the length of the field row of the previous
       // input.
       if (i - 1 >= 0) {

--- a/core/keyboard_nav/field_navigation_policy.ts
+++ b/core/keyboard_nav/field_navigation_policy.ts
@@ -48,6 +48,9 @@ export class FieldNavigationPolicy implements INavigationPolicy<Field<any>> {
     let fieldIdx = input.fieldRow.indexOf(current) + 1;
     for (let i = curIdx; i < block.inputList.length; i++) {
       const newInput = block.inputList[i];
+      if (!newInput.isVisible()) {
+        continue;
+      }
       const fieldRow = newInput.fieldRow;
       if (fieldIdx < fieldRow.length) return fieldRow[fieldIdx];
       fieldIdx = 0;
@@ -73,6 +76,9 @@ export class FieldNavigationPolicy implements INavigationPolicy<Field<any>> {
     let fieldIdx = parentInput.fieldRow.indexOf(current) - 1;
     for (let i = curIdx; i >= 0; i--) {
       const input = block.inputList[i];
+      if (!input.isVisible()) {
+        continue;
+      }
       if (input.connection?.targetBlock() && input !== parentInput) {
         return input.connection.targetBlock() as BlockSvg;
       }

--- a/tests/mocha/navigation_test.js
+++ b/tests/mocha/navigation_test.js
@@ -534,6 +534,13 @@ suite('Navigation', function () {
         const nextNode = this.navigator.getNextSibling(this.blocks.buttonBlock);
         assert.equal(nextNode.id, this.blocks.buttonNext.id);
       });
+      test('fromFieldSkipsHiddenInputs', function () {
+        this.blocks.buttonBlock.inputList[2].setVisible(false);
+        const fieldStart = this.blocks.buttonBlock.getField('BUTTON2');
+        const fieldEnd = this.blocks.buttonBlock.getField('BUTTON3');
+        const nextNode = this.navigator.getNextSibling(fieldStart);
+        assert.equal(nextNode.name, fieldEnd.name);
+      });
     });
 
     suite('Previous', function () {
@@ -668,6 +675,13 @@ suite('Navigation', function () {
           this.blocks.buttonNext,
         );
         assert.equal(prevNode.id, this.blocks.buttonBlock.id);
+      });
+      test('fromFieldSkipsHiddenInputs', function () {
+        this.blocks.buttonBlock.inputList[2].setVisible(false);
+        const fieldStart = this.blocks.buttonBlock.getField('BUTTON3');
+        const fieldEnd = this.blocks.buttonBlock.getField('BUTTON2');
+        const nextNode = this.navigator.getPreviousSibling(fieldStart);
+        assert.equal(nextNode.name, fieldEnd.name);
       });
     });
 


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes https://github.com/google/blockly-keyboard-experimentation/issues/524
![image](https://github.com/user-attachments/assets/706ac5ae-c79a-494e-a61d-f2adf940b6c9)


### Proposed Changes

Skips over hidden inputs when finding the next/prev node in field_navigation_policy.

### Reason for Changes

If you had a field before or after an input that had visible set to false the hidden input could be navigated to.

### Test Coverage

Added tests to cover next and previous for this case.

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
