### PR TITLE
fix: Remove extra image ARIA properties for drop-down fields (experimental)

### DIFF
--- a/core/field_dropdown.ts
+++ b/core/field_dropdown.ts
@@ -624,9 +624,6 @@ export class FieldDropdown extends Field<string> {
       const element = this.getFocusableElement();
       aria.setState(element, aria.State.ACTIVEDESCENDANT, imageElement.id);
     }
-
-    aria.setRole(imageElement, aria.Role.IMAGE);
-    aria.setState(imageElement, aria.State.LABEL, imageJson.alt);
   }
 
   /** Renders the selected option, which must be text. */


### PR DESCRIPTION
## The basics

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

Fixes #9461

### Proposed Changes

Remove image-specific ARIA properties (role and label) for the current selected item in `FieldDropdown`.

### Reason for Changes

This intentionally changes a behavior introduced in #9384 because the alternative ARIA behavior works better. As the images in #9461 show the actual focus outline when the current drop-down value has ARIA properties goes to that element (separate from active focus in this case) since the screen reader will read out those properties. However, this makes the reader lose context on the combo box itself.

This basically goes away from leveraging active descendant (though that's still necessary for correct combo box implementation) and just forces the label in a way that keeps the combo box context. Text-based combo boxes already do this, so this change simply brings image-based items in alignment with text combo box behaviors.

### Test Coverage

No new automated tests are needed for this experimental change. Manual testing was done via core Blockly's advanced playground (using the 'test blocks' toolbox).

### Documentation

No documentation changes are needed.

### Additional Information

None.