### PR TITLE
feat: add copy api and paste into correct workspace

### DIFF
--- a/core/clipboard.ts
+++ b/core/clipboard.ts
@@ -25,6 +25,10 @@ let stashedCoordinates: Coordinate | undefined = undefined;
  * Copy a copyable item, and record its data and the workspace it was
  * copied from.
  *
+ * This function does not perform any checks to ensure the copy
+ * should be allowed, e.g. to ensure the block is deletable. Such
+ * checks should be done before calling this function.
+ *
  * Note that if the copyable item is not an `ISelectable` or its
  * `workspace` property is not a `WorkspaceSvg`, the copy will be
  * successful, but there will be no saved workspace data. This will
@@ -123,6 +127,11 @@ export function setLastCopiedLocation(location: Coordinate) {
 
 /**
  * Paste a pasteable element into the given workspace.
+ *
+ * This function does not perform any checks to ensure the paste
+ * is allowed, e.g. that the workspace is rendered or the block
+ * is pasteable. Such checks should be done before calling this
+ * function.
  *
  * @param copyData The data to paste into the workspace.
  * @param workspace The workspace to paste the data into.

--- a/core/shortcut_items.ts
+++ b/core/shortcut_items.ts
@@ -248,7 +248,9 @@ export function registerPaste() {
       // paste into the last-copied-from workspace.
       const workspace = clipboard.getLastCopiedWorkspace();
       // If we don't know where we copied from, we don't know where to paste.
-      if (!workspace) return false;
+      // If the workspace isn't rendered (e.g. closed mutator workspace),
+      // we can't paste into it.
+      if (!workspace || !workspace.rendered) return false;
       const targetWorkspace = workspace.isFlyout
         ? workspace.targetWorkspace
         : workspace;

--- a/core/shortcut_items.ts
+++ b/core/shortcut_items.ts
@@ -255,7 +255,7 @@ export function registerPaste() {
         ? workspace.targetWorkspace
         : workspace;
       return (
-        !!clipboard.getLastCopiedData &&
+        !!clipboard.getLastCopiedData() &&
         !!targetWorkspace &&
         !targetWorkspace.isReadOnly() &&
         !targetWorkspace.isDragging() &&

--- a/tests/mocha/clipboard_test.js
+++ b/tests/mocha/clipboard_test.js
@@ -76,11 +76,39 @@ suite('Clipboard', function () {
       await mutatorIcon.setBubbleVisible(true);
       const mutatorWorkspace = mutatorIcon.getWorkspace();
       const elseIf = mutatorWorkspace.getBlocksByType('controls_if_elseif')[0];
-      assert.notEqual(elseIf, undefined);
+      assert.isDefined(elseIf);
       assert.lengthOf(mutatorWorkspace.getAllBlocks(), 2);
       assert.lengthOf(this.workspace.getAllBlocks(), 1);
       const data = elseIf.toCopyData();
       Blockly.clipboard.paste(data, mutatorWorkspace);
+      assert.lengthOf(mutatorWorkspace.getAllBlocks(), 3);
+      assert.lengthOf(this.workspace.getAllBlocks(), 1);
+    });
+
+    test('pasting into a mutator flyout pastes into the mutator workspace', async function () {
+      const block = Blockly.serialization.blocks.append(
+        {
+          'type': 'controls_if',
+          'id': 'blockId',
+          'extraState': {
+            'elseIfCount': 1,
+          },
+        },
+        this.workspace,
+      );
+      const mutatorIcon = block.getIcon(Blockly.icons.IconType.MUTATOR);
+      await mutatorIcon.setBubbleVisible(true);
+      const mutatorWorkspace = mutatorIcon.getWorkspace();
+      const mutatorFlyoutWorkspace = mutatorWorkspace
+        .getFlyout()
+        .getWorkspace();
+      const elseIf =
+        mutatorFlyoutWorkspace.getBlocksByType('controls_if_elseif')[0];
+      assert.isDefined(elseIf);
+      assert.lengthOf(mutatorWorkspace.getAllBlocks(), 2);
+      assert.lengthOf(this.workspace.getAllBlocks(), 1);
+      const data = elseIf.toCopyData();
+      Blockly.clipboard.paste(data, mutatorFlyoutWorkspace);
       assert.lengthOf(mutatorWorkspace.getAllBlocks(), 3);
       assert.lengthOf(this.workspace.getAllBlocks(), 1);
     });
@@ -139,8 +167,7 @@ suite('Clipboard', function () {
   });
 
   suite('pasting comments', function () {
-    // TODO: Reenable test when we readd copy-paste.
-    test.skip('pasted comments are bumped to not overlap', function () {
+    test('pasted comments are bumped to not overlap', function () {
       Blockly.Xml.domToWorkspace(
         Blockly.utils.xml.textToDom(
           '<xml><comment id="test" x=10 y=10/></xml>',
@@ -153,7 +180,7 @@ suite('Clipboard', function () {
       const newComment = Blockly.clipboard.paste(data, this.workspace);
       assert.deepEqual(
         newComment.getRelativeToSurfaceXY(),
-        new Blockly.utils.Coordinate(60, 60),
+        new Blockly.utils.Coordinate(40, 40),
       );
     });
   });

--- a/tests/mocha/shortcut_items_test.js
+++ b/tests/mocha/shortcut_items_test.js
@@ -5,6 +5,7 @@
  */
 
 import * as Blockly from '../../build/src/core/blockly.js';
+import {assert} from '../../node_modules/chai/chai.js';
 import {defineStackBlock} from './test_helpers/block_definitions.js';
 import {
   sharedTestSetup,
@@ -396,6 +397,19 @@ suite('Keyboard Shortcut Items', function () {
           sinon.assert.calledOnce(this.disposeSpy);
         });
       });
+    });
+  });
+
+  suite('Paste', function () {
+    test('Disabled when nothing has been copied', function () {
+      const pasteShortcut =
+        Blockly.ShortcutRegistry.registry.getRegistry()[
+          Blockly.ShortcutItems.names.PASTE
+        ];
+      Blockly.clipboard.setLastCopiedData(undefined);
+
+      const isPasteEnabled = pasteShortcut.preconditionFn();
+      assert.isFalse(isPasteEnabled);
     });
   });
 


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #9177 
Necessary to address https://github.com/google/blockly-keyboard-experimentation/issues/615

### Proposed Changes

- Adds a copy API to `Blockly.clipboard`, as well as other functions that can be used to set or get the most-recently-copied-data
- Fixes a bug where pasting into the mutator flyout would paste into the main workspace instead of the mutator workspace (due to using `getRootWorkspace` instead of `getParentWorkspace`)
- Adds a test for the above case

### Reason for Changes

- We previously removed state information from the `clipboard` module and moved it into the `keyboard_shortcut_items` module. The goal was to make the `clipboard` module stateless. But copy/paste is inherently not a stateless operation. Someone has to remember the copied data. (In theory, now that the web clipboard API is generally supported, it could be the system. but that is future work.) Storing the data in the keyboard shortcut items module means the data is not accessible outside of that module, so it becomes impossible to, e.g. implement a copy/paste context menu item. If you were to copy with the keyboard and paste with the context menu, there would be no way for the context menu to access the copied data unless we export it from somewhere. Thus, we need an API to set and retrieve the copied data.

You can read more information in https://github.com/google/blockly-keyboard-experimentation/issues/615

### Test Coverage

We lack an end-to-end test for copy/paste, but I'm working on that as part of #9178 
I've updated the mocha tests we do have for this.

### Documentation

N/A

### Additional Information

There will be an accompanying PR to remove the saved copyWorkspace from the keyboard-experiment plugin
