### PR TITLE
fix!: Make `ISelectable.workspace` an instance of `WorkspaceSvg`

### DIFF
--- a/core/interfaces/i_selectable.ts
+++ b/core/interfaces/i_selectable.ts
@@ -6,7 +6,7 @@
 
 // Former goog.module ID: Blockly.ISelectable
 
-import type {Workspace} from '../workspace.js';
+import type {WorkspaceSvg} from '../workspace_svg.js';
 import {IFocusableNode, isFocusableNode} from './i_focusable_node.js';
 
 /**
@@ -20,7 +20,7 @@ import {IFocusableNode, isFocusableNode} from './i_focusable_node.js';
 export interface ISelectable extends IFocusableNode {
   id: string;
 
-  workspace: Workspace;
+  workspace: WorkspaceSvg;
 
   /** Select this.  Highlight it visually. */
   select(): void;


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #9214

### Proposed Changes
This PR updates the type of the `workspace` field of `ISelectable` to be `WorkspaceSvg` instead of `Workspace`, because only rendered things can be selectable.