### PR TITLE
chore: Fix typo in `getRelativeToSurfaceXY()`

### DIFF
--- a/packages/blockly/core/block_svg.ts
+++ b/packages/blockly/core/block_svg.ts
@@ -354,8 +354,8 @@ export class BlockSvg
    * @returns Object with .x and .y properties in workspace coordinates.
    */
   override getRelativeToSurfaceXY(): Coordinate {
-    const layerManger = this.workspace.getLayerManager();
-    if (!layerManger) {
+    const layerManager = this.workspace.getLayerManager();
+    if (!layerManager) {
       throw new Error(
         'Cannot calculate position because the workspace has not been appended',
       );
@@ -371,7 +371,7 @@ export class BlockSvg
         x += xy.x;
         y += xy.y;
         element = element.parentNode as SVGElement;
-      } while (element && !layerManger.hasLayer(element));
+      } while (element && !layerManager.hasLayer(element));
     }
     return new Coordinate(x, y);
   }


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details

### Proposed Changes
This PR fixes a typo in a variable name.