### PR TITLE
feat: Identify root stack blocks in ARIA label

### DIFF
--- a/core/block_svg.ts
+++ b/core/block_svg.ts
@@ -301,6 +301,10 @@ export class BlockSvg
       prefix = `${parentInput.getFieldRowLabel()} `;
     }
 
+    if (this.getRootBlock() === this) {
+      prefix = 'Begin stack, ' + prefix;
+    }
+
     let additionalInfo = blockTypeText;
     if (inputSummary && !nestedStatementBlockCount) {
       additionalInfo = `${additionalInfo} with ${inputSummary}`;


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #[9434](https://github.com/RaspberryPiFoundation/blockly/issues/9434)

### Proposed Changes
This PR adds "Begin stack" to the ARIA label of root blocks in the workspace, so that navigating to a new root block identifies it as the start of a stack. Although the bug also requested this for the end of stacks, the technically-last block in a stack often doesn't pass the vibes test in terms of user expectations (e.g. a deeply nested input block or statement), so I've omitted that for now. Navigating past it will of course call out "Begin stack", so it would be a bit redundant anyway. We can revisit if testing shows it would be valuable however.