### PR TITLE
feat: Lay the foundation for keyboard navigation into flyout items.

### DIFF
--- a/core/blockly.ts
+++ b/core/blockly.ts
@@ -171,7 +171,7 @@ import {
 import {IVariableMap} from './interfaces/i_variable_map.js';
 import {IVariableModel, IVariableState} from './interfaces/i_variable_model.js';
 import * as internalConstants from './internal_constants.js';
-import {LineCursor} from './keyboard_nav/line_cursor.js';
+import {LineCursor, NavigationDirection} from './keyboard_nav/line_cursor.js';
 import {Marker} from './keyboard_nav/marker.js';
 import {
   KeyboardNavigationController,
@@ -466,6 +466,7 @@ export {
   Events,
   Extensions,
   LineCursor,
+  NavigationDirection,
   Procedures,
   ShortcutItems,
   Themes,

--- a/core/keyboard_nav/flyout_navigation_policy.ts
+++ b/core/keyboard_nav/flyout_navigation_policy.ts
@@ -26,7 +26,7 @@ export class FlyoutNavigationPolicy<T> implements INavigationPolicy<T> {
   /**
    * Returns null to prevent navigating into flyout items.
    *
-   * @param _current The flyout item to navigate from.
+   * @param current The flyout item to navigate from.
    * @returns Null to prevent navigating into flyout items.
    */
   getFirstChild(current: T): IFocusableNode | null {

--- a/core/keyboard_nav/flyout_navigation_policy.ts
+++ b/core/keyboard_nav/flyout_navigation_policy.ts
@@ -29,8 +29,8 @@ export class FlyoutNavigationPolicy<T> implements INavigationPolicy<T> {
    * @param _current The flyout item to navigate from.
    * @returns Null to prevent navigating into flyout items.
    */
-  getFirstChild(_current: T): IFocusableNode | null {
-    return null;
+  getFirstChild(current: T): IFocusableNode | null {
+    return this.policy.getFirstChild(current);
   }
 
   /**
@@ -57,10 +57,10 @@ export class FlyoutNavigationPolicy<T> implements INavigationPolicy<T> {
       (flyoutItem) => flyoutItem.getElement() === current,
     );
 
-    if (index === -1) return null;
+    if (index === -1) return this.policy.getNextSibling(current);
     index++;
     if (index >= flyoutContents.length) {
-      index = 0;
+      return null;
     }
 
     return flyoutContents[index].getElement();
@@ -80,10 +80,10 @@ export class FlyoutNavigationPolicy<T> implements INavigationPolicy<T> {
       (flyoutItem) => flyoutItem.getElement() === current,
     );
 
-    if (index === -1) return null;
+    if (index === -1) return this.policy.getPreviousSibling(current);
     index--;
     if (index < 0) {
-      index = flyoutContents.length - 1;
+      return null;
     }
 
     return flyoutContents[index].getElement();

--- a/core/keyboard_nav/line_cursor.ts
+++ b/core/keyboard_nav/line_cursor.ts
@@ -25,6 +25,16 @@ import {WorkspaceSvg} from '../workspace_svg.js';
 import {Marker} from './marker.js';
 
 /**
+ * Representation of the direction of travel within a navigation context.
+ */
+export enum NavigationDirection {
+  NEXT,
+  PREVIOUS,
+  IN,
+  OUT,
+}
+
+/**
  * Class for a line cursor.
  */
 export class LineCursor extends Marker {
@@ -54,14 +64,8 @@ export class LineCursor extends Marker {
     }
     const newNode = this.getNextNode(
       curNode,
-      (candidate: IFocusableNode | null) => {
-        return (
-          (candidate instanceof BlockSvg &&
-            !candidate.outputConnection?.targetBlock()) ||
-          candidate instanceof RenderedWorkspaceComment
-        );
-      },
-      true,
+      this.getValidationFunction(NavigationDirection.NEXT),
+      this.shouldLoop(NavigationDirection.NEXT),
     );
 
     if (newNode) {
@@ -83,7 +87,11 @@ export class LineCursor extends Marker {
       return null;
     }
 
-    const newNode = this.getNextNode(curNode, () => true, true);
+    const newNode = this.getNextNode(
+      curNode,
+      this.getValidationFunction(NavigationDirection.IN),
+      this.shouldLoop(NavigationDirection.IN),
+    );
 
     if (newNode) {
       this.setCurNode(newNode);
@@ -104,14 +112,8 @@ export class LineCursor extends Marker {
     }
     const newNode = this.getPreviousNode(
       curNode,
-      (candidate: IFocusableNode | null) => {
-        return (
-          (candidate instanceof BlockSvg &&
-            !candidate.outputConnection?.targetBlock()) ||
-          candidate instanceof RenderedWorkspaceComment
-        );
-      },
-      true,
+      this.getValidationFunction(NavigationDirection.PREVIOUS),
+      this.shouldLoop(NavigationDirection.PREVIOUS),
     );
 
     if (newNode) {
@@ -133,12 +135,57 @@ export class LineCursor extends Marker {
       return null;
     }
 
-    const newNode = this.getPreviousNode(curNode, () => true, true);
+    const newNode = this.getPreviousNode(
+      curNode,
+      this.getValidationFunction(NavigationDirection.OUT),
+      this.shouldLoop(NavigationDirection.OUT),
+    );
 
     if (newNode) {
       this.setCurNode(newNode);
     }
     return newNode;
+  }
+
+  /**
+   * Returns a function that will be used to determine whether a candidate for
+   * navigation is valid.
+   *
+   * @param direction The direction in which the user is navigating.
+   * @returns A function that takes a proposed navigation candidate and returns
+   *     true if navigation should be allowed to proceed to it, or false to find
+   *     a different candidate.
+   */
+  getValidationFunction(
+    direction: NavigationDirection,
+  ): (node: IFocusableNode | null) => boolean {
+    switch (direction) {
+      case NavigationDirection.IN:
+      case NavigationDirection.OUT:
+        return () => true;
+      case NavigationDirection.NEXT:
+      case NavigationDirection.PREVIOUS:
+        return (candidate: IFocusableNode | null) => {
+          return (
+            (candidate instanceof BlockSvg &&
+              !candidate.outputConnection?.targetBlock()) ||
+            (!!candidate &&
+              this.workspace.getNavigator().getParent(candidate) ===
+                this.workspace)
+          );
+        };
+    }
+  }
+
+  /**
+   * Returns whether or not navigation should loop around when reaching the end/
+   * beginning of navigable items.
+   *
+   * @param direction The direction in which the user is navigating.
+   * @returns True if navigation should be allowed to loop, otherwise false.
+   */
+  shouldLoop(direction: NavigationDirection): boolean {
+    return true;
   }
 
   /**

--- a/core/keyboard_nav/line_cursor.ts
+++ b/core/keyboard_nav/line_cursor.ts
@@ -181,10 +181,10 @@ export class LineCursor extends Marker {
    * Returns whether or not navigation should loop around when reaching the end/
    * beginning of navigable items.
    *
-   * @param direction The direction in which the user is navigating.
+   * @param _direction The direction in which the user is navigating.
    * @returns True if navigation should be allowed to loop, otherwise false.
    */
-  shouldLoop(direction: NavigationDirection): boolean {
+  shouldLoop(_direction: NavigationDirection): boolean {
     return true;
   }
 

--- a/core/keyboard_nav/workspace_navigation_policy.ts
+++ b/core/keyboard_nav/workspace_navigation_policy.ts
@@ -5,6 +5,7 @@
  */
 
 import type {IFocusableNode} from '../interfaces/i_focusable_node.js';
+import {isFocusableNode} from '../interfaces/i_focusable_node.js';
 import type {INavigationPolicy} from '../interfaces/i_navigation_policy.js';
 import {WorkspaceSvg} from '../workspace_svg.js';
 
@@ -21,6 +22,15 @@ export class WorkspaceNavigationPolicy
    * @returns The top block of the first block stack, if any.
    */
   getFirstChild(current: WorkspaceSvg): IFocusableNode | null {
+    if (current.isFlyout) {
+      for (const item of current.targetWorkspace?.getFlyout()?.getContents() ??
+        []) {
+        const element = item.getElement();
+        if (isFocusableNode(element) && element.canBeFocused()) {
+          return element;
+        }
+      }
+    }
     const blocks = current.getTopBlocks(true);
     return blocks.length ? blocks[0] : null;
   }


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes part of https://github.com/google/blockly-keyboard-experimentation/issues/320

### Proposed Changes
This PR makes changes to enable a future PR in the keyboard-experiment repo that allows navigating into items located in the flyout. Presently, navigation is only supported between top-level flyout items, but e.g. fields in blocks in the flyout are not accessible or editable via keyboard navigation as they are via the mouse.

This PR:
* Introduces a new `NavigationDirection` enum used in several cursor methods.
* Refactors `LineCursor` to make the navigation candidate validation callback and looping behavior more easily overridable by subclasses without having to copy-paste significant parts of the superclass' implementation.
* Updates the `WorkspaceNavigationPolicy` to return the first element when the workspace in question is a flyout (which allows arbitrary types of elements), rather than hardcoding only returning blocks
* Updates `FlyoutNavigationPolicy` to pass through navigation calls to the underlying policy unless navigating across a top-level item boundary