### PR TITLE
fix: Don't open the toolbox when clicking beneath the categories

### DIFF
--- a/core/toolbox/toolbox.ts
+++ b/core/toolbox/toolbox.ts
@@ -108,6 +108,7 @@ export class Toolbox
   /** The workspace this toolbox is on. */
   protected readonly workspace_: WorkspaceSvg;
 
+  /** Whether the mouse is currently being clicked. */
   private mouseDown = false;
 
   /** @param workspace The workspace in which to create new blocks. */

--- a/core/toolbox/toolbox.ts
+++ b/core/toolbox/toolbox.ts
@@ -108,6 +108,8 @@ export class Toolbox
   /** The workspace this toolbox is on. */
   protected readonly workspace_: WorkspaceSvg;
 
+  private mouseDown = false;
+
   /** @param workspace The workspace in which to create new blocks. */
   constructor(workspace: WorkspaceSvg) {
     super();
@@ -243,6 +245,16 @@ export class Toolbox
     );
     this.boundEvents_.push(clickEvent);
 
+    const mouseUpEvent = browserEvents.bind(
+      container,
+      'pointerup',
+      this,
+      () => {
+        this.mouseDown = false;
+      },
+    );
+    this.boundEvents_.push(mouseUpEvent);
+
     const keyDownEvent = browserEvents.conditionalBind(
       contentsContainer,
       'keydown',
@@ -259,6 +271,7 @@ export class Toolbox
    * @param e Click event to handle.
    */
   protected onClick_(e: PointerEvent) {
+    this.mouseDown = true;
     if (browserEvents.isRightButton(e) || e.target === this.HtmlDiv) {
       // Close flyout.
       (common.getMainWorkspace() as WorkspaceSvg).hideChaff(false);
@@ -1134,7 +1147,7 @@ export class Toolbox
   ): void {
     if (node !== this) {
       // Only select the item if it isn't already selected so as to not toggle.
-      if (this.getSelectedItem() !== node) {
+      if (this.getSelectedItem() !== node && !this.mouseDown) {
         this.setSelectedItem(node as IToolboxItem);
       }
     } else {

--- a/core/toolbox/toolbox.ts
+++ b/core/toolbox/toolbox.ts
@@ -1148,6 +1148,9 @@ export class Toolbox
   ): void {
     if (node !== this) {
       // Only select the item if it isn't already selected so as to not toggle.
+      // Also require that the mouse not be down, i.e. that the focusing of
+      // the toolbox was keyboard-driven, to avoid opening the flyout when
+      // clicking on an empty part of the toolbox.
       if (this.getSelectedItem() !== node && !this.mouseDown) {
         this.setSelectedItem(node as IToolboxItem);
       }

--- a/tests/browser/test/toolbox_drag_test.mjs
+++ b/tests/browser/test/toolbox_drag_test.mjs
@@ -207,4 +207,13 @@ suite('Open toolbox categories', function () {
     );
     await openCategories(this.browser, testCategories, screenDirection.RTL);
   });
+
+  test('clicking the toolbox itself does not open the flyout', async function () {
+    this.browser = await testSetup(testFileLocations.PLAYGROUND);
+    await this.browser.$('.blocklyToolbox').click();
+    const flyoutOpen = await this.browser.execute(() => {
+      return Blockly.getMainWorkspace().getFlyout().isVisible();
+    });
+    chai.assert.isFalse(flyoutOpen);
+  });
 });


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #9198

### Proposed Changes
This PR fixes a bug where clicking in the toolbox below the list of categories would cause the flyout to open with the first toolbox category selected. That behavior is preserved when the toolbox is focused via the keyboard. If the flyout is open, clicking in the toolbox below the list of categories will still dismiss it, as will clicking the selected category.