### PR TITLE
fix: Don't include 'begin stack' in block ARIA labels in the flyout

### DIFF
--- a/core/block_svg.ts
+++ b/core/block_svg.ts
@@ -245,7 +245,7 @@ export class BlockSvg
   private computeAriaLabel(): string {
     const labelComponents = [];
 
-    if (this.getRootBlock() === this) {
+    if (!this.workspace.isFlyout && this.getRootBlock() === this) {
       labelComponents.push('Begin stack');
     }
 

--- a/core/block_svg.ts
+++ b/core/block_svg.ts
@@ -242,7 +242,7 @@ export class BlockSvg
     );
   }
 
-  private computeAriaLabel(verbose: boolean = false): string {
+  computeAriaLabel(verbose: boolean = false): string {
     const labelComponents = [];
 
     if (!this.workspace.isFlyout && this.getRootBlock() === this) {

--- a/core/block_svg.ts
+++ b/core/block_svg.ts
@@ -243,70 +243,75 @@ export class BlockSvg
   }
 
   private computeAriaLabel(): string {
-    const {commaSeparatedSummary, inputCount} = buildBlockSummary(this);
-    let inputSummary = '';
-    if (inputCount > 1) {
-      inputSummary = 'has inputs';
-    } else if (inputCount === 1) {
-      inputSummary = 'has input';
+    const labelComponents = [];
+
+    if (this.getRootBlock() === this) {
+      labelComponents.push('Begin stack');
     }
 
-    let blockTypeText = 'block';
-    if (this.isShadow()) {
-      blockTypeText = 'replaceable block';
-    } else if (this.outputConnection) {
-      blockTypeText = 'input block';
-    } else if (this.statementInputCount) {
-      blockTypeText = 'C-shaped block';
-    }
-
-    const modifiers = [];
-    if (!this.isEnabled()) {
-      modifiers.push('disabled');
-    }
-    if (this.isCollapsed()) {
-      modifiers.push('collapsed');
-    }
-    if (modifiers.length) {
-      blockTypeText = `${modifiers.join(' ')} ${blockTypeText}`;
-    }
-
-    let prefix = '';
     const parentInput = (
       this.previousConnection ?? this.outputConnection
     )?.targetConnection?.getParentInput();
     if (parentInput && parentInput.type === inputTypes.STATEMENT) {
-      prefix = `Begin ${parentInput.getFieldRowLabel()}, `;
+      labelComponents.push(`Begin ${parentInput.getFieldRowLabel()}`);
     } else if (
       parentInput &&
       parentInput.type === inputTypes.VALUE &&
       this.getParent()?.statementInputCount
     ) {
-      prefix = `${parentInput.getFieldRowLabel()} `;
+      labelComponents.push(`${parentInput.getFieldRowLabel()}`);
     }
 
-    if (this.getRootBlock() === this) {
-      prefix = 'Begin stack, ' + prefix;
+    const {commaSeparatedSummary, inputCount} = buildBlockSummary(this);
+    labelComponents.push(commaSeparatedSummary);
+
+    if (!this.isEnabled()) {
+      labelComponents.push('disabled');
+    }
+    if (this.isCollapsed()) {
+      labelComponents.push('collapsed');
     }
 
-    let additionalInfo = blockTypeText;
-    if (inputSummary) {
-      additionalInfo = `${additionalInfo}, ${inputSummary}`;
+    if (inputCount > 1) {
+      labelComponents.push('has inputs');
+    } else if (inputCount === 1) {
+      labelComponents.push('has input');
     }
 
-    return prefix + commaSeparatedSummary + ', ' + additionalInfo;
+    return labelComponents.join(', ');
   }
 
   private computeAriaRole() {
     if (this.workspace.isFlyout) {
       aria.setRole(this.pathObject.svgPath, aria.Role.TREEITEM);
     } else {
+      const roleDescription = this.getAriaRoleDescription();
       aria.setState(
         this.pathObject.svgPath,
         aria.State.ROLEDESCRIPTION,
-        'block',
+        roleDescription,
       );
       aria.setRole(this.pathObject.svgPath, aria.Role.FIGURE);
+    }
+  }
+
+  /**
+   * Returns the ARIA role description for this block.
+   *
+   * Block definitions may override this method via a mixin to customize
+   * their role description.
+   *
+   * @returns The ARIA roledescription for this block.
+   */
+  protected getAriaRoleDescription() {
+    if (this.isShadow()) {
+      return 'replaceable block';
+    } else if (this.outputConnection) {
+      return 'value block';
+    } else if (this.statementInputCount) {
+      return 'container block';
+    } else {
+      return 'statement block';
     }
   }
 


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #9506

### Proposed Changes
This PR omits "Begin stack" when navigating between blocks in the flyout since typically every block in the flyout is its own stack, and even in the case of multi-block assemblages only the root block is navigable in a flyout context.

Note that this is based on the branch from #9507; I will rebase to the screenreader branch once that PR is merged, but this saves having to resolve merge conflicts later. 