### PR TITLE
fix: dont add comments to full block fields

### DIFF
--- a/core/block.ts
+++ b/core/block.ts
@@ -1118,7 +1118,7 @@ export class Block {
    *
    * @yields A generator that can be used to iterate the fields on the block.
    */
-  *getFields(): Generator<Field> {
+  *getFields(): Generator<Field, undefined, void> {
     for (const input of this.inputList) {
       for (const field of input.fieldRow) {
         yield field;

--- a/core/contextmenu_items.ts
+++ b/core/contextmenu_items.ts
@@ -25,6 +25,12 @@ import {StatementInput} from './renderers/zelos/zelos.js';
 import {Coordinate} from './utils/coordinate.js';
 import type {WorkspaceSvg} from './workspace_svg.js';
 
+function isFullBlockField(block?: BlockSvg) {
+  if (!block || !block.isSimpleReporter()) return false;
+  const firstField = block.getFields().next().value;
+  return firstField?.isFullBlockField();
+}
+
 /**
  * Option to undo previous action.
  */
@@ -365,7 +371,11 @@ export function registerComment() {
         !block!.isInFlyout &&
         block!.workspace.options.comments &&
         !block!.isCollapsed() &&
-        block!.isEditable()
+        block!.isEditable() &&
+        // Either block already has a comment so let us remove it,
+        // or the block isn't just one full-block field block, which
+        // shouldn't be allowed to have comments as there's no way to read them.
+        (block!.hasIcon(CommentIcon.TYPE) || !isFullBlockField(block))
       ) {
         return 'enabled';
       }

--- a/core/contextmenu_items.ts
+++ b/core/contextmenu_items.ts
@@ -368,14 +368,15 @@ export function registerComment() {
     preconditionFn(scope: Scope) {
       const block = scope.block;
       if (
-        !block!.isInFlyout &&
-        block!.workspace.options.comments &&
-        !block!.isCollapsed() &&
-        block!.isEditable() &&
+        block &&
+        !block.isInFlyout &&
+        block.workspace.options.comments &&
+        !block.isCollapsed() &&
+        block.isEditable() &&
         // Either block already has a comment so let us remove it,
         // or the block isn't just one full-block field block, which
         // shouldn't be allowed to have comments as there's no way to read them.
-        (block!.hasIcon(CommentIcon.TYPE) || !isFullBlockField(block))
+        (block.hasIcon(CommentIcon.TYPE) || !isFullBlockField(block))
       ) {
         return 'enabled';
       }
@@ -383,8 +384,8 @@ export function registerComment() {
     },
     callback(scope: Scope) {
       const block = scope.block;
-      if (block!.hasIcon(CommentIcon.TYPE)) {
-        block!.setCommentText(null);
+      if (block && block.hasIcon(CommentIcon.TYPE)) {
+        block.setCommentText(null);
       } else {
         block!.setCommentText('');
       }


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #9260 

### Proposed Changes

- Modifies precondition for "add comment" context menu option to hide the option if the block is a simple reporter block with a full-block field. If the block already has a comment, the option is shown so that it can be removed.
- Also fixed the type of the `getFields` generator so that `next().value` would be typed correctly as `Field | undefined` instead of `any`

### Reason for Changes

You can't interact with the comment icon on full-block fields.

### Test Coverage

1. Drag a math_number block to the advanced playground in geras renderer
2. Add a comment to it with context menu
3. Change renderer to zelos
4. You can remove the comment with context menu
5. Now you can no longer add a comment with context menu

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
