### PR TITLE
fix: fix broken dragging in non-zelos renderers

### DIFF
--- a/core/block_svg.ts
+++ b/core/block_svg.ts
@@ -269,7 +269,7 @@ export class BlockSvg
       const firstSibling: BlockSvg = surroundParent.getChildren(false)[0];
       const siblings: BlockSvg[] = [firstSibling];
       let nextSibling: BlockSvg | null = firstSibling;
-      while ((nextSibling = nextSibling.getNextBlock())) {
+      while ((nextSibling = nextSibling?.getNextBlock())) {
         siblings.push(nextSibling);
       }
       return siblings;


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #9367 

### Proposed Changes

Adds guard against undefined nextSibling

### Test Coverage

Manually tested with geras, and linked against kbe and verified that tests pass there.