### PR TITLE
fix: Ensure field ARIA labels are correct for invalid values (experimental)

### DIFF
--- a/core/field_input.ts
+++ b/core/field_input.ts
@@ -227,6 +227,7 @@ export abstract class FieldInput<T extends InputTypes> extends Field<
       const oldValue = this.value_;
       // Revert value when the text becomes invalid.
       this.value_ = this.valueWhenEditorWasOpened_;
+      this.recomputeAriaLabel();
       if (
         this.sourceBlock_ &&
         eventUtils.isEnabled() &&


### PR DESCRIPTION
## The basics

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

Fixes #9466

### Proposed Changes

Ensures `FieldInput`'s ARIA labels are recomputed when an invalid value is attempted to be set.

### Reason for Changes

Previously the `FieldInput` would continuously update its ARIA label as the value changed, including for invalid values. If the editor was cancelled this would correctly revert but if an invalid value was attempted to be saved then it would cancel the update but not correct the ARIA label.

### Test Coverage

No new tests are needed for this experimental change. This has been manually verified locally using `FieldNumber` in Core's advanced playground.

### Documentation

No documentation changes are needed for this experimental change.

### Additional Information

None.