### PR TITLE
fix: Display focused icons without transparency.

### DIFF
--- a/core/css.ts
+++ b/core/css.ts
@@ -241,7 +241,7 @@ let content = `
   cursor: default;
 }
 
-.blocklyIconGroup:not(:hover),
+.blocklyIconGroup:not(:hover):not(:focus),
 .blocklyIconGroupReadonly {
   opacity: .6;
 }


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #9267 

### Proposed Changes
This PR adjusts the built-in style sheet to not apply partial opacity to icons that are focused. This ensures that the focus ring is not faded relative to its typical appearance.