### PR TITLE
fix: dont save ids when copying blocks and comments

### DIFF
--- a/core/block_svg.ts
+++ b/core/block_svg.ts
@@ -962,6 +962,7 @@ export class BlockSvg
       blockState: blocks.save(this, {
         addCoordinates: true,
         addNextBlocks: false,
+        saveIds: false,
       }) as blocks.State,
       typeCounts: common.getBlockTypeCounts(this, true),
     };

--- a/core/comments/rendered_workspace_comment.ts
+++ b/core/comments/rendered_workspace_comment.ts
@@ -280,6 +280,7 @@ export class RenderedWorkspaceComment
       paster: WorkspaceCommentPaster.TYPE,
       commentState: commentSerialization.save(this, {
         addCoordinates: true,
+        saveIds: false,
       }),
     };
   }


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #9226 

### Proposed Changes

Don't save IDs when copying blocks and workspace comments

### Reason for Changes

Saving the IDs doesn't make sense and can break some multi-workspace scenarios:

imagine you are mirroring events into a workspace, and you paste a block into one workspace but a block with that id already exists on the mirroring workspace.

if you're just pasting into the same workspace, the id won't be the same anyway because pasting will detect there's an id collision and automatically get a new one. we might as well always get a new id when pasting instead.

### Test Coverage

I also tested this with the additional webdriver tests I added in #9254 and those also pass

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
