### PR TITLE
fix: improve aria markup for toolboxes

### DIFF
--- a/core/toolbox/collapsible_category.ts
+++ b/core/toolbox/collapsible_category.ts
@@ -137,18 +137,6 @@ export class CollapsibleToolboxCategory
     aria.setState(this.htmlDiv_ as HTMLDivElement, aria.State.EXPANDED, false);
     aria.setRole(this.htmlDiv_!, aria.Role.TREEITEM);
 
-    // Ensure this group has properly set children.
-    const selectableChildren =
-      this.getChildToolboxItems().filter((item) => item.isSelectable()) ?? null;
-    const focusableChildIds = selectableChildren.map(
-      (selectable) => selectable.getFocusableElement().id,
-    );
-    aria.setState(
-      this.htmlDiv_!,
-      aria.State.OWNS,
-      [...new Set(focusableChildIds)].join(' '),
-    );
-
     return this.htmlDiv_!;
   }
 

--- a/core/toolbox/toolbox.ts
+++ b/core/toolbox/toolbox.ts
@@ -369,7 +369,6 @@ export class Toolbox
     this.renderContents_(toolboxDef['contents']);
     this.position();
     this.handleToolboxItemResize();
-    this.recomputeAriaOwners();
   }
 
   /**
@@ -446,7 +445,6 @@ export class Toolbox
         this.addToolboxItem_(child);
       }
     }
-    this.recomputeAriaOwners();
   }
 
   /**
@@ -1146,32 +1144,6 @@ export class Toolbox
     if (!nextTree || nextTree !== this.flyout?.getWorkspace()) {
       this.autoHide(false);
     }
-  }
-
-  /**
-   * Recomputes ARIA tree ownership relationships for all of this toolbox's
-   * categories and items.
-   *
-   * This should only be done when the toolbox's contents have changed.
-   */
-  recomputeAriaOwners() {
-    const focusable = this.getFocusableElement();
-    const selectableChildren =
-      this.getToolboxItems().filter((item) => item.isSelectable()) ?? null;
-    const focusableChildElems = selectableChildren.map((selectable) =>
-      selectable.getFocusableElement(),
-    );
-    const focusableChildIds = focusableChildElems.map((elem) => elem.id);
-    aria.setState(
-      focusable,
-      aria.State.OWNS,
-      [...new Set(focusableChildIds)].join(' '),
-    );
-    // Ensure children have the correct position set.
-    // TODO: Fix collapsible subcategories. Their groups aren't set up correctly yet, and they aren't getting a correct accounting in top-level toolbox tree.
-    focusableChildElems.forEach((elem, index) =>
-      aria.setState(elem, aria.State.POSINSET, index + 1),
-    );
   }
 }
 

--- a/core/toolbox/toolbox.ts
+++ b/core/toolbox/toolbox.ts
@@ -881,11 +881,7 @@ export class Toolbox
     this.selectedItem_ = null;
     this.previouslySelectedItem_ = item;
     item.setSelected(false);
-    aria.setState(
-      this.contentsDiv_ as Element,
-      aria.State.ACTIVEDESCENDANT,
-      '',
-    );
+    aria.clearState(this.HtmlDiv!, aria.State.ACTIVEDESCENDANT);
   }
 
   /**
@@ -901,11 +897,7 @@ export class Toolbox
     this.selectedItem_ = newItem;
     this.previouslySelectedItem_ = oldItem;
     newItem.setSelected(true);
-    aria.setState(
-      this.contentsDiv_ as Element,
-      aria.State.ACTIVEDESCENDANT,
-      newItem.getId(),
-    );
+    aria.setState(this.HtmlDiv!, aria.State.ACTIVEDESCENDANT, newItem.getId());
   }
 
   /**

--- a/core/toolbox/toolbox.ts
+++ b/core/toolbox/toolbox.ts
@@ -879,7 +879,6 @@ export class Toolbox
     this.selectedItem_ = null;
     this.previouslySelectedItem_ = item;
     item.setSelected(false);
-    aria.clearState(this.HtmlDiv!, aria.State.ACTIVEDESCENDANT);
   }
 
   /**
@@ -895,7 +894,6 @@ export class Toolbox
     this.selectedItem_ = newItem;
     this.previouslySelectedItem_ = oldItem;
     newItem.setSelected(true);
-    aria.setState(this.HtmlDiv!, aria.State.ACTIVEDESCENDANT, newItem.getId());
   }
 
   /**


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #9293 

### Proposed Changes

- Removes the `aria-activedescendant` state
- Removes setting `aria-posinset`
- Removes setting `aria-owns`
- Does NOT remove setting `aria-selected=false`

### Reason for Changes

There is a comment with justification for each of these things in the linked issue. I've verified that removing the active-descendant state and the aria-owns state does not change the screenreader output, and removing the posinset state improves the output (in my opinion, as discussed in the issue)

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
