### PR TITLE
fix: read parent hierarchy with shift+i

### DIFF
--- a/core/block_svg.ts
+++ b/core/block_svg.ts
@@ -246,7 +246,7 @@ export class BlockSvg
   computeAriaLabel(
     verbose: boolean = false,
     minimal: boolean = false,
-    currentBlock?: this,
+    currentBlock: this | undefined = undefined,
   ): string {
     const labelComponents = [];
 

--- a/core/block_svg.ts
+++ b/core/block_svg.ts
@@ -243,7 +243,11 @@ export class BlockSvg
     );
   }
 
-  computeAriaLabel(verbose: boolean = false): string {
+  computeAriaLabel(
+    verbose: boolean = false,
+    minimal: boolean = false,
+    currentBlock?: this,
+  ): string {
     const labelComponents = [];
 
     if (!this.workspace.isFlyout && this.getRootBlock() === this) {
@@ -274,23 +278,26 @@ export class BlockSvg
     const {commaSeparatedSummary, inputCount} = buildBlockSummary(
       this,
       verbose,
+      currentBlock,
     );
     labelComponents.push(commaSeparatedSummary);
 
-    if (!this.isEnabled()) {
-      labelComponents.push('disabled');
-    }
-    if (this.isCollapsed()) {
-      labelComponents.push('collapsed');
-    }
-    if (this.isShadow()) {
-      labelComponents.push('replaceable');
-    }
+    if (!minimal) {
+      if (!this.isEnabled()) {
+        labelComponents.push('disabled');
+      }
+      if (this.isCollapsed()) {
+        labelComponents.push('collapsed');
+      }
+      if (this.isShadow()) {
+        labelComponents.push('replaceable');
+      }
 
-    if (inputCount > 1) {
-      labelComponents.push('has inputs');
-    } else if (inputCount === 1) {
-      labelComponents.push('has input');
+      if (inputCount > 1) {
+        labelComponents.push('has inputs');
+      } else if (inputCount === 1) {
+        labelComponents.push('has input');
+      }
     }
 
     return labelComponents.join(', ');
@@ -2063,7 +2070,11 @@ interface BlockSummary {
   inputCount: number;
 }
 
-function buildBlockSummary(block: BlockSvg, verbose: boolean): BlockSummary {
+function buildBlockSummary(
+  block: BlockSvg,
+  verbose: boolean,
+  currentBlock?: BlockSvg,
+): BlockSummary {
   let inputCount = 0;
 
   // Produce structured segments
@@ -2119,6 +2130,10 @@ function buildBlockSummary(block: BlockSvg, verbose: boolean): BlockSummary {
             targetBlock as BlockSvg,
             true,
           );
+
+          if (targetBlock === currentBlock) {
+            nestedSegments.unshift({kind: 'label', text: 'Current block: '});
+          }
 
           if (!isNestedInput) {
             // treat the whole nested summary as a single input segment


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes part of https://github.com/RaspberryPiFoundation/blockly-keyboard-experimentation/issues/764

### Proposed Changes

- Changes the whereami shortcut shift+i to read out the full hierarchy of how the current block is connected
- Adds a new "minimal" mode for aria labels that doesn't include the information about having inputs, shadow blocks, etc.
- Does some kinda gross stuff to account for the fact that the aria label for blocks with value inputs already includes the text of connected blocks

### Reason for Changes

Lets you hear the full context of how the current block is connected

The code that computes the ariaLabel 100% needs to be refactored, but I don't think it's worth doing that until after we find out if people actually want this particular shortcut.

### Test Coverage

In lieu of tests, please accept these screenshots

<img width="767" height="421" alt="Screenshot 2025-12-11 at 2 47 09 PM" src="https://github.com/user-attachments/assets/0eb601c8-739a-4330-a43d-b8895361e7d7" />
<img width="769" height="469" alt="Screenshot 2025-12-11 at 2 47 25 PM" src="https://github.com/user-attachments/assets/d542607d-bbf3-4485-9762-2d0d6538cb9f" />
<img width="769" height="461" alt="Screenshot 2025-12-11 at 2 47 39 PM" src="https://github.com/user-attachments/assets/489eb7fd-ba79-4948-b5ce-c924ab96ff67" />
<img width="772" height="464" alt="Screenshot 2025-12-11 at 2 48 01 PM" src="https://github.com/user-attachments/assets/39ea8149-5165-4505-b33a-af70a158d57f" />


### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
