### PR TITLE
fix: Make left and right arrow keys only navigate within the current block/comment

### DIFF
--- a/core/comments/comment_editor.ts
+++ b/core/comments/comment_editor.ts
@@ -4,7 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import type {BlockSvg} from '../block_svg.js';
 import * as browserEvents from '../browser_events.js';
+import type {RenderedWorkspaceComment} from '../comments/rendered_workspace_comment.js';
 import {getFocusManager} from '../focus_manager.js';
 import {IFocusableNode} from '../interfaces/i_focusable_node.js';
 import {IFocusableTree} from '../interfaces/i_focusable_tree.js';
@@ -39,6 +41,8 @@ export class CommentEditor implements IFocusableNode {
 
   /** The current text of the comment. Updates on text area change. */
   private text: string = '';
+
+  private parent?: BlockSvg | RenderedWorkspaceComment;
 
   constructor(
     public workspace: WorkspaceSvg,
@@ -206,5 +210,22 @@ export class CommentEditor implements IFocusableNode {
   canBeFocused(): boolean {
     if (this.id) return true;
     return false;
+  }
+
+  /**
+   * Sets the parent object that owns this comment editor.
+   *
+   * @param newParent The parent of this comment editor.
+   * @internal
+   */
+  setParent(newParent: BlockSvg | RenderedWorkspaceComment) {
+    this.parent = newParent;
+  }
+
+  /**
+   * Returns the parent object that owns this comment editor, if any.
+   */
+  getParent() {
+    return this.parent;
   }
 }

--- a/core/comments/rendered_workspace_comment.ts
+++ b/core/comments/rendered_workspace_comment.ts
@@ -31,6 +31,7 @@ import {Rect} from '../utils/rect.js';
 import {Size} from '../utils/size.js';
 import * as svgMath from '../utils/svg_math.js';
 import {WorkspaceSvg} from '../workspace_svg.js';
+import type {CommentEditor} from './comment_editor.js';
 import {CommentView} from './comment_view.js';
 import {WorkspaceComment} from './workspace_comment.js';
 
@@ -60,6 +61,7 @@ export class RenderedWorkspaceComment
     this.workspace = workspace;
 
     this.view = new CommentView(workspace, this.id);
+    (this.view.getEditorFocusableNode() as CommentEditor).setParent(this);
     // Set the size to the default size as defined in the superclass.
     this.view.setSize(this.getSize());
     this.view.setEditable(this.isEditable());

--- a/core/icons/comment_icon.ts
+++ b/core/icons/comment_icon.ts
@@ -381,6 +381,9 @@ export class CommentIcon extends Icon implements IHasBubble, ISerializable {
       this.getBubbleOwnerRect(),
       this,
     );
+    this.textInputBubble
+      .getEditor()
+      .setParent(this.getSourceBlock() as BlockSvg);
     this.textInputBubble.setText(this.getText());
     this.textInputBubble.setSize(this.bubbleSize, true);
     if (this.bubbleLocation) {

--- a/core/keyboard_nav/line_cursor.ts
+++ b/core/keyboard_nav/line_cursor.ts
@@ -345,7 +345,28 @@ export class LineCursor extends Marker {
     switch (direction) {
       case NavigationDirection.IN:
       case NavigationDirection.OUT:
-        return () => true;
+        return (candidate: IFocusableNode | null) => {
+          const candidateBlock = this.getSourceBlockFromNode(candidate);
+          const currentBlock = this.getSourceBlock();
+
+          // Preventing escaping the current block/comment/etc by:
+          // Disallow moving from a node with a block to a non-block node (other than a block comment editor)
+          // Disallow moving from a non-block node to a block node
+          // Disallow moving to the workspace
+          if (
+            (currentBlock && !candidateBlock) ||
+            (!currentBlock && candidateBlock) ||
+            candidate === this.workspace
+          ) {
+            return false;
+          }
+
+          if (!candidateBlock || !currentBlock) return true;
+
+          const currentParents = this.getOutputParents(currentBlock);
+          const candidateParents = this.getOutputParents(candidateBlock);
+          return candidateParents.intersection(currentParents).size > 0;
+        };
       case NavigationDirection.NEXT:
       case NavigationDirection.PREVIOUS:
         return (candidate: IFocusableNode | null) => {
@@ -447,6 +468,24 @@ export class LineCursor extends Marker {
     while (parent) {
       parents.add(parent);
       parent = parent.getParent();
+    }
+
+    return parents;
+  }
+
+  /**
+   * Returns a set of all of the parent blocks of the given block.
+   *
+   * @param block The block to retrieve the parents of.
+   * @returns A set of the parents of the given block.
+   */
+  private getOutputParents(block: BlockSvg): Set<BlockSvg> {
+    const parents = new Set<BlockSvg>();
+    parents.add(block);
+    let parent = block.outputConnection?.targetBlock();
+    while (parent) {
+      parents.add(parent);
+      parent = parent.outputConnection?.targetBlock();
     }
 
     return parents;

--- a/core/keyboard_nav/line_cursor.ts
+++ b/core/keyboard_nav/line_cursor.ts
@@ -365,6 +365,12 @@ export class LineCursor extends Marker {
 
           const currentParents = this.getOutputParents(currentBlock);
           const candidateParents = this.getOutputParents(candidateBlock);
+          // If we're navigating from a block (or nested element) to a block
+          // (or nested element), ensure that we're not crossing a statement
+          // block boundary (i.e. moving to a next or previous block vertically)
+          // by verifying that the two blocks in question are either the same
+          // or have a common parent accessible only by traversing output
+          // connections, meaning that they are part of the same row.
           return candidateParents.intersection(currentParents).size > 0;
         };
       case NavigationDirection.NEXT:
@@ -474,10 +480,11 @@ export class LineCursor extends Marker {
   }
 
   /**
-   * Returns a set of all of the parent blocks of the given block.
+   * Returns a set of all of the parent blocks connected to an output of the
+   * given block or one of its parents. Also includes the given block.
    *
-   * @param block The block to retrieve the parents of.
-   * @returns A set of the parents of the given block.
+   * @param block The block to retrieve the output-connected parents of.
+   * @returns A set of the output-connected parents of the given block.
    */
   private getOutputParents(block: BlockSvg): Set<BlockSvg> {
     const parents = new Set<BlockSvg>();

--- a/core/keyboard_nav/marker.ts
+++ b/core/keyboard_nav/marker.ts
@@ -13,6 +13,8 @@
 // Former goog.module ID: Blockly.Marker
 
 import {BlockSvg} from '../block_svg.js';
+import {TextInputBubble} from '../bubbles/textinput_bubble.js';
+import {CommentEditor} from '../comments/comment_editor.js';
 import {Field} from '../field.js';
 import {Icon} from '../icons/icon.js';
 import type {IFocusableNode} from '../interfaces/i_focusable_node.js';
@@ -69,6 +71,18 @@ export class Marker {
       return node.getSourceBlock();
     } else if (node instanceof Icon) {
       return node.getSourceBlock() as BlockSvg;
+    } else if (node instanceof TextInputBubble) {
+      const owner = node.getOwner();
+      if (owner instanceof BlockSvg) {
+        return owner;
+      } else if (owner) {
+        return this.getSourceBlockFromNode(owner);
+      }
+    } else if (node instanceof CommentEditor) {
+      const parent = node.getParent();
+      if (parent instanceof BlockSvg) {
+        return parent;
+      }
     }
 
     return null;

--- a/tests/mocha/cursor_test.js
+++ b/tests/mocha/cursor_test.js
@@ -11,7 +11,7 @@ import {
   sharedTestTeardown,
 } from './test_helpers/setup_teardown.js';
 
-suite('Cursor', function () {
+suite.only('Cursor', function () {
   suite('Movement', function () {
     setup(function () {
       sharedTestSetup.call(this);
@@ -163,126 +163,13 @@ suite('Cursor', function () {
       assert.equal(curNode, this.blocks.E);
     });
 
-    test('Out - From first connection loop to last next connection', function () {
+    test('Out - From previous connection loop to last input connection on block', function () {
       const prevConnection = this.blocks.A.previousConnection;
       const prevConnectionNode = prevConnection;
       this.cursor.setCurNode(prevConnectionNode);
       this.cursor.out();
       const curNode = this.cursor.getCurNode();
-      assert.equal(curNode, this.blocks.D.nextConnection);
-    });
-  });
-
-  suite('Multiple statement inputs', function () {
-    setup(function () {
-      sharedTestSetup.call(this);
-      Blockly.defineBlocksWithJsonArray([
-        {
-          'type': 'multi_statement_input',
-          'message0': '%1 %2',
-          'args0': [
-            {
-              'type': 'input_statement',
-              'name': 'FIRST',
-            },
-            {
-              'type': 'input_statement',
-              'name': 'SECOND',
-            },
-          ],
-        },
-        {
-          'type': 'simple_statement',
-          'message0': '%1',
-          'args0': [
-            {
-              'type': 'field_input',
-              'name': 'NAME',
-              'text': 'default',
-            },
-          ],
-          'previousStatement': null,
-          'nextStatement': null,
-        },
-      ]);
-      this.workspace = Blockly.inject('blocklyDiv', {});
-      this.cursor = this.workspace.getCursor();
-
-      this.multiStatement1 = createRenderedBlock(
-        this.workspace,
-        'multi_statement_input',
-      );
-      this.multiStatement2 = createRenderedBlock(
-        this.workspace,
-        'multi_statement_input',
-      );
-      this.firstStatement = createRenderedBlock(
-        this.workspace,
-        'simple_statement',
-      );
-      this.secondStatement = createRenderedBlock(
-        this.workspace,
-        'simple_statement',
-      );
-      this.thirdStatement = createRenderedBlock(
-        this.workspace,
-        'simple_statement',
-      );
-      this.fourthStatement = createRenderedBlock(
-        this.workspace,
-        'simple_statement',
-      );
-      this.multiStatement1
-        .getInput('FIRST')
-        .connection.connect(this.firstStatement.previousConnection);
-      this.firstStatement.nextConnection.connect(
-        this.secondStatement.previousConnection,
-      );
-      this.multiStatement1
-        .getInput('SECOND')
-        .connection.connect(this.thirdStatement.previousConnection);
-      this.multiStatement2
-        .getInput('FIRST')
-        .connection.connect(this.fourthStatement.previousConnection);
-    });
-
-    teardown(function () {
-      sharedTestTeardown.call(this);
-    });
-
-    test('In - from field in nested statement block to next nested statement block', function () {
-      this.cursor.setCurNode(this.secondStatement.getField('NAME'));
-      this.cursor.in();
-      // Skip over the next connection
-      this.cursor.in();
-      const curNode = this.cursor.getCurNode();
-      assert.equal(curNode, this.thirdStatement);
-    });
-    test('In - from field in nested statement block to next stack', function () {
-      this.cursor.setCurNode(this.thirdStatement.getField('NAME'));
-      this.cursor.in();
-      // Skip over the next connection
-      this.cursor.in();
-      const curNode = this.cursor.getCurNode();
-      assert.equal(curNode, this.multiStatement2);
-    });
-
-    test('Out - from nested statement block to last field of previous nested statement block', function () {
-      this.cursor.setCurNode(this.thirdStatement);
-      this.cursor.out();
-      // Skip over the previous next connection
-      this.cursor.out();
-      const curNode = this.cursor.getCurNode();
-      assert.equal(curNode, this.secondStatement.getField('NAME'));
-    });
-
-    test('Out - from root block to last field of last nested statement block in previous stack', function () {
-      this.cursor.setCurNode(this.multiStatement2);
-      this.cursor.out();
-      // Skip over the previous next connection
-      this.cursor.out();
-      const curNode = this.cursor.getCurNode();
-      assert.equal(curNode, this.thirdStatement.getField('NAME'));
+      assert.equal(curNode, this.blocks.A.getInput('NAME4').connection);
     });
   });
 

--- a/tests/mocha/cursor_test.js
+++ b/tests/mocha/cursor_test.js
@@ -173,6 +173,120 @@ suite('Cursor', function () {
     });
   });
 
+  suite('Multiple statement inputs', function () {
+    setup(function () {
+      sharedTestSetup.call(this);
+      Blockly.defineBlocksWithJsonArray([
+        {
+          'type': 'multi_statement_input',
+          'message0': '%1 %2',
+          'args0': [
+            {
+              'type': 'input_statement',
+              'name': 'FIRST',
+            },
+            {
+              'type': 'input_statement',
+              'name': 'SECOND',
+            },
+          ],
+        },
+        {
+          'type': 'simple_statement',
+          'message0': '%1',
+          'args0': [
+            {
+              'type': 'field_input',
+              'name': 'NAME',
+              'text': 'default',
+            },
+          ],
+          'previousStatement': null,
+          'nextStatement': null,
+        },
+      ]);
+      this.workspace = Blockly.inject('blocklyDiv', {});
+      this.cursor = this.workspace.getCursor();
+
+      this.multiStatement1 = createRenderedBlock(
+        this.workspace,
+        'multi_statement_input',
+      );
+      this.multiStatement2 = createRenderedBlock(
+        this.workspace,
+        'multi_statement_input',
+      );
+      this.firstStatement = createRenderedBlock(
+        this.workspace,
+        'simple_statement',
+      );
+      this.secondStatement = createRenderedBlock(
+        this.workspace,
+        'simple_statement',
+      );
+      this.thirdStatement = createRenderedBlock(
+        this.workspace,
+        'simple_statement',
+      );
+      this.fourthStatement = createRenderedBlock(
+        this.workspace,
+        'simple_statement',
+      );
+      this.multiStatement1
+        .getInput('FIRST')
+        .connection.connect(this.firstStatement.previousConnection);
+      this.firstStatement.nextConnection.connect(
+        this.secondStatement.previousConnection,
+      );
+      this.multiStatement1
+        .getInput('SECOND')
+        .connection.connect(this.thirdStatement.previousConnection);
+      this.multiStatement2
+        .getInput('FIRST')
+        .connection.connect(this.fourthStatement.previousConnection);
+    });
+
+    teardown(function () {
+      sharedTestTeardown.call(this);
+    });
+
+    test('In - from field in nested statement block to next nested statement block', function () {
+      this.cursor.setCurNode(this.secondStatement.getField('NAME'));
+      this.cursor.next();
+      // Skip over the next connection
+      this.cursor.next();
+      const curNode = this.cursor.getCurNode();
+      assert.equal(curNode, this.thirdStatement);
+    });
+
+    test('In - from field in nested statement block to next stack', function () {
+      this.cursor.setCurNode(this.thirdStatement.getField('NAME'));
+      this.cursor.next();
+      // Skip over the next connection
+      this.cursor.next();
+      const curNode = this.cursor.getCurNode();
+      assert.equal(curNode, this.multiStatement2);
+    });
+
+    test('Out - from nested statement block to previous nested statement block', function () {
+      this.cursor.setCurNode(this.thirdStatement);
+      this.cursor.prev();
+      // Skip over the previous next connection
+      this.cursor.prev();
+      const curNode = this.cursor.getCurNode();
+      assert.equal(curNode, this.secondStatement);
+    });
+
+    test('Out - from root block to last nested statement block in previous stack', function () {
+      this.cursor.setCurNode(this.multiStatement2);
+      this.cursor.prev();
+      // Skip over the previous next connection
+      this.cursor.prev();
+      const curNode = this.cursor.getCurNode();
+      assert.equal(curNode, this.thirdStatement);
+    });
+  });
+
   suite('Searching', function () {
     setup(function () {
       sharedTestSetup.call(this);

--- a/tests/mocha/cursor_test.js
+++ b/tests/mocha/cursor_test.js
@@ -11,7 +11,7 @@ import {
   sharedTestTeardown,
 } from './test_helpers/setup_teardown.js';
 
-suite.only('Cursor', function () {
+suite('Cursor', function () {
   suite('Movement', function () {
     setup(function () {
       sharedTestSetup.call(this);


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details

### Proposed Changes
This PR updates the behavior of the left and right arrow keys to only navigate within the current block/workspace comment, rather than traversing through the entire workspace. This is in response to feedback from screen reader user testing. Up and down may still be used to navigate from block to block and across stacks.