### PR TITLE
fix: Fix bug that prevented the first block change event in a flyout from being dispatched

### DIFF
--- a/core/flyout_base.ts
+++ b/core/flyout_base.ts
@@ -136,6 +136,12 @@ export abstract class Flyout
   private reflowWrapper: ((e: AbstractEvent) => void) | null = null;
 
   /**
+   * If true, prevents the reflow wrapper from running. Used to prevent infinite
+   * recursion.
+   */
+  private inhibitReflowWrapper = false;
+
+  /**
    * List of flyout elements.
    */
   protected contents: FlyoutItem[] = [];
@@ -647,6 +653,7 @@ export abstract class Flyout
     // accommodates e.g. resizing a non-autoclosing flyout in response to the
     // user typing long strings into fields on the blocks in the flyout.
     this.reflowWrapper = (event) => {
+      if (this.inhibitReflowWrapper) return;
       if (
         event.type === EventType.BLOCK_CHANGE ||
         event.type === EventType.BLOCK_FIELD_INTERMEDIATE_CHANGE
@@ -844,13 +851,9 @@ export abstract class Flyout
    * Reflow flyout contents.
    */
   reflow() {
-    if (this.reflowWrapper) {
-      this.workspace_.removeChangeListener(this.reflowWrapper);
-    }
+    this.inhibitReflowWrapper = true;
     this.reflowInternal_();
-    if (this.reflowWrapper) {
-      this.workspace_.addChangeListener(this.reflowWrapper);
-    }
+    this.inhibitReflowWrapper = false;
   }
 
   /**

--- a/tests/mocha/flyout_test.js
+++ b/tests/mocha/flyout_test.js
@@ -43,6 +43,26 @@ suite('Flyout', function () {
     sharedTestTeardown.call(this);
   });
 
+  suite('workspace change listeners', function () {
+    test('are triggered when a child block changes', function () {
+      let listenerTriggered = false;
+      const listener = (e) => {
+        if (e.type === Blockly.Events.BLOCK_CHANGE) {
+          listenerTriggered = true;
+        }
+      };
+      this.workspace.getFlyout().getWorkspace().addChangeListener(listener);
+      const boolBlock = this.workspace
+        .getFlyout()
+        .getWorkspace()
+        .getBlocksByType('logic_compare')[0];
+      boolBlock.getField('OP').setValue('LTE');
+      this.clock.tick(1000);
+      assert.isTrue(listenerTriggered);
+      this.workspace.getFlyout().getWorkspace().removeChangeListener(listener);
+    });
+  });
+
   suite('position', function () {
     suite('vertical flyout', function () {
       suite('simple flyout', function () {


### PR DESCRIPTION

<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #9486

### Proposed Changes
This PR adds an `inhibitReflowWrapper` instance variable to the base `Flyout` class and uses it to prevent the reflow wrapper from running in preference to unregistering and reregistering the reflow wrapper listener. The latter approach was mutating the listener array such that other listeners could be missed when dispatching events.