### PR TITLE
feat: ephemeral focus public getter, use in shortcut precondition

### DIFF
--- a/core/focus_manager.ts
+++ b/core/focus_manager.ts
@@ -459,6 +459,13 @@ export class FocusManager {
   }
 
   /**
+   * @returns whether something is currently holding ephemeral focus
+   */
+  ephemeralFocusTaken(): boolean {
+    return this.currentlyHoldsEphemeralFocus;
+  }
+
+  /**
    * Ensures that the manager is currently allowing operations that change its
    * internal focus state (such as via focusNode()).
    *

--- a/core/shortcut_items.ts
+++ b/core/shortcut_items.ts
@@ -9,6 +9,7 @@
 import {BlockSvg} from './block_svg.js';
 import * as clipboard from './clipboard.js';
 import * as eventUtils from './events/utils.js';
+import {getFocusManager} from './focus_manager.js';
 import {Gesture} from './gesture.js';
 import {
   ICopyable,
@@ -72,7 +73,9 @@ export function registerDelete() {
         focused != null &&
         isIDeletable(focused) &&
         focused.isDeletable() &&
-        !Gesture.inProgress()
+        !Gesture.inProgress() &&
+        // Don't delete the block if a field editor is open
+        !getFocusManager().ephemeralFocusTaken()
       );
     },
     callback(workspace, e, shortcut, scope) {
@@ -152,7 +155,8 @@ export function registerCopy() {
         !workspace.isReadOnly() &&
         !Gesture.inProgress() &&
         !!focused &&
-        isCopyable(focused)
+        isCopyable(focused) &&
+        !getFocusManager().ephemeralFocusTaken()
       );
     },
     callback(workspace, e, shortcut, scope) {
@@ -199,7 +203,8 @@ export function registerCut() {
         isCopyable(focused) &&
         // Extra criteria for cut (not just copy):
         !focused.workspace.isFlyout &&
-        focused.isDeletable()
+        focused.isDeletable() &&
+        !getFocusManager().ephemeralFocusTaken()
       );
     },
     callback(workspace, e, shortcut, scope) {
@@ -246,7 +251,11 @@ export function registerPaste() {
   const pasteShortcut: KeyboardShortcut = {
     name: names.PASTE,
     preconditionFn(workspace) {
-      return !workspace.isReadOnly() && !Gesture.inProgress();
+      return (
+        !workspace.isReadOnly() &&
+        !Gesture.inProgress() &&
+        !getFocusManager().ephemeralFocusTaken()
+      );
     },
     callback(workspace: WorkspaceSvg, e: Event) {
       if (!copyData || !copyWorkspace) return false;
@@ -305,7 +314,11 @@ export function registerUndo() {
   const undoShortcut: KeyboardShortcut = {
     name: names.UNDO,
     preconditionFn(workspace) {
-      return !workspace.isReadOnly() && !Gesture.inProgress();
+      return (
+        !workspace.isReadOnly() &&
+        !Gesture.inProgress() &&
+        !getFocusManager().ephemeralFocusTaken()
+      );
     },
     callback(workspace, e) {
       // 'z' for undo 'Z' is for redo.
@@ -340,7 +353,11 @@ export function registerRedo() {
   const redoShortcut: KeyboardShortcut = {
     name: names.REDO,
     preconditionFn(workspace) {
-      return !Gesture.inProgress() && !workspace.isReadOnly();
+      return (
+        !Gesture.inProgress() &&
+        !workspace.isReadOnly() &&
+        !getFocusManager().ephemeralFocusTaken()
+      );
     },
     callback(workspace, e) {
       // 'z' for undo 'Z' is for redo.


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Required for https://github.com/google/blockly/issues/9101

### Proposed Changes

- Adds a public method for whether something has taken ephemeral focus. I called this `ephemeralFocusTaken` instead of matching the `currentlyHoldsEphemeralFocus` because I feel like the latter implies that the focus manager is holding it, when really, it's some other object that has taken it. let me know if you hate this though. the name of the property is private so we could probably also change that. cc @BenHenning for feedback on this.
- Uses this method in the precondition for most shortcuts (not escape, which hides chaff) in core

### Reason for Changes

It's confusing when a keyboard shortcut acts in the "background" of an open field editor. Most shortcuts shouldn't do that. Specific widget divs or dropdown div editors can always bind their own key listeners, or bind a keyboard shortcut that doesn't have this in the precondition. For example, you could imagine the pitch field editor using the up/down arrow keys to move the note up and down the staff. In that case, you would definitely want to disable the keyboard-navigation behavior of the arrow keys while that field editor is open (so you don't navigate between blocks) but you could register your own shortcut that only applies when that editor is open, or just register keypress listeners directly on the field editor.

### Test Coverage

Will add webdriver tests when I make the corresponding change in kbe to add this to that plugin's preconditions.

### Documentation

We should probably include information about this when explaining ephemeral focus.

### Additional Information

cc @RoboErikG this precondition should be included in the cut/copy/paste preconditions, so whichever of us merges second will have to include this in the merge conflict cleanup
