### PR TITLE
fix: Fix toolbox categories tests

### DIFF
--- a/tests/browser/test/toolbox_drag_test.mjs
+++ b/tests/browser/test/toolbox_drag_test.mjs
@@ -179,9 +179,9 @@ async function openCategories(browser, categoryList, directionMultiplier) {
   chai.assert.equal(failureCount, 0);
 }
 
-// TODO (#9217) These take too long to run and are very flakey. Need to find a
-// better way to test whatever this is trying to test.
-suite.skip('Open toolbox categories', function () {
+// TODO (#9217) These take too long to run and are very flakey. Need to pull
+// these out into their own test runner.
+suite('Open toolbox categories', function () {
   this.timeout(0);
 
   test('opening every toolbox category in the category toolbox in LTR', async function () {

--- a/tests/browser/test/toolbox_drag_test.mjs
+++ b/tests/browser/test/toolbox_drag_test.mjs
@@ -11,7 +11,7 @@
 import * as chai from 'chai';
 import {Key} from 'webdriverio';
 import {
-  dragBlockTypeFromFlyout,
+  getBlockTypeFromCategory,
   getCategory,
   PAUSE_TIME,
   screenDirection,
@@ -148,7 +148,12 @@ async function openCategories(browser, categoryList, directionMultiplier) {
           continue;
         }
         const blockType = await getNthBlockType(browser, categoryName, i);
-        dragBlockTypeFromFlyout(browser, categoryName, blockType, 50, 20);
+        const blockElem = await getBlockTypeFromCategory(
+          browser,
+          categoryName,
+          blockType,
+        );
+        await blockElem.dragAndDrop({x: 50 * directionMultiplier, y: 20});
         await browser.pause(PAUSE_TIME);
         // Should be one top level block on the workspace.
         const topBlockCount = await browser.execute(() => {


### PR DESCRIPTION
This fixes the the toolbox categories tests except for dragging out the four empty statement blocks, which is fixed by https://github.com/google/blockly-samples/pull/2580

Tests will continue to fail until the latest version of samples is published.

<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #8953 and half of #9217 

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
Fixes and re-enables the toolbox categories test.

### Reason for Changes

Tests were broken.
<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
