### PR TITLE
fix: Refer to connections as positions in ARIA descriptions

### DIFF
--- a/core/rendered_connection.ts
+++ b/core/rendered_connection.ts
@@ -335,7 +335,10 @@ export class RenderedConnection
     if (highlightSvg) {
       highlightSvg.style.display = '';
       aria.setRole(highlightSvg, aria.Role.FIGURE);
-      aria.setState(highlightSvg, aria.State.ROLEDESCRIPTION, 'Connection');
+      const connectionType =
+        this.type === ConnectionType.INPUT_VALUE ? 'value' : 'statement';
+      const roleDescription = `${connectionType} block position`;
+      aria.setState(highlightSvg, aria.State.ROLEDESCRIPTION, roleDescription);
       if (this.type === ConnectionType.NEXT_STATEMENT) {
         const parentInput =
           this.getParentInput() ??
@@ -359,7 +362,7 @@ export class RenderedConnection
           `${this.getParentInput()?.getFieldRowLabel()}`,
         );
       } else {
-        aria.setState(highlightSvg, aria.State.LABEL, 'Open connection');
+        aria.setState(highlightSvg, aria.State.LABEL, 'Empty');
       }
     }
   }


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #9493

### Proposed Changes
This PR updates the `aria-roledescription` for connections to refer to them as "value block positions" or "statement block positions" rather than "connections", to communicate their purpose more clearly.