### PR TITLE
fix: Fix bug that prevented redoing adding empty block comments

### DIFF
--- a/core/events/events_block_change.ts
+++ b/core/events/events_block_change.ts
@@ -193,7 +193,7 @@ export class BlockChange extends BlockBase {
         break;
       }
       case 'comment':
-        block.setCommentText((value as string) || null);
+        block.setCommentText((value as string) ?? null);
         break;
       case 'collapsed':
         block.setCollapsed(!!value);

--- a/tests/mocha/comment_test.js
+++ b/tests/mocha/comment_test.js
@@ -167,4 +167,27 @@ suite('Comments', function () {
       assertBubbleLocation(this.comment, 100, 100);
     });
   });
+  suite('Undo/Redo', function () {
+    test('Adding a comment can be undone', function () {
+      const block = this.workspace.newBlock('empty_block');
+      block.setCommentText('');
+      assert.isNotNull(block.getIcon(Blockly.icons.IconType.COMMENT));
+      assert.equal(block.getCommentText(), '');
+
+      this.workspace.undo(false);
+
+      assert.isUndefined(block.getIcon(Blockly.icons.IconType.COMMENT));
+      assert.isNull(block.getCommentText());
+    });
+
+    test('Adding a comment can be redone', function () {
+      const block = this.workspace.newBlock('empty_block');
+      block.setCommentText('');
+      this.workspace.undo(false);
+      this.workspace.undo(true);
+
+      assert.isNotNull(block.getIcon(Blockly.icons.IconType.COMMENT));
+      assert.equal(block.getCommentText(), '');
+    });
+  });
 });

--- a/tests/mocha/comment_test.js
+++ b/tests/mocha/comment_test.js
@@ -168,7 +168,7 @@ suite('Comments', function () {
     });
   });
   suite('Undo/Redo', function () {
-    test('Adding a comment can be undone', function () {
+    test('Adding an empty comment can be undone', function () {
       const block = this.workspace.newBlock('empty_block');
       block.setCommentText('');
       assert.isNotNull(block.getIcon(Blockly.icons.IconType.COMMENT));
@@ -180,7 +180,7 @@ suite('Comments', function () {
       assert.isNull(block.getCommentText());
     });
 
-    test('Adding a comment can be redone', function () {
+    test('Adding an empty comment can be redone', function () {
       const block = this.workspace.newBlock('empty_block');
       block.setCommentText('');
       this.workspace.undo(false);
@@ -188,6 +188,28 @@ suite('Comments', function () {
 
       assert.isNotNull(block.getIcon(Blockly.icons.IconType.COMMENT));
       assert.equal(block.getCommentText(), '');
+    });
+
+    test('Adding a non-empty comment can be undone', function () {
+      const block = this.workspace.newBlock('empty_block');
+      block.setCommentText('hey there');
+      assert.isNotNull(block.getIcon(Blockly.icons.IconType.COMMENT));
+      assert.equal(block.getCommentText(), 'hey there');
+
+      this.workspace.undo(false);
+
+      assert.isUndefined(block.getIcon(Blockly.icons.IconType.COMMENT));
+      assert.isNull(block.getCommentText());
+    });
+
+    test('Adding a non-empty comment can be redone', function () {
+      const block = this.workspace.newBlock('empty_block');
+      block.setCommentText('hey there');
+      this.workspace.undo(false);
+      this.workspace.undo(true);
+
+      assert.isNotNull(block.getIcon(Blockly.icons.IconType.COMMENT));
+      assert.equal(block.getCommentText(), 'hey there');
     });
   });
 });


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #6708

### Proposed Changes
This PR fixes a bug that prevented redoing adding a comment to a block. By default comments are added as `''`, which is falsey, so when the comment text was set it fell back to null. I switched it to `??` to only fall back in the case of `undefined`.