### PR TITLE
fix(ci): pass PR title to commitlint via environment variable

### DIFF
--- a/.github/workflows/conventional-label.yml
+++ b/.github/workflows/conventional-label.yml
@@ -7,6 +7,8 @@ name: commit lint & label
 jobs:
   lint:
     runs-on: ubuntu-latest
+    env:
+      PR_TITLE: ${{ github.event.pull_request.title }}
     permissions:
       pull-requests: read
       contents: read
@@ -23,7 +25,7 @@ jobs:
         run: npm ci
       - name: Check PR title
         id: check-pr-title
-        run: echo "${{ github.event.pull_request.title }}" | npx commitlint --verbose
+        run: echo "$PR_TITLE" | npx commitlint --verbose
 
   label:
     runs-on: ubuntu-latest


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

The commitlint workflow currently uses the PR title via actions context variable which can be used to pass code. Fortunately the GITHUB_TOKEN is scoped down, but this can turn into a problem later if a privileged workflow (such as one that has contents:write) consumes from the cache. This PR fixes that risk.

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details

<!-- TODO: What Github issue does this resolve? Please include a link. -->

### Proposed Changes

Sanitize PR title via env var.

### Reason for Changes

Fix actions injection.

### Test Coverage

N/A

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
