### PR TITLE
fix: Fix bug that prevented deleting a variable referenced by two connected blocks

### DIFF
--- a/core/connection.ts
+++ b/core/connection.ts
@@ -291,7 +291,10 @@ export class Connection {
     }
 
     let event;
-    if (eventUtils.isEnabled()) {
+    if (
+      eventUtils.isEnabled() &&
+      !childConnection.getSourceBlock().isDeadOrDying()
+    ) {
       event = new (eventUtils.get(EventType.BLOCK_MOVE))(
         childConnection.getSourceBlock(),
       ) as BlockMove;

--- a/core/variable_map.ts
+++ b/core/variable_map.ts
@@ -315,6 +315,8 @@ export class VariableMap
     }
     try {
       for (let i = 0; i < uses.length; i++) {
+        if (uses[i].isDeadOrDying()) continue;
+
         uses[i].dispose(true);
       }
       const variables = this.variableMap.get(variable.getType());

--- a/tests/mocha/blocks/variables_test.js
+++ b/tests/mocha/blocks/variables_test.js
@@ -15,7 +15,7 @@ import {
   sharedTestTeardown,
 } from '../test_helpers/setup_teardown.js';
 
-suite.only('Variables', function () {
+suite('Variables', function () {
   setup(function () {
     sharedTestSetup.call(this);
     this.workspace = new Blockly.Workspace();

--- a/tests/mocha/blocks/variables_test.js
+++ b/tests/mocha/blocks/variables_test.js
@@ -15,7 +15,7 @@ import {
   sharedTestTeardown,
 } from '../test_helpers/setup_teardown.js';
 
-suite('Variables', function () {
+suite.only('Variables', function () {
   setup(function () {
     sharedTestSetup.call(this);
     this.workspace = new Blockly.Workspace();
@@ -30,6 +30,25 @@ suite('Variables', function () {
             'variableTypes': ['', 'type1', 'type2'],
           },
         ],
+        'output': null,
+      },
+      // Block for variable setter.
+      {
+        'type': 'set_var_block',
+        'message0': '%{BKY_VARIABLES_SET}',
+        'args0': [
+          {
+            'type': 'field_variable',
+            'name': 'VAR',
+            'variableTypes': ['', 'type1', 'type2'],
+          },
+          {
+            'type': 'input_value',
+            'name': 'VALUE',
+          },
+        ],
+        'previousStatement': null,
+        'nextStatement': null,
       },
     ]);
     this.variableMap = this.workspace.getVariableMap();
@@ -58,6 +77,21 @@ suite('Variables', function () {
     Blockly.Events.enable();
     return block;
   }
+
+  test('can be deleted when two connected blocks reference the same variable', function () {
+    const getter = new Blockly.Block(this.workspace, 'get_var_block');
+    getter.getField('VAR').setValue('1');
+
+    const setter = new Blockly.Block(this.workspace, 'set_var_block');
+    setter.getField('VAR').setValue('1');
+    setter.getInput('VALUE').connection.connect(getter.outputConnection);
+
+    this.variableMap.deleteVariable(this.variableMap.getVariableById('1'));
+    // Both blocks should have been deleted.
+    assert.equal(0, this.workspace.getAllBlocks(false).length);
+    // The variable itself should have been deleted.
+    assert.equal(this.variableMap.getVariableById('1'), undefined);
+  });
 
   suite('allUsedVarModels', function () {
     test('All used', function () {


### PR DESCRIPTION

<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #8455 

### Proposed Changes
This PR fixes a bug that caused an exception to be thrown if a variable was deleted when two blocks referencing the variable were connected to one another.