### PR TITLE
feat: Include parent category in verbose block descriptions

### DIFF
--- a/core/block_svg.ts
+++ b/core/block_svg.ts
@@ -56,8 +56,7 @@ import {RenderedConnection} from './rendered_connection.js';
 import type {IPathObject} from './renderers/common/i_path_object.js';
 import * as blocks from './serialization/blocks.js';
 import type {BlockStyle} from './theme.js';
-import {ToolboxCategory} from './toolbox/category.js';
-import {Toolbox} from './toolbox/toolbox.js';
+import type {ToolboxCategory} from './toolbox/category.js';
 import * as Tooltip from './tooltip.js';
 import {idGenerator} from './utils.js';
 import * as aria from './utils/aria.js';
@@ -2147,9 +2146,22 @@ function buildBlockSummary(block: BlockSvg, verbose: boolean): BlockSummary {
     const toolbox = block.workspace.getToolbox();
     let parentCategory: ToolboxCategory | undefined = undefined;
     let colourMatchingCategory: ToolboxCategory | undefined = undefined;
-    if (toolbox instanceof Toolbox) {
+    if (
+      toolbox &&
+      'getToolboxItems' in toolbox &&
+      typeof toolbox.getToolboxItems === 'function'
+    ) {
       for (const category of toolbox.getToolboxItems()) {
-        if (!(category instanceof ToolboxCategory)) continue;
+        if (
+          !(
+            'getColour' in category &&
+            typeof category.getColour === 'function' &&
+            'getContents' in category &&
+            typeof category.getContents === 'function'
+          )
+        ) {
+          continue;
+        }
         if (category.getColour() === block.getColour()) {
           colourMatchingCategory = category;
         }

--- a/core/block_svg.ts
+++ b/core/block_svg.ts
@@ -56,6 +56,8 @@ import {RenderedConnection} from './rendered_connection.js';
 import type {IPathObject} from './renderers/common/i_path_object.js';
 import * as blocks from './serialization/blocks.js';
 import type {BlockStyle} from './theme.js';
+import {ToolboxCategory} from './toolbox/category.js';
+import {Toolbox} from './toolbox/toolbox.js';
 import * as Tooltip from './tooltip.js';
 import {idGenerator} from './utils.js';
 import * as aria from './utils/aria.js';
@@ -2140,6 +2142,38 @@ function buildBlockSummary(block: BlockSvg, verbose: boolean): BlockSummary {
     }
   }
   flushLabels();
+
+  if (verbose) {
+    const toolbox = block.workspace.getToolbox();
+    let parentCategory: ToolboxCategory | undefined = undefined;
+    let colourMatchingCategory: ToolboxCategory | undefined = undefined;
+    if (toolbox instanceof Toolbox) {
+      for (const category of toolbox.getToolboxItems()) {
+        if (!(category instanceof ToolboxCategory)) continue;
+        if (category.getColour() === block.getColour()) {
+          colourMatchingCategory = category;
+        }
+        const contents = category.getContents();
+        if (!Array.isArray(contents)) break;
+        for (const item of contents) {
+          if (
+            item.kind.toLowerCase() === 'block' &&
+            'type' in item &&
+            item.type === block.type
+          ) {
+            parentCategory = category;
+            break;
+          }
+        }
+        if (parentCategory) break;
+      }
+    }
+    if (parentCategory || colourMatchingCategory) {
+      spokenParts.push(
+        `${(parentCategory ?? colourMatchingCategory)?.getName()} category`,
+      );
+    }
+  }
 
   // comma-separate label runs and inputs
   const commaSeparatedSummary = spokenParts.join(', ');

--- a/core/toolbox/category.ts
+++ b/core/toolbox/category.ts
@@ -382,6 +382,14 @@ export class ToolboxCategory
   }
 
   /**
+   * Returns the colour of this category.
+   * @internal
+   */
+  getColour() {
+    return this.colour_;
+  }
+
+  /**
    * Gets the HTML element that is clickable.
    * The parent toolbox element receives clicks. The parent toolbox will add an
    * ID to this element so it can pass the onClick event to the correct

--- a/core/toolbox/category.ts
+++ b/core/toolbox/category.ts
@@ -383,6 +383,7 @@ export class ToolboxCategory
 
   /**
    * Returns the colour of this category.
+   *
    * @internal
    */
   getColour() {


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #9499 

### Proposed Changes
This PR adds blocks' parent category to their verbose description in order to better orient users. By default each category is searched through to see if the block is part of it; if no match is found (e.g. if the block is part of a dynamic category) then matching falls back to checking the block's color against each category's color.