### PR TITLE
fix: Improve flyout behavior

### DIFF
--- a/packages/blockly/core/flyout_base.ts
+++ b/packages/blockly/core/flyout_base.ts
@@ -38,7 +38,6 @@ import * as dom from './utils/dom.js';
 import * as idGenerator from './utils/idgenerator.js';
 import {Svg} from './utils/svg.js';
 import * as toolbox from './utils/toolbox.js';
-import * as Variables from './variables.js';
 import {WorkspaceSvg} from './workspace_svg.js';
 
 /**
@@ -813,44 +812,16 @@ export abstract class Flyout
    * @internal
    */
   createBlock(originalBlock: BlockSvg): BlockSvg {
-    let newBlock = null;
-    eventUtils.disable();
-    const variablesBeforeCreation = this.targetWorkspace
-      .getVariableMap()
-      .getAllVariables();
-    this.targetWorkspace.setResizesEnabled(false);
     try {
-      newBlock = this.placeNewBlock(originalBlock);
+      return this.placeNewBlock(originalBlock);
     } finally {
-      eventUtils.enable();
-    }
+      this.targetWorkspace.hideChaff();
 
-    // Close the flyout.
-    this.targetWorkspace.hideChaff();
-
-    const newVariables = Variables.getAddedVariables(
-      this.targetWorkspace,
-      variablesBeforeCreation,
-    );
-
-    if (eventUtils.isEnabled()) {
-      eventUtils.setGroup(true);
-      // Fire a VarCreate event for each (if any) new variable created.
-      for (let i = 0; i < newVariables.length; i++) {
-        const thisVariable = newVariables[i];
-        eventUtils.fire(
-          new (eventUtils.get(EventType.VAR_CREATE))(thisVariable),
-        );
+      // Close the flyout.
+      if (this.autoClose) {
+        this.hide();
       }
-
-      // Block events come after var events, in case they refer to newly created
-      // variables.
-      eventUtils.fire(new (eventUtils.get(EventType.BLOCK_CREATE))(newBlock));
     }
-    if (this.autoClose) {
-      this.hide();
-    }
-    return newBlock;
   }
 
   /**
@@ -890,7 +861,7 @@ export abstract class Flyout
     const json = this.serializeBlock(oldBlock);
     // Normally this resizes leading to weird jumps. Save it for terminateDrag.
     targetWorkspace.setResizesEnabled(false);
-    const block = blocks.append(json, targetWorkspace) as BlockSvg;
+    const block = blocks.append(json, targetWorkspace, {recordUndo: true}) as BlockSvg;
 
     this.positionNewBlock(oldBlock, block);
 

--- a/packages/blockly/core/flyout_base.ts
+++ b/packages/blockly/core/flyout_base.ts
@@ -812,16 +812,24 @@ export abstract class Flyout
    * @internal
    */
   createBlock(originalBlock: BlockSvg): BlockSvg {
-    try {
-      return this.placeNewBlock(originalBlock);
-    } finally {
-      this.targetWorkspace.hideChaff();
-
-      // Close the flyout.
-      if (this.autoClose) {
-        this.hide();
-      }
+    const targetWorkspace = this.targetWorkspace;
+    targetWorkspace.hideChaff();
+    const svgRootOld = originalBlock.getSvgRoot();
+    if (!svgRootOld) {
+      throw Error('oldBlock is not rendered');
     }
+
+    // Clone the block.
+    const json = this.serializeBlock(originalBlock);
+    // Normally this resizes leading to weird jumps. Save it for terminateDrag.
+    targetWorkspace.setResizesEnabled(false);
+    const block = blocks.appendInternal(json, targetWorkspace, {
+      recordUndo: true,
+    }) as BlockSvg;
+
+    this.positionNewBlock(originalBlock, block);
+
+    return block;
   }
 
   /**
@@ -842,32 +850,6 @@ export abstract class Flyout
     return this.workspace_.scrollbar
       ? this.workspace_.scrollbar.isVisible()
       : false;
-  }
-
-  /**
-   * Copy a block from the flyout to the workspace and position it correctly.
-   *
-   * @param oldBlock The flyout block to copy.
-   * @returns The new block in the main workspace.
-   */
-  private placeNewBlock(oldBlock: BlockSvg): BlockSvg {
-    const targetWorkspace = this.targetWorkspace;
-    const svgRootOld = oldBlock.getSvgRoot();
-    if (!svgRootOld) {
-      throw Error('oldBlock is not rendered');
-    }
-
-    // Clone the block.
-    const json = this.serializeBlock(oldBlock);
-    // Normally this resizes leading to weird jumps. Save it for terminateDrag.
-    targetWorkspace.setResizesEnabled(false);
-    const block = blocks.appendInternal(json, targetWorkspace, {
-      recordUndo: true,
-    }) as BlockSvg;
-
-    this.positionNewBlock(oldBlock, block);
-
-    return block;
   }
 
   /**

--- a/packages/blockly/core/flyout_base.ts
+++ b/packages/blockly/core/flyout_base.ts
@@ -813,7 +813,6 @@ export abstract class Flyout
    */
   createBlock(originalBlock: BlockSvg): BlockSvg {
     const targetWorkspace = this.targetWorkspace;
-    targetWorkspace.hideChaff();
     const svgRootOld = originalBlock.getSvgRoot();
     if (!svgRootOld) {
       throw Error('oldBlock is not rendered');
@@ -828,7 +827,7 @@ export abstract class Flyout
     }) as BlockSvg;
 
     this.positionNewBlock(originalBlock, block);
-
+    targetWorkspace.hideChaff();
     return block;
   }
 

--- a/packages/blockly/core/flyout_base.ts
+++ b/packages/blockly/core/flyout_base.ts
@@ -861,7 +861,9 @@ export abstract class Flyout
     const json = this.serializeBlock(oldBlock);
     // Normally this resizes leading to weird jumps. Save it for terminateDrag.
     targetWorkspace.setResizesEnabled(false);
-    const block = blocks.appendInternal(json, targetWorkspace, {recordUndo: true}) as BlockSvg;
+    const block = blocks.appendInternal(json, targetWorkspace, {
+      recordUndo: true,
+    }) as BlockSvg;
 
     this.positionNewBlock(oldBlock, block);
 

--- a/packages/blockly/core/flyout_base.ts
+++ b/packages/blockly/core/flyout_base.ts
@@ -861,7 +861,7 @@ export abstract class Flyout
     const json = this.serializeBlock(oldBlock);
     // Normally this resizes leading to weird jumps. Save it for terminateDrag.
     targetWorkspace.setResizesEnabled(false);
-    const block = blocks.append(json, targetWorkspace, {recordUndo: true}) as BlockSvg;
+    const block = blocks.appendInternal(json, targetWorkspace, {recordUndo: true}) as BlockSvg;
 
     this.positionNewBlock(oldBlock, block);
 

--- a/packages/blockly/core/gesture.ts
+++ b/packages/blockly/core/gesture.ts
@@ -274,19 +274,18 @@ export class Gesture {
           'flyout's target workspace is undefined`);
     }
 
-      this.startWorkspace_ = this.flyout.targetWorkspace;
-      this.startWorkspace_.updateScreenCalculationsIfScrolled();
-      // Start the event group now, so that the same event group is used for
-      // block creation and block dragging.
-      if (!eventUtils.getGroup()) {
-        eventUtils.setGroup(true);
-      }
-      // The start block is no longer relevant, because this is a drag.
-      this.startBlock = null;
-      this.targetBlock = this.flyout.createBlock(this.targetBlock);
-      getFocusManager().focusNode(this.targetBlock);
-      return true;
-
+    this.startWorkspace_ = this.flyout.targetWorkspace;
+    this.startWorkspace_.updateScreenCalculationsIfScrolled();
+    // Start the event group now, so that the same event group is used for
+    // block creation and block dragging.
+    if (!eventUtils.getGroup()) {
+      eventUtils.setGroup(true);
+    }
+    // The start block is no longer relevant, because this is a drag.
+    this.startBlock = null;
+    this.targetBlock = this.flyout.createBlock(this.targetBlock);
+    getFocusManager().focusNode(this.targetBlock);
+    return true;
   }
 
   /**

--- a/packages/blockly/core/gesture.ts
+++ b/packages/blockly/core/gesture.ts
@@ -273,10 +273,7 @@ export class Gesture {
       throw new Error(`Cannot update dragging from the flyout because the ' +
           'flyout's target workspace is undefined`);
     }
-    if (
-      !this.flyout.isScrollable() ||
-      this.flyout.isDragTowardWorkspace(this.currentDragDeltaXY)
-    ) {
+
       this.startWorkspace_ = this.flyout.targetWorkspace;
       this.startWorkspace_.updateScreenCalculationsIfScrolled();
       // Start the event group now, so that the same event group is used for
@@ -289,8 +286,7 @@ export class Gesture {
       this.targetBlock = this.flyout.createBlock(this.targetBlock);
       getFocusManager().focusNode(this.targetBlock);
       return true;
-    }
-    return false;
+
   }
 
   /**


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
* Fixes #8547
* Fixes #8769
* Fixes #9239

### Proposed Changes
This PR is a bit of a grab bag of flyout related fixes. Specifically, it:

* Removes a bunch of special handling of variable and block creation events when dragging a block out of the flyout. Experimentally this still seems to work fine, including undo, and including blocks that reference potential variables, and all tests still pass.
* Avoids a race condition that could result in inadvertent block bumps when dragging out a new block by calling `appendInternal()` instead of `append()`, the latter of which triggers an immediate (and unnecessary) render before the state of things is fully combobulated.
* Changes the behavior such that dragging on a block will not ever drag-to-scroll the flyout. The flyout can still be scrolled by clicking and dragging on the flyout workspace background, but clicks targeting blocks will always be treated as a drag on the block. 