### PR TITLE
fix: Don't include 'begin' in label for blocks in the first statement input

### DIFF
--- a/core/block_svg.ts
+++ b/core/block_svg.ts
@@ -252,7 +252,15 @@ export class BlockSvg
     const parentInput = (
       this.previousConnection ?? this.outputConnection
     )?.targetConnection?.getParentInput();
-    if (parentInput && parentInput.type === inputTypes.STATEMENT) {
+    if (
+      parentInput &&
+      parentInput.type === inputTypes.STATEMENT &&
+      // The first statement input is redundant with the parent block's label.
+      parentInput !==
+        parentInput
+          .getSourceBlock()
+          .inputList.find((input) => input.type === inputTypes.STATEMENT)
+    ) {
       labelComponents.push(`Begin ${parentInput.getFieldRowLabel()}`);
     } else if (
       parentInput &&


### PR DESCRIPTION

<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #9487

### Proposed Changes
This PR removes "Begin <parent block label>" from the ARIA label for blocks that are attached to the first statement input in their parent. The information this provides would have been previously read out when the parent block was focused.