### PR TITLE
fix: Display dragged comments and bubbles atop the toolbox

### DIFF
--- a/core/comments/rendered_workspace_comment.ts
+++ b/core/comments/rendered_workspace_comment.ts
@@ -23,7 +23,6 @@ import {IFocusableNode} from '../interfaces/i_focusable_node.js';
 import type {IFocusableTree} from '../interfaces/i_focusable_tree.js';
 import {IRenderedElement} from '../interfaces/i_rendered_element.js';
 import {ISelectable} from '../interfaces/i_selectable.js';
-import * as layers from '../layers.js';
 import * as commentSerialization from '../serialization/workspace_comments.js';
 import {Coordinate} from '../utils/coordinate.js';
 import * as dom from '../utils/dom.js';
@@ -346,7 +345,7 @@ export class RenderedWorkspaceComment
   onNodeFocus(): void {
     this.select();
     // Ensure that the comment is always at the top when focused.
-    this.workspace.getLayerManager()?.append(this, layers.BLOCK);
+    this.getSvgRoot().parentElement?.appendChild(this.getSvgRoot());
     this.workspace.scrollBoundsIntoView(this.getBoundingRectangle());
   }
 

--- a/core/layer_manager.ts
+++ b/core/layer_manager.ts
@@ -215,4 +215,13 @@ export class LayerManager {
   getBubbleLayer(): SVGGElement {
     return this.layers.get(layerNums.BUBBLE)!;
   }
+
+  /**
+   * Returns the drag layer.
+   *
+   * @internal
+   */
+  getDragLayer(): SVGGElement | undefined {
+    return this.dragLayer;
+  }
 }

--- a/core/layer_manager.ts
+++ b/core/layer_manager.ts
@@ -99,12 +99,15 @@ export class LayerManager {
    * Moves the given element to the drag layer, which exists on top of all other
    * layers, and the drag surface.
    *
+   * @param elem The element to move onto the drag layer.
+   * @param focus Whether or not to focus the element post-move.
+   *
    * @internal
    */
-  moveToDragLayer(elem: IRenderedElement & IFocusableNode) {
+  moveToDragLayer(elem: IRenderedElement & IFocusableNode, focus = true) {
     this.dragLayer?.appendChild(elem.getSvgRoot());
 
-    if (elem.canBeFocused()) {
+    if (focus && elem.canBeFocused()) {
       // Since moving the element to the drag layer will cause it to lose focus,
       // ensure it regains focus (to ensure proper highlights & sent events).
       getFocusManager().focusNode(elem);
@@ -114,12 +117,22 @@ export class LayerManager {
   /**
    * Moves the given element off of the drag layer.
    *
+   * @param elem The element to move off of the drag layer.
+   * @param layerNum The identifier of the layer to move the element onto.
+   *     Should be a constant from layers.ts.
+   * @param focus Whether or not the element should be focused once moved onto
+   *     the destination layer.
+   *
    * @internal
    */
-  moveOffDragLayer(elem: IRenderedElement & IFocusableNode, layerNum: number) {
+  moveOffDragLayer(
+    elem: IRenderedElement & IFocusableNode,
+    layerNum: number,
+    focus = true,
+  ) {
     this.append(elem, layerNum);
 
-    if (elem.canBeFocused()) {
+    if (focus && elem.canBeFocused()) {
       // Since moving the element off the drag layer will cause it to lose focus,
       // ensure it regains focus (to ensure proper highlights & sent events).
       getFocusManager().focusNode(elem);

--- a/tests/mocha/block_test.js
+++ b/tests/mocha/block_test.js
@@ -2883,4 +2883,50 @@ suite('Blocks', function () {
       assert.equal(block.inputList[1].fieldRow[0].getValue(), 'Row2');
     });
   });
+
+  suite('Dragging', function () {
+    setup(function () {
+      this.workspace = Blockly.inject('blocklyDiv');
+      this.blocks = createTestBlocks(this.workspace, false);
+      for (const block of Object.values(this.blocks)) {
+        block.initSvg();
+        block.render();
+      }
+    });
+    test('Bubbles are moved to drag layer along with their blocks', async function () {
+      this.blocks.A.setCommentText('a');
+      this.blocks.B.setCommentText('b');
+      this.blocks.C.setCommentText('c');
+      const v1 = this.blocks.A.getIcon(
+        Blockly.icons.IconType.COMMENT,
+      ).setBubbleVisible(true);
+      const v2 = this.blocks.B.getIcon(
+        Blockly.icons.IconType.COMMENT,
+      ).setBubbleVisible(true);
+      const v3 = this.blocks.C.getIcon(
+        Blockly.icons.IconType.COMMENT,
+      ).setBubbleVisible(true);
+
+      this.clock.tick(1000);
+      await Promise.all([v1, v2, v3]);
+
+      this.blocks.B.startDrag();
+
+      // Block A stays put and should have its comment stay on the bubble layer.
+      assert.equal(
+        this.blocks.A.getIcon(Blockly.icons.IconType.COMMENT)
+          .getBubble()
+          .getSvgRoot().parentElement,
+        this.blocks.A.workspace.getLayerManager()?.getBubbleLayer(),
+      );
+
+      // Block B moves to the drag layer and its comment should follow.
+      assert.equal(
+        this.blocks.B.getIcon(Blockly.icons.IconType.COMMENT)
+          .getBubble()
+          .getSvgRoot().parentElement,
+        this.blocks.B.workspace.getLayerManager()?.getDragLayer(),
+      );
+    });
+  });
 });

--- a/tests/mocha/workspace_comment_test.js
+++ b/tests/mocha/workspace_comment_test.js
@@ -168,8 +168,10 @@ suite('Workspace comment', function () {
         this.workspace.id,
       );
     });
+  });
 
-    test('focuses the workspace when deleted', function () {
+  suite('Focus', function () {
+    test('moves to the workspace when deleted', function () {
       const comment = new Blockly.comments.RenderedWorkspaceComment(
         this.workspace,
       );
@@ -177,6 +179,19 @@ suite('Workspace comment', function () {
       assert.equal(Blockly.getFocusManager().getFocusedNode(), comment);
       comment.view.getCommentBarButtons()[1].performAction();
       assert.equal(Blockly.getFocusManager().getFocusedNode(), this.workspace);
+    });
+
+    test('does not change the layer', function () {
+      const comment = new Blockly.comments.RenderedWorkspaceComment(
+        this.workspace,
+      );
+
+      this.workspace.getLayerManager()?.moveToDragLayer(comment);
+      Blockly.getFocusManager().focusNode(comment);
+      assert.equal(
+        comment.getSvgRoot().parentElement,
+        this.workspace.getLayerManager()?.getDragLayer(),
+      );
     });
   });
 });


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #9537

### Proposed Changes
This PR fixes two bugs with identical presentation:

* When workspace comments were dragged over the toolbox (to delete them), they appeared behind the toolbox. They were being added to the drag layer correctly, but on focus moved themselves to the block layer. Now, they just append themselves to their current parent on focus, which preserves the raise-on-focus behavior but also keeps them on whatever layer they're currently on, and thus correctly z-ordered.
* When blocks were dragged over the toolbox, their attached bubbles appeared behind the toolbox. Bubbles are not children of blocks in the DOM; they live on a separate, unrelated layer and were not being moved to the drag layer with their parent blocks. They now are.
