### PR TITLE
fix: improve screenreader output for workspace comments

### DIFF
--- a/core/bubbles/bubble.ts
+++ b/core/bubbles/bubble.ts
@@ -144,7 +144,6 @@ export abstract class Bubble implements IBubble, ISelectable, IFocusableNode {
     this.focusableElement = overriddenFocusableElement ?? this.svgRoot;
     this.focusableElement.setAttribute('id', this.id);
     aria.setRole(this.focusableElement, aria.Role.GROUP);
-    aria.setState(this.focusableElement, aria.State.LABEL, 'Bubble');
 
     browserEvents.conditionalBind(
       this.background,

--- a/core/comments/collapse_comment_bar_button.ts
+++ b/core/comments/collapse_comment_bar_button.ts
@@ -5,6 +5,7 @@
  */
 
 import * as browserEvents from '../browser_events.js';
+import {Msg} from '../msg.js';
 import * as touch from '../touch.js';
 import * as aria from '../utils/aria.js';
 import * as dom from '../utils/dom.js';
@@ -57,6 +58,7 @@ export class CollapseCommentBarButton extends CommentBarButton {
       },
       this.container,
     );
+    this.initAria();
     this.bindId = browserEvents.conditionalBind(
       this.icon,
       'pointerdown',
@@ -74,7 +76,7 @@ export class CollapseCommentBarButton extends CommentBarButton {
 
   override initAria(): void {
     aria.setRole(this.icon, aria.Role.BUTTON);
-    aria.setState(this.icon, aria.State.LABEL, 'DoNotDefine?');
+    aria.setState(this.icon, aria.State.LABEL, Msg['COLLAPSE_COMMENT']);
   }
 
   /**

--- a/core/comments/comment_editor.ts
+++ b/core/comments/comment_editor.ts
@@ -58,7 +58,6 @@ export class CommentEditor implements IFocusableNode {
     this.textArea.setAttribute('tabindex', '-1');
     this.textArea.setAttribute('dir', this.workspace.RTL ? 'RTL' : 'LTR');
     aria.setRole(this.textArea, aria.Role.TEXTBOX);
-    aria.setState(this.textArea, aria.State.LABEL, 'DoNotDefine?');
     dom.addClass(this.textArea, 'blocklyCommentText');
     dom.addClass(this.textArea, 'blocklyTextarea');
     dom.addClass(this.textArea, 'blocklyText');

--- a/core/comments/comment_view.ts
+++ b/core/comments/comment_view.ts
@@ -109,9 +109,6 @@ export class CommentView implements IRenderedElement {
       'class': 'blocklyComment blocklyEditable blocklyDraggable',
     });
 
-    aria.setRole(this.svgRoot, aria.Role.TEXTBOX);
-    aria.setState(this.svgRoot, aria.State.LABEL, 'DoNotOverride?');
-
     this.highlightRect = this.createHighlightRect(this.svgRoot);
 
     ({
@@ -126,6 +123,12 @@ export class CommentView implements IRenderedElement {
     this.commentEditor = this.createTextArea();
 
     this.resizeHandle = this.createResizeHandle(this.svgRoot, workspace);
+
+    aria.setRole(this.svgRoot, aria.Role.BUTTON);
+    if (this.commentEditor.id) {
+      aria.setState(this.svgRoot, aria.State.LABELLEDBY, this.commentEditor.id);
+    }
+    this.svgRoot.setAttribute('aria-description', 'Comment');
 
     // TODO: Remove this comment before merging.
     // I think we want comments to exist on the same layer as blocks.

--- a/core/comments/comment_view.ts
+++ b/core/comments/comment_view.ts
@@ -128,7 +128,7 @@ export class CommentView implements IRenderedElement {
     if (this.commentEditor.id) {
       aria.setState(this.svgRoot, aria.State.LABELLEDBY, this.commentEditor.id);
     }
-    this.svgRoot.setAttribute('aria-description', 'Comment');
+    aria.setState(this.svgRoot, aria.State.ROLEDESCRIPTION, 'Comment');
 
     // TODO: Remove this comment before merging.
     // I think we want comments to exist on the same layer as blocks.

--- a/core/comments/delete_comment_bar_button.ts
+++ b/core/comments/delete_comment_bar_button.ts
@@ -6,6 +6,7 @@
 
 import * as browserEvents from '../browser_events.js';
 import {getFocusManager} from '../focus_manager.js';
+import {Msg} from '../msg.js';
 import * as touch from '../touch.js';
 import * as aria from '../utils/aria.js';
 import * as dom from '../utils/dom.js';
@@ -57,6 +58,7 @@ export class DeleteCommentBarButton extends CommentBarButton {
       },
       container,
     );
+    this.initAria();
     this.bindId = browserEvents.conditionalBind(
       this.icon,
       'pointerdown',
@@ -74,7 +76,7 @@ export class DeleteCommentBarButton extends CommentBarButton {
 
   override initAria(): void {
     aria.setRole(this.icon, aria.Role.BUTTON);
-    aria.setState(this.icon, aria.State.LABEL, 'DoNotDefine?');
+    aria.setState(this.icon, aria.State.LABEL, Msg['REMOVE_COMMENT']);
   }
 
   /**

--- a/msg/json/en.json
+++ b/msg/json/en.json
@@ -1,7 +1,7 @@
 {
 	"@metadata": {
 		"author": "Ellen Spertus <ellen.spertus@gmail.com>",
-		"lastupdated": "2025-09-08 16:26:57.642330",
+		"lastupdated": "2025-09-09 09:40:56.729862",
 		"locale": "en",
 		"messagedocumentation" : "qqq"
 	},
@@ -12,6 +12,7 @@
 	"ADD_COMMENT": "Add Comment",
 	"REMOVE_COMMENT": "Remove Comment",
 	"DUPLICATE_COMMENT": "Duplicate Comment",
+	"COLLAPSE_COMMENT": "Collapse Comment",
 	"EXTERNAL_INPUTS": "External Inputs",
 	"INLINE_INPUTS": "Inline Inputs",
 	"DELETE_BLOCK": "Delete Block",

--- a/msg/json/qqq.json
+++ b/msg/json/qqq.json
@@ -1,5 +1,5 @@
 {
-	"@metadata": {
+		"@metadata": {
 		"authors": [
 			"Ajeje Brazorf",
 			"Amire80",
@@ -19,6 +19,7 @@
 	"ADD_COMMENT": "context menu - Add a descriptive comment to the selected block.",
 	"REMOVE_COMMENT": "context menu - Remove the descriptive comment from the selected block.",
 	"DUPLICATE_COMMENT": "context menu - Make a copy of the selected workspace comment.\n{{Identical|Duplicate}}",
+	"COLLAPSE_COMMENT": "context menu - Collapse the selected workspace comment.",
 	"EXTERNAL_INPUTS": "context menu - Change from 'external' to 'inline' mode for displaying blocks used as inputs to the selected block.  See [[Translating:Blockly#context_menus]].\n\nThe opposite of {{msg-blockly|INLINE INPUTS}}.",
 	"INLINE_INPUTS": "context menu - Change from 'internal' to 'external' mode for displaying blocks used as inputs to the selected block.  See [[Translating:Blockly#context_menus]].\n\nThe opposite of {{msg-blockly|EXTERNAL INPUTS}}.",
 	"DELETE_BLOCK": "context menu - Permanently delete the selected block.",

--- a/msg/json/qqq.json
+++ b/msg/json/qqq.json
@@ -1,5 +1,5 @@
 {
-		"@metadata": {
+	"@metadata": {
 		"authors": [
 			"Ajeje Brazorf",
 			"Amire80",

--- a/msg/messages.js
+++ b/msg/messages.js
@@ -85,6 +85,9 @@ Blockly.Msg.REMOVE_COMMENT = 'Remove Comment';
 /// context menu - Make a copy of the selected workspace comment.\n{{Identical|Duplicate}}
 Blockly.Msg.DUPLICATE_COMMENT = 'Duplicate Comment';
 /** @type {string} */
+/// context menu - Collapse the selected workspace comment.
+Blockly.Msg.COLLAPSE_COMMENT = 'Collapse Comment';
+/** @type {string} */
 /// context menu - Change from 'external' to 'inline' mode for displaying blocks used as inputs to the selected block.  See [[Translating:Blockly#context_menus]].\n\nThe opposite of {{msg-blockly|INLINE INPUTS}}.
 Blockly.Msg.EXTERNAL_INPUTS = 'External Inputs';
 /** @type {string} */


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #9314 
Addresses the workspace comment part of #9311 

### Proposed Changes

When a workspace comment is selected the output is:
> [The text of the comment], Comment, button, group (24 of 9)

(tbh I don't understand the group part)

When you press enter to go into editing mode the output is:
> Edit text [The text of the comment], insertion at end of text

When you focus the collapse icon:
> Collapse comment, button

Focus the delete icon:
> Remove comment, button

(the context menu uses the word remove, not delete, and i used the same message for that)

Note that previously these had labels set to things like `DoNotOveride?` and I don't know what that means. I have to assume that was something Ben set for testing or the initial version of this, I'm not sure.

### Reason for Changes

The most controversial thing here, I think, is that I'm calling the entire comment a button. I think it's basically true since you press enter to edit it. I think we talked about saying fields with editors are buttons too, for that reason. But I'm not sure where landed with that. I think we should do the same thing here that we do for fields with editors.

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

~~Note that after #9350 is submitted I will need to run `npm run messages` and commit the results. This shouldn't be merged before then.~~ Done
