### PR TITLE
fix: Remove count of child blocks from ARIA labels

### DIFF
--- a/core/block_svg.ts
+++ b/core/block_svg.ts
@@ -248,22 +248,6 @@ export class BlockSvg
       ? ` ${inputCount} ${inputCount > 1 ? 'inputs' : 'input'}`
       : '';
 
-    let currentBlock: BlockSvg | null = null;
-    let nestedStatementBlockCount = 0;
-
-    for (const input of this.inputList) {
-      if (
-        input.connection &&
-        input.connection.type === ConnectionType.NEXT_STATEMENT
-      ) {
-        currentBlock = input.connection.targetBlock() as BlockSvg | null;
-        while (currentBlock) {
-          nestedStatementBlockCount++;
-          currentBlock = currentBlock.getNextBlock();
-        }
-      }
-    }
-
     let blockTypeText = 'block';
     if (this.isShadow()) {
       blockTypeText = 'replaceable block';
@@ -299,15 +283,8 @@ export class BlockSvg
     }
 
     let additionalInfo = blockTypeText;
-    if (inputSummary && !nestedStatementBlockCount) {
+    if (inputSummary) {
       additionalInfo = `${additionalInfo} with ${inputSummary}`;
-    } else if (nestedStatementBlockCount) {
-      const childBlockSummary = `${nestedStatementBlockCount} child ${nestedStatementBlockCount > 1 ? 'blocks' : 'block'}`;
-      if (inputSummary) {
-        additionalInfo = `${additionalInfo} with ${inputSummary} and ${childBlockSummary}`;
-      } else {
-        additionalInfo = `${additionalInfo} with ${childBlockSummary}`;
-      }
     }
 
     return prefix + blockSummary + ', ' + additionalInfo;


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #9490

### Proposed Changes
This PR removes the count of child blocks from the ARIA labels of C-shaped blocks.