### PR TITLE
feat: Beep when navigating across nesting levels

### DIFF
--- a/core/block_svg.ts
+++ b/core/block_svg.ts
@@ -1983,6 +1983,22 @@ export class BlockSvg
   }
 
   /**
+   * Returns how deeply nested this block is in parent C-shaped blocks.
+   *
+   * @internal
+   * @returns The nesting level of this block, starting at 0 for root blocks.
+   */
+  getNestingLevel(): number {
+    // Don't consider value blocks to be nested.
+    if (this.outputConnection) {
+      return this.getParent()?.getNestingLevel() ?? 0;
+    }
+
+    const surroundParent = this.getSurroundParent();
+    return surroundParent ? surroundParent.getNestingLevel() + 1 : 0;
+  }
+
+  /**
    * Announces the current dynamic state of the specified block, if any.
    *
    * An example of dynamic state is whether the block is currently being moved,

--- a/core/keyboard_nav/line_cursor.ts
+++ b/core/keyboard_nav/line_cursor.ts
@@ -542,6 +542,17 @@ export class LineCursor extends Marker {
    * @param newNode The new location of the cursor.
    */
   setCurNode(newNode: IFocusableNode) {
+    const oldBlock = this.getSourceBlock();
+    const newBlock = this.getSourceBlockFromNode(newNode);
+    if (
+      oldBlock &&
+      newBlock &&
+      oldBlock.getNestingLevel() !== newBlock.getNestingLevel()
+    ) {
+      newBlock.workspace
+        .getAudioManager()
+        .beep(400 + newBlock.getNestingLevel() * 40);
+    }
     getFocusManager().focusNode(newNode);
   }
 


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #9500

### Proposed Changes
This PR plays a beep when navigating between block nesting levels, increasing in pitch the more nested the destination block is. Currently this is done unconditionally; when we eventually need to merge this branch back into `main` we'll probably need to figure out a way to do it just in a screenreader context or at least make it configurable.
