### PR TITLE
feat: Remove main workspace tree/treeitem & use top-level regions (experimental)

### DIFF
--- a/core/block_svg.ts
+++ b/core/block_svg.ts
@@ -285,40 +285,16 @@ export class BlockSvg
   private computeAriaRole() {
     if (this.isSimpleReporter()) {
       aria.setRole(this.pathObject.svgPath, aria.Role.BUTTON);
-    } else {
-      // This isn't read out by VoiceOver and it will read in the wrong place
-      // as a duplicate in ChromeVox due to the other changes in this branch.
-      // aria.setState(
-      //   this.pathObject.svgPath,
-      //   aria.State.ROLEDESCRIPTION,
-      //   'block',
-      // );
+    } else if (this.workspace.isFlyout) {
       aria.setRole(this.pathObject.svgPath, aria.Role.TREEITEM);
-    }
-  }
-
-  collectSiblingBlocks(surroundParent: BlockSvg | null): BlockSvg[] {
-    // NOTE TO DEVELOPERS: it's very important that these are NOT sorted. The
-    // returned list needs to be relatively stable for consistent block indexes
-    // read out to users via screen readers.
-    if (surroundParent) {
-      // Start from the first sibling and iterate in navigation order.
-      const firstSibling: BlockSvg = surroundParent.getChildren(false)[0];
-      const siblings: BlockSvg[] = [firstSibling];
-      let nextSibling: BlockSvg | null = firstSibling;
-      while ((nextSibling = nextSibling?.getNextBlock())) {
-        siblings.push(nextSibling);
-      }
-      return siblings;
     } else {
-      // For top-level blocks, simply return those from the workspace.
-      return this.workspace.getTopBlocks(false);
+      aria.setState(
+        this.pathObject.svgPath,
+        aria.State.ROLEDESCRIPTION,
+        'block',
+      );
+      aria.setRole(this.pathObject.svgPath, aria.Role.FIGURE);
     }
-  }
-
-  computeLevelInWorkspace(): number {
-    const surroundParent = this.getSurroundParent();
-    return surroundParent ? surroundParent.computeLevelInWorkspace() + 1 : 0;
   }
 
   /**

--- a/core/toolbox/toolbox.ts
+++ b/core/toolbox/toolbox.ts
@@ -154,9 +154,6 @@ export class Toolbox
     this.setVisible(true);
     this.flyout.init(workspace);
 
-    aria.setRole(this.HtmlDiv, aria.Role.TREE);
-    aria.setState(this.HtmlDiv, aria.State.LABEL, Msg['TOOLBOX_ARIA_LABEL']);
-
     this.render(this.toolboxDef_);
     const themeManager = workspace.getThemeManager();
     themeManager.subscribe(
@@ -208,6 +205,12 @@ export class Toolbox
     toolboxContainer.setAttribute('layout', this.isHorizontal() ? 'h' : 'v');
     dom.addClass(toolboxContainer, 'blocklyToolbox');
     toolboxContainer.setAttribute('dir', this.RTL ? 'RTL' : 'LTR');
+    aria.setRole(toolboxContainer, aria.Role.REGION);
+    aria.setState(
+      toolboxContainer,
+      aria.State.LABEL,
+      Msg['TOOLBOX_ARIA_LABEL'],
+    );
     return toolboxContainer;
   }
 
@@ -222,6 +225,7 @@ export class Toolbox
     if (this.isHorizontal()) {
       contentsContainer.style.flexDirection = 'row';
     }
+    aria.setRole(contentsContainer, aria.Role.TREE);
     return contentsContainer;
   }
 

--- a/core/utils/aria.ts
+++ b/core/utils/aria.ts
@@ -53,6 +53,7 @@ export enum Role {
   TEXTBOX = 'textbox',
   COMBOBOX = 'combobox',
   SPINBUTTON = 'spinbutton',
+  REGION = 'region',
 }
 
 /**


### PR DESCRIPTION
## The basics

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

Fixes #9395
Fixes https://github.com/google/blockly-keyboard-experimentation/issues/428
Fixes part of #9312

### Proposed Changes

Removes all `tree` and `treeitem` roles from non-flyout workspaces, and uses `region` for top-level workspace, toolbox, and flyout roles.

Demonstration of changes:

[Screen recording 2025-10-08 10.37.10 AM.webm](https://github.com/user-attachments/assets/a42084b2-06fa-48a2-9661-710c630f3ba0)

(This shows the reintroduction of block role description, the new regions, the removal of tree/tree items for blocks, and an attempt at fixing mutators though with apparent issues).

### Reason for Changes

Recent feedback from micro:bit panelists and accessibility experts suggests that the tree-based approach may be adding too much contextual information to the point of not actually being helpful (and potentially even being harmful from a UX perspective). Additionally, VoiceOver has mixed support for trees and tree items and it may be very difficult or impossible to work around these and continue with those roles.

The new plan is to test with less explicit context and add some more context through block labeling (particularly for C-shaped blocks), which is ongoing work in #9299. Longer term it may be necessary to add a more 'verbose' readout mode, or add some sort of 'where am I?' shortcut to re-add the contextual positioning information (so the code removed in this PR may be useful for future referencing).

Some specific notes on regions:
- Regions provide explicit readout context (at least in ChromeVox) usually when entered and exited. This actually makes it possible to leverage both regions and trees for context (in the case of toolboxes and flyouts) which is actually quite clean.
- Mutators are still very fuzzy. Mutators are being made a region since they are technically distinct workspaces from the main workspace, but the readouts for them on ChromeVox aren't working as expected which is why #9312 isn't being fully closed here. More work is needed to get mutators to have a good readout experience.

Note also that this reintroduces the 'block' role description for the main workspace and is leveraging `figure` (https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/figure_role) as the base role for blocks. This _seems_ like the best fit as blocks are not inherently buttons, and overwriting the role description is supposed to provide the correct context to readers. This may well need to change if more incompatibilities are discovered (such as with VoiceOver).

### Test Coverage

None since this is an experimental change.

### Documentation

None since this is an experimental change.

### Additional Information

None
