### PR TITLE
feat: make FlyoutButton.callbackKey public

### DIFF
--- a/core/flyout_button.ts
+++ b/core/flyout_button.ts
@@ -42,9 +42,11 @@ export class FlyoutButton
   /** The radius of the flyout button's borders. */
   static BORDER_RADIUS = 4;
 
+  /** The key to the function called when this button is activated. */
+  readonly callbackKey: string;
+
   private readonly text: string;
   private readonly position: Coordinate;
-  private readonly callbackKey: string;
   private readonly cssClass: string | null;
 
   /** Mouse up event data. */
@@ -90,12 +92,13 @@ export class FlyoutButton
 
     this.position = new Coordinate(0, 0);
 
-    /** The key to the function called when this button is clicked. */
+    /**
+     * The key to the function called when this button is activated.
+     * Check both the uppercase and lowercase version, because the docs
+     * say `callbackKey` but the type says `callbackkey`.
+     */
     this.callbackKey =
-      (json as AnyDuringMigration)[
-        'callbackKey'
-      ] /* Check the lower case version
-                                                   too to satisfy IE */ ||
+      (json as AnyDuringMigration)['callbackKey'] ||
       (json as AnyDuringMigration)['callbackkey'];
 
     /** If specified, a CSS class to add to this button. */


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

Needed for https://github.com/google/blockly-keyboard-experimentation/issues/727

### Proposed Changes

- Makes `callbackKey` public
- Reformats the code where it's set to be less weird
- Updates the comments with better reasoning for why we look for both properties in the json

### Reason for Changes

The comment implies that we only check the lowercase version because of IE11, but that can't be correct, because the `ButtonInfo` type definition uses the lowercase version, despite our docs saying to use the camelcase version. We have supported both for a long time and should continue supporting both.

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
