### PR TITLE
fix: make the aria live region assertive

### DIFF
--- a/core/inject.ts
+++ b/core/inject.ts
@@ -86,7 +86,7 @@ export function inject(
   const ariaAnnouncementSpan = document.createElement('span');
   ariaAnnouncementSpan.id = 'blocklyAriaAnnounce';
   dom.addClass(ariaAnnouncementSpan, 'hiddenForAria');
-  aria.setState(ariaAnnouncementSpan, aria.State.LIVE, 'polite');
+  aria.setState(ariaAnnouncementSpan, aria.State.LIVE, 'assertive');
   subContainer.appendChild(ariaAnnouncementSpan);
 
   return workspace;

--- a/core/utils/aria.ts
+++ b/core/utils/aria.ts
@@ -202,20 +202,20 @@ export function getState(element: Element, stateName: State): string | null {
 }
 
 /**
- * Softly requests that the specified text be read to the user if a screen
+ * Assertively requests that the specified text be read to the user if a screen
  * reader is currently active.
  *
- * This relies on a centrally managed ARIA live region that should not interrupt
- * existing announcements (that is, this is what's considered a polite
- * announcement).
+ * This relies on a centrally managed ARIA live region that is hidden from the
+ * visual DOM. This live region is assertive, meaning it will interrupt other
+ * text being read.
  *
  * Callers should use this judiciously. It's often considered bad practice to
- * over announce information that can be inferred from other sources on the
- * page, so this ought to only be used when certain context cannot be easily
+ * over-announce information that can be inferred from other sources on the
+ * page, so this ought to be used only when certain context cannot be easily
  * determined (such as dynamic states that may not have perfect ARIA
  * representations or indications).
  *
- * @param text The text to politely read to the user.
+ * @param text The text to read to the user.
  */
 export function announceDynamicAriaState(text: string) {
   const ariaAnnouncementSpan = document.getElementById('blocklyAriaAnnounce');


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Required for https://github.com/google/blockly-keyboard-experimentation/issues/764

### Proposed Changes

- Makes the aria-live announcement region assertive. Currently this is only used for move mode announcement where assertive is appropriate, and it's soon to be used for announcements that will be made in response to keyboard shortcuts which should also be assertive

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
