### PR TITLE
fix: Make cut/copy/paste work consistently and as expected

### DIFF
--- a/core/shortcut_items.ts
+++ b/core/shortcut_items.ts
@@ -213,7 +213,9 @@ export function registerCopy() {
         : targetWorkspace;
       if (!targetWorkspace) return false;
 
-      targetWorkspace.hideChaff();
+      if (!focused.workspace.isFlyout) {
+        targetWorkspace.hideChaff();
+      }
       copyData = focused.toCopyData();
       copyWorkspace = targetWorkspace;
       copyCoords =

--- a/core/shortcut_items.ts
+++ b/core/shortcut_items.ts
@@ -130,8 +130,7 @@ function isCopyable(
     isIDeletable(focused) &&
     focused.isOwnDeletable() &&
     isDraggable(focused) &&
-    focused.isOwnMovable() &&
-    focused.isOwnEditable()
+    focused.isOwnMovable()
   );
 }
 
@@ -164,8 +163,7 @@ function isCuttable(focused: IFocusableNode): boolean {
     isIDeletable(focused) &&
     focused.isDeletable() &&
     isDraggable(focused) &&
-    focused.isMovable() &&
-    focused.isEditable()
+    focused.isMovable()
   );
 }
 

--- a/core/shortcut_items.ts
+++ b/core/shortcut_items.ts
@@ -101,7 +101,7 @@ let copyWorkspace: WorkspaceSvg | null = null;
 let copyCoords: Coordinate | null = null;
 
 /**
- * Determine if a focusable node can be copied using cut or copy.
+ * Determine if a focusable node can be copied.
  *
  * Unfortunately the ICopyable interface doesn't include an isCopyable
  * method, so we must use some other criteria to make the decision.
@@ -110,8 +110,8 @@ let copyCoords: Coordinate | null = null;
  * - It must be an ICopyable.
  * - So that a pasted copy can be manipluated and/or disposed of, it
  *   must be both an IDraggable and an IDeletable.
- * - Additionally, both .isMovable() and .isDeletable() must return
- *   true (i.e., can currently be moved and deleted).
+ * - Additionally, both .isOwnMovable() and .isOwnDeletable() must return
+ *   true (i.e., the copy could be moved and deleted).
  *
  * TODO(#9098): Revise these criteria.  The latter criteria prevents
  * shadow blocks from being copied; additionally, there are likely to
@@ -124,12 +124,48 @@ let copyCoords: Coordinate | null = null;
 function isCopyable(
   focused: IFocusableNode,
 ): focused is ICopyable<ICopyData> & IDeletable & IDraggable {
+  if (!(focused instanceof BlockSvg)) return false;
+  return (
+    isICopyable(focused) &&
+    isIDeletable(focused) &&
+    focused.isOwnDeletable() &&
+    isDraggable(focused) &&
+    focused.isOwnMovable() &&
+    focused.isOwnEditable()
+  );
+}
+
+/**
+ * Determine if a focusable node can be cut.
+ *
+ * Unfortunately the ICopyable interface doesn't include an isCuttable
+ * method, so we must use some other criteria to make the decision.
+ * Specifically,
+ *
+ * - It must be an ICopyable.
+ * - So that a pasted copy can be manipluated and/or disposed of, it
+ *   must be both an IDraggable and an IDeletable.
+ * - Additionally, both .isMovable() and .isDeletable() must return
+ *   true (i.e., can currently be moved and deleted). This is the main
+ *   difference with isCopyable.
+ *
+ * TODO(#9098): Revise these criteria.  The latter criteria prevents
+ * shadow blocks from being copied; additionally, there are likely to
+ * be other circumstances were it is desirable to allow movable /
+ * copyable copies of a currently-unmovable / -copyable block to be
+ * made.
+ *
+ * @param focused The focused object.
+ */
+function isCuttable(focused: IFocusableNode): boolean {
+  if (!(focused instanceof BlockSvg)) return false;
   return (
     isICopyable(focused) &&
     isIDeletable(focused) &&
     focused.isDeletable() &&
     isDraggable(focused) &&
-    focused.isMovable()
+    focused.isMovable() &&
+    focused.isEditable()
   );
 }
 
@@ -148,10 +184,16 @@ export function registerCopy() {
     name: names.COPY,
     preconditionFn(workspace, scope) {
       const focused = scope.focusedNode;
+      if (!(focused instanceof BlockSvg)) return false;
+
+      const targetWorkspace = workspace.isFlyout
+        ? workspace.targetWorkspace
+        : workspace;
       return (
-        !workspace.isReadOnly() &&
-        !Gesture.inProgress() &&
         !!focused &&
+        !!targetWorkspace &&
+        !targetWorkspace.isReadOnly() &&
+        !targetWorkspace.isDragging() &&
         isCopyable(focused)
       );
     },
@@ -159,17 +201,25 @@ export function registerCopy() {
       // Prevent the default copy behavior, which may beep or otherwise indicate
       // an error due to the lack of a selection.
       e.preventDefault();
-      workspace.hideChaff();
+
       const focused = scope.focusedNode;
-      if (!focused || !isICopyable(focused)) return false;
-      copyData = focused.toCopyData();
-      copyWorkspace =
+      if (!focused || !isCopyable(focused)) return false;
+      let targetWorkspace: WorkspaceSvg | null =
         focused.workspace instanceof WorkspaceSvg
           ? focused.workspace
           : workspace;
-      copyCoords = isDraggable(focused)
-        ? focused.getRelativeToSurfaceXY()
-        : null;
+      targetWorkspace = targetWorkspace.isFlyout
+        ? targetWorkspace.targetWorkspace
+        : targetWorkspace;
+      if (!targetWorkspace) return false;
+
+      targetWorkspace.hideChaff();
+      copyData = focused.toCopyData();
+      copyWorkspace = targetWorkspace;
+      copyCoords =
+        isDraggable(focused) && focused.workspace == targetWorkspace
+          ? focused.getRelativeToSurfaceXY()
+          : null;
       return !!copyData;
     },
     keyCodes: [ctrlC, metaC],
@@ -193,13 +243,10 @@ export function registerCut() {
     preconditionFn(workspace, scope) {
       const focused = scope.focusedNode;
       return (
-        !workspace.isReadOnly() &&
-        !Gesture.inProgress() &&
         !!focused &&
-        isCopyable(focused) &&
-        // Extra criteria for cut (not just copy):
-        !focused.workspace.isFlyout &&
-        focused.isDeletable()
+        !workspace.isReadOnly() &&
+        !workspace.isDragging() &&
+        isCuttable(focused)
       );
     },
     callback(workspace, e, shortcut, scope) {
@@ -246,7 +293,15 @@ export function registerPaste() {
   const pasteShortcut: KeyboardShortcut = {
     name: names.PASTE,
     preconditionFn(workspace) {
-      return !workspace.isReadOnly() && !Gesture.inProgress();
+      const targetWorkspace = workspace.isFlyout
+        ? workspace.targetWorkspace
+        : workspace;
+      return (
+        !!copyData &&
+        !!targetWorkspace &&
+        !targetWorkspace.isReadOnly() &&
+        !targetWorkspace.isDragging()
+      );
     },
     callback(workspace: WorkspaceSvg, e: Event) {
       if (!copyData || !copyWorkspace) return false;

--- a/tests/mocha/shortcut_items_test.js
+++ b/tests/mocha/shortcut_items_test.js
@@ -181,13 +181,13 @@ suite('Keyboard Shortcut Items', function () {
         runReadOnlyTest(keyEvent, testCaseName);
       });
     });
-    // Do not copy a block if a gesture is in progress.
-    suite('Gesture in progress', function () {
+    // Do not copy a block if a drag is in progress.
+    suite('Drag in progress', function () {
       testCases.forEach(function (testCase) {
         const testCaseName = testCase[0];
         const keyEvent = testCase[1];
         test(testCaseName, function () {
-          sinon.stub(Blockly.Gesture, 'inProgress').returns(true);
+          sinon.stub(this.workspace, 'isDragging').returns(true);
           this.injectionDiv.dispatchEvent(keyEvent);
           sinon.assert.notCalled(this.copySpy);
           sinon.assert.notCalled(this.hideChaffSpy);
@@ -201,7 +201,7 @@ suite('Keyboard Shortcut Items', function () {
         const keyEvent = testCase[1];
         test(testCaseName, function () {
           sinon
-            .stub(Blockly.common.getSelected(), 'isDeletable')
+            .stub(Blockly.common.getSelected(), 'isOwnDeletable')
             .returns(false);
           this.injectionDiv.dispatchEvent(keyEvent);
           sinon.assert.notCalled(this.copySpy);
@@ -215,7 +215,9 @@ suite('Keyboard Shortcut Items', function () {
         const testCaseName = testCase[0];
         const keyEvent = testCase[1];
         test(testCaseName, function () {
-          sinon.stub(Blockly.common.getSelected(), 'isMovable').returns(false);
+          sinon
+            .stub(Blockly.common.getSelected(), 'isOwnMovable')
+            .returns(false);
           this.injectionDiv.dispatchEvent(keyEvent);
           sinon.assert.notCalled(this.copySpy);
           sinon.assert.notCalled(this.hideChaffSpy);


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes https://github.com/google/blockly-keyboard-experimentation/issues/546

This is a dependency for https://github.com/google/blockly-keyboard-experimentation/pull/556 

### Proposed Changes

Updates the preconditions for cut/copy/paste to be more aware of flyouts and to use the following criteria:
- Allow copying any blocks that could be moved, deleted, and edited once pasted (isOwn<X>able)
- Allow cutting any blocks that are currently movable and deletable (is<X>able).
- Allow pasting onto editable workspaces when there's copydata available.

### Reason for Changes

You couldn't copy a block in the toolbox and then paste it into the workspace and when paste was enabled was inconsistent.

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
