### PR TITLE
feat: Allow calling `WorkspaceSvg.getGesture()` without passing an event

### DIFF
--- a/packages/blockly/core/workspace_svg.ts
+++ b/packages/blockly/core/workspace_svg.ts
@@ -2467,17 +2467,17 @@ export class WorkspaceSvg
    *     valid gesture exists.
    * @internal
    */
-  getGesture(e: PointerEvent): Gesture | null {
+  getGesture(e?: PointerEvent): Gesture | null {
     // TODO(#8960): Query Mover.isMoving to see if move is in progress
     // rather than relying on .keyboardMoveInProgress status flag.
     if (this.keyboardMoveInProgress) {
       // Normally these would be called from Gesture.doStart.
-      e.preventDefault();
-      e.stopPropagation();
+      e?.preventDefault();
+      e?.stopPropagation();
       return null;
     }
 
-    const isStart = e.type === 'pointerdown';
+    const isStart = e?.type === 'pointerdown';
     if (isStart && this.currentGesture_?.hasStarted()) {
       console.warn('Tried to start the same gesture twice.');
       // That's funny.  We must have missed a mouse up.

--- a/packages/blockly/tests/mocha/workspace_svg_test.js
+++ b/packages/blockly/tests/mocha/workspace_svg_test.js
@@ -16,6 +16,7 @@ import {
   sharedTestSetup,
   sharedTestTeardown,
 } from './test_helpers/setup_teardown.js';
+import {dispatchPointerEvent} from './test_helpers/user_input.js';
 import {testAWorkspace} from './test_helpers/workspace.js';
 
 suite('WorkspaceSvg', function () {
@@ -112,6 +113,17 @@ suite('WorkspaceSvg', function () {
     inputConnection.connect(block.outputConnection);
     assert.equal(false, block.isDeadOrDying());
     assert.equal(true, shadowBlock.isDeadOrDying());
+  });
+
+  test('getGesture returns null when no gesture is in progress', function () {
+    const gesture = this.workspace.getGesture();
+    assert.isNull(gesture);
+  });
+
+  test('getGesture returns the current gesture when one is in progress', function () {
+    dispatchPointerEvent(this.workspace.getSvgGroup(), 'pointerdown');
+    const gesture = this.workspace.getGesture();
+    assert.isNotNull(gesture);
   });
 
   suite('updateToolbox', function () {


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #8133

### Proposed Changes
This PR updates `WorkspaceSvg.getGesture()` to return the current gesture, if any, without having to pass in a `PointerEvent`. This also avoids the behavior of starting a gesture if one is not already in progress.