### PR TITLE
fix: Prevent loss of focus when deleting a workspace comment.

### DIFF
--- a/core/comments/delete_comment_bar_button.ts
+++ b/core/comments/delete_comment_bar_button.ts
@@ -5,6 +5,7 @@
  */
 
 import * as browserEvents from '../browser_events.js';
+import {getFocusManager} from '../focus_manager.js';
 import * as touch from '../touch.js';
 import * as dom from '../utils/dom.js';
 import {Svg} from '../utils/svg.js';
@@ -98,5 +99,6 @@ export class DeleteCommentBarButton extends CommentBarButton {
 
     this.getParentComment().dispose();
     e?.stopPropagation();
+    getFocusManager().focusNode(this.workspace);
   }
 }

--- a/tests/mocha/workspace_comment_test.js
+++ b/tests/mocha/workspace_comment_test.js
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import {assert} from '../../node_modules/chai/chai.js';
 import {
   assertEventFired,
   createChangeListenerSpy,
@@ -166,6 +167,16 @@ suite('Workspace comment', function () {
         },
         this.workspace.id,
       );
+    });
+
+    test('focuses the workspace when deleted', function () {
+      const comment = new Blockly.comments.RenderedWorkspaceComment(
+        this.workspace,
+      );
+      Blockly.getFocusManager().focusNode(comment);
+      assert.equal(Blockly.getFocusManager().getFocusedNode(), comment);
+      comment.view.getCommentBarButtons()[1].performAction();
+      assert.equal(Blockly.getFocusManager().getFocusedNode(), this.workspace);
     });
   });
 });


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves
This PR fixes a bug that could cause focus to be lost in keyboard navigation mode when deleting a workspace comment via its comment bar button.