### PR TITLE
fix: Fire a `VarTypeChange` event when changing a variable's type.

### DIFF
--- a/core/variable_map.ts
+++ b/core/variable_map.ts
@@ -109,6 +109,9 @@ export class VariableMap
     variable: IVariableModel<IVariableState>,
     newType: string,
   ): IVariableModel<IVariableState> {
+    const oldType = variable.getType();
+    if (oldType === newType) return variable;
+
     this.variableMap.get(variable.getType())?.delete(variable.getId());
     variable.setType(newType);
     const newTypeVariables =
@@ -118,6 +121,13 @@ export class VariableMap
     if (!this.variableMap.has(newType)) {
       this.variableMap.set(newType, newTypeVariables);
     }
+    eventUtils.fire(
+      new (eventUtils.get(EventType.VAR_TYPE_CHANGE))(
+        variable,
+        oldType,
+        newType,
+      ),
+    );
     return variable;
   }
 

--- a/tests/mocha/variable_map_test.js
+++ b/tests/mocha/variable_map_test.js
@@ -505,5 +505,26 @@ suite('Variable Map', function () {
         });
       });
     });
+
+    suite('variable type change events', function () {
+      test('are fired when a variable has its type changed', function () {
+        const variable = this.variableMap.createVariable(
+          'name1',
+          'type1',
+          'id1',
+        );
+        this.variableMap.changeVariableType(variable, 'type2');
+        assertEventFired(
+          this.eventSpy,
+          Blockly.Events.VarTypeChange,
+          {
+            oldType: 'type1',
+            newType: 'type2',
+            varId: 'id1',
+          },
+          this.workspace.id,
+        );
+      });
+    });
   });
 });


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #[9229](https://github.com/google/blockly/issues/9229) 

### Proposed Changes
This PR fires a `VarTypeChange` event when a variable's type is changed via the `VariableMap`. It also adds a test of this behavior.