### PR TITLE
fix: Don't select shadow blocks on click

### DIFF
--- a/core/gesture.ts
+++ b/core/gesture.ts
@@ -777,13 +777,11 @@ export class Gesture {
     this.setStartWorkspace(ws);
     this.mostRecentEvent = e;
 
-    if (!this.startBlock && !this.startBubble && !this.startComment) {
+    if (!this.targetBlock && !this.startBubble && !this.startComment) {
       // Ensure the workspace is selected if nothing else should be. Note that
       // this is focusNode() instead of focusTree() because if any active node
       // is focused in the workspace it should be defocused.
       getFocusManager().focusNode(ws);
-    } else if (this.startBlock) {
-      getFocusManager().focusNode(this.startBlock);
     }
 
     this.doStart(e);

--- a/tests/mocha/gesture_test.js
+++ b/tests/mocha/gesture_test.js
@@ -13,6 +13,7 @@ import {
   sharedTestTeardown,
 } from './test_helpers/setup_teardown.js';
 import {dispatchPointerEvent} from './test_helpers/user_input.js';
+import {getProperSimpleJson} from './test_helpers/toolbox_definitions.js';
 
 suite('Gesture', function () {
   function testGestureIsFieldClick(block, isFieldClick, eventsFireStub) {
@@ -54,8 +55,12 @@ suite('Gesture', function () {
   setup(function () {
     sharedTestSetup.call(this);
     defineBasicBlockWithField();
-    const toolbox = document.getElementById('gesture-test-toolbox');
-    this.workspace = Blockly.inject('blocklyDiv', {toolbox: toolbox});
+    const toolbox = getProperSimpleJson();
+    toolbox.contents.unshift({
+        'kind': 'block',
+        'type': 'test_field_block',
+		});
+    this.workspace = Blockly.inject('blocklyDiv', {toolbox});
   });
 
   teardown(function () {
@@ -94,4 +99,33 @@ suite('Gesture', function () {
     const block = getTopFlyoutBlock(flyout);
     testGestureIsFieldClick(block, true, this.eventsFireStub);
   });
+  
+  test('Clicking on shadow block does not select it', function () {
+		const flyout = this.workspace.getFlyout(true);
+		flyout.createBlock(flyout.getWorkspace().getBlocksByType('logic_compare')[0]);
+		const block = this.workspace.getBlocksByType('logic_compare')[0];
+		const shadowBlock = block.getInput('A').connection.targetBlock();
+		
+    this.eventsFireStub.resetHistory();
+		const eventTarget = shadowBlock.getSvgRoot();
+    dispatchPointerEvent(eventTarget, 'pointerdown');
+    dispatchPointerEvent(eventTarget, 'pointerup');
+    dispatchPointerEvent(eventTarget, 'click');
+
+	// The shadow block should not be selected, even though it was clicked.
+    assertEventNotFired(
+      this.eventsFireStub,
+      Blockly.Events.Selected,
+      {newElementId: shadowBlock.id, type: EventType.SELECTED},
+      this.workspace.id,
+    );
+    
+		// Its parent block should be selected, however.
+    assertEventFired(
+      this.eventsFireStub,
+      Blockly.Events.Selected,
+      {newElementId: block.id, type: EventType.SELECTED},
+      this.workspace.id,
+    );
+  })
 });

--- a/tests/mocha/gesture_test.js
+++ b/tests/mocha/gesture_test.js
@@ -12,8 +12,8 @@ import {
   sharedTestSetup,
   sharedTestTeardown,
 } from './test_helpers/setup_teardown.js';
-import {dispatchPointerEvent} from './test_helpers/user_input.js';
 import {getProperSimpleJson} from './test_helpers/toolbox_definitions.js';
+import {dispatchPointerEvent} from './test_helpers/user_input.js';
 
 suite('Gesture', function () {
   function testGestureIsFieldClick(block, isFieldClick, eventsFireStub) {
@@ -57,9 +57,9 @@ suite('Gesture', function () {
     defineBasicBlockWithField();
     const toolbox = getProperSimpleJson();
     toolbox.contents.unshift({
-        'kind': 'block',
-        'type': 'test_field_block',
-		});
+      'kind': 'block',
+      'type': 'test_field_block',
+    });
     this.workspace = Blockly.inject('blocklyDiv', {toolbox});
   });
 
@@ -99,33 +99,35 @@ suite('Gesture', function () {
     const block = getTopFlyoutBlock(flyout);
     testGestureIsFieldClick(block, true, this.eventsFireStub);
   });
-  
+
   test('Clicking on shadow block does not select it', function () {
-		const flyout = this.workspace.getFlyout(true);
-		flyout.createBlock(flyout.getWorkspace().getBlocksByType('logic_compare')[0]);
-		const block = this.workspace.getBlocksByType('logic_compare')[0];
-		const shadowBlock = block.getInput('A').connection.targetBlock();
-		
+    const flyout = this.workspace.getFlyout(true);
+    flyout.createBlock(
+      flyout.getWorkspace().getBlocksByType('logic_compare')[0],
+    );
+    const block = this.workspace.getBlocksByType('logic_compare')[0];
+    const shadowBlock = block.getInput('A').connection.targetBlock();
+
     this.eventsFireStub.resetHistory();
-		const eventTarget = shadowBlock.getSvgRoot();
+    const eventTarget = shadowBlock.getSvgRoot();
     dispatchPointerEvent(eventTarget, 'pointerdown');
     dispatchPointerEvent(eventTarget, 'pointerup');
     dispatchPointerEvent(eventTarget, 'click');
 
-	// The shadow block should not be selected, even though it was clicked.
+    // The shadow block should not be selected, even though it was clicked.
     assertEventNotFired(
       this.eventsFireStub,
       Blockly.Events.Selected,
       {newElementId: shadowBlock.id, type: EventType.SELECTED},
       this.workspace.id,
     );
-    
-		// Its parent block should be selected, however.
+
+    // Its parent block should be selected, however.
     assertEventFired(
       this.eventsFireStub,
       Blockly.Events.Selected,
       {newElementId: block.id, type: EventType.SELECTED},
       this.workspace.id,
     );
-  })
+  });
 });


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #9180

### Proposed Changes
This PR fixes a bug that could cause shadow blocks to temporarily or permanently become selected when clicked on. Clicking on a block triggers a block start gesture, which correctly handles shadow blocks when determining what to select (their parent block). Click events bubble up to the workspace and trigger a workspace start gesture as well though, and that was focusing the start block, which is sometimes different than the target block that the block gesture start handler resolves. I updated the check for "nothing else should be focused" to check `targetBlock` rather than `startBlock`, and removed the explicit call focus the target/start block, since that would have already happened in the block start gesture handler.

I verified that shadow blocks still become selected via keyboard navigation, that clicking a shadow block focuses its parent block, that workspace comments and bubbles are still selectable, and that clicking the workspace focuses the workspace.