### PR TITLE
feat: Add support for playing beeps

### DIFF
--- a/core/workspace_audio.ts
+++ b/core/workspace_audio.ts
@@ -163,7 +163,7 @@ export class WorkspaceAudio {
   /**
    * Returns whether or not playing sounds is currently allowed.
    *
-   * @returns False is audio is muted or a sound has just been played, otherwise
+   * @returns False if audio is muted or a sound has just been played, otherwise
    *     true.
    */
   private isPlayingAllowed() {

--- a/core/workspace_audio.ts
+++ b/core/workspace_audio.ts
@@ -124,20 +124,11 @@ export class WorkspaceAudio {
    * @param opt_volume Volume of sound (0-1).
    */
   play(name: string, opt_volume?: number) {
-    if (this.muted) {
-      return;
-    }
+    if (!this.isPlayingAllowed()) return;
+
     const sound = this.sounds.get(name);
     if (sound) {
-      // Don't play one sound on top of another.
-      const now = new Date();
-      if (
-        this.lastSound !== null &&
-        now.getTime() - this.lastSound.getTime() < SOUND_LIMIT
-      ) {
-        return;
-      }
-      this.lastSound = now;
+      this.lastSound = new Date();
       let mySound;
       if (userAgent.IPAD || userAgent.ANDROID) {
         // Creating a new audio node causes lag in Android and iPad.  Android
@@ -167,5 +158,51 @@ export class WorkspaceAudio {
    */
   getMuted(): boolean {
     return this.muted;
+  }
+
+  /**
+   * Returns whether or not playing sounds is currently allowed.
+   *
+   * @returns False is audio is muted or a sound has just been played, otherwise
+   *     true.
+   */
+  private isPlayingAllowed() {
+    const now = new Date();
+
+    if (
+      this.getMuted() ||
+      (this.lastSound !== null &&
+        now.getTime() - this.lastSound.getTime() < SOUND_LIMIT)
+    ) {
+      return false;
+    }
+    return true;
+  }
+
+  /**
+   * Plays a brief beep at the given frequency.
+   *
+   * @param tone The frequency of the beep to play.
+   */
+  beep(tone: number) {
+    if (!this.isPlayingAllowed()) return;
+    this.lastSound = new Date();
+
+    const context = new AudioContext();
+
+    const oscillator = context.createOscillator();
+    oscillator.type = 'sine';
+    oscillator.frequency.setValueAtTime(tone, context.currentTime);
+
+    const gainNode = context.createGain();
+    gainNode.gain.setValueAtTime(0, context.currentTime);
+    gainNode.gain.linearRampToValueAtTime(0.5, context.currentTime + 0.01); // Fade in
+    gainNode.gain.linearRampToValueAtTime(0, context.currentTime + 0.2); // Fade out
+
+    oscillator.connect(gainNode);
+    gainNode.connect(context.destination);
+
+    oscillator.start(context.currentTime);
+    oscillator.stop(context.currentTime + 0.2);
   }
 }


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details

### Proposed Changes
This PR adds a `beep()` method to `WorkspaceAudio` that synthesizes and plays a brief beep of a given frequency using the WebAudio API. This may be useful for accessibility earcons or error beeps, e.g. #9500 or #9496.