### PR TITLE
fix: Make the 'welcome new contributors' workflow run again

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,6 +20,10 @@ updates:
     target-branch: 'develop'
     schedule:
       interval: 'weekly'
+    ignore:
+      # See notes in welcome_new_contributors.yml for details on this.
+      - dependency-name: "actions/first-interaction"
+        versions: ["*"]
     commit-message:
       prefix: 'chore(deps)'
     labels:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,8 +22,8 @@ updates:
       interval: 'weekly'
     ignore:
       # See notes in welcome_new_contributors.yml for details on this.
-      - dependency-name: "actions/first-interaction"
-        versions: ["*"]
+      - dependency-name: 'actions/first-interaction'
+        versions: ['*']
     commit-message:
       prefix: 'chore(deps)'
     labels:

--- a/.github/workflows/welcome_new_contributors.yml
+++ b/.github/workflows/welcome_new_contributors.yml
@@ -11,8 +11,8 @@ jobs:
     steps:
       - uses: actions/first-interaction@v3.0.0
         with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          pr-message: >
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          pr_message: >
             Welcome! It looks like this is your first pull request in Blockly,
             so here are a couple of tips:
 

--- a/.github/workflows/welcome_new_contributors.yml
+++ b/.github/workflows/welcome_new_contributors.yml
@@ -9,10 +9,10 @@ jobs:
     permissions:
       pull-requests: write
     steps:
-      - uses: actions/first-interaction@v3
+      - uses: actions/first-interaction@v2
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          pr_message: >
+          pr-message: >
             Welcome! It looks like this is your first pull request in Blockly,
             so here are a couple of tips:
 

--- a/.github/workflows/welcome_new_contributors.yml
+++ b/.github/workflows/welcome_new_contributors.yml
@@ -9,7 +9,7 @@ jobs:
     permissions:
       pull-requests: write
     steps:
-      - uses: actions/first-interaction@v2
+      - uses: actions/first-interaction@v3.0.0
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           pr-message: >

--- a/.github/workflows/welcome_new_contributors.yml
+++ b/.github/workflows/welcome_new_contributors.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/first-interaction@v3
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          pr-message: >
+          pr_message: >
             Welcome! It looks like this is your first pull request in Blockly,
             so here are a couple of tips:
 

--- a/.github/workflows/welcome_new_contributors.yml
+++ b/.github/workflows/welcome_new_contributors.yml
@@ -9,10 +9,15 @@ jobs:
     permissions:
       pull-requests: write
     steps:
-      - uses: actions/first-interaction@v3.0.0
+      # NOTE TO DEVELOPER: Per #9447 this is pinned to v1.3.0 and all updates
+      # have been disabled for it. There are some largely incompatibilities on
+      # v2 and v3 of the action that, without resolution, will break the first
+      # interaction experience for new contributors. This dependency should not
+      # be upgraded until those issues are resolved.
+      - uses: actions/first-interaction@v1.3.0
         with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
-          pr_message: >
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          pr-message: >
             Welcome! It looks like this is your first pull request in Blockly,
             so here are a couple of tips:
 


### PR DESCRIPTION
## The basics

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

Fixes #9447

### Proposed Changes

Pin the `actions/first-interactions` action to v1.3.0 and update the input parameters. Configure Dependabot to no longer try to upgrade this version.

### Reason for Changes

There are three sets of failures being addressed here:
1. `v3.0.0` introduces a breaking changes by renaming the input names.
2. `v3.1.0` introduces a breaking change that somehow enforces `issue_message` being required which isn't being defined for Blockly (we only welcome on PRs). This hasn't been addressed by the action author so this PR pins to v3.0.0 to go back to a working version.\*
3. `v2` introduced a breaking behavioral change that caused all runs of the workflow to outright fail by not being compatible with `pull_request_target`.

\* Technically it was broken when upgraded in #9323 due to a warning (rather than error) enforcing the now-required parameters. That was hiding a failure introduced when upgraded in #9274 that outright broke the workflow due to it running with `pull_request_target`.

### Test Coverage

The team doesn't utilize automated tests for the workflow configurations themselves thus verifying them through running CI is sufficient.

https://github.com/BenHenning/blockly/pull/16#pullrequestreview-3400731300 demonstrates this passing and working correctly with a merged in version of this branch (since the workflow uses `pull_request_target` it cannot be verified in this PR's CI workflow) for a 'new' contributor (thanks for the help @rpbourret and @maribethb).

### Documentation

No documentation changes are needed for this workflow configuration change.

### Additional Information

Nothing to add that's not above or in the filed bug.