### PR TITLE
fix: Remove more instances of `AnyDuringMigration`

### DIFF
--- a/blocks/procedures.ts
+++ b/blocks/procedures.ts
@@ -462,7 +462,7 @@ const PROCEDURE_DEF_COMMON = {
     // Add option to create caller.
     const name = this.getFieldValue('NAME');
     const callProcedureBlockState = {
-      type: (this as AnyDuringMigration).callType_,
+      type: this.callType_,
       extraState: {name: name, params: this.arguments_},
     };
     options.push({

--- a/core/gesture.ts
+++ b/core/gesture.ts
@@ -208,10 +208,6 @@ export class Gesture {
       browserEvents.unbind(event);
     }
     this.boundEvents.length = 0;
-
-    if (this.workspaceDragger) {
-      this.workspaceDragger.dispose();
-    }
   }
 
   /**

--- a/core/inputs/input.ts
+++ b/core/inputs/input.ts
@@ -172,7 +172,7 @@ export class Input {
     // Note: Currently there are only unit tests for block.setCollapsed()
     // because this function is package. If this function goes back to being a
     // public API tests (lots of tests) should be added.
-    let renderList: AnyDuringMigration[] = [];
+    let renderList: BlockSvg[] = [];
     if (this.visible === visible) {
       return renderList;
     }

--- a/core/rendered_connection.ts
+++ b/core/rendered_connection.ts
@@ -11,7 +11,6 @@
  */
 // Former goog.module ID: Blockly.RenderedConnection
 
-import type {Block} from './block.js';
 import type {BlockSvg} from './block_svg.js';
 import {config} from './config.js';
 import {Connection} from './connection.js';

--- a/core/rendered_connection.ts
+++ b/core/rendered_connection.ts
@@ -416,13 +416,13 @@ export class RenderedConnection
    *
    * @returns List of blocks to render.
    */
-  startTrackingAll(): Block[] {
+  startTrackingAll(): BlockSvg[] {
     this.setTracking(true);
     // All blocks that are not tracked must start tracking before any
     // rendering takes place, since rendering requires knowing the dimensions
     // of lower blocks. Also, since rendering a block renders all its parents,
     // we only need to render the leaf nodes.
-    let renderList: Block[] = [];
+    let renderList: BlockSvg[] = [];
     if (
       this.type !== ConnectionType.INPUT_VALUE &&
       this.type !== ConnectionType.NEXT_STATEMENT

--- a/core/serialization/blocks.ts
+++ b/core/serialization/blocks.ts
@@ -104,52 +104,36 @@ export function save(
   if (block.isInsertionMarker()) {
     return null;
   }
-  const state = {
+  const state: State = {
     'type': block.type,
     'id': saveIds ? block.id : undefined,
   };
 
   if (addCoordinates) {
-    // AnyDuringMigration because:  Argument of type '{ type: string; id:
-    // string; }' is not assignable to parameter of type 'State'.
-    saveCoords(block, state as AnyDuringMigration);
+    saveCoords(block, state);
   }
-  // AnyDuringMigration because:  Argument of type '{ type: string; id: string;
-  // }' is not assignable to parameter of type 'State'.
-  saveAttributes(block, state as AnyDuringMigration);
-  // AnyDuringMigration because:  Argument of type '{ type: string; id: string;
-  // }' is not assignable to parameter of type 'State'.
-  saveExtraState(block, state as AnyDuringMigration, doFullSerialization);
-  // AnyDuringMigration because:  Argument of type '{ type: string; id: string;
-  // }' is not assignable to parameter of type 'State'.
-  saveIcons(block, state as AnyDuringMigration, doFullSerialization);
-  // AnyDuringMigration because:  Argument of type '{ type: string; id: string;
-  // }' is not assignable to parameter of type 'State'.
-  saveFields(block, state as AnyDuringMigration, doFullSerialization);
+  saveAttributes(block, state);
+  saveExtraState(block, state, doFullSerialization);
+  saveIcons(block, state, doFullSerialization);
+  saveFields(block, state, doFullSerialization);
   if (addInputBlocks) {
-    // AnyDuringMigration because:  Argument of type '{ type: string; id:
-    // string; }' is not assignable to parameter of type 'State'.
     saveInputBlocks(
       block,
-      state as AnyDuringMigration,
+      state,
       doFullSerialization,
       saveIds,
     );
   }
   if (addNextBlocks) {
-    // AnyDuringMigration because:  Argument of type '{ type: string; id:
-    // string; }' is not assignable to parameter of type 'State'.
     saveNextBlocks(
       block,
-      state as AnyDuringMigration,
+      state,
       doFullSerialization,
       saveIds,
     );
   }
 
-  // AnyDuringMigration because:  Type '{ type: string; id: string; }' is not
-  // assignable to type 'State'.
-  return state as AnyDuringMigration;
+  return state;
 }
 
 /**

--- a/core/serialization/blocks.ts
+++ b/core/serialization/blocks.ts
@@ -117,20 +117,10 @@ export function save(
   saveIcons(block, state, doFullSerialization);
   saveFields(block, state, doFullSerialization);
   if (addInputBlocks) {
-    saveInputBlocks(
-      block,
-      state,
-      doFullSerialization,
-      saveIds,
-    );
+    saveInputBlocks(block, state, doFullSerialization, saveIds);
   }
   if (addNextBlocks) {
-    saveNextBlocks(
-      block,
-      state,
-      doFullSerialization,
-      saveIds,
-    );
+    saveNextBlocks(block, state, doFullSerialization, saveIds);
   }
 
   return state;

--- a/core/serialization/workspace_comments.ts
+++ b/core/serialization/workspace_comments.ts
@@ -110,7 +110,7 @@ export class WorkspaceCommentSerializer implements ISerializer {
   save(workspace: Workspace): State[] | null {
     const commentStates = [];
     for (const comment of workspace.getTopComments()) {
-      const state = saveComment(comment as AnyDuringMigration, {
+      const state = saveComment(comment, {
         addCoordinates: true,
         saveIds: true,
       });

--- a/core/touch.ts
+++ b/core/touch.ts
@@ -49,7 +49,7 @@ export const TOUCH_MAP: {[key: string]: string[]} = {
 };
 
 /** PID of queued long-press task. */
-let longPid_: AnyDuringMigration = 0;
+let longPid_: ReturnType<typeof setTimeout> = 0;
 
 /**
  * Context menus on touch devices are activated using a long-press.

--- a/core/workspace_dragger.ts
+++ b/core/workspace_dragger.ts
@@ -40,17 +40,6 @@ export class WorkspaceDragger {
   }
 
   /**
-   * Sever all links from this object.
-   *
-   * @internal
-   */
-  dispose() {
-    // AnyDuringMigration because:  Type 'null' is not assignable to type
-    // 'WorkspaceSvg'.
-    this.workspace = null as AnyDuringMigration;
-  }
-
-  /**
    * Start dragging the workspace.
    *
    * @internal

--- a/core/xml.ts
+++ b/core/xml.ts
@@ -47,9 +47,7 @@ export function workspaceToDom(workspace: Workspace, skipId = false): Element {
     treeXml.appendChild(variablesElement);
   }
   for (const comment of workspace.getTopComments()) {
-    treeXml.appendChild(
-      saveWorkspaceComment(comment, skipId),
-    );
+    treeXml.appendChild(saveWorkspaceComment(comment, skipId));
   }
   const blocks = workspace.getTopBlocks(true);
   for (let i = 0; i < blocks.length; i++) {

--- a/core/xml.ts
+++ b/core/xml.ts
@@ -48,7 +48,7 @@ export function workspaceToDom(workspace: Workspace, skipId = false): Element {
   }
   for (const comment of workspace.getTopComments()) {
     treeXml.appendChild(
-      saveWorkspaceComment(comment as AnyDuringMigration, skipId),
+      saveWorkspaceComment(comment, skipId),
     );
   }
   const blocks = workspace.getTopBlocks(true);

--- a/generators/dart/dart_generator.ts
+++ b/generators/dart/dart_generator.ts
@@ -232,7 +232,7 @@ export class DartGenerator extends CodeGenerator {
       let comment = block.getCommentText();
       if (comment) {
         comment = stringUtils.wrap(comment, this.COMMENT_WRAP - 3);
-        if ((block as AnyDuringMigration).getProcedureDef) {
+        if ('getProcedureDef' in block) {
           // Use documentation comment for function comments.
           commentCode += this.prefixLines(comment + '\n', '/// ');
         } else {


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes part of #6920

### Proposed Changes
This PR removes some casts to `AnyDuringMigration` and replaces them with accurate types.