### PR TITLE
fix: Failing `npm ci` in GitHub CI actions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5427,6 +5427,21 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/function-bind": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",


### PR DESCRIPTION
## The basics

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

Fixes #9475

### Proposed Changes

Updates to `package-lock.json` to include the missing `fsevents` that is triggering CI failures.

### Reason for Changes

It's not entirely clear why this is triggering a failure now though some additional thoughts have been added to #9475.

### Test Coverage

CI passing is sufficient to validate this is working as expected. This PR demonstrated the failure from #9475 by starting with an empty commit.

Note that the 'commit lint & label' workflow will fail since it uses `pull_requqest_target` (meaning this needs to be merged into `develop` before it will start working). However the other workflows passing indicates it too should pass once this is merged.

### Documentation

No documentation changes are needed.

### Additional Information

This required a local update of `npm` to `11.x` from `9.x` in order to actually correctly update the lock file.