### PR TITLE
fix: Don't auto-close flyout for new vars

### DIFF
--- a/core/flyout_base.ts
+++ b/core/flyout_base.ts
@@ -22,6 +22,7 @@ import {FlyoutItem} from './flyout_item.js';
 import {FlyoutMetricsManager} from './flyout_metrics_manager.js';
 import {FlyoutNavigator} from './flyout_navigator.js';
 import {FlyoutSeparator, SeparatorAxis} from './flyout_separator.js';
+import { getFocusManager } from './focus_manager.js';
 import {IAutoHideable} from './interfaces/i_autohideable.js';
 import type {IFlyout} from './interfaces/i_flyout.js';
 import type {IFlyoutInflater} from './interfaces/i_flyout_inflater.js';
@@ -615,6 +616,10 @@ export abstract class Flyout
    *     toolbox definition, or a string with the name of the dynamic category.
    */
   show(flyoutDef: toolbox.FlyoutDefinition | string) {
+    const previouslyFocusedNode = getFocusManager().getFocusedNode();
+    const hadFocusedItem =
+      this.getContents().some(
+        (item) => item.getElement() === previouslyFocusedNode);
     this.workspace_.setResizesEnabled(false);
     this.hide();
     this.clearOldBlocks();
@@ -655,6 +660,14 @@ export abstract class Flyout
       }
     };
     this.workspace_.addChangeListener(this.reflowWrapper);
+
+    // It's difficult to restore the actual element that was focused since
+    // everything gets recreated (and it may no longer exist). Instead, if the
+    // flyout previously held focus then force it to focus the first element.
+    const contents = this.getContents();
+    if (hadFocusedItem && contents.length > 0) {
+      getFocusManager().focusNode(contents[0].getElement());
+    }
   }
 
   /**

--- a/core/variables.ts
+++ b/core/variables.ts
@@ -9,6 +9,7 @@
 import type {Block} from './block.js';
 import {Blocks} from './blocks.js';
 import * as dialog from './dialog.js';
+import { getFocusManager } from './focus_manager.js';
 import {isLegacyProcedureDefBlock} from './interfaces/i_legacy_procedure_blocks.js';
 import {isVariableBackedParameterModel} from './interfaces/i_variable_backed_parameter_model.js';
 import {IVariableModel, IVariableState} from './interfaces/i_variable_model.js';
@@ -519,6 +520,8 @@ export function promptName(
   defaultText: string,
   callback: (p1: string | null) => void,
 ) {
+  const returnEphemeralFocus =
+    getFocusManager().takeEphemeralFocus(document.body);
   dialog.prompt(promptText, defaultText, function (newVar) {
     // Merge runs of whitespace.  Strip leading and trailing whitespace.
     // Beyond this, all names are legal.
@@ -529,6 +532,7 @@ export function promptName(
         newVar = null;
       }
     }
+    returnEphemeralFocus();
     callback(newVar);
   });
 }

--- a/core/workspace_svg.ts
+++ b/core/workspace_svg.ts
@@ -2859,8 +2859,9 @@ export class WorkspaceSvg
       const flyout = this.targetWorkspace.getFlyout();
       const toolbox = this.targetWorkspace.getToolbox();
       if (toolbox && nextTree === toolbox) return;
-      if (toolbox) toolbox.clearSelection();
-      if (flyout && isAutoHideable(flyout)) flyout.autoHide(false);
+      // TODO: Figure out how to fix this.
+      // if (toolbox) toolbox.clearSelection();
+      // if (flyout && isAutoHideable(flyout)) flyout.autoHide(false);
     }
   }
 


### PR DESCRIPTION
## The basics

- [ ] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

Fixes #9106
Fixes #9122

### Proposed Changes

This ensures `Flyout` doesn't close when it shouldn't (i.e. when creating or renaming variables).

### Reason for Changes

The main issue is that the window prompt takes focus away from Blockly entirely, so ephemeral focus is now being used for variable creation and renaming to restore focus back to the original node.

However, that's not a complete solution since creating a variable causes the flyout to fully be laid out again. As a result, there's no trivial way to track and restore focus back to the element that had held focus previously (or to use the ephemerally-restored focus to even realize that focus _should_ be restored). To make this work reasonably well, when the `Flyout` is re-laid out it will now check if it had focus before and, if it did, will focus the first new element it creates after being relaid out. It's not a perfect solution, but it seems like a reasonable medium or long-term solution.

### Test Coverage

TODO: Tests need to be added yet.

### Documentation

No new documentation changes should be needed.

### Additional Information

Note that this PR is **not** production ready yet as it completely disables auto-flyout closing. The main issue here is that there's a moment either due to the prompt or due to elements with focus being deleted that eventually lead to the flyout's workspace being blurred and attempts to restore focus after that completely fail since it's been closed and the nodes no longer exist. It's unclear at the moment how to solve this problem.