### PR TITLE
feat!: Use box-sizing: border-box by default

### DIFF
--- a/core/css.ts
+++ b/core/css.ts
@@ -59,6 +59,15 @@ export function inject(hasCss: boolean, pathToMedia: string) {
  * The CSS content for Blockly.
  */
 let content = `
+:is(
+  .injectionDiv,
+  .blocklyWidgetDiv,
+  .blocklyDropdownDiv,
+  .blocklyTooltipDiv,
+) * {
+  box-sizing: border-box;
+}
+
 .blocklySvg {
   background-color: #fff;
   outline: none;


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #9205 

### Proposed Changes
This PR updates Blockly's CSS to use `box-sizing: border-box` by default for the core Blockly elements.


## Breaking Changes

If you add custom elements as children of the blockly containers, ensure that your custom elements' styling is compatible with `box-sizing: border-box`. If you do not add custom elements as children of the blockly containers (such as the injection div) then this change is unlikely to affect you.