### PR TITLE
fix: Disable undoing events generated from flyout layout

### DIFF
--- a/core/flyout_base.ts
+++ b/core/flyout_base.ts
@@ -616,6 +616,7 @@ export abstract class Flyout
    */
   show(flyoutDef: toolbox.FlyoutDefinition | string) {
     this.workspace_.setResizesEnabled(false);
+    eventUtils.setRecordUndo(false);
     this.hide();
     this.clearOldBlocks();
 
@@ -641,6 +642,7 @@ export abstract class Flyout
       this.width_ = 0;
     }
     this.reflow();
+    eventUtils.setRecordUndo(true);
     this.workspace_.setResizesEnabled(true);
 
     // Listen for block change events, and reflow the flyout in response. This


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #9482

### Proposed Changes
This PR disables recording undo events before populating and laying out flyouts. This prevents undoing adding/moving blocks and other flyout items.