### PR TITLE
fix: check for a drag specifically rather than a gesture for shortcuts

### DIFF
--- a/core/shortcut_items.ts
+++ b/core/shortcut_items.ts
@@ -11,7 +11,6 @@ import * as clipboard from './clipboard.js';
 import {RenderedWorkspaceComment} from './comments.js';
 import * as eventUtils from './events/utils.js';
 import {getFocusManager} from './focus_manager.js';
-import {Gesture} from './gesture.js';
 import {ICopyData, isCopyable as isICopyable} from './interfaces/i_copyable.js';
 import {isDeletable as isIDeletable} from './interfaces/i_deletable.js';
 import {isDraggable} from './interfaces/i_draggable.js';
@@ -67,7 +66,7 @@ export function registerDelete() {
         focused != null &&
         isIDeletable(focused) &&
         focused.isDeletable() &&
-        !Gesture.inProgress() &&
+        !workspace.isDragging() &&
         // Don't delete the block if a field editor is open
         !getFocusManager().ephemeralFocusTaken()
       );
@@ -322,7 +321,7 @@ export function registerUndo() {
     preconditionFn(workspace) {
       return (
         !workspace.isReadOnly() &&
-        !Gesture.inProgress() &&
+        !workspace.isDragging() &&
         !getFocusManager().ephemeralFocusTaken()
       );
     },
@@ -360,7 +359,7 @@ export function registerRedo() {
     name: names.REDO,
     preconditionFn(workspace) {
       return (
-        !Gesture.inProgress() &&
+        !workspace.isDragging() &&
         !workspace.isReadOnly() &&
         !getFocusManager().ephemeralFocusTaken()
       );

--- a/tests/mocha/shortcut_items_test.js
+++ b/tests/mocha/shortcut_items_test.js
@@ -434,13 +434,13 @@ suite('Keyboard Shortcut Items', function () {
         });
       });
     });
-    // Do not undo if a gesture is in progress.
-    suite('Gesture in progress', function () {
+    // Do not undo if a drag is in progress.
+    suite('Drag in progress', function () {
       testCases.forEach(function (testCase) {
         const testCaseName = testCase[0];
         const keyEvent = testCase[1];
         test(testCaseName, function () {
-          sinon.stub(Blockly.Gesture, 'inProgress').returns(true);
+          sinon.stub(this.workspace, 'isDragging').returns(true);
           this.injectionDiv.dispatchEvent(keyEvent);
           sinon.assert.notCalled(this.undoSpy);
           sinon.assert.notCalled(this.hideChaffSpy);
@@ -494,13 +494,13 @@ suite('Keyboard Shortcut Items', function () {
         });
       });
     });
-    // Do not undo if a gesture is in progress.
-    suite('Gesture in progress', function () {
+    // Do not redo if a drag is in progress.
+    suite('Drag in progress', function () {
       testCases.forEach(function (testCase) {
         const testCaseName = testCase[0];
         const keyEvent = testCase[1];
         test(testCaseName, function () {
-          sinon.stub(Blockly.Gesture, 'inProgress').returns(true);
+          sinon.stub(this.workspace, 'isDragging').returns(true);
           this.injectionDiv.dispatchEvent(keyEvent);
           sinon.assert.notCalled(this.redoSpy);
           sinon.assert.notCalled(this.hideChaffSpy);
@@ -534,8 +534,8 @@ suite('Keyboard Shortcut Items', function () {
       sinon.assert.calledWith(this.undoSpy, true);
       sinon.assert.calledOnce(this.hideChaffSpy);
     });
-    test('Not called when a gesture is in progress', function () {
-      sinon.stub(Blockly.Gesture, 'inProgress').returns(true);
+    test('Not called when a drag is in progress', function () {
+      sinon.stub(this.workspace, 'isDragging').returns(true);
       this.injectionDiv.dispatchEvent(this.ctrlYEvent);
       sinon.assert.notCalled(this.undoSpy);
       sinon.assert.notCalled(this.hideChaffSpy);


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #9113 

### Proposed Changes

Checks if there is a drag in progress instead of any gesture, for all remaining shortcut items.

### Reason for Changes

See https://github.com/google/blockly-keyboard-experimentation/issues/548

### Test Coverage

Updated tests

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
