### PR TITLE
chore: Make JSDom a peer/dev dependency on NodeJS only

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,14 +16,74 @@
         "@commitlint/config-conventional": "^20.0.0"
       }
     },
-    "node_modules/@babel/code-frame": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
-      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+    "node_modules/@acemir/cssom": {
+      "version": "0.9.31",
+      "resolved": "https://registry.npmjs.org/@acemir/cssom/-/cssom-0.9.31.tgz",
+      "integrity": "sha512-ZnR3GSaH+/vJ0YlHau21FjfLYjMpYVIzTD8M8vIEQvIGxeOXyXdzCI140rrCY862p/C/BbzWsjc1dgnM9mkoTA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-4.1.2.tgz",
+      "integrity": "sha512-NfBUvBaYgKIuq6E/RBLY1m0IohzNHAYyaJGuTK79Z23uNwmz2jl1mPsC5ZxCCxylinKhT1Amn5oNTlx1wN8cQg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.28.5",
+        "@csstools/css-calc": "^3.0.0",
+        "@csstools/css-color-parser": "^4.0.1",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0",
+        "lru-cache": "^11.2.5"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+      "version": "11.2.7",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.7.tgz",
+      "integrity": "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "6.8.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-6.8.1.tgz",
+      "integrity": "sha512-MvRz1nCqW0fsy8Qz4dnLIvhOlMzqDVBabZx6lH+YywFDdjXhMY37SmpV1XFX3JzG5GWHn63j6HX6QPr3lZXHvQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.1.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.2.6"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector/node_modules/lru-cache": {
+      "version": "11.2.7",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.7.tgz",
+      "integrity": "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.27.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.27.1",
         "js-tokens": "^4.0.0",
         "picocolors": "^1.1.1"
       },
@@ -31,10 +91,13 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@babel/code-frame/node_modules/picocolors": {
+      "version": "1.1.1",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
-      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "version": "7.27.1",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -42,17 +105,15 @@
       }
     },
     "node_modules/@commitlint/cli": {
-      "version": "20.4.2",
-      "resolved": "https://registry.npmjs.org/@commitlint/cli/-/cli-20.4.2.tgz",
-      "integrity": "sha512-YjYSX2yj/WsVoxh9mNiymfFS2ADbg2EK4+1WAsMuckwKMCqJ5PDG0CJU/8GvmHWcv4VRB2V02KqSiecRksWqZQ==",
+      "version": "20.1.0",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@commitlint/format": "^20.4.0",
-        "@commitlint/lint": "^20.4.2",
-        "@commitlint/load": "^20.4.0",
-        "@commitlint/read": "^20.4.0",
-        "@commitlint/types": "^20.4.0",
+        "@commitlint/format": "^20.0.0",
+        "@commitlint/lint": "^20.0.0",
+        "@commitlint/load": "^20.1.0",
+        "@commitlint/read": "^20.0.0",
+        "@commitlint/types": "^20.0.0",
         "tinyexec": "^1.0.0",
         "yargs": "^17.0.0"
       },
@@ -64,27 +125,23 @@
       }
     },
     "node_modules/@commitlint/config-conventional": {
-      "version": "20.4.2",
-      "resolved": "https://registry.npmjs.org/@commitlint/config-conventional/-/config-conventional-20.4.2.tgz",
-      "integrity": "sha512-rwkTF55q7Q+6dpSKUmJoScV0f3EpDlWKw2UPzklkLS4o5krMN1tPWAVOgHRtyUTMneIapLeQwaCjn44Td6OzBQ==",
+      "version": "20.0.0",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@commitlint/types": "^20.4.0",
-        "conventional-changelog-conventionalcommits": "^9.1.0"
+        "@commitlint/types": "^20.0.0",
+        "conventional-changelog-conventionalcommits": "^7.0.2"
       },
       "engines": {
         "node": ">=v18"
       }
     },
     "node_modules/@commitlint/config-validator": {
-      "version": "20.4.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/config-validator/-/config-validator-20.4.0.tgz",
-      "integrity": "sha512-zShmKTF+sqyNOfAE0vKcqnpvVpG0YX8F9G/ZIQHI2CoKyK+PSdladXMSns400aZ5/QZs+0fN75B//3Q5CHw++w==",
+      "version": "20.0.0",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@commitlint/types": "^20.4.0",
+        "@commitlint/types": "^20.0.0",
         "ajv": "^8.11.0"
       },
       "engines": {
@@ -92,13 +149,11 @@
       }
     },
     "node_modules/@commitlint/ensure": {
-      "version": "20.4.1",
-      "resolved": "https://registry.npmjs.org/@commitlint/ensure/-/ensure-20.4.1.tgz",
-      "integrity": "sha512-WLQqaFx1pBooiVvBrA1YfJNFqZF8wS/YGOtr5RzApDbV9tQ52qT5VkTsY65hFTnXhW8PcDfZLaknfJTmPejmlw==",
+      "version": "20.0.0",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@commitlint/types": "^20.4.0",
+        "@commitlint/types": "^20.0.0",
         "lodash.camelcase": "^4.3.0",
         "lodash.kebabcase": "^4.1.1",
         "lodash.snakecase": "^4.1.1",
@@ -111,8 +166,6 @@
     },
     "node_modules/@commitlint/execute-rule": {
       "version": "20.0.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/execute-rule/-/execute-rule-20.0.0.tgz",
-      "integrity": "sha512-xyCoOShoPuPL44gVa+5EdZsBVao/pNzpQhkzq3RdtlFdKZtjWcLlUFQHSWBuhk5utKYykeJPSz2i8ABHQA+ZZw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -120,74 +173,98 @@
       }
     },
     "node_modules/@commitlint/format": {
-      "version": "20.4.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/format/-/format-20.4.0.tgz",
-      "integrity": "sha512-i3ki3WR0rgolFVX6r64poBHXM1t8qlFel1G1eCBvVgntE3fCJitmzSvH5JD/KVJN/snz6TfaX2CLdON7+s4WVQ==",
+      "version": "20.0.0",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@commitlint/types": "^20.4.0",
-        "picocolors": "^1.1.1"
+        "@commitlint/types": "^20.0.0",
+        "chalk": "^5.3.0"
       },
       "engines": {
         "node": ">=v18"
       }
     },
+    "node_modules/@commitlint/format/node_modules/chalk": {
+      "version": "5.6.2",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
     "node_modules/@commitlint/is-ignored": {
-      "version": "20.4.1",
-      "resolved": "https://registry.npmjs.org/@commitlint/is-ignored/-/is-ignored-20.4.1.tgz",
-      "integrity": "sha512-In5EO4JR1lNsAv1oOBBO24V9ND1IqdAJDKZiEpdfjDl2HMasAcT7oA+5BKONv1pRoLG380DGPE2W2RIcUwdgLA==",
+      "version": "20.0.0",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@commitlint/types": "^20.4.0",
+        "@commitlint/types": "^20.0.0",
         "semver": "^7.6.0"
       },
       "engines": {
         "node": ">=v18"
       }
     },
+    "node_modules/@commitlint/is-ignored/node_modules/semver": {
+      "version": "7.7.2",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/@commitlint/lint": {
-      "version": "20.4.2",
-      "resolved": "https://registry.npmjs.org/@commitlint/lint/-/lint-20.4.2.tgz",
-      "integrity": "sha512-buquzNRtFng6xjXvBU1abY/WPEEjCgUipNQrNmIWe8QuJ6LWLtei/LDBAzEe5ASm45+Q9L2Xi3/GVvlj50GAug==",
+      "version": "20.0.0",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@commitlint/is-ignored": "^20.4.1",
-        "@commitlint/parse": "^20.4.1",
-        "@commitlint/rules": "^20.4.2",
-        "@commitlint/types": "^20.4.0"
+        "@commitlint/is-ignored": "^20.0.0",
+        "@commitlint/parse": "^20.0.0",
+        "@commitlint/rules": "^20.0.0",
+        "@commitlint/types": "^20.0.0"
       },
       "engines": {
         "node": ">=v18"
       }
     },
     "node_modules/@commitlint/load": {
-      "version": "20.4.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/load/-/load-20.4.0.tgz",
-      "integrity": "sha512-Dauup/GfjwffBXRJUdlX/YRKfSVXsXZLnINXKz0VZkXdKDcaEILAi9oflHGbfydonJnJAbXEbF3nXPm9rm3G6A==",
+      "version": "20.1.0",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@commitlint/config-validator": "^20.4.0",
+        "@commitlint/config-validator": "^20.0.0",
         "@commitlint/execute-rule": "^20.0.0",
-        "@commitlint/resolve-extends": "^20.4.0",
-        "@commitlint/types": "^20.4.0",
+        "@commitlint/resolve-extends": "^20.1.0",
+        "@commitlint/types": "^20.0.0",
+        "chalk": "^5.3.0",
         "cosmiconfig": "^9.0.0",
         "cosmiconfig-typescript-loader": "^6.1.0",
-        "is-plain-obj": "^4.1.0",
-        "lodash.mergewith": "^4.6.2",
-        "picocolors": "^1.1.1"
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.merge": "^4.6.2",
+        "lodash.uniq": "^4.5.0"
       },
       "engines": {
         "node": ">=v18"
       }
     },
+    "node_modules/@commitlint/load/node_modules/chalk": {
+      "version": "5.6.2",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
     "node_modules/@commitlint/message": {
-      "version": "20.4.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/message/-/message-20.4.0.tgz",
-      "integrity": "sha512-B5lGtvHgiLAIsK5nLINzVW0bN5hXv+EW35sKhYHE8F7V9Uz1fR4tx3wt7mobA5UNhZKUNgB/+ldVMQE6IHZRyA==",
+      "version": "20.0.0",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -195,29 +272,25 @@
       }
     },
     "node_modules/@commitlint/parse": {
-      "version": "20.4.1",
-      "resolved": "https://registry.npmjs.org/@commitlint/parse/-/parse-20.4.1.tgz",
-      "integrity": "sha512-XNtZjeRcFuAfUnhYrCY02+mpxwY4OmnvD3ETbVPs25xJFFz1nRo/25nHj+5eM+zTeRFvWFwD4GXWU2JEtoK1/w==",
+      "version": "20.0.0",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@commitlint/types": "^20.4.0",
-        "conventional-changelog-angular": "^8.1.0",
-        "conventional-commits-parser": "^6.2.1"
+        "@commitlint/types": "^20.0.0",
+        "conventional-changelog-angular": "^7.0.0",
+        "conventional-commits-parser": "^5.0.0"
       },
       "engines": {
         "node": ">=v18"
       }
     },
     "node_modules/@commitlint/read": {
-      "version": "20.4.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/read/-/read-20.4.0.tgz",
-      "integrity": "sha512-QfpFn6/I240ySEGv7YWqho4vxqtPpx40FS7kZZDjUJ+eHxu3azfhy7fFb5XzfTqVNp1hNoI3tEmiEPbDB44+cg==",
+      "version": "20.0.0",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@commitlint/top-level": "^20.4.0",
-        "@commitlint/types": "^20.4.0",
+        "@commitlint/top-level": "^20.0.0",
+        "@commitlint/types": "^20.0.0",
         "git-raw-commits": "^4.0.0",
         "minimist": "^1.2.8",
         "tinyexec": "^1.0.0"
@@ -227,14 +300,12 @@
       }
     },
     "node_modules/@commitlint/resolve-extends": {
-      "version": "20.4.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/resolve-extends/-/resolve-extends-20.4.0.tgz",
-      "integrity": "sha512-ay1KM8q0t+/OnlpqXJ+7gEFQNlUtSU5Gxr8GEwnVf2TPN3+ywc5DzL3JCxmpucqxfHBTFwfRMXxPRRnR5Ki20g==",
+      "version": "20.1.0",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@commitlint/config-validator": "^20.4.0",
-        "@commitlint/types": "^20.4.0",
+        "@commitlint/config-validator": "^20.0.0",
+        "@commitlint/types": "^20.0.0",
         "global-directory": "^4.0.1",
         "import-meta-resolve": "^4.0.0",
         "lodash.mergewith": "^4.6.2",
@@ -244,17 +315,23 @@
         "node": ">=v18"
       }
     },
+    "node_modules/@commitlint/resolve-extends/node_modules/resolve-from": {
+      "version": "5.0.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/@commitlint/rules": {
-      "version": "20.4.2",
-      "resolved": "https://registry.npmjs.org/@commitlint/rules/-/rules-20.4.2.tgz",
-      "integrity": "sha512-oz83pnp5Yq6uwwTAabuVQPNlPfeD2Y5ZjMb7Wx8FSUlu4sLYJjbBWt8031Z0osCFPfHzAwSYrjnfDFKtuSMdKg==",
+      "version": "20.0.0",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@commitlint/ensure": "^20.4.1",
-        "@commitlint/message": "^20.4.0",
+        "@commitlint/ensure": "^20.0.0",
+        "@commitlint/message": "^20.0.0",
         "@commitlint/to-lines": "^20.0.0",
-        "@commitlint/types": "^20.4.0"
+        "@commitlint/types": "^20.0.0"
       },
       "engines": {
         "node": ">=v18"
@@ -262,8 +339,6 @@
     },
     "node_modules/@commitlint/to-lines": {
       "version": "20.0.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/to-lines/-/to-lines-20.0.0.tgz",
-      "integrity": "sha512-2l9gmwiCRqZNWgV+pX1X7z4yP0b3ex/86UmUFgoRt672Ez6cAM2lOQeHFRUTuE6sPpi8XBCGnd8Kh3bMoyHwJw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -271,30 +346,272 @@
       }
     },
     "node_modules/@commitlint/top-level": {
-      "version": "20.4.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/top-level/-/top-level-20.4.0.tgz",
-      "integrity": "sha512-NDzq8Q6jmFaIIBC/GG6n1OQEaHdmaAAYdrZRlMgW6glYWGZ+IeuXmiymDvQNXPc82mVxq2KiE3RVpcs+1OeDeA==",
+      "version": "20.0.0",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "escalade": "^3.2.0"
+        "find-up": "^7.0.0"
       },
       "engines": {
         "node": ">=v18"
       }
     },
-    "node_modules/@commitlint/types": {
-      "version": "20.4.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/types/-/types-20.4.0.tgz",
-      "integrity": "sha512-aO5l99BQJ0X34ft8b0h7QFkQlqxC6e7ZPVmBKz13xM9O8obDaM1Cld4sQlJDXXU/VFuUzQ30mVtHjVz74TuStw==",
+    "node_modules/@commitlint/top-level/node_modules/find-up": {
+      "version": "7.0.0",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "conventional-commits-parser": "^6.2.1",
-        "picocolors": "^1.1.1"
+        "locate-path": "^7.2.0",
+        "path-exists": "^5.0.0",
+        "unicorn-magic": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@commitlint/top-level/node_modules/locate-path": {
+      "version": "7.2.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^6.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@commitlint/top-level/node_modules/p-limit": {
+      "version": "4.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^1.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@commitlint/top-level/node_modules/p-locate": {
+      "version": "6.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@commitlint/top-level/node_modules/path-exists": {
+      "version": "5.0.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      }
+    },
+    "node_modules/@commitlint/top-level/node_modules/yocto-queue": {
+      "version": "1.2.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@commitlint/types": {
+      "version": "20.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/conventional-commits-parser": "^5.0.0",
+        "chalk": "^5.3.0"
       },
       "engines": {
         "node": ">=v18"
+      }
+    },
+    "node_modules/@commitlint/types/node_modules/chalk": {
+      "version": "5.6.2",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
+      "integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.1.1.tgz",
+      "integrity": "sha512-HJ26Z/vmsZQqs/o3a6bgKslXGFAungXGbinULZO3eMsOyNJHeBBZfup5FiZInOghgoM4Hwnmw+OgbJCNg1wwUQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.0.2.tgz",
+      "integrity": "sha512-0GEfbBLmTFf0dJlpsNU7zwxRIH0/BGEMuXLTCvFYxuL1tNhqzTbtnFICyJLTNK4a+RechKP75e7w42ClXSnJQw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.0.2",
+        "@csstools/css-calc": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.1.tgz",
+      "integrity": "sha512-BvqN0AMWNAnLk9G8jnUT77D+mUbY/H2b3uDTvg2isJkHaOufUE2R3AOwxWo7VBQKT1lOdwdvorddo2B/lk64+w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.0.tgz",
+      "integrity": "sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
       }
     },
     "node_modules/@isaacs/balanced-match": {
@@ -316,17 +633,28 @@
         "node": "20 || >=22"
       }
     },
-    "node_modules/@simple-libs/stream-utils": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@simple-libs/stream-utils/-/stream-utils-1.2.0.tgz",
-      "integrity": "sha512-KxXvfapcixpz6rVEB6HPjOUZT22yN6v0vI0urQSk1L8MlEWPDFCZkhw2xmkyoTGYeFw7tWTZd7e3lVzRZRN/EA==",
+    "node_modules/@types/conventional-commits-parser": {
+      "version": "5.0.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.21",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.3",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://ko-fi.com/dangreen"
+        "node": ">= 14"
       }
     },
     "node_modules/ajv": {
@@ -373,8 +701,6 @@
     },
     "node_modules/array-ify": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/array-ify/-/array-ify-1.0.0.tgz",
-      "integrity": "sha512-c5AMf34bKdvPhQ7tBGhqkgKNUzMr4WUs+WDtC2ZUGOUncbxKMTvqxYctiseW3+L4bA8ec+GcZ6/A/FW4m8ukng==",
       "dev": true,
       "license": "MIT"
     },
@@ -404,6 +730,16 @@
         }
       }
     },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
+      }
+    },
     "node_modules/blockly": {
       "resolved": "packages/blockly",
       "link": true
@@ -418,8 +754,6 @@
     },
     "node_modules/chalk": {
       "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
-      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -468,8 +802,6 @@
     },
     "node_modules/compare-func": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/compare-func/-/compare-func-2.0.0.tgz",
-      "integrity": "sha512-zHig5N+tPWARooBnb0Zx1MFcdfpyJrfTJ3Y5L+IFvUm8rM74hHz66z0gw0x4tijh5CorKkKUCnW82R2vmpeCRA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -478,52 +810,46 @@
       }
     },
     "node_modules/conventional-changelog-angular": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-8.2.0.tgz",
-      "integrity": "sha512-4YB1zEXqB17oBI8yRsAs1T+ZhbdsOgJqkl6Trz+GXt/eKf1e4jnA0oW+sOd9BEENzEViuNW0DNoFFjSf3CeC5Q==",
+      "version": "7.0.0",
       "dev": true,
       "license": "ISC",
       "dependencies": {
         "compare-func": "^2.0.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=16"
       }
     },
     "node_modules/conventional-changelog-conventionalcommits": {
-      "version": "9.2.0",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-9.2.0.tgz",
-      "integrity": "sha512-fCf+ODjseueTV09wVBoC0HXLi3OyuBJ+HfE3L63Khxqnr99f9nUcnQh3a15lCWHlGLihyZShW/mVVkBagr9JvQ==",
+      "version": "7.0.2",
       "dev": true,
       "license": "ISC",
       "dependencies": {
         "compare-func": "^2.0.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=16"
       }
     },
     "node_modules/conventional-commits-parser": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-6.3.0.tgz",
-      "integrity": "sha512-RfOq/Cqy9xV9bOA8N+ZH6DlrDR+5S3Mi0B5kACEjESpE+AviIpAptx9a9cFpWCCvgRtWT+0BbUw+e1BZfts9jg==",
+      "version": "5.0.0",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@simple-libs/stream-utils": "^1.2.0",
-        "meow": "^13.0.0"
+        "is-text-path": "^2.0.0",
+        "JSONStream": "^1.3.5",
+        "meow": "^12.0.1",
+        "split2": "^4.0.0"
       },
       "bin": {
-        "conventional-commits-parser": "dist/cli/index.js"
+        "conventional-commits-parser": "cli.mjs"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=16"
       }
     },
     "node_modules/cosmiconfig": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.1.tgz",
-      "integrity": "sha512-hr4ihw+DBqcvrsEDioRO31Z17x71pUYoNe/4h6Z0wB72p7MU7/9gH8Q3s12NFhHPfYBBOV3qyfUxmr/Yn3shnQ==",
+      "version": "9.0.0",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -548,13 +874,11 @@
       }
     },
     "node_modules/cosmiconfig-typescript-loader": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/cosmiconfig-typescript-loader/-/cosmiconfig-typescript-loader-6.2.0.tgz",
-      "integrity": "sha512-GEN39v7TgdxgIoNcdkRE3uiAzQt3UXLyHbRHD6YoL048XAeOomyxaP+Hh/+2C6C2wYjxJ2onhJcsQp+L4YEkVQ==",
+      "version": "6.1.0",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "jiti": "^2.6.1"
+        "jiti": "^2.4.1"
       },
       "engines": {
         "node": ">=v18"
@@ -565,10 +889,38 @@
         "typescript": ">=5"
       }
     },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/cssstyle": {
+      "version": "5.3.7",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-5.3.7.tgz",
+      "integrity": "sha512-7D2EPVltRrsTkhpQmksIu+LxeWAIEk6wRDMJ1qljlv+CKHJM+cJLlfhWIzNA44eAsHXSNe3+vO6DW1yCYx8SuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^4.1.1",
+        "@csstools/css-syntax-patches-for-csstree": "^1.0.21",
+        "css-tree": "^3.1.0",
+        "lru-cache": "^11.2.4"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/dargs": {
       "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/dargs/-/dargs-8.1.0.tgz",
-      "integrity": "sha512-wAV9QHOsNbwnWdNW2FYvE1P56wtgSbM+3SZcdGiWQILwVjACCXDCI3Ai8QlCjMDB8YK5zySiXZYBiwGmNY3lnw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -578,10 +930,55 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/data-urls": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-6.0.1.tgz",
+      "integrity": "sha512-euIQENZg6x8mj3fO6o9+fOW8MimUI4PpD/fZBhJfeioZVy9TUpM4UY7KjQNVZFlqwJ0UdzRDzkycB997HEq1BQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^15.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/data-urls/node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/dot-prop": {
       "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-5.3.0.tgz",
-      "integrity": "sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -598,8 +995,6 @@
     },
     "node_modules/env-paths": {
       "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
-      "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -608,8 +1003,6 @@
     },
     "node_modules/error-ex": {
       "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz",
-      "integrity": "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -667,9 +1060,6 @@
     },
     "node_modules/git-raw-commits": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/git-raw-commits/-/git-raw-commits-4.0.0.tgz",
-      "integrity": "sha512-ICsMM1Wk8xSGMowkOmPrzo2Fgmfo4bMHLNX6ytHjajRJUqvHOw/TFapQ+QG75c3X/tTDDhOSRPGC52dDbNM8FQ==",
-      "deprecated": "This package is no longer maintained. For the JavaScript API, please use @conventional-changelog/git-client instead.",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -682,19 +1072,6 @@
       },
       "engines": {
         "node": ">=16"
-      }
-    },
-    "node_modules/git-raw-commits/node_modules/meow": {
-      "version": "12.1.1",
-      "resolved": "https://registry.npmjs.org/meow/-/meow-12.1.1.tgz",
-      "integrity": "sha512-BhXM0Au22RwUneMPwSCnyhTOizdWoIEPU9sp0Aqa1PnDMR5Wv2FGXYDjuzJEIX+Eo2Rb8xuYe5jrnm5QowQFkw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=16.10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/glob": {
@@ -715,8 +1092,6 @@
     },
     "node_modules/global-directory": {
       "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/global-directory/-/global-directory-4.0.1.tgz",
-      "integrity": "sha512-wHTUcDUoZ1H5/0iVqEudYW4/kAlN5cZ3j/bXn0Dpbizl9iaUVeWSHqiOjsgk6OW2bkLclbBjzewBz6weQ1zA2Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -729,10 +1104,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/global-directory/node_modules/ini": {
+      "version": "4.1.1",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
     "node_modules/google-closure-compiler": {
       "version": "20260225.0.0",
-      "resolved": "https://registry.npmjs.org/google-closure-compiler/-/google-closure-compiler-20260225.0.0.tgz",
-      "integrity": "sha512-qUu5r4DNRUJVd1FOkigJxfK1XJWfJdUs+AWc5ArehYavgCFBJcVsa5C9spqrJEua7+xtBSXuC2J2ggS5fEpaKg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -757,44 +1138,11 @@
     },
     "node_modules/google-closure-compiler-java": {
       "version": "20260225.0.0",
-      "resolved": "https://registry.npmjs.org/google-closure-compiler-java/-/google-closure-compiler-java-20260225.0.0.tgz",
-      "integrity": "sha512-sxxHBpF0ph878cjozdqpEBgR/rv7fN5aYgDgNXcHdNWPs5Qr5uQaV3rdViqi/vMpqC+CYMft7tuY6375IfkfOg==",
       "dev": true,
       "license": "Apache-2.0"
     },
-    "node_modules/google-closure-compiler-linux": {
-      "version": "20260225.0.0",
-      "resolved": "https://registry.npmjs.org/google-closure-compiler-linux/-/google-closure-compiler-linux-20260225.0.0.tgz",
-      "integrity": "sha512-8rPCjLuqvbFUL6Pk+lrrhj9BE9jFFymx2bMHJjQQtuT0NYHBBdy6zm7tN++zp3zPOOUupBizNsWLj2pkkP24Ag==",
-      "cpu": [
-        "x32",
-        "x64"
-      ],
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/google-closure-compiler-linux-arm64": {
-      "version": "20260225.0.0",
-      "resolved": "https://registry.npmjs.org/google-closure-compiler-linux-arm64/-/google-closure-compiler-linux-arm64-20260225.0.0.tgz",
-      "integrity": "sha512-L7/kXqh5wmpnU44ierzHMevpaQgZHTIwp9LPPJLAvUWJ/K54HUGcz4sUhCbUzAbXE96YzQ+q87dG9ueBkZqffA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
     "node_modules/google-closure-compiler-macos": {
       "version": "20260225.0.0",
-      "resolved": "https://registry.npmjs.org/google-closure-compiler-macos/-/google-closure-compiler-macos-20260225.0.0.tgz",
-      "integrity": "sha512-QTxlYCTbyE80OyiNmxf0JAxiKKNECIQ1jINTG6ezKpBefERvoLkezhsjlfxm/KXE6YwCWXd6+puZ9vxnoWUMqQ==",
       "cpu": [
         "arm64"
       ],
@@ -805,20 +1153,29 @@
         "darwin"
       ]
     },
-    "node_modules/google-closure-compiler-windows": {
-      "version": "20260225.0.0",
-      "resolved": "https://registry.npmjs.org/google-closure-compiler-windows/-/google-closure-compiler-windows-20260225.0.0.tgz",
-      "integrity": "sha512-tDpH19bEFqo7R+GxDWvvpeBg/HfPpCohCNG6a0Jc9im40zfVKa0YwJxuStXk0Tr4T9mIg7OnnEfVla5aeJkLzg==",
-      "cpu": [
-        "x32",
-        "x64"
-      ],
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
       "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "win32"
-      ]
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
     },
     "node_modules/import-fresh": {
       "version": "3.3.1",
@@ -852,20 +1209,8 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
-    "node_modules/ini": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-4.1.1.tgz",
-      "integrity": "sha512-QQnnxNyfvmHFIsj7gkPcYymR8Jdw/o7mp5ZFihxn6h8Ci6fh3Dx4E1gPjpQEpIuPo9XVNY/ZUwh4BPMjGyL01g==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-      }
-    },
     "node_modules/is-arrayish": {
       "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
       "dev": true,
       "license": "MIT"
     },
@@ -879,8 +1224,6 @@
     },
     "node_modules/is-obj": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
-      "integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -898,10 +1241,24 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/is-text-path": {
+      "version": "2.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "text-extensions": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/jiti": {
       "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
-      "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -910,8 +1267,6 @@
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -926,10 +1281,87 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/jsdom": {
+      "version": "27.4.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-27.4.0.tgz",
+      "integrity": "sha512-mjzqwWRD9Y1J1KUi7W97Gja1bwOOM5Ug0EZ6UDK3xS7j7mndrkwozHtSblfomlzyB4NepioNt+B2sOSzczVgtQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@acemir/cssom": "^0.9.28",
+        "@asamuzakjp/dom-selector": "^6.7.6",
+        "@exodus/bytes": "^1.6.0",
+        "cssstyle": "^5.3.4",
+        "data-urls": "^6.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.6",
+        "is-potential-custom-element-name": "^1.0.1",
+        "parse5": "^8.0.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.0",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^15.1.0",
+        "ws": "^8.18.3",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/jsdom/node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jsdom/node_modules/parse5": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.0.tgz",
+      "integrity": "sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
     "node_modules/json-parse-even-better-errors": {
       "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
-      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
       "dev": true,
       "license": "MIT"
     },
@@ -938,52 +1370,76 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/jsonparse": {
+      "version": "1.3.1",
+      "dev": true,
+      "engines": [
+        "node >= 0.2.0"
+      ],
+      "license": "MIT"
+    },
+    "node_modules/JSONStream": {
+      "version": "1.3.5",
+      "dev": true,
+      "license": "(MIT OR Apache-2.0)",
+      "dependencies": {
+        "jsonparse": "^1.2.0",
+        "through": ">=2.2.7 <3"
+      },
+      "bin": {
+        "JSONStream": "bin.js"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
-      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.camelcase": {
       "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
-      "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.kebabcase": {
       "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/lodash.kebabcase/-/lodash.kebabcase-4.1.1.tgz",
-      "integrity": "sha512-N8XRTIMMqqDgSy4VLKPnJ/+hpGZN+PHQiJnSenYqPaVV/NCqEogTnAdZLQiGKhxX+JCs8waWq2t1XHWKOmlY8g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.merge": {
+      "version": "4.6.2",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.mergewith": {
       "version": "4.6.2",
-      "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.2.tgz",
-      "integrity": "sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.snakecase": {
       "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/lodash.snakecase/-/lodash.snakecase-4.1.1.tgz",
-      "integrity": "sha512-QZ1d4xoBHYUeuouhEq3lk3Uq7ldgyFXGBhg04+oRLnIz8o9T65Eh+8YdroUwn846zchkA9yDsDl5CVVaV2nqYw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.startcase": {
       "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/lodash.startcase/-/lodash.startcase-4.4.0.tgz",
-      "integrity": "sha512-+WKqsK294HMSc2jEbNgpHpd0JfIBhp7rEV4aqXWqFr6AlXov+SlcgB1Fv01y2kGe3Gc8nMW7VA0SrGuSkRfIEg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.uniq": {
+      "version": "4.5.0",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.upperfirst": {
       "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/lodash.upperfirst/-/lodash.upperfirst-4.3.1.tgz",
-      "integrity": "sha512-sReKOYJIJf74dhJONhU4e0/shzi1trVbSWDOhKYE5XV2O+H7Sb2Dihwuc7xWxVl+DgFPyTqIN3zMfT9cq5iWDg==",
       "dev": true,
       "license": "MIT"
     },
@@ -995,14 +1451,19 @@
         "node": "20 || >=22"
       }
     },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
     "node_modules/meow": {
-      "version": "13.2.0",
-      "resolved": "https://registry.npmjs.org/meow/-/meow-13.2.0.tgz",
-      "integrity": "sha512-pxQJQzB6djGPXh08dacEloMFopsOqGVRKFPYvPOt9XDZ1HasbgDZA74CJGreSU4G3Ak7EFJGoiH2auq+yXISgA==",
+      "version": "12.1.1",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=18"
+        "node": ">=16.10"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -1038,6 +1499,11 @@
         "node": ">=16 || 14 >=14.17"
       }
     },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/package-json-from-dist": {
       "version": "1.0.1",
       "dev": true,
@@ -1056,8 +1522,6 @@
     },
     "node_modules/parse-json": {
       "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
-      "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1088,12 +1552,13 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/picocolors": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
-      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+    "node_modules/punycode": {
+      "version": "2.3.1",
       "dev": true,
-      "license": "ISC"
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/remove-trailing-separator": {
       "version": "1.1.0",
@@ -1124,16 +1589,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/resolve-from": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
-      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/rimraf": {
       "version": "6.1.2",
       "dev": true,
@@ -1152,21 +1607,29 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+    "node_modules/saxes": {
+      "version": "6.0.0",
       "dev": true,
       "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
+      "dependencies": {
+        "xmlchars": "^2.2.0"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=v12.22.7"
       }
     },
     "node_modules/source-map": {
       "version": "0.5.7",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
       "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
@@ -1215,6 +1678,11 @@
         "node": ">=8"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/teex": {
       "version": "1.0.1",
       "dev": true,
@@ -1231,20 +1699,91 @@
         "b4a": "^1.6.4"
       }
     },
+    "node_modules/text-extensions": {
+      "version": "2.4.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/through": {
+      "version": "2.3.8",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tinyexec": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.2.tgz",
-      "integrity": "sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==",
+      "version": "1.0.1",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tldts": {
+      "version": "7.0.26",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.26.tgz",
+      "integrity": "sha512-WiGwQjr0qYdNNG8KpMKlSvpxz652lqa3Rd+/hSaDcY4Uo6SKWZq2LAF+hsAhUewTtYhXlorBKgNF3Kk8hnjGoQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.0.26"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.0.26",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.26.tgz",
+      "integrity": "sha512-5WJ2SqFsv4G2Dwi7ZFVRnz6b2H1od39QME1lc2y5Ew3eWiZMAeqOAfWpRP9jHvhUl881406QtZTODvjttJs+ew==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
+      "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/unicorn-magic": {
+      "version": "0.1.0",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/vinyl": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-3.0.1.tgz",
-      "integrity": "sha512-0QwqXteBNXgnLCdWdvPQBX6FXRHtIH3VhJPTd5Lwn28tJXc34YqSCWUmkOvtJHBmB3gGoPtrOKk3Ts8/kEZ9aA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1265,6 +1804,49 @@
         "source-map": "^0.5.1"
       }
     },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "15.1.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-15.1.0.tgz",
+      "integrity": "sha512-2ytDk0kiEj/yu90JOAp44PVPUkO9+jVhyf+SybKlRHSDlvOOZhdPIrr7xTH64l4WixO2cP+wQIcgujkGBPPz6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/wrap-ansi": {
       "version": "7.0.0",
       "dev": true,
@@ -1280,6 +1862,39 @@
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
+    },
+    "node_modules/ws": {
+      "version": "8.18.3",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/y18n": {
       "version": "5.0.8",
@@ -1318,9 +1933,6 @@
       "version": "12.4.1",
       "hasInstallScript": true,
       "license": "Apache-2.0",
-      "dependencies": {
-        "jsdom": "26.1.0"
-      },
       "devDependencies": {
         "@blockly/block-test": "^7.0.2",
         "@blockly/dev-tools": "^9.0.2",
@@ -1355,6 +1967,7 @@
         "gulp-sourcemaps": "^3.0.0",
         "gulp-umd": "^2.0.0",
         "http-server": "^14.0.0",
+        "jsdom": "27.4.0",
         "json5": "^2.2.0",
         "markdown-tables-to-json": "^0.1.7",
         "mocha": "^11.3.0",
@@ -1371,6 +1984,9 @@
       },
       "engines": {
         "node": ">=22"
+      },
+      "peerDependencies": {
+        "jsdom": "^27.4.0"
       }
     },
     "packages/blockly/node_modules/@aashutoshrathi/word-wrap": {
@@ -1380,21 +1996,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "packages/blockly/node_modules/@asamuzakjp/css-color": {
-      "version": "3.1.1",
-      "license": "MIT",
-      "dependencies": {
-        "@csstools/css-calc": "^2.1.2",
-        "@csstools/css-color-parser": "^3.0.8",
-        "@csstools/css-parser-algorithms": "^3.0.4",
-        "@csstools/css-tokenizer": "^3.0.3",
-        "lru-cache": "^10.4.3"
-      }
-    },
-    "packages/blockly/node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
-      "version": "10.4.3",
-      "license": "ISC"
     },
     "packages/blockly/node_modules/@blockly/block-test": {
       "version": "7.0.2",
@@ -1555,106 +2156,6 @@
       },
       "peerDependencies": {
         "blockly": "^12.0.0"
-      }
-    },
-    "packages/blockly/node_modules/@csstools/color-helpers": {
-      "version": "5.0.2",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/csstools"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/csstools"
-        }
-      ],
-      "license": "MIT-0",
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "packages/blockly/node_modules/@csstools/css-calc": {
-      "version": "2.1.2",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/csstools"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/csstools"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@csstools/css-parser-algorithms": "^3.0.4",
-        "@csstools/css-tokenizer": "^3.0.3"
-      }
-    },
-    "packages/blockly/node_modules/@csstools/css-color-parser": {
-      "version": "3.0.8",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/csstools"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/csstools"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "@csstools/color-helpers": "^5.0.2",
-        "@csstools/css-calc": "^2.1.2"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@csstools/css-parser-algorithms": "^3.0.4",
-        "@csstools/css-tokenizer": "^3.0.3"
-      }
-    },
-    "packages/blockly/node_modules/@csstools/css-parser-algorithms": {
-      "version": "3.0.4",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/csstools"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/csstools"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@csstools/css-tokenizer": "^3.0.3"
-      }
-    },
-    "packages/blockly/node_modules/@csstools/css-tokenizer": {
-      "version": "3.0.3",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/csstools"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/csstools"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
       }
     },
     "packages/blockly/node_modules/@es-joy/jsdoccomment": {
@@ -3169,6 +3670,7 @@
     },
     "packages/blockly/node_modules/agent-base": {
       "version": "7.1.3",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 14"
@@ -4318,17 +4820,6 @@
         "node": ">=0.10.0"
       }
     },
-    "packages/blockly/node_modules/cssstyle": {
-      "version": "4.3.0",
-      "license": "MIT",
-      "dependencies": {
-        "@asamuzakjp/css-color": "^3.1.1",
-        "rrweb-cssom": "^0.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "packages/blockly/node_modules/d": {
       "version": "1.0.1",
       "dev": true,
@@ -4351,19 +4842,9 @@
         "node": ">= 12"
       }
     },
-    "packages/blockly/node_modules/data-urls": {
-      "version": "5.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "whatwg-mimetype": "^4.0.0",
-        "whatwg-url": "^14.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "packages/blockly/node_modules/debug": {
       "version": "4.4.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -4405,10 +4886,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "packages/blockly/node_modules/decimal.js": {
-      "version": "10.5.0",
-      "license": "MIT"
     },
     "packages/blockly/node_modules/decode-uri-component": {
       "version": "0.2.2",
@@ -4655,6 +5132,7 @@
     },
     "packages/blockly/node_modules/entities": {
       "version": "4.5.0",
+      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.12"
@@ -6306,6 +6784,7 @@
     },
     "packages/blockly/node_modules/http-proxy-agent": {
       "version": "7.0.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "agent-base": "^7.1.0",
@@ -6343,6 +6822,7 @@
     },
     "packages/blockly/node_modules/https-proxy-agent": {
       "version": "7.0.6",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "agent-base": "^7.1.2",
@@ -6354,6 +6834,7 @@
     },
     "packages/blockly/node_modules/iconv-lite": {
       "version": "0.6.3",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
@@ -6558,10 +7039,6 @@
         "node": ">=0.10.0"
       }
     },
-    "packages/blockly/node_modules/is-potential-custom-element-name": {
-      "version": "1.0.1",
-      "license": "MIT"
-    },
     "packages/blockly/node_modules/is-promise": {
       "version": "2.2.2",
       "dev": true,
@@ -6701,63 +7178,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=12.0.0"
-      }
-    },
-    "packages/blockly/node_modules/jsdom": {
-      "version": "26.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "cssstyle": "^4.2.1",
-        "data-urls": "^5.0.0",
-        "decimal.js": "^10.5.0",
-        "html-encoding-sniffer": "^4.0.0",
-        "http-proxy-agent": "^7.0.2",
-        "https-proxy-agent": "^7.0.6",
-        "is-potential-custom-element-name": "^1.0.1",
-        "nwsapi": "^2.2.16",
-        "parse5": "^7.2.1",
-        "rrweb-cssom": "^0.8.0",
-        "saxes": "^6.0.0",
-        "symbol-tree": "^3.2.4",
-        "tough-cookie": "^5.1.1",
-        "w3c-xmlserializer": "^5.0.0",
-        "webidl-conversions": "^7.0.0",
-        "whatwg-encoding": "^3.1.1",
-        "whatwg-mimetype": "^4.0.0",
-        "whatwg-url": "^14.1.1",
-        "ws": "^8.18.0",
-        "xml-name-validator": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "canvas": "^3.0.0"
-      },
-      "peerDependenciesMeta": {
-        "canvas": {
-          "optional": true
-        }
-      }
-    },
-    "packages/blockly/node_modules/jsdom/node_modules/html-encoding-sniffer": {
-      "version": "4.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "whatwg-encoding": "^3.1.1"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "packages/blockly/node_modules/jsdom/node_modules/whatwg-encoding": {
-      "version": "3.1.1",
-      "license": "MIT",
-      "dependencies": {
-        "iconv-lite": "0.6.3"
-      },
-      "engines": {
-        "node": ">=18"
       }
     },
     "packages/blockly/node_modules/json-buffer": {
@@ -7369,6 +7789,7 @@
     },
     "packages/blockly/node_modules/ms": {
       "version": "2.1.3",
+      "dev": true,
       "license": "MIT"
     },
     "packages/blockly/node_modules/mute-stdout": {
@@ -7473,10 +7894,6 @@
       "funding": {
         "url": "https://github.com/fb55/nth-check?sponsor=1"
       }
-    },
-    "packages/blockly/node_modules/nwsapi": {
-      "version": "2.2.20",
-      "license": "MIT"
     },
     "packages/blockly/node_modules/object-assign": {
       "version": "4.1.1",
@@ -7676,6 +8093,7 @@
     },
     "packages/blockly/node_modules/parse5": {
       "version": "7.2.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "entities": "^4.5.0"
@@ -8019,6 +8437,7 @@
     },
     "packages/blockly/node_modules/punycode": {
       "version": "2.3.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -8268,10 +8687,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "packages/blockly/node_modules/rrweb-cssom": {
-      "version": "0.8.0",
-      "license": "MIT"
-    },
     "packages/blockly/node_modules/run-parallel": {
       "version": "1.2.0",
       "dev": true,
@@ -8322,17 +8737,8 @@
     },
     "packages/blockly/node_modules/safer-buffer": {
       "version": "2.1.2",
+      "dev": true,
       "license": "MIT"
-    },
-    "packages/blockly/node_modules/saxes": {
-      "version": "6.0.0",
-      "license": "ISC",
-      "dependencies": {
-        "xmlchars": "^2.2.0"
-      },
-      "engines": {
-        "node": ">=v12.22.7"
-      }
     },
     "packages/blockly/node_modules/secure-compare": {
       "version": "3.0.1",
@@ -8778,10 +9184,6 @@
         "semver": "bin/semver.js"
       }
     },
-    "packages/blockly/node_modules/symbol-tree": {
-      "version": "3.2.4",
-      "license": "MIT"
-    },
     "packages/blockly/node_modules/synckit": {
       "version": "0.11.8",
       "dev": true,
@@ -8847,20 +9249,6 @@
         "next-tick": "1"
       }
     },
-    "packages/blockly/node_modules/tldts": {
-      "version": "6.1.86",
-      "license": "MIT",
-      "dependencies": {
-        "tldts-core": "^6.1.86"
-      },
-      "bin": {
-        "tldts": "bin/cli.js"
-      }
-    },
-    "packages/blockly/node_modules/tldts-core": {
-      "version": "6.1.86",
-      "license": "MIT"
-    },
     "packages/blockly/node_modules/tmp": {
       "version": "0.2.5",
       "dev": true,
@@ -8889,26 +9277,6 @@
       },
       "engines": {
         "node": ">=10.13.0"
-      }
-    },
-    "packages/blockly/node_modules/tough-cookie": {
-      "version": "5.1.2",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "tldts": "^6.1.32"
-      },
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "packages/blockly/node_modules/tr46": {
-      "version": "5.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "punycode": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=18"
       }
     },
     "packages/blockly/node_modules/tree-kill": {
@@ -9269,16 +9637,6 @@
         "node": ">= 0.10"
       }
     },
-    "packages/blockly/node_modules/w3c-xmlserializer": {
-      "version": "5.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "xml-name-validator": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "packages/blockly/node_modules/wait-port": {
       "version": "1.1.0",
       "dev": true,
@@ -9371,13 +9729,6 @@
         }
       }
     },
-    "packages/blockly/node_modules/webidl-conversions": {
-      "version": "7.0.0",
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "packages/blockly/node_modules/whatwg-encoding": {
       "version": "2.0.0",
       "dev": true,
@@ -9391,18 +9742,8 @@
     },
     "packages/blockly/node_modules/whatwg-mimetype": {
       "version": "4.0.0",
+      "dev": true,
       "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "packages/blockly/node_modules/whatwg-url": {
-      "version": "14.2.0",
-      "license": "MIT",
-      "dependencies": {
-        "tr46": "^5.1.0",
-        "webidl-conversions": "^7.0.0"
-      },
       "engines": {
         "node": ">=18"
       }
@@ -9450,6 +9791,7 @@
     },
     "packages/blockly/node_modules/ws": {
       "version": "8.18.3",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -9466,17 +9808,6 @@
           "optional": true
         }
       }
-    },
-    "packages/blockly/node_modules/xml-name-validator": {
-      "version": "5.0.0",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "packages/blockly/node_modules/xmlchars": {
-      "version": "2.2.0",
-      "license": "MIT"
     },
     "packages/blockly/node_modules/xtend": {
       "version": "4.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1113,12 +1113,14 @@
       }
     },
     "node_modules/google-closure-compiler": {
-      "version": "20260225.0.0",
+      "version": "20260315.0.0",
+      "resolved": "https://registry.npmjs.org/google-closure-compiler/-/google-closure-compiler-20260315.0.0.tgz",
+      "integrity": "sha512-z+Zdkth5+bdt+bSy3HuYRgjSAgx4WncBZ0Rd+/1Hf3wFemkkTxXGXpG7A5Y8n5WrTsPd1n/fxVuD5xfFL6s5Dw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "chalk": "^2.0.0 || ^3.0.0 || ^4.0.0 || ^5.0.0 <5.6.1 || ^5.6.2 >5.6.1",
-        "google-closure-compiler-java": "^20260225.0.0",
+        "google-closure-compiler-java": "^20260315.0.0",
         "minimist": "^1.0.0",
         "vinyl": "^3.0.1",
         "vinyl-sourcemaps-apply": "^0.2.0"
@@ -1130,19 +1132,52 @@
         "node": ">=18"
       },
       "optionalDependencies": {
-        "google-closure-compiler-linux": "^20260225.0.0",
-        "google-closure-compiler-linux-arm64": "^20260225.0.0",
-        "google-closure-compiler-macos": "^20260225.0.0",
-        "google-closure-compiler-windows": "^20260225.0.0"
+        "google-closure-compiler-linux": "^20260315.0.0",
+        "google-closure-compiler-linux-arm64": "^20260315.0.0",
+        "google-closure-compiler-macos": "^20260315.0.0",
+        "google-closure-compiler-windows": "^20260315.0.0"
       }
     },
     "node_modules/google-closure-compiler-java": {
-      "version": "20260225.0.0",
+      "version": "20260315.0.0",
+      "resolved": "https://registry.npmjs.org/google-closure-compiler-java/-/google-closure-compiler-java-20260315.0.0.tgz",
+      "integrity": "sha512-3CYSN3x7S7xCc/7Yx9vmH4pOc/8tkJdPjftUV1tUt2/tYKYEeH9mGv5dtrs22Uf6qXdIqlEBGg+ZQXX13xVpww==",
       "dev": true,
       "license": "Apache-2.0"
     },
+    "node_modules/google-closure-compiler-linux": {
+      "version": "20260315.0.0",
+      "resolved": "https://registry.npmjs.org/google-closure-compiler-linux/-/google-closure-compiler-linux-20260315.0.0.tgz",
+      "integrity": "sha512-jXUnyY3Cr5kmBDmGuxw3HULjzX69AeXVRcIpI+YuFGfo8qX1dIbkOpNK7JHWtJ7qE01foGmCwjnx5WOSrplYyg==",
+      "cpu": [
+        "x32",
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/google-closure-compiler-linux-arm64": {
+      "version": "20260315.0.0",
+      "resolved": "https://registry.npmjs.org/google-closure-compiler-linux-arm64/-/google-closure-compiler-linux-arm64-20260315.0.0.tgz",
+      "integrity": "sha512-e0dSgFEg/bE9gscw+u2Roy/FkJOQ/6MvG3nBCPR8IqAkJ+ibBAQKnYOSK1sAUp1bXJROiUJy6a+GTJ312FKS+A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
     "node_modules/google-closure-compiler-macos": {
-      "version": "20260225.0.0",
+      "version": "20260315.0.0",
+      "resolved": "https://registry.npmjs.org/google-closure-compiler-macos/-/google-closure-compiler-macos-20260315.0.0.tgz",
+      "integrity": "sha512-yhY46Mdbqs7HAPsYAhXlt9Q2rROLZfaZrTFZZqyVo/uufEmGH3vOyxshTbBQWhaJQHkELWsc/XKSVfvX4rcoYA==",
       "cpu": [
         "arm64"
       ],
@@ -1151,6 +1186,21 @@
       "optional": true,
       "os": [
         "darwin"
+      ]
+    },
+    "node_modules/google-closure-compiler-windows": {
+      "version": "20260315.0.0",
+      "resolved": "https://registry.npmjs.org/google-closure-compiler-windows/-/google-closure-compiler-windows-20260315.0.0.tgz",
+      "integrity": "sha512-EpIPPU6vQ5EzuzKQMe3vhEWLqqXY4SKNoLjXrr4GWXoses9h7xT6nkHDuDe/7x5MWZOMRv4qmlW3PzLCsx98qg==",
+      "cpu": [
+        "x32",
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
       ]
     },
     "node_modules/http-proxy-agent": {
@@ -1954,7 +2004,7 @@
         "eslint-plugin-prettier": "^5.2.1",
         "glob": "^11.0.1",
         "globals": "^16.0.0",
-        "google-closure-compiler": "^20260225.0.0",
+        "google-closure-compiler": "^20260315.0.0",
         "gulp": "^5.0.0",
         "gulp-concat": "^2.6.1",
         "gulp-gzip": "^1.4.2",

--- a/packages/blockly/package.json
+++ b/packages/blockly/package.json
@@ -123,7 +123,7 @@
     "eslint-plugin-prettier": "^5.2.1",
     "glob": "^11.0.1",
     "globals": "^16.0.0",
-    "google-closure-compiler": "^20260225.0.0",
+    "google-closure-compiler": "^20260315.0.0",
     "gulp": "^5.0.0",
     "gulp-concat": "^2.6.1",
     "gulp-gzip": "^1.4.2",

--- a/packages/blockly/package.json
+++ b/packages/blockly/package.json
@@ -16,6 +16,9 @@
   "author": {
     "name": "Neil Fraser"
   },
+  "browser": {
+    "jsdom": false
+  },
   "scripts": {
     "build": "gulp build",
     "build-debug": "gulp build --verbose --debug",
@@ -133,6 +136,7 @@
     "gulp-sourcemaps": "^3.0.0",
     "gulp-umd": "^2.0.0",
     "http-server": "^14.0.0",
+    "jsdom": "27.4.0",
     "json5": "^2.2.0",
     "markdown-tables-to-json": "^0.1.7",
     "mocha": "^11.3.0",
@@ -147,10 +151,10 @@
     "webdriverio": "^9.0.7",
     "yargs": "^17.2.1"
   },
-  "dependencies": {
-    "jsdom": "26.1.0"
-  },
   "engines": {
     "node": ">=22"
+  },
+  "peerDependencies": {
+    "jsdom": "^27.4.0"
   }
 }


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #8775 

### Proposed Changes
This PR removes JSDom as a normal dependency, and adds the latest version as a peer and dev dependency. It also uses the `browser` field in package.json to indicate to bundlers and the like that it should be omitted for builds targeting a browser, rather than Node-based, deployment environment.