### PR TITLE
fix: Fix running browser tests

### DIFF
--- a/packages/blockly/package.json
+++ b/packages/blockly/package.json
@@ -43,7 +43,7 @@
     "start": "npm run build && concurrently -n tsc,server \"tsc --watch --preserveWatchOutput --outDir \"build/src\" --declarationDir \"build/declarations\"\" \"http-server ./ -s -o /tests/playground.html -c-1\"",
     "tsc": "gulp tsc",
     "test": "gulp test",
-    "test:browser": "cd tests/browser && npx mocha",
+    "test:browser": "npx mocha --config tests/browser/.mocharc.js",
     "test:generators": "gulp testGenerators",
     "test:mocha:interactive": "npm run build && concurrently -n tsc,server \"tsc --watch --preserveWatchOutput --outDir \"build/src\" --declarationDir \"build/declarations\"\" \"gulp interactiveMocha\"",
     "test:compile:advanced": "gulp buildAdvancedCompilationTest --debug",

--- a/packages/blockly/tests/browser/.mocharc.js
+++ b/packages/blockly/tests/browser/.mocharc.js
@@ -3,4 +3,5 @@
 module.exports = {
   ui: 'tdd',
   require: __dirname + '/test/hooks.mjs',
+  spec: 'tests/browser/test/**/*_test.mjs'
 };

--- a/packages/blockly/tests/browser/.mocharc.js
+++ b/packages/blockly/tests/browser/.mocharc.js
@@ -3,5 +3,5 @@
 module.exports = {
   ui: 'tdd',
   require: __dirname + '/test/hooks.mjs',
-  spec: 'tests/browser/test/**/*_test.mjs'
+  spec: 'tests/browser/test/**/*_test.mjs',
 };


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves
This PR fixes `npm run test:browser`, which had been failing with `Error: No test files found: "test"`. I'm not entirely clear why, but it seems like Mocha was not running from the path we were `cd`ing to, I assume due to either a version change or the monorepo work. In any case, the browser tests now work correctly.