### PR TITLE
chore: Update CODEOWNERS to point to RPF group

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* RaspberryPiFoundation/blockly-collaborators
+* @RaspberryPiFoundation/blockly-collaborators

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @raspberrypifoundation/blockly-collaborators
+* RaspberryPiFoundation/blockly-collaborators

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @google/blockly-eng
+* @raspberrypifoundation/blockly-collaborators


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [ ] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

Sets the code owners to the RPF group instead of the google group so that auto assignment works as expected
