### PR TITLE
fix: Refer to empty statement inputs as ending rather than beginning a clause

### DIFF
--- a/core/rendered_connection.ts
+++ b/core/rendered_connection.ts
@@ -349,7 +349,7 @@ export class RenderedConnection
           aria.setState(
             highlightSvg,
             aria.State.LABEL,
-            `${this.getParentInput() ? 'Begin' : 'End'} ${parentInput.getFieldRowLabel()}`,
+            `End ${parentInput.getFieldRowLabel()}`,
           );
         }
       } else if (


### PR DESCRIPTION

<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #[9488](https://github.com/RaspberryPiFoundation/blockly/issues/9488)

### Proposed Changes
This PR reads out empty statement inputs as "end <preceding parent block row's label>" rather than "begin <preceding parent block row's label>". I did not move the position of the connection indicator to the bottom notch because (a) that's a Zelos-ism that doesn't exist in the other renderers and (b) it would be hard since that notch isn't a connection at all, just a quirk of the renderering of the parent block...in Zelos.