### PR TITLE
fix: Add class to shadow blocks in Geras

### DIFF
--- a/core/renderers/geras/path_object.ts
+++ b/core/renderers/geras/path_object.ts
@@ -37,7 +37,6 @@ export class PathObject extends BasePathObject {
     style: BlockStyle,
     public override constants: ConstantProvider,
   ) {
-    console.trace();
     super(root, style, constants);
 
     /** The dark path of the block. */

--- a/core/renderers/geras/path_object.ts
+++ b/core/renderers/geras/path_object.ts
@@ -37,6 +37,7 @@ export class PathObject extends BasePathObject {
     style: BlockStyle,
     public override constants: ConstantProvider,
   ) {
+    console.trace();
     super(root, style, constants);
 
     /** The dark path of the block. */
@@ -81,12 +82,6 @@ export class PathObject extends BasePathObject {
   override applyColour(block: BlockSvg) {
     this.svgPathLight.style.display = '';
     this.svgPathDark.style.display = '';
-    if (!this.style.colourTertiary) {
-      throw new Error(
-        'The renderer did not properly initialize the tertiary colour of ' +
-          'the block style',
-      );
-    }
     this.svgPathLight.setAttribute('stroke', this.style.colourTertiary);
     this.svgPathDark.setAttribute('fill', this.colourDark);
 
@@ -111,17 +106,10 @@ export class PathObject extends BasePathObject {
   }
 
   override updateShadow_(shadow: boolean) {
+    super.updateShadow_(shadow);
     if (shadow) {
       this.svgPathLight.style.display = 'none';
-      if (!this.style.colourSecondary) {
-        throw new Error(
-          'The renderer did not properly initialize the secondary colour ' +
-            'of the block style block style',
-        );
-      }
       this.svgPathDark.setAttribute('fill', this.style.colourSecondary);
-      this.svgPath.setAttribute('stroke', 'none');
-      this.svgPath.setAttribute('fill', this.style.colourSecondary);
     }
   }
 


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #9465

### Proposed Changes
This PR updates Geras' path object to call super in `updateShadow_`, which adds the `blocklyShadow` class, allowing it to be reliably used in stylesheets for styling shadow blocks. It also removes checks for `style.colourTertiary` and `style.colourSecondary`; at the time these were added, those fields were nullable, but they no longer are and the presence of the fields is enforced/backfilled by `Constants.validatedBlockStyle_()`.