### PR TITLE
fix: navigation in dropdown menu with a separator

### DIFF
--- a/core/menu.ts
+++ b/core/menu.ts
@@ -274,7 +274,7 @@ export class Menu {
    */
   highlightNext() {
     const index = this.highlightedItem
-      ? this.menuItems.indexOf(this.highlightedItem)
+      ? this.getMenuItems().indexOf(this.highlightedItem)
       : -1;
     this.highlightHelper(index, 1);
   }
@@ -287,7 +287,7 @@ export class Menu {
    */
   highlightPrevious() {
     const index = this.highlightedItem
-      ? this.menuItems.indexOf(this.highlightedItem)
+      ? this.getMenuItems().indexOf(this.highlightedItem)
       : -1;
     this.highlightHelper(index < 0 ? this.menuItems.length : index, -1);
   }


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes https://github.com/RaspberryPiFoundation/blockly/issues/9473

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
Consistently use `getMenuItems()` for highlight methods in dropdown menus.

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
The `getMenuItems()` method filters out menu separators that otherwise break keyboard navigation in the menus due to an index error.

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
