### PR TITLE
chore: Fix documentation generation warnings.

### DIFF
--- a/core/block.ts
+++ b/core/block.ts
@@ -1126,7 +1126,7 @@ export class Block {
   /**
    * Returns a generator that provides every field on the block.
    *
-   * @yields A generator that can be used to iterate the fields on the block.
+   * @returns A generator that can be used to iterate the fields on the block.
    */
   *getFields(): Generator<Field, undefined, void> {
     for (const input of this.inputList) {

--- a/core/field.ts
+++ b/core/field.ts
@@ -119,9 +119,6 @@ export abstract class Field<T = any>
     return this.size;
   }
 
-  /**
-   * Sets the size of this field.
-   */
   protected set size_(newValue: Size) {
     this.size = newValue;
   }

--- a/core/field_input.ts
+++ b/core/field_input.ts
@@ -102,11 +102,9 @@ export abstract class FieldInput<T extends InputTypes> extends Field<
    */
   override SERIALIZABLE = true;
 
-  /**
-   * Sets the size of this field. Although this appears to be a no-op, it must
-   * exist since the getter is overridden below.
-   */
   protected override set size_(newValue: Size) {
+    // Although this appears to be a no-op, it must exist since the getter is
+    // overridden below.
     super.size_ = newValue;
   }
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -88,7 +88,8 @@ function buildTSOverride({files, tsconfig}) {
       '@typescript-eslint/no-explicit-any': ['off'],
       // We use this pattern extensively for block (e.g. controls_if) interfaces.
       '@typescript-eslint/no-empty-object-type': ['off'],
-
+      // TSDoc doesn't support @yields, so don't require that we use it.
+      'jsdoc/require-yields': ['off'],
       // params and returns docs are optional.
       'jsdoc/require-param-description': ['off'],
       'jsdoc/require-returns': ['off'],


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #9061

### Proposed Changes
This PR removes the use of `@yields`, which is not supported by TSDoc, and updates the ESLint config to not complain about its absence. It also removes the docs from the size_ setter; the docs for the setter and getter are merged in the output, and are only supposed to be present on the getter.