### PR TITLE
fix: create more comprehensive field row labels

### DIFF
--- a/core/inputs/input.ts
+++ b/core/inputs/input.ts
@@ -324,9 +324,17 @@ export class Input {
     if (!fieldRowLabel) {
       const inputs = this.getSourceBlock().inputList;
       const index = inputs.indexOf(this);
-      if (index > 0) {
-        return inputs[index - 1].getFieldRowLabel();
-      }
+      const precedingInputs = inputs.slice(0, index);
+      return precedingInputs
+        .flatMap((input) => {
+          const fields = input.fieldRow.map((field) => {
+            if (!field.isVisible()) return undefined;
+            return [field.getText() ?? field.getValue()];
+          });
+          return fields;
+        })
+        .filter(Boolean)
+        .join(' ');
     }
     return fieldRowLabel;
   }


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes https://github.com/google/blockly/issues/9457

### Proposed Changes

This PR uses all preceding inputs to create a more comprehensive field row label.

There is a scenario where this fix won't do exactly the right thing. In the case where a block has multiple branches (e.g., an `if` block) and also doesn't have inline text for the statement input (e.g., there is no "do"), then the entire block to the current input index is going to be output, which might be something like "Begin if true then else if false...". Thoughts on this scenario are welcome. In such situations, `getFieldRowLabel` could be overridden by the developer, but I wonder if a better default can be provided.
