### PR TITLE
feat: Add support for keyboard navigation to/from block comments.

### DIFF
--- a/core/bubbles/bubble.ts
+++ b/core/bubbles/bubble.ts
@@ -102,6 +102,7 @@ export abstract class Bubble implements IBubble, ISelectable, IFocusableNode {
    *     element that's represented by this bubble (as a focusable node). This
    *     element will have its ID overwritten. If not provided, the focusable
    *     element of this node will default to the bubble's SVG root.
+   * @param owner The object responsible for hosting/spawning this bubble.
    */
   constructor(
     public readonly workspace: WorkspaceSvg,

--- a/core/bubbles/bubble.ts
+++ b/core/bubbles/bubble.ts
@@ -9,6 +9,7 @@ import * as common from '../common.js';
 import {BubbleDragStrategy} from '../dragging/bubble_drag_strategy.js';
 import {getFocusManager} from '../focus_manager.js';
 import {IBubble} from '../interfaces/i_bubble.js';
+import type {IFocusableNode} from '../interfaces/i_focusable_node.js';
 import type {IFocusableTree} from '../interfaces/i_focusable_tree.js';
 import {ISelectable} from '../interfaces/i_selectable.js';
 import {ContainerRegion} from '../metrics_manager.js';
@@ -27,7 +28,7 @@ import {WorkspaceSvg} from '../workspace_svg.js';
  * bubble, where it has a "tail" that points to the block, and a "head" that
  * displays arbitrary svg elements.
  */
-export abstract class Bubble implements IBubble, ISelectable {
+export abstract class Bubble implements IBubble, ISelectable, IFocusableNode {
   /** The width of the border around the bubble. */
   static readonly BORDER_WIDTH = 6;
 

--- a/core/bubbles/textinput_bubble.ts
+++ b/core/bubbles/textinput_bubble.ts
@@ -6,6 +6,9 @@
 
 import {CommentEditor} from '../comments/comment_editor.js';
 import * as Css from '../css.js';
+import {getFocusManager} from '../focus_manager.js';
+import type {IFocusableNode} from '../interfaces/i_focusable_node.js';
+import type {IHasBubble} from '../interfaces/i_has_bubble.js';
 import * as touch from '../touch.js';
 import {browserEvents} from '../utils.js';
 import {Coordinate} from '../utils/coordinate.js';
@@ -66,16 +69,19 @@ export class TextInputBubble extends Bubble {
    *     The tail of the bubble will point to this location.
    * @param ownerRect An optional rect we don't want the bubble to overlap with
    *     when automatically positioning.
+   * @param owner The object that owns/hosts this bubble.
    */
   constructor(
     public readonly workspace: WorkspaceSvg,
     protected anchor: Coordinate,
     protected ownerRect?: Rect,
+    protected owner?: IHasBubble & IFocusableNode,
   ) {
-    const commentEditor = new CommentEditor(workspace);
-    super(workspace, anchor, ownerRect, commentEditor.getFocusableElement());
+    super(workspace, anchor, ownerRect, undefined, owner);
     dom.addClass(this.svgRoot, 'blocklyTextInputBubble');
-    this.editor = commentEditor;
+    this.editor = new CommentEditor(workspace, this.id, () => {
+      getFocusManager().focusNode(this);
+    });
     this.contentContainer.appendChild(this.editor.getDom());
     this.resizeGroup = this.createResizeHandle(this.svgRoot, workspace);
     this.setSize(this.DEFAULT_SIZE, true);
@@ -263,6 +269,15 @@ export class TextInputBubble extends Bubble {
     for (const listener of this.locationChangeListeners) {
       listener();
     }
+  }
+
+  /**
+   * Returns the text editor component of this bubble.
+   *
+   * @internal
+   */
+  getEditor() {
+    return this.editor;
   }
 }
 

--- a/core/comments/comment_editor.ts
+++ b/core/comments/comment_editor.ts
@@ -87,6 +87,11 @@ export class CommentEditor implements IFocusableNode {
       },
     );
 
+    // Don't zoom with mousewheel; let it scroll instead.
+    browserEvents.conditionalBind(this.textArea, 'wheel', this, (e: Event) => {
+      e.stopPropagation();
+    });
+
     // Register listener for keydown events that would finish editing.
     browserEvents.conditionalBind(
       this.textArea,

--- a/core/comments/comment_editor.ts
+++ b/core/comments/comment_editor.ts
@@ -53,6 +53,7 @@ export class CommentEditor implements IFocusableNode {
       'textarea',
     ) as HTMLTextAreaElement;
     this.textArea.setAttribute('tabindex', '-1');
+    this.textArea.setAttribute('dir', this.workspace.RTL ? 'RTL' : 'LTR');
     dom.addClass(this.textArea, 'blocklyCommentText');
     dom.addClass(this.textArea, 'blocklyTextarea');
     dom.addClass(this.textArea, 'blocklyText');

--- a/core/comments/rendered_workspace_comment.ts
+++ b/core/comments/rendered_workspace_comment.ts
@@ -74,15 +74,6 @@ export class RenderedWorkspaceComment
       this,
       this.startGesture,
     );
-    // Don't zoom with mousewheel; let it scroll instead.
-    browserEvents.conditionalBind(
-      this.view.getSvgRoot(),
-      'wheel',
-      this,
-      (e: Event) => {
-        e.stopPropagation();
-      },
-    );
   }
 
   /**

--- a/core/icons/comment_icon.ts
+++ b/core/icons/comment_icon.ts
@@ -11,7 +11,6 @@ import type {BlockSvg} from '../block_svg.js';
 import {TextInputBubble} from '../bubbles/textinput_bubble.js';
 import {EventType} from '../events/type.js';
 import * as eventUtils from '../events/utils.js';
-import type {IBubble} from '../interfaces/i_bubble.js';
 import type {IHasBubble} from '../interfaces/i_has_bubble.js';
 import type {ISerializable} from '../interfaces/i_serializable.js';
 import * as renderManagement from '../render_management.js';
@@ -62,7 +61,7 @@ export class CommentIcon extends Icon implements IHasBubble, ISerializable {
   /**
    * The visibility of the bubble for this comment.
    *
-   * This is used to track what the visibile state /should/ be, not necessarily
+   * This is used to track what the visible state /should/ be, not necessarily
    * what it currently /is/. E.g. sometimes this will be true, but the block
    * hasn't been rendered yet, so the bubble will not currently be visible.
    */
@@ -340,7 +339,7 @@ export class CommentIcon extends Icon implements IHasBubble, ISerializable {
   }
 
   /** See IHasBubble.getBubble. */
-  getBubble(): IBubble | null {
+  getBubble(): TextInputBubble | null {
     return this.textInputBubble;
   }
 
@@ -365,6 +364,7 @@ export class CommentIcon extends Icon implements IHasBubble, ISerializable {
       this.sourceBlock.workspace as WorkspaceSvg,
       this.getAnchorLocation(),
       this.getBubbleOwnerRect(),
+      this,
     );
     this.textInputBubble.setText(this.getText());
     this.textInputBubble.setSize(this.bubbleSize, true);

--- a/core/keyboard_nav/block_comment_navigation_policy.ts
+++ b/core/keyboard_nav/block_comment_navigation_policy.ts
@@ -1,0 +1,76 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {TextInputBubble} from '../bubbles/textinput_bubble.js';
+import type {IFocusableNode} from '../interfaces/i_focusable_node.js';
+import type {INavigationPolicy} from '../interfaces/i_navigation_policy.js';
+
+/**
+ * Set of rules controlling keyboard navigation from an TextInputBubble.
+ */
+export class BlockCommentNavigationPolicy
+  implements INavigationPolicy<TextInputBubble>
+{
+  /**
+   * Returns the first child of the given block comment.
+   *
+   * @param current The block comment to return the first child of.
+   * @returns The text editor of the given block comment bubble.
+   */
+  getFirstChild(current: TextInputBubble): IFocusableNode | null {
+    return current.getEditor();
+  }
+
+  /**
+   * Returns the parent of the given block comment.
+   *
+   * @param current The block comment to return the parent of.
+   * @returns The parent block of the given block comment.
+   */
+  getParent(current: TextInputBubble): IFocusableNode | null {
+    return current.getOwner() ?? null;
+  }
+
+  /**
+   * Returns the next peer node of the given block comment.
+   *
+   * @param _current The block comment to find the following element of.
+   * @returns Null.
+   */
+  getNextSibling(_current: TextInputBubble): IFocusableNode | null {
+    return null;
+  }
+
+  /**
+   * Returns the previous peer node of the given block comment.
+   *
+   * @param _current The block comment to find the preceding element of.
+   * @returns Null.
+   */
+  getPreviousSibling(_current: TextInputBubble): IFocusableNode | null {
+    return null;
+  }
+
+  /**
+   * Returns whether or not the given block comment can be navigated to.
+   *
+   * @param current The instance to check for navigability.
+   * @returns True if the given block comment can be focused.
+   */
+  isNavigable(current: TextInputBubble): boolean {
+    return current.canBeFocused();
+  }
+
+  /**
+   * Returns whether the given object can be navigated from by this policy.
+   *
+   * @param current The object to check if this policy applies to.
+   * @returns True if the object is an TextInputBubble.
+   */
+  isApplicable(current: any): current is TextInputBubble {
+    return current instanceof TextInputBubble;
+  }
+}

--- a/core/keyboard_nav/comment_editor_navigation_policy.ts
+++ b/core/keyboard_nav/comment_editor_navigation_policy.ts
@@ -1,0 +1,54 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {CommentEditor} from '../comments/comment_editor.js';
+import type {IFocusableNode} from '../interfaces/i_focusable_node.js';
+import type {INavigationPolicy} from '../interfaces/i_navigation_policy.js';
+
+/**
+ * Set of rules controlling keyboard navigation from a comment editor.
+ * This is a no-op placeholder (other than isNavigable/isApplicable) since
+ * comment editors handle their own navigation when editing ends.
+ */
+export class CommentEditorNavigationPolicy
+  implements INavigationPolicy<CommentEditor>
+{
+  getFirstChild(_current: CommentEditor): IFocusableNode | null {
+    return null;
+  }
+
+  getParent(_current: CommentEditor): IFocusableNode | null {
+    return null;
+  }
+
+  getNextSibling(_current: CommentEditor): IFocusableNode | null {
+    return null;
+  }
+
+  getPreviousSibling(_current: CommentEditor): IFocusableNode | null {
+    return null;
+  }
+
+  /**
+   * Returns whether or not the given comment editor can be navigated to.
+   *
+   * @param current The instance to check for navigability.
+   * @returns False.
+   */
+  isNavigable(current: CommentEditor): boolean {
+    return current.canBeFocused();
+  }
+
+  /**
+   * Returns whether the given object can be navigated from by this policy.
+   *
+   * @param current The object to check if this policy applies to.
+   * @returns True if the object is a CommentEditor.
+   */
+  isApplicable(current: any): current is CommentEditor {
+    return current instanceof CommentEditor;
+  }
+}

--- a/core/keyboard_nav/icon_navigation_policy.ts
+++ b/core/keyboard_nav/icon_navigation_policy.ts
@@ -6,6 +6,7 @@
 
 import {BlockSvg} from '../block_svg.js';
 import {getFocusManager} from '../focus_manager.js';
+import {CommentIcon} from '../icons/comment_icon.js';
 import {Icon} from '../icons/icon.js';
 import {MutatorIcon} from '../icons/mutator_icon.js';
 import type {IFocusableNode} from '../interfaces/i_focusable_node.js';
@@ -29,6 +30,12 @@ export class IconNavigationPolicy implements INavigationPolicy<Icon> {
       getFocusManager().getFocusedNode() === current
     ) {
       return current.getBubble()?.getWorkspace() ?? null;
+    } else if (
+      current instanceof CommentIcon &&
+      current.bubbleIsVisible() &&
+      getFocusManager().getFocusedNode() === current
+    ) {
+      return current.getBubble()?.getEditor() ?? null;
     }
 
     return null;

--- a/core/navigator.ts
+++ b/core/navigator.ts
@@ -6,8 +6,10 @@
 
 import type {IFocusableNode} from './interfaces/i_focusable_node.js';
 import type {INavigationPolicy} from './interfaces/i_navigation_policy.js';
+import {BlockCommentNavigationPolicy} from './keyboard_nav/block_comment_navigation_policy.js';
 import {BlockNavigationPolicy} from './keyboard_nav/block_navigation_policy.js';
 import {CommentBarButtonNavigationPolicy} from './keyboard_nav/comment_bar_button_navigation_policy.js';
+import {CommentEditorNavigationPolicy} from './keyboard_nav/comment_editor_navigation_policy.js';
 import {ConnectionNavigationPolicy} from './keyboard_nav/connection_navigation_policy.js';
 import {FieldNavigationPolicy} from './keyboard_nav/field_navigation_policy.js';
 import {IconNavigationPolicy} from './keyboard_nav/icon_navigation_policy.js';
@@ -33,6 +35,8 @@ export class Navigator {
     new IconNavigationPolicy(),
     new WorkspaceCommentNavigationPolicy(),
     new CommentBarButtonNavigationPolicy(),
+    new BlockCommentNavigationPolicy(),
+    new CommentEditorNavigationPolicy(),
   ];
 
   /**

--- a/core/workspace_svg.ts
+++ b/core/workspace_svg.ts
@@ -22,6 +22,7 @@ import type {Block} from './block.js';
 import type {BlockSvg} from './block_svg.js';
 import type {BlocklyOptions} from './blockly_options.js';
 import * as browserEvents from './browser_events.js';
+import {TextInputBubble} from './bubbles/textinput_bubble.js';
 import {COMMENT_COLLAPSE_BAR_BUTTON_FOCUS_IDENTIFIER} from './comments/collapse_comment_bar_button.js';
 import {COMMENT_EDITOR_FOCUS_IDENTIFIER} from './comments/comment_editor.js';
 import {COMMENT_DELETE_BAR_BUTTON_FOCUS_IDENTIFIER} from './comments/delete_comment_bar_button.js';
@@ -2868,6 +2869,11 @@ export class WorkspaceSvg
           bubble.getFocusableElement().id === id
         ) {
           return bubble;
+        } else if (
+          bubble instanceof TextInputBubble &&
+          bubble.getEditor().getFocusableElement().id === id
+        ) {
+          return bubble.getEditor();
         }
       }
     }


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #9166 and part of https://github.com/google/blockly-keyboard-experimentation/issues/636.

### Proposed Changes
This PR adds support for keyboard navigation to/from block comments. To that end:

* `TextInputBubble` is refactored to reuse `CommentEditor` (also used by workspace comments) to handle text editing
* Bubbles have been updated to close themselves when Escape is pressed
* Several additional navigation policies have been added.

A corresponding change will be needed in keyboard-experiment, and tests will be added there.