### PR TITLE
fix: exclude svg root from aria tree

### DIFF
--- a/core/flyout_base.ts
+++ b/core/flyout_base.ts
@@ -33,6 +33,7 @@ import * as renderManagement from './render_management.js';
 import {ScrollbarPair} from './scrollbar_pair.js';
 import {SEPARATOR_TYPE} from './separator_flyout_inflater.js';
 import * as blocks from './serialization/blocks.js';
+import {aria} from './utils.js';
 import {Coordinate} from './utils/coordinate.js';
 import * as dom from './utils/dom.js';
 import * as idGenerator from './utils/idgenerator.js';
@@ -309,6 +310,9 @@ export abstract class Flyout
       'class': 'blocklyFlyout',
     });
     this.svgGroup_.style.display = 'none';
+    // Ignore the svg root in the accessibility tree since is is not focusable.
+    aria.setRole(this.svgGroup_, aria.Role.PRESENTATION);
+
     this.svgBackground_ = dom.createSvgElement(
       Svg.PATH,
       {'class': 'blocklyFlyoutBackground'},

--- a/core/inject.ts
+++ b/core/inject.ts
@@ -55,6 +55,9 @@ export function inject(
     dom.addClass(subContainer, 'blocklyRTL');
   }
 
+  // Ignore the subcontainer in aria since it is not focusable
+  aria.setRole(subContainer, aria.Role.PRESENTATION);
+
   containerElement!.appendChild(subContainer);
   const svg = createDom(subContainer, options);
 


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #9317 

### Proposed Changes

Sets the aria role to presentation in 2 places:

- svg root of the flyout (this prevents screenreader from reading "SvgRoot" when opening the flyout)
- subcontainer of the injection div, which previously is just listed as "generic" in the accessibility tree

### Reason for Changes

These 2 places are just containers for the interactive children, they shouldn't be interacted with in the accessibility tree. Their contents are still accessible.

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
