### PR TITLE
fix: Use field ARIA labels for field-only blocks.

### DIFF
--- a/core/block_svg.ts
+++ b/core/block_svg.ts
@@ -241,12 +241,14 @@ export class BlockSvg
       // Shadow blocks are best represented directly by their field since they
       // effectively operate like a field does for keyboard navigation purposes.
       const field = Array.from(this.getFields())[0];
-      let label = 'Unknown?';
       try {
-        label =
-          aria.getState(field.getFocusableElement(), aria.State.LABEL) ?? label;
-      } catch {}
-      return label;
+        return (
+          aria.getState(field.getFocusableElement(), aria.State.LABEL) ??
+          'Unknown?'
+        );
+      } catch {
+        return 'Unknown?';
+      }
     }
 
     const fieldLabels = [];

--- a/core/block_svg.ts
+++ b/core/block_svg.ts
@@ -224,9 +224,6 @@ export class BlockSvg
     this.currentConnectionCandidate = null;
 
     this.doInit_();
-
-    // Note: This must be done after initialization of the block's fields.
-    this.recomputeAriaLabel();
   }
 
   private recomputeAriaLabel() {
@@ -239,15 +236,17 @@ export class BlockSvg
 
   private computeAriaLabel(): string {
     // Guess the block's aria label based on its field labels.
-    if (this.isShadow()) {
+    if (this.isShadow() || this.isSimpleReporter()) {
       // TODO: Shadows may have more than one field.
       // Shadow blocks are best represented directly by their field since they
       // effectively operate like a field does for keyboard navigation purposes.
       const field = Array.from(this.getFields())[0];
-      return (
-        aria.getState(field.getFocusableElement(), aria.State.LABEL) ??
-        'Unknown?'
-      );
+      let label = 'Unknown?';
+      try {
+        label =
+          aria.getState(field.getFocusableElement(), aria.State.LABEL) ?? label;
+      } catch {}
+      return label;
     }
 
     const fieldLabels = [];
@@ -306,6 +305,8 @@ export class BlockSvg
     if (!svg.parentNode) {
       this.workspace.getCanvas().appendChild(svg);
     }
+    // Note: This must be done after initialization of the block's fields.
+    this.recomputeAriaLabel();
     this.initialized = true;
   }
 


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #9316

### Proposed Changes
This PR makes blocks containing full-block fields derive their ARIA label from the label of their child field. Previously, these blocks did not have a label at all. The current field labels seem a bit suboptimal, but if they are updated that change will propagate through.

Because block labels are derived from their field labels, and Field's `getFocusableElement()` can throw if called early during initialization, I wrapped the access in a try-catch and moved the recalculation of the label into `initSvg()`, a bit later in the initialization sequence than the block constructor.