### PR TITLE
fix: Remove clickable image labels from block summary (experimental)

### DIFF
--- a/core/block_svg.ts
+++ b/core/block_svg.ts
@@ -33,6 +33,7 @@ import {BlockDragStrategy} from './dragging/block_drag_strategy.js';
 import type {BlockMove} from './events/events_block_move.js';
 import {EventType} from './events/type.js';
 import * as eventUtils from './events/utils.js';
+import {FieldImage} from './field_image.js';
 import {FieldLabel} from './field_label.js';
 import {getFocusManager} from './focus_manager.js';
 import {IconType} from './icons/icon_types.js';
@@ -2059,15 +2060,22 @@ function buildBlockSummary(block: BlockSvg): BlockSummary {
   ): string {
     return block.inputList
       .flatMap((input) => {
-        const fields = input.fieldRow.map((field) => {
-          if (!field.isVisible()) return [];
-          // If the block is a full block field, we only want to know if it's an
-          // editable field if we're not directly on it.
-          if (field.EDITABLE && !field.isFullBlockField() && !isNestedInput) {
-            inputCount++;
-          }
-          return [field.getText() ?? field.getValue()];
-        });
+        const fields = input.fieldRow
+          .filter((field) => {
+            if (!field.isVisible()) return false;
+            if (field instanceof FieldImage && field.isClickable()) {
+              return false;
+            }
+            return true;
+          })
+          .map((field) => {
+            // If the block is a full block field, we only want to know if it's an
+            // editable field if we're not directly on it.
+            if (field.EDITABLE && !field.isFullBlockField() && !isNestedInput) {
+              inputCount++;
+            }
+            return [field.getText() ?? field.getValue()];
+          });
         if (
           input.isVisible() &&
           input.connection &&


### PR DESCRIPTION
## The basics

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

Fixes #9452

### Proposed Changes

This change filters out `FieldImage` labels from `BlockSvg`'s ARIA summary when they are clickable.

### Reason for Changes

The discussions in #9452 provide more context but largely this change seems to be a net positive for users:
- Clickable images are less likely to provide block-identifying context that makes them worthy of being in the block's label (unlike `FieldLabel` or non-interactive `FieldImage`s), whereas including them can create additional confusion due to extra, possibly unnecessary, context being added to the block label that could be determined based on navigation discovery.
- It creates consistency with clickable icons (such as for opening mutator bubbles) which are also not included as part of the block label.

Behavior without change:

[Screen recording 2025-11-19 5.36.06 PM.webm](https://github.com/user-attachments/assets/716f7f61-6297-4770-9717-24f1f04c072c)

Behavior with change (notice the shorter block readout for the 'Image click handler' block):

[Screen recording 2025-11-19 5.34.32 PM.webm](https://github.com/user-attachments/assets/d645093b-2819-473a-bec8-c6214e925729)

### Test Coverage

No additional automated testing is needed as part of this change. Manual testing was conducted using core Blockly's advanced playground with the 'test blocks' toolbox (to test with the 'Image click handler' block).

### Documentation

No new documentation is needed for this experimental change.

### Additional Information

None.