### PR TITLE
fix: Fix bug that caused flyout buttons to retain their active appearance on mobile

### DIFF
--- a/packages/blockly/core/flyout_button.ts
+++ b/packages/blockly/core/flyout_button.ts
@@ -427,7 +427,13 @@ Css.register(`
   fill: #666;
 }
 
-.blocklyFlyoutButton:hover {
+@media (hover: hover) {
+  .blocklyFlyoutButton:hover {
+    fill: #aaa;
+  }
+}
+
+.blocklyFlyoutButton:active {
   fill: #aaa;
 }
 


### PR DESCRIPTION

<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #6029

### Proposed Changes
This PR fixes a bug that caused flyout buttons to remain visually highlighted after being tapped on mobile. This is because mobile browser apply :hover styles on :active, but don't stop applying them until something else gets focus. Now, the :hover style is limited to devices that actually support hovering via a media query, and an :active style has been added for mobile, which automatically gets removed post-tap.