### PR TITLE
fix: Don't include count of inputs in block ARIA label

### DIFF
--- a/core/block_svg.ts
+++ b/core/block_svg.ts
@@ -244,7 +244,12 @@ export class BlockSvg
 
   private computeAriaLabel(): string {
     const {blockSummary, inputCount} = buildBlockSummary(this);
-    const inputSummary = inputCount >= 1 ? 'has inputs' : '';
+    let inputSummary = '';
+    if (inputCount > 1) {
+      inputSummary = 'has inputs';
+    } else if (inputCount === 1) {
+      inputSummary = 'has input';
+    }
 
     let currentBlock: BlockSvg | null = null;
     let nestedStatementBlockCount = 0;

--- a/core/block_svg.ts
+++ b/core/block_svg.ts
@@ -244,9 +244,7 @@ export class BlockSvg
 
   private computeAriaLabel(): string {
     const {blockSummary, inputCount} = buildBlockSummary(this);
-    const inputSummary = inputCount
-      ? ` ${inputCount} ${inputCount > 1 ? 'inputs' : 'input'}`
-      : '';
+    const inputSummary = inputCount >= 1 ? 'has inputs' : '';
 
     let currentBlock: BlockSvg | null = null;
     let nestedStatementBlockCount = 0;
@@ -300,11 +298,11 @@ export class BlockSvg
 
     let additionalInfo = blockTypeText;
     if (inputSummary && !nestedStatementBlockCount) {
-      additionalInfo = `${additionalInfo} with ${inputSummary}`;
+      additionalInfo = `${additionalInfo}, ${inputSummary}`;
     } else if (nestedStatementBlockCount) {
       const childBlockSummary = `${nestedStatementBlockCount} child ${nestedStatementBlockCount > 1 ? 'blocks' : 'block'}`;
       if (inputSummary) {
-        additionalInfo = `${additionalInfo} with ${inputSummary} and ${childBlockSummary}`;
+        additionalInfo = `${additionalInfo}, ${inputSummary} and ${childBlockSummary}`;
       } else {
         additionalInfo = `${additionalInfo} with ${childBlockSummary}`;
       }


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #9491

### Proposed Changes
This PR removes the count of input blocks from blocks' ARIA labels, and instead notes simply "has inputs" if that is the case.