### PR TITLE
fix: handle pointercancel only for in-progress gestures

### DIFF
--- a/core/gesture.ts
+++ b/core/gesture.ts
@@ -467,6 +467,15 @@ export class Gesture {
         /* opt_noCaptureIdentifier */ true,
       ),
     );
+    this.boundEvents.push(
+      browserEvents.conditionalBind(
+        document,
+        'pointercancel',
+        null,
+        this.handleUp.bind(this),
+        /* opt_noCaptureIdentifier */ true,
+      ),
+    );
 
     e.preventDefault();
     e.stopPropagation();

--- a/core/touch.ts
+++ b/core/touch.ts
@@ -46,7 +46,6 @@ export const TOUCH_MAP: {[key: string]: string[]} = {
   'mouseup': ['pointerup', 'pointercancel'],
   'touchend': ['pointerup'],
   'touchcancel': ['pointercancel'],
-  'pointerup': ['pointerup', 'pointercancel'],
 };
 
 /** PID of queued long-press task. */


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #9249 and fixes #9371 

### Proposed Changes

- #9250 fixed #9249 but used too big of a hammer, it would fire pointerup events when scrolling dropdowns. Scrolling a dropdown is something handled by the browser, so it would fire a pointercancel event once it determined that the touch is a scroll instead of a pointerevent the application should handle. This broke dropdowns and possibly other scenarios.
- Reverting #9250 alone would reintroduce #9249
- I fixed that by adding an event listener for `pointercancel` that ends the gesture. This event is only added when a gesture is started.

### Reason for Changes

Fixes a regression.

### Test Coverage

Tested both bugs using a real touch device. I pushed my changes to github pages so I could test physically. https://maribethb.github.io/blockly/tests/playground.html

### Documentation

n/a

### Additional Information

This will need to go in a patch release
