### PR TITLE
fix: caret position when editing block comments

### DIFF
--- a/core/bubbles/textinput_bubble.ts
+++ b/core/bubbles/textinput_bubble.ts
@@ -173,6 +173,10 @@ export class TextInputBubble extends Bubble {
     browserEvents.conditionalBind(textArea, 'wheel', this, (e: Event) => {
       e.stopPropagation();
     });
+    // Don't let the pointerdown event get to the workspace.
+    browserEvents.conditionalBind(textArea, 'pointerdown', this, (e: Event) => {
+      e.stopPropagation();
+    });
 
     browserEvents.conditionalBind(textArea, 'change', this, this.onTextChange);
   }


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #9125 

### Proposed Changes

Adds a pointerdown event that just captures the event and stops it from propagating.

### Reason for Changes

There was a pointerdown event that was being fired on the workspace when clicking on the block comment's textarea. I didn't look further into figuring out exactly why that caused the caret not to move.

This approach of capturing the event is already being used in the workspace comment textarea, and those don't have this problem (they have other problems, but this isn't one of them).

### Test Coverage

Manual testing including with bke.

### Documentation

### Additional Information

<!-- Anything else we should know? -->
