### PR TITLE
fix: Add 'blocks' to toolbox category ARIA labels

### DIFF
--- a/core/toolbox/category.ts
+++ b/core/toolbox/category.ts
@@ -307,6 +307,7 @@ export class ToolboxCategory
     if (className) {
       dom.addClass(toolboxLabel, className);
     }
+    aria.setState(toolboxLabel, aria.State.LABEL, `${name} blocks`);
     return toolboxLabel;
   }
 


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #9492 

### Proposed Changes
This PR adds "blocks" to the label of toolbox categories for screenreader purposes; e.g. "Logic" will be read out as "Logic blocks". This is a little grammatically funky with plural categories like Variables, but that can be sorted out later once we have feedback on whether this is helpful or not (and are ready to tackle localization...)