### PR TITLE
feat: make comment editor separately focusable from comment itself

### DIFF
--- a/core/comments.ts
+++ b/core/comments.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+export {CommentEditor} from './comments/comment_editor';
 export {CommentView} from './comments/comment_view.js';
 export {RenderedWorkspaceComment} from './comments/rendered_workspace_comment.js';
 export {WorkspaceComment} from './comments/workspace_comment.js';

--- a/core/comments.ts
+++ b/core/comments.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-export {CommentEditor} from './comments/comment_editor';
+export {CommentEditor} from './comments/comment_editor.js';
 export {CommentView} from './comments/comment_view.js';
 export {RenderedWorkspaceComment} from './comments/rendered_workspace_comment.js';
 export {WorkspaceComment} from './comments/workspace_comment.js';

--- a/core/comments/comment_editor.ts
+++ b/core/comments/comment_editor.ts
@@ -1,0 +1,77 @@
+/**
+ * @license
+ * Copyright 2024 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as browserEvents from '../browser_events.js';
+import {getFocusManager} from '../focus_manager.js';
+import {IFocusableNode} from '../interfaces/i_focusable_node.js';
+import {IFocusableTree} from '../interfaces/i_focusable_tree.js';
+import * as dom from '../utils/dom.js';
+import {Svg} from '../utils/svg.js';
+import {WorkspaceSvg} from '../workspace_svg.js';
+
+export class CommentEditor implements IFocusableNode {
+  id?: string;
+  /** The foreignObject containing the HTML text area. */
+  foreignObject: SVGForeignObjectElement;
+
+  /** The text area where the user can type. */
+  textArea: HTMLTextAreaElement;
+
+  constructor(
+    public workspace: WorkspaceSvg,
+    commentSvgRoot: SVGGElement,
+    commentId?: string,
+  ) {
+    this.foreignObject = dom.createSvgElement(
+      Svg.FOREIGNOBJECT,
+      {
+        'class': 'blocklyCommentForeignObject',
+      },
+      commentSvgRoot,
+    );
+    const body = document.createElementNS(dom.HTML_NS, 'body');
+    body.setAttribute('xmlns', dom.HTML_NS);
+    body.className = 'blocklyMinimalBody';
+    this.textArea = document.createElementNS(
+      dom.HTML_NS,
+      'textarea',
+    ) as HTMLTextAreaElement;
+    dom.addClass(this.textArea, 'blocklyCommentText');
+    dom.addClass(this.textArea, 'blocklyTextarea');
+    dom.addClass(this.textArea, 'blocklyText');
+    body.appendChild(this.textArea);
+    this.foreignObject.appendChild(body);
+
+    if (commentId) {
+      this.id = commentId + '_textarea_';
+      this.textArea.setAttribute('id', this.id);
+    }
+
+    browserEvents.conditionalBind(
+      this.textArea,
+      'pointerdown',
+      this,
+      (e: PointerEvent) => {
+        // don't allow this event to bubble up
+        // and steal focus away from the editor/comment.
+        e.stopPropagation();
+        getFocusManager().focusNode(this);
+      },
+    );
+  }
+
+  getFocusableElement(): HTMLElement | SVGElement {
+    return this.textArea;
+  }
+  getFocusableTree(): IFocusableTree {
+    return this.workspace;
+  }
+  onNodeFocus(): void {}
+  onNodeBlur(): void {}
+  canBeFocused(): boolean {
+    return true;
+  }
+}

--- a/core/comments/comment_editor.ts
+++ b/core/comments/comment_editor.ts
@@ -33,6 +33,7 @@ export class CommentEditor implements IFocusableNode {
   constructor(
     public workspace: WorkspaceSvg,
     commentId?: string,
+    private onFinishEditing?: () => void,
   ) {
     this.foreignObject = dom.createSvgElement(Svg.FOREIGNOBJECT, {
       'class': 'blocklyCommentForeignObject',
@@ -75,6 +76,14 @@ export class CommentEditor implements IFocusableNode {
         getFocusManager().focusNode(this);
       },
     );
+
+    // Register listener for keydown events that would finish editing.
+    browserEvents.conditionalBind(
+      this.textArea,
+      'keydown',
+      this,
+      this.handleKeyDown,
+    );
   }
 
   /** Gets the dom structure for this comment editor. */
@@ -86,6 +95,7 @@ export class CommentEditor implements IFocusableNode {
   getText(): string {
     return this.text;
   }
+
   /** Sets the current text of the comment and fires change listeners. */
   setText(text: string) {
     this.textArea.value = text;
@@ -102,6 +112,18 @@ export class CommentEditor implements IFocusableNode {
     // Loop through listeners backwards in case they remove themselves.
     for (let i = this.textChangeListeners.length - 1; i >= 0; i--) {
       this.textChangeListeners[i](oldText, this.text);
+    }
+  }
+
+  /**
+   * Do something when the user indicates they've finished editing.
+   *
+   * @param e Keyboard event.
+   */
+  private handleKeyDown(e: KeyboardEvent) {
+    if (e.key === 'Escape' || (e.key === 'Enter' && (e.ctrlKey || e.metaKey))) {
+      if (this.onFinishEditing) this.onFinishEditing();
+      e.stopPropagation();
     }
   }
 

--- a/core/comments/comment_editor.ts
+++ b/core/comments/comment_editor.ts
@@ -13,6 +13,12 @@ import {Size} from '../utils/size.js';
 import {Svg} from '../utils/svg.js';
 import {WorkspaceSvg} from '../workspace_svg.js';
 
+/**
+ * String added to the ID of a workspace comment to identify
+ * the focusable node for the comment editor.
+ */
+export const COMMENT_EDITOR_FOCUS_IDENTIFIER = '_comment_textarea_';
+
 /** The part of a comment that can be typed into. */
 export class CommentEditor implements IFocusableNode {
   id?: string;
@@ -52,7 +58,7 @@ export class CommentEditor implements IFocusableNode {
     this.foreignObject.appendChild(body);
 
     if (commentId) {
-      this.id = commentId + '_comment_textarea_';
+      this.id = commentId + COMMENT_EDITOR_FOCUS_IDENTIFIER;
       this.textArea.setAttribute('id', this.id);
     }
 

--- a/core/comments/comment_view.ts
+++ b/core/comments/comment_view.ts
@@ -116,7 +116,7 @@ export class CommentView implements IRenderedElement {
       textPreviewNode: this.textPreviewNode,
     } = this.createTopBar(this.svgRoot, workspace));
 
-    this.commentEditor = this.createTextArea(this.svgRoot);
+    this.commentEditor = this.createTextArea();
 
     this.resizeHandle = this.createResizeHandle(this.svgRoot, workspace);
 
@@ -229,7 +229,7 @@ export class CommentView implements IRenderedElement {
   /**
    * Creates the text area where users can type. Registers event listeners.
    */
-  private createTextArea(svgRoot: SVGGElement) {
+  private createTextArea() {
     const commentEditor = new CommentEditor(this.workspace, this.commentId);
 
     this.svgRoot.appendChild(commentEditor.getDom());

--- a/core/comments/comment_view.ts
+++ b/core/comments/comment_view.ts
@@ -230,7 +230,13 @@ export class CommentView implements IRenderedElement {
    * Creates the text area where users can type. Registers event listeners.
    */
   private createTextArea() {
-    const commentEditor = new CommentEditor(this.workspace, this.commentId);
+    // When the user is done editing comment, focus the entire comment.
+    const onFinishEditing = () => this.svgRoot.focus();
+    const commentEditor = new CommentEditor(
+      this.workspace,
+      this.commentId,
+      onFinishEditing,
+    );
 
     this.svgRoot.appendChild(commentEditor.getDom());
 

--- a/core/comments/comment_view.ts
+++ b/core/comments/comment_view.ts
@@ -15,6 +15,7 @@ import * as drag from '../utils/drag.js';
 import {Size} from '../utils/size.js';
 import {Svg} from '../utils/svg.js';
 import {WorkspaceSvg} from '../workspace_svg.js';
+import {CommentEditor} from './comment_editor.js';
 
 export class CommentView implements IRenderedElement {
   /** The root group element of the comment view. */
@@ -106,7 +107,12 @@ export class CommentView implements IRenderedElement {
   /** The default size of newly created comments. */
   static defaultCommentSize = new Size(120, 100);
 
-  constructor(readonly workspace: WorkspaceSvg) {
+  public commentEditor: CommentEditor | undefined;
+
+  constructor(
+    readonly workspace: WorkspaceSvg,
+    private commentId?: string,
+  ) {
     this.svgRoot = dom.createSvgElement(Svg.G, {
       'class': 'blocklyComment blocklyEditable blocklyDraggable',
     });
@@ -240,26 +246,12 @@ export class CommentView implements IRenderedElement {
     foreignObject: SVGForeignObjectElement;
     textArea: HTMLTextAreaElement;
   } {
-    const foreignObject = dom.createSvgElement(
-      Svg.FOREIGNOBJECT,
-      {
-        'class': 'blocklyCommentForeignObject',
-      },
+    this.commentEditor = new CommentEditor(
+      this.workspace,
       svgRoot,
+      this.commentId,
     );
-    const body = document.createElementNS(dom.HTML_NS, 'body');
-    body.setAttribute('xmlns', dom.HTML_NS);
-    body.className = 'blocklyMinimalBody';
-    const textArea = document.createElementNS(
-      dom.HTML_NS,
-      'textarea',
-    ) as HTMLTextAreaElement;
-    dom.addClass(textArea, 'blocklyCommentText');
-    dom.addClass(textArea, 'blocklyTextarea');
-    dom.addClass(textArea, 'blocklyText');
-    body.appendChild(textArea);
-    foreignObject.appendChild(body);
-
+    const {foreignObject, textArea} = this.commentEditor;
     browserEvents.conditionalBind(textArea, 'change', this, this.onTextChange);
 
     return {foreignObject, textArea};

--- a/core/comments/rendered_workspace_comment.ts
+++ b/core/comments/rendered_workspace_comment.ts
@@ -333,6 +333,13 @@ export class RenderedWorkspaceComment
     }
   }
 
+  /**
+   * @returns The FocusableNode representing the editor portion of this comment.
+   */
+  getEditorFocusableNode(): IFocusableNode {
+    return this.view.getEditorFocusableNode();
+  }
+
   /** See IFocusableNode.getFocusableElement. */
   getFocusableElement(): HTMLElement | SVGElement {
     return this.getSvgRoot();

--- a/core/comments/rendered_workspace_comment.ts
+++ b/core/comments/rendered_workspace_comment.ts
@@ -47,7 +47,7 @@ export class RenderedWorkspaceComment
     IFocusableNode
 {
   /** The class encompassing the svg elements making up the workspace comment. */
-  private view: CommentView;
+  view: CommentView;
 
   public readonly workspace: WorkspaceSvg;
 
@@ -59,7 +59,7 @@ export class RenderedWorkspaceComment
 
     this.workspace = workspace;
 
-    this.view = new CommentView(workspace);
+    this.view = new CommentView(workspace, this.id);
     // Set the size to the default size as defined in the superclass.
     this.view.setSize(this.getSize());
     this.view.setEditable(this.isEditable());
@@ -224,13 +224,7 @@ export class RenderedWorkspaceComment
   private startGesture(e: PointerEvent) {
     const gesture = this.workspace.getGesture(e);
     if (gesture) {
-      if (browserEvents.isTargetInput(e)) {
-        // If the text area was the focus, don't allow this event to bubble up
-        // and steal focus away from the editor/comment.
-        e.stopPropagation();
-      } else {
-        gesture.handleCommentStart(e, this);
-      }
+      gesture.handleCommentStart(e, this);
       getFocusManager().focusNode(this);
     }
   }

--- a/core/workspace_svg.ts
+++ b/core/workspace_svg.ts
@@ -22,6 +22,7 @@ import type {Block} from './block.js';
 import type {BlockSvg} from './block_svg.js';
 import type {BlocklyOptions} from './blockly_options.js';
 import * as browserEvents from './browser_events.js';
+import {COMMENT_EDITOR_FOCUS_IDENTIFIER} from './comments/comment_editor.js';
 import {RenderedWorkspaceComment} from './comments/rendered_workspace_comment.js';
 import {WorkspaceComment} from './comments/workspace_comment.js';
 import * as common from './common.js';
@@ -2779,7 +2780,7 @@ export class WorkspaceSvg
 
     // Search for a specific workspace comment editor
     // (only if id seems like it is one).
-    const commentEditorIndicator = id.indexOf('_comment_textarea_');
+    const commentEditorIndicator = id.indexOf(COMMENT_EDITOR_FOCUS_IDENTIFIER);
     if (commentEditorIndicator !== -1) {
       const commentId = id.substring(0, commentEditorIndicator);
       const comment = this.searchForWorkspaceComment(commentId);


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #9121 

### Proposed Changes

- Makes the textarea of the workspace comment separately editable from the comment as a whole.
- Accomplishes this by adding a new class that implements `IFocusableNode`, `CommentEditor`
- This should still be compatible with subclasses of `RenderedWorkspaceComment`

![Screenshot 2025-06-18 at 4 57 52 PM](https://github.com/user-attachments/assets/c7a4ac62-c568-4560-bbbc-e9a8a875e588)


### Reason for Changes

FocusManager does not currently support the scenario where some node is focused, but the thing with browser focus is not the exact element that it thinks should have focus (i.e. the one returned from `getFocusableElement`). Therefore, it is impossible to have the comment editor textarea separately focusable from the comment as a whole unless there is a separate `IFocusableNode` object.

These changes not only fix the bug, but they'll allow us to make keyboard navigation possible for workspace comments. Theoretically all we need to do is add a navigation policy that can navigate from the comment as a whole to the text input, similar to how you can navigate to a text input field on a block. So a user could move, delete, or copy a workspace comment when the whole comment is focused, and edit the text when just the editor part is focused.

### Test Coverage

Will add tests for workspace comments during this sprint after webdriver tests are working again.

### Documentation

The workspace comments documentation focuses on the css class available, so I don't think anything changes there.

### Additional Information

