### PR TITLE
chore: use beta kb nav in advanced playground

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
       "devDependencies": {
         "@blockly/block-test": "^7.0.2",
         "@blockly/dev-tools": "^9.0.2",
-        "@blockly/keyboard-navigation": "^3.0.1",
+        "@blockly/keyboard-navigation": "^4.0.0-beta.0",
         "@blockly/theme-modern": "^7.0.1",
         "@hyperjump/browser": "^1.1.4",
         "@hyperjump/json-schema": "^1.5.0",
@@ -201,9 +201,9 @@
       }
     },
     "node_modules/@blockly/keyboard-navigation": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@blockly/keyboard-navigation/-/keyboard-navigation-3.0.1.tgz",
-      "integrity": "sha512-qSOPqsqRgkSLEoUeEZc81PWe558pXqY0e+4jkRODoAD+I1hMpCoD+6ivveRp7Jpb8WE1lj2PrAFOVuIVpphjHA==",
+      "version": "4.0.0-beta.0",
+      "resolved": "https://registry.npmjs.org/@blockly/keyboard-navigation/-/keyboard-navigation-4.0.0-beta.0.tgz",
+      "integrity": "sha512-jeFHyXNrFMFk6ZFlcdjJvmSXkiq8w/y/h49pZSe3E6o01pUtuVVf4PEUKj1KW2v+F0IwlhyHY5cvPu+JudyZKg==",
       "dev": true,
       "peerDependencies": {
         "blockly": "^12.3.0"

--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
   "devDependencies": {
     "@blockly/block-test": "^7.0.2",
     "@blockly/dev-tools": "^9.0.2",
-    "@blockly/keyboard-navigation": "^3.0.1",
+    "@blockly/keyboard-navigation": "^4.0.0-beta.0",
     "@blockly/theme-modern": "^7.0.1",
     "@hyperjump/browser": "^1.1.4",
     "@hyperjump/json-schema": "^1.5.0",


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes 

### Proposed Changes

Uses the beta of the screenreader branch in the advanced playground in this branch.

### Reason for Changes

Easier testing with screenreaders if you don't need to use the plugin test page. 

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
