### PR TITLE
fix: Don't filter out falsey input values when generating ARIA labels.

### DIFF
--- a/core/field_input.ts
+++ b/core/field_input.ts
@@ -191,7 +191,7 @@ export abstract class FieldInput<T extends InputTypes> extends Field<
 
     const element = this.getFocusableElement();
     const label = [this.getValue(), this.getAriaName()]
-      .filter((item) => !!item)
+      .filter((item) => item !== null)
       .join(', ');
 
     aria.setState(element, aria.State.LABEL, label);


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #9431

### Proposed Changes
This PR updates the logic for generating ARIA labels for `FieldInput` to not omit falsey values like `false` or `0`, which can be valid input values that should be read out.