### PR TITLE
chore: lint error on only in mocha tests

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,6 +1,7 @@
 import eslint from '@eslint/js';
 import googleStyle from 'eslint-config-google';
 import jsdoc from 'eslint-plugin-jsdoc';
+import mochaPlugin from 'eslint-plugin-mocha';
 import eslintPluginPrettierRecommended from 'eslint-plugin-prettier/recommended';
 import globals from 'globals';
 import tseslint from 'typescript-eslint';
@@ -200,6 +201,9 @@ export default [
   },
   {
     files: ['tests/**'],
+    plugins: {
+      mocha: mochaPlugin,
+    },
     languageOptions: {
       globals: {
         'Blockly': true,
@@ -219,6 +223,7 @@ export default [
       'jsdoc/check-tag-names': ['warn', {'definedTags': ['record']}],
       'jsdoc/tag-lines': ['off'],
       'jsdoc/no-defaults': ['off'],
+      'mocha/no-exclusive-tests': 'error',
     },
   },
   {

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "eslint-config-google": "^0.14.0",
         "eslint-config-prettier": "^10.1.1",
         "eslint-plugin-jsdoc": "^52.0.2",
+        "eslint-plugin-mocha": "^11.1.0",
         "eslint-plugin-prettier": "^5.2.1",
         "glob": "^11.0.1",
         "globals": "^16.0.0",
@@ -4135,6 +4136,31 @@
       "dependencies": {
         "spdx-exceptions": "^2.1.0",
         "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-mocha": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-mocha/-/eslint-plugin-mocha-11.1.0.tgz",
+      "integrity": "sha512-rKntVWRsQFPbf8OkSgVNRVRrcVAPaGTyEgWCEyXaPDJkTl0v5/lwu1vTk5sWiUJU8l2sxwvGUZzSNrEKdVMeQw==",
+      "dev": true,
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.4.1",
+        "globals": "^15.14.0"
+      },
+      "peerDependencies": {
+        "eslint": ">=9.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-mocha/node_modules/globals": {
+      "version": "15.15.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-15.15.0.tgz",
+      "integrity": "sha512-7ACyT3wmyp3I61S4fG682L0VA2RGD9otkqGJIwNUMF1SWUombIIk+af1unuDYgMm082aHYwD+mzJvv9Iu8dsgg==",
+      "dev": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/eslint-plugin-prettier": {

--- a/package.json
+++ b/package.json
@@ -115,6 +115,7 @@
     "eslint-config-google": "^0.14.0",
     "eslint-config-prettier": "^10.1.1",
     "eslint-plugin-jsdoc": "^52.0.2",
+    "eslint-plugin-mocha": "^11.1.0",
     "eslint-plugin-prettier": "^5.2.1",
     "glob": "^11.0.1",
     "globals": "^16.0.0",


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #9298 

### Proposed Changes

- Adds lint configuration to forbid calling `only` in mocha tests

### Reason for Changes

See comment on the issue above for a discussion why I chose the lint config over using `--forbid-only` in mocha

### Test Coverage

Added `.only` to a suite and lint failed.

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

There are other rules we could consider enabling but wanted to keep this focused. https://github.com/lo1tuma/eslint-plugin-mocha?tab=readme-ov-file#rules
