### PR TITLE
chore: add keyboard nav to advanced playground

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
       "devDependencies": {
         "@blockly/block-test": "^7.0.2",
         "@blockly/dev-tools": "^9.0.2",
+        "@blockly/keyboard-navigation": "^3.0.1",
         "@blockly/theme-modern": "^7.0.1",
         "@hyperjump/browser": "^1.1.4",
         "@hyperjump/json-schema": "^1.5.0",
@@ -197,6 +198,15 @@
       "dev": true,
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/@blockly/keyboard-navigation": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@blockly/keyboard-navigation/-/keyboard-navigation-3.0.1.tgz",
+      "integrity": "sha512-qSOPqsqRgkSLEoUeEZc81PWe558pXqY0e+4jkRODoAD+I1hMpCoD+6ivveRp7Jpb8WE1lj2PrAFOVuIVpphjHA==",
+      "dev": true,
+      "peerDependencies": {
+        "blockly": "^12.3.0"
       }
     },
     "node_modules/@blockly/theme-dark": {

--- a/package.json
+++ b/package.json
@@ -102,6 +102,7 @@
   "devDependencies": {
     "@blockly/block-test": "^7.0.2",
     "@blockly/dev-tools": "^9.0.2",
+    "@blockly/keyboard-navigation": "^3.0.1",
     "@blockly/theme-modern": "^7.0.1",
     "@hyperjump/browser": "^1.1.4",
     "@hyperjump/json-schema": "^1.5.0",

--- a/tests/playgrounds/advanced_playground.html
+++ b/tests/playgrounds/advanced_playground.html
@@ -18,6 +18,11 @@
       await loadScript(
         '../../node_modules/@blockly/theme-modern/dist/index.js',
       );
+      await loadScript(
+        '../../node_modules/@blockly/keyboard-navigation/dist/index.js',
+      );
+
+      let kbNavigation;
 
       function start() {
         setBackgroundColour();
@@ -47,6 +52,28 @@
             // Refresh theme.
             ws.setTheme(ws.getTheme());
           });
+
+        // Keyboard navigation options.
+        const kbOptions = {
+          'Enable keyboard navigation': false,
+        };
+        gui.remember(kbOptions);
+        gui.add(kbOptions, 'Enable keyboard navigation').onChange((enabled) => {
+          setupKeyboardNav(enabled, playground);
+        });
+
+        // Set up keyboard navigation on page load
+        setupKeyboardNav(kbOptions['Enable keyboard navigation'], playground);
+      }
+
+      function setupKeyboardNav(enabled, playground) {
+        if (enabled) {
+          kbNavigation = new KeyboardNavigation(playground.getWorkspace());
+        } else {
+          if (kbNavigation) {
+            kbNavigation.dispose();
+          }
+        }
       }
 
       function initPlayground() {
@@ -101,6 +128,8 @@
         };
 
         Blockly.ContextMenuItems.registerCommentOptions();
+        KeyboardNavigation.registerKeyboardNavigationStyles();
+        // TODO: register the navigation-deferring toolbox.
 
         createPlayground(
           document.getElementById('root'),
@@ -153,6 +182,7 @@
     </style>
   </head>
   <body>
+    <div id="shortcuts"></div>
     <div id="root"></div>
   </body>
 </html>


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #9355 

### Proposed Changes

- Adds a control to the advanced playground to enable/disable keyboard navigation

### Reason for Changes

- Make it easier to test changes in core that impact keyboard navigation

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

This is mildly janky for a few reasons:

- While the advanced playground API exposes enough necessary to add additional controls to the gui, it doesn't handle saving the value of those added controls. The dev-tools plugin does its own save/load logic for some reason, instead of using the built-in save functionality. So to get this value to save, I used the built-in save functionality which adds a little section to save/load some preset preferences. However because dev-tools does its own save/load, this only saves the value of the keyboard navigation checkbox.
- If you change any of the other values in the playground controls, a change listener is run that destroys and reinjects the workspace. But there is no way to get a handle on that change listener so we are unable to follow it up with our own listener that reactivates keyboard navigation. So, if you change any of the other values in the playground, you have to re-load the page in order to re-initialize keyboard navigation.
- We need to register the navigation-deferring toolbox but the code exposing that method hasn't been released yet, so I left a todo.
