### PR TITLE
fix: Add support for icons to `getSourceBlockFromNode()`.

### DIFF
--- a/core/keyboard_nav/marker.ts
+++ b/core/keyboard_nav/marker.ts
@@ -14,6 +14,7 @@
 
 import {BlockSvg} from '../block_svg.js';
 import {Field} from '../field.js';
+import {Icon} from '../icons/icon.js';
 import type {IFocusableNode} from '../interfaces/i_focusable_node.js';
 import {RenderedConnection} from '../rendered_connection.js';
 
@@ -66,6 +67,8 @@ export class Marker {
       return node.getSourceBlock() as BlockSvg;
     } else if (node instanceof RenderedConnection) {
       return node.getSourceBlock();
+    } else if (node instanceof Icon) {
+      return node.getSourceBlock() as BlockSvg;
     }
 
     return null;


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #9435

### Proposed Changes
This PR updates `getSourceBlockFromNode()` to support retrieving the source block of icons.