### PR TITLE
chore: Disable macOS keyboard experiment CI

### DIFF
--- a/.github/workflows/keyboard_plugin_test.yml
+++ b/.github/workflows/keyboard_plugin_test.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest]
 
     steps:
       - name: Checkout core Blockly


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics
This PR disables running the keyboard-experimentation CI test under macOS, since this has been failing for months and the same test under Ubuntu is working fine. Until we can resolve the failure, this is just noise and makes it harder to spot legitimate regressions or failures.