### PR TITLE
fix: enable i shortcuts for items on blocks

### DIFF
--- a/core/shortcut_items.ts
+++ b/core/shortcut_items.ts
@@ -393,9 +393,11 @@ export function registerRedo() {
  * Registers a keyboard shortcut for re-reading the current selected block's
  * summary with additional verbosity to help provide context on where the user
  * is currently navigated (for screen reader users only).
+ *
+ * This works when a block is selected, or some other part of a block
+ * such as a field or icon.
  */
 export function registerReadFullBlockSummary() {
-  const i = ShortcutRegistry.registry.createSerializedKey(KeyCodes.I, null);
   const readFullBlockSummaryShortcut: KeyboardShortcut = {
     name: names.READ_FULL_BLOCK_SUMMARY,
     preconditionFn(workspace) {
@@ -403,17 +405,19 @@ export function registerReadFullBlockSummary() {
         !workspace.isDragging() &&
         !getFocusManager().ephemeralFocusTaken() &&
         !!getFocusManager().getFocusedNode() &&
-        getFocusManager().getFocusedNode() instanceof BlockSvg
+        // Either a block or something that has a parent block is focused
+        !!workspace.getCursor().getSourceBlock()
       );
     },
-    callback(_, e) {
-      const selectedBlock = getFocusManager().getFocusedNode() as BlockSvg;
+    callback(workspace, e) {
+      const selectedBlock = workspace.getCursor().getSourceBlock();
+      if (!selectedBlock) return false;
       const blockSummary = selectedBlock.computeAriaLabel(true);
       aria.announceDynamicAriaState(`Current block: ${blockSummary}`);
       e.preventDefault();
       return true;
     },
-    keyCodes: [i],
+    keyCodes: [KeyCodes.I],
   };
   ShortcutRegistry.registry.register(readFullBlockSummaryShortcut);
 }
@@ -434,11 +438,13 @@ export function registerReadBlockParentSummary() {
         !workspace.isDragging() &&
         !getFocusManager().ephemeralFocusTaken() &&
         !!getFocusManager().getFocusedNode() &&
-        getFocusManager().getFocusedNode() instanceof BlockSvg
+        // Either a block or something that has a parent block is focused
+        !!workspace.getCursor().getSourceBlock()
       );
     },
-    callback(_, e) {
-      const selectedBlock = getFocusManager().getFocusedNode() as BlockSvg;
+    callback(workspace, e) {
+      const selectedBlock = workspace.getCursor().getSourceBlock();
+      if (!selectedBlock) return false;
       const parentBlock = selectedBlock.getParent();
       if (parentBlock) {
         const blockSummary = parentBlock.computeAriaLabel(true);


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes part of https://github.com/RaspberryPiFoundation/blockly-keyboard-experimentation/issues/764

### Proposed Changes

- Makes the where am i shortcuts work on things other than just blocks, such as fields, icons, anything that has a source block

### Reason for Changes

- This shortcut is supposed to let you hear the current block's information even when you're on a sub-piece of the block

### Test Coverage

Manual testing, will add tests in kbe repo

### Documentation

n/a

### Additional Information

We still want some adjustments to the exact info to read out, so that's why I'm not closing the issue yet
