### PR TITLE
fix: collapsed warning propagation across siblings (#9566)

### DIFF
--- a/core/block_svg.ts
+++ b/core/block_svg.ts
@@ -539,12 +539,22 @@ export class BlockSvg
    * @returns true if any child has a warning, false otherwise.
    */
   private childHasWarning(): boolean {
-    const children = this.getChildren(false);
-    for (const child of children) {
-      if (child.getIcon(WarningIcon.TYPE) || child.childHasWarning()) {
+    const next = this.getNextBlock();
+    const excluded = next ? new Set(next.getDescendants(false)) : null;
+    const descendants = this.getDescendants(false);
+
+    for (const descendant of descendants) {
+      if (descendant === this) {
+        continue;
+      }
+      if (excluded?.has(descendant)) {
+        continue;
+      }
+      if (descendant.getIcon(WarningIcon.TYPE)) {
         return true;
       }
     }
+
     return false;
   }
 

--- a/tests/mocha/block_test.js
+++ b/tests/mocha/block_test.js
@@ -1950,6 +1950,23 @@ suite('Blocks', function () {
           'Warning should be removed from parent after expanding',
         );
       });
+
+      test('Collapsing a block should not inherit warnings from following siblings', function () {
+        const nextBlock = createRenderedBlock(
+          this.workspace,
+          'statement_block',
+        );
+        this.childBlock.nextConnection.connect(nextBlock.previousConnection);
+        nextBlock.setWarningText('Warning Text');
+
+        this.childBlock.setCollapsed(true);
+
+        const icon = this.childBlock.getIcon(Blockly.icons.WarningIcon.TYPE);
+        assert.isUndefined(
+          icon,
+          'Collapsed block should not show warnings from following siblings',
+        );
+      });
     });
 
     suite('Bubbles and collapsing', function () {


### PR DESCRIPTION
## The basics
- [ ] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves
Fixes https://github.com/raspberrypifoundation/blockly/issues/9566

### Proposed Changes
- Add a regression test for collapsed blocks inheriting warnings from following sibling stacks.
- Update collapsed warning propagation to ignore following siblings.

### Reason for Changes
Collapsed blocks should only surface warnings from blocks contained within them. Warnings from following siblings are misleading and don’t represent the collapsed block’s contents.

### Test Coverage
- Added a Mocha regression test in `tests/mocha/block_test.js`.
- Manual verification in playground: collapse a block in a stack where the next sibling has a warning; the collapsed block should not show a warning.

### Documentation
No documentation updates needed.

### Additional Information

screenshot of the fix (compare with screenshots on issue)

<img width="278" height="160" alt="Screenshot 2026-01-13 at 11 39 43" src="https://github.com/user-attachments/assets/119ad501-dbc5-492f-b93a-90a5babede0b" />

