### PR TITLE
fix: enforce placeholder usage for workspace comment

### DIFF
--- a/core/comments/comment_editor.ts
+++ b/core/comments/comment_editor.ts
@@ -8,6 +8,7 @@ import * as browserEvents from '../browser_events.js';
 import {getFocusManager} from '../focus_manager.js';
 import {IFocusableNode} from '../interfaces/i_focusable_node.js';
 import {IFocusableTree} from '../interfaces/i_focusable_tree.js';
+import {Msg} from '../msg.js';
 import * as touch from '../touch.js';
 import * as dom from '../utils/dom.js';
 import {Rect} from '../utils/rect.js';
@@ -56,6 +57,7 @@ export class CommentEditor implements IFocusableNode {
     ) as HTMLTextAreaElement;
     this.textArea.setAttribute('tabindex', '-1');
     this.textArea.setAttribute('dir', this.workspace.RTL ? 'RTL' : 'LTR');
+    this.textArea.setAttribute('placeholder', Msg['WORKSPACE_COMMENT_DEFAULT_TEXT'])
     dom.addClass(this.textArea, 'blocklyCommentText');
     dom.addClass(this.textArea, 'blocklyTextarea');
     dom.addClass(this.textArea, 'blocklyText');

--- a/core/comments/comment_editor.ts
+++ b/core/comments/comment_editor.ts
@@ -57,7 +57,10 @@ export class CommentEditor implements IFocusableNode {
     ) as HTMLTextAreaElement;
     this.textArea.setAttribute('tabindex', '-1');
     this.textArea.setAttribute('dir', this.workspace.RTL ? 'RTL' : 'LTR');
-    this.textArea.setAttribute('placeholder', Msg['WORKSPACE_COMMENT_DEFAULT_TEXT'])
+    this.textArea.setAttribute(
+      'placeholder',
+      Msg['WORKSPACE_COMMENT_DEFAULT_TEXT'],
+    );
     dom.addClass(this.textArea, 'blocklyCommentText');
     dom.addClass(this.textArea, 'blocklyTextarea');
     dom.addClass(this.textArea, 'blocklyText');

--- a/core/contextmenu_items.ts
+++ b/core/contextmenu_items.ts
@@ -636,7 +636,6 @@ export function registerCommentCreate() {
       if (!workspace) return;
       eventUtils.setGroup(true);
       const comment = new RenderedWorkspaceComment(workspace);
-      comment.setPlaceholderText(Msg['WORKSPACE_COMMENT_DEFAULT_TEXT']);
       comment.moveTo(
         svgMath.screenToWsCoordinates(
           workspace,


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
Workspace comment's placeholder don't get duplicated with comment itself. This pr make workspace comment uses placeholder by default.
### Resolves
<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #9462
### Proposed Changes
Make workspace comment uses placeholder by default.
<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->

### Reason for Changes
Placeholder should keep exists.
<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
