### PR TITLE
fix: Make non-autoclosing flyouts stay open.

### DIFF
--- a/core/toolbox/toolbox.ts
+++ b/core/toolbox/toolbox.ts
@@ -22,10 +22,7 @@ import '../events/events_toolbox_item_select.js';
 import {EventType} from '../events/type.js';
 import * as eventUtils from '../events/utils.js';
 import {getFocusManager} from '../focus_manager.js';
-import {
-  isAutoHideable,
-  type IAutoHideable,
-} from '../interfaces/i_autohideable.js';
+import {type IAutoHideable} from '../interfaces/i_autohideable.js';
 import type {ICollapsibleToolboxItem} from '../interfaces/i_collapsible_toolbox_item.js';
 import {isDeletable} from '../interfaces/i_deletable.js';
 import type {IDraggable} from '../interfaces/i_draggable.js';
@@ -1150,10 +1147,7 @@ export class Toolbox
     // If navigating to anything other than the toolbox's flyout then clear the
     // selection so that the toolbox's flyout can automatically close.
     if (!nextTree || nextTree !== this.flyout?.getWorkspace()) {
-      this.clearSelection();
-      if (this.flyout && isAutoHideable(this.flyout)) {
-        this.flyout.autoHide(false);
-      }
+      this.autoHide(false);
     }
   }
 }

--- a/core/workspace_svg.ts
+++ b/core/workspace_svg.ts
@@ -2908,11 +2908,9 @@ export class WorkspaceSvg
       // Only hide the flyout if the flyout's workspace is losing focus and that
       // focus isn't returning to the flyout itself, the toolbox, or ephemeral.
       if (getFocusManager().ephemeralFocusTaken()) return;
-      const flyout = this.targetWorkspace.getFlyout();
       const toolbox = this.targetWorkspace.getToolbox();
       if (toolbox && nextTree === toolbox) return;
-      if (toolbox) toolbox.clearSelection();
-      if (flyout && isAutoHideable(flyout)) flyout.autoHide(false);
+      if (isAutoHideable(toolbox)) toolbox.autoHide(false);
     }
   }
 

--- a/tests/mocha/toolbox_test.js
+++ b/tests/mocha/toolbox_test.js
@@ -183,6 +183,57 @@ suite('Toolbox', function () {
     });
   });
 
+  suite('focus management', function () {
+    setup(function () {
+      this.toolbox = getInjectedToolbox();
+    });
+    teardown(function () {
+      this.toolbox.dispose();
+    });
+
+    test('Losing focus hides autoclosing flyout', function () {
+      // Focus the toolbox and select a category to open the flyout.
+      const target = this.toolbox.HtmlDiv.querySelector(
+        '.blocklyToolboxCategory',
+      );
+      Blockly.getFocusManager().focusNode(this.toolbox);
+      target.dispatchEvent(
+        new PointerEvent('pointerdown', {
+          target,
+          bubbles: true,
+        }),
+      );
+      assert.isTrue(this.toolbox.getFlyout().isVisible());
+
+      // Focus the workspace to trigger the toolbox to close the flyout.
+      Blockly.getFocusManager().focusNode(this.toolbox.getWorkspace());
+      assert.isFalse(this.toolbox.getFlyout().isVisible());
+    });
+
+    test('Losing focus does not hide non-autoclosing flyout', function () {
+      // Make the toolbox's flyout non-autoclosing.
+      this.toolbox.getFlyout().setAutoClose(false);
+
+      // Focus the toolbox and select a category to open the flyout.
+      const target = this.toolbox.HtmlDiv.querySelector(
+        '.blocklyToolboxCategory',
+      );
+      Blockly.getFocusManager().focusNode(this.toolbox);
+      target.dispatchEvent(
+        new PointerEvent('pointerdown', {
+          target,
+          bubbles: true,
+        }),
+      );
+      assert.isTrue(this.toolbox.getFlyout().isVisible());
+
+      // Focus the workspace; this should *not* trigger the toolbox to close the
+      // flyout, which should remain visible.
+      Blockly.getFocusManager().focusNode(this.toolbox.getWorkspace());
+      assert.isTrue(this.toolbox.getFlyout().isVisible());
+    });
+  });
+
   suite('onClick_', function () {
     setup(function () {
       this.toolbox = getInjectedToolbox();


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #[9126](https://github.com/google/blockly/issues/9126)

### Proposed Changes
This PR fixes the behavior for non-autoclosing flyouts. As part of the recent focus changes, flyouts were more or less forced to always autoclose. This is because `Toolbox.clearSelection()` winds up calling `this.setSelectedItem(null)` -> `this.updateFlyout(*, null)`, and the latter unconditionally hides the flyout if the new item is `null`. Now, in situations where the toolbox is losing focus, its `autoHide` method is called, which gates the call to `clearSelection()` on a check for whether the toolbox's flyout is in autoclose mode. The explicit call to `Flyout.autoHide` in `WorkspaceSvg` has been removed because it's redundant as the prior call to `autoHide()` on the toolbox will wind up invoking it.