### PR TITLE
fix: Focus nearest neighbor when deleting a focused block

### DIFF
--- a/packages/blockly/core/block_svg.ts
+++ b/packages/blockly/core/block_svg.ts
@@ -932,9 +932,12 @@ export class BlockSvg
       } else {
         const nearestNeighbour = this.getNearestNeighbour();
         if (nearestNeighbour) {
-          setTimeout(() => focusManager.focusNode(nearestNeighbour), 0);
+          focusManager.focusNode(nearestNeighbour);
         } else {
-          setTimeout(() => focusManager.focusTree(this.workspace), 0);
+          setTimeout(() => {
+            if (!this.workspace.rendered) return;
+            focusManager.focusTree(this.workspace);
+          }, 0);
         }
       }
     }

--- a/packages/blockly/core/block_svg.ts
+++ b/packages/blockly/core/block_svg.ts
@@ -864,6 +864,32 @@ export class BlockSvg
   }
 
   /**
+   * Returns the closest live block to this one, if any.
+   */
+  private getNearestNeighbour() {
+    if (!this.workspace.rendered) return null;
+
+    const blocks = this.workspace
+      .getAllBlocks(false)
+      .filter((block) => !block.isDeadOrDying());
+    let nearestNeighbour = null;
+    let closestDistance = Number.MAX_SAFE_INTEGER;
+    const self = this.getRelativeToSurfaceXY();
+    for (const block of blocks) {
+      const other = block.getRelativeToSurfaceXY();
+      const distance = Math.sqrt(
+        Math.pow(other.x - self.x, 2) + Math.pow(other.y - self.y, 2),
+      );
+      if (distance < closestDistance) {
+        nearestNeighbour = block;
+        closestDistance = distance;
+      }
+    }
+
+    return nearestNeighbour;
+  }
+
+  /**
    * Dispose of this block.
    *
    * @param healStack If true, then try to heal any gap by connecting the next
@@ -904,7 +930,12 @@ export class BlockSvg
       if (parent) {
         focusManager.focusNode(parent);
       } else {
-        setTimeout(() => focusManager.focusTree(this.workspace), 0);
+        const nearestNeighbour = this.getNearestNeighbour();
+        if (nearestNeighbour) {
+          setTimeout(() => focusManager.focusNode(nearestNeighbour), 0);
+        } else {
+          setTimeout(() => focusManager.focusTree(this.workspace), 0);
+        }
       }
     }
 

--- a/packages/blockly/tests/mocha/block_test.js
+++ b/packages/blockly/tests/mocha/block_test.js
@@ -3050,5 +3050,13 @@ suite('Blocks', function () {
         'Focus should not change when an unfocused block is deleted',
       );
     });
+
+    test('Disposing a workspace with a focused block succeeds', function () {
+      Blockly.getFocusManager().focusNode(this.workspace.getTopBlocks(false)[0]);
+      this.workspace.dispose();
+      this.clock.runAll();
+
+      // No assert, this just shouldn't throw.
+    });
   });
 });

--- a/packages/blockly/tests/mocha/block_test.js
+++ b/packages/blockly/tests/mocha/block_test.js
@@ -2987,7 +2987,7 @@ suite('Blocks', function () {
     });
 
     test('Bulk deleting blocks does not focus another dying block', function () {
-      for (let i = 0; i < 50; i++) {
+      for (let i = 0; i < 5; i++) {
         this.workspace.newBlock('stack_block');
       }
 

--- a/packages/blockly/tests/mocha/block_test.js
+++ b/packages/blockly/tests/mocha/block_test.js
@@ -2987,21 +2987,36 @@ suite('Blocks', function () {
     });
 
     test('Bulk deleting blocks does not focus another dying block', function () {
+      const blocks = this.workspace.getTopBlocks(false);
       for (let i = 0; i < 5; i++) {
-        this.workspace.newBlock('stack_block');
+        blocks.push(this.workspace.newBlock('stack_block'));
       }
 
+      // Focus the last block we added; clearing the workspace proceeds in block
+      // creation order, so if we focused an earlier block, it would (correctly)
+      // assign focus to a later-added block which is not yet dying, on down the
+      // chain. If we focus the last block, by the time deletion gets to it, all
+      // the other blocks will have already been marked as disposing, and should
+      // thus be ineligible to be focused.
       Blockly.getFocusManager().focusNode(
-        this.workspace.getTopBlocks(false)[0],
+        this.workspace.getTopBlocks(false)[5],
       );
+
+      const spy = sinon.spy(Blockly.getFocusManager(), 'focusNode');
+
       this.workspace.clear();
       this.clock.runAll();
 
+      for (const block of blocks) {
+        assert.isFalse(spy.calledWith(block));
+      }
       assert.strictEqual(
         Blockly.getFocusManager().getFocusedNode(),
         this.workspace,
         'Focus should move to the workspace, not a dying peer block',
       );
+
+      spy.restore();
     });
 
     test('Deleting a block focuses its parent block', function () {

--- a/packages/blockly/tests/mocha/block_test.js
+++ b/packages/blockly/tests/mocha/block_test.js
@@ -2946,4 +2946,94 @@ suite('Blocks', function () {
       );
     });
   });
+
+  suite('Disposal focus management', function () {
+    setup(function () {
+      this.workspace = Blockly.inject('blocklyDiv');
+      const firstBlock = this.workspace.newBlock('stack_block');
+      firstBlock.moveBy(-500, -500);
+    });
+
+    test('Deleting the sole block on the workspace focuses the workspace', function () {
+      const block = this.workspace.getTopBlocks(false)[0];
+      Blockly.getFocusManager().focusNode(block);
+      block.dispose();
+      this.clock.runAll();
+
+      assert.equal(
+        Blockly.getFocusManager().getFocusedNode(),
+        this.workspace,
+        'Focus should move to the workspace when the focused block is deleted',
+      );
+    });
+
+    test('Deleting a block with several adjacent blocks focuses the closest one', function () {
+      this.workspace.newBlock('stack_block');
+      const blockMiddle = this.workspace.newBlock('stack_block');
+      const blockRight = this.workspace.newBlock('stack_block');
+      blockMiddle.moveBy(60, 0);
+      blockRight.moveBy(100, 0);
+
+      Blockly.getFocusManager().focusNode(blockMiddle);
+      blockMiddle.dispose();
+      this.clock.runAll();
+
+      const focused = Blockly.getFocusManager().getFocusedNode();
+      assert.equal(
+        focused,
+        blockRight,
+        'Focus should move to the closest remaining block (blockRight at (100, 0))',
+      );
+    });
+
+    test('Bulk deleting blocks does not focus another dying block', function () {
+      for (let i = 0; i < 50; i++) {
+        this.workspace.newBlock('stack_block');
+      }
+
+      Blockly.getFocusManager().focusNode(
+        this.workspace.getTopBlocks(false)[0],
+      );
+      this.workspace.clear();
+      this.clock.runAll();
+
+      assert.equal(
+        Blockly.getFocusManager().getFocusedNode(),
+        this.workspace,
+        'Focus should move to the workspace, not a dying peer block',
+      );
+    });
+
+    test('Deleting a block focuses its parent block', function () {
+      const parent = this.workspace.newBlock('stack_block');
+      const child = this.workspace.newBlock('stack_block');
+      parent.nextConnection.connect(child.previousConnection);
+
+      Blockly.getFocusManager().focusNode(child);
+      child.dispose();
+      this.clock.runAll();
+
+      assert.equal(
+        Blockly.getFocusManager().getFocusedNode(),
+        parent,
+        'Focus should move to the parent block when a connected child is deleted',
+      );
+    });
+
+    test('Deleting an unfocused block does not change focus', function () {
+      const a = this.workspace.getTopBlocks(false)[0];
+      const b = this.workspace.newBlock('stack_block');
+      this.workspace.newBlock('stack_block');
+
+      Blockly.getFocusManager().focusNode(a);
+      b.dispose();
+      this.clock.runAll();
+
+      assert.equal(
+        Blockly.getFocusManager().getFocusedNode(),
+        a,
+        'Focus should not change when an unfocused block is deleted',
+      );
+    });
+  });
 });

--- a/packages/blockly/tests/mocha/block_test.js
+++ b/packages/blockly/tests/mocha/block_test.js
@@ -3052,7 +3052,9 @@ suite('Blocks', function () {
     });
 
     test('Disposing a workspace with a focused block succeeds', function () {
-      Blockly.getFocusManager().focusNode(this.workspace.getTopBlocks(false)[0]);
+      Blockly.getFocusManager().focusNode(
+        this.workspace.getTopBlocks(false)[0],
+      );
       this.workspace.dispose();
       this.clock.runAll();
 

--- a/packages/blockly/tests/mocha/block_test.js
+++ b/packages/blockly/tests/mocha/block_test.js
@@ -2960,7 +2960,7 @@ suite('Blocks', function () {
       block.dispose();
       this.clock.runAll();
 
-      assert.equal(
+      assert.strictEqual(
         Blockly.getFocusManager().getFocusedNode(),
         this.workspace,
         'Focus should move to the workspace when the focused block is deleted',
@@ -2979,7 +2979,7 @@ suite('Blocks', function () {
       this.clock.runAll();
 
       const focused = Blockly.getFocusManager().getFocusedNode();
-      assert.equal(
+      assert.strictEqual(
         focused,
         blockRight,
         'Focus should move to the closest remaining block (blockRight at (100, 0))',
@@ -2997,7 +2997,7 @@ suite('Blocks', function () {
       this.workspace.clear();
       this.clock.runAll();
 
-      assert.equal(
+      assert.strictEqual(
         Blockly.getFocusManager().getFocusedNode(),
         this.workspace,
         'Focus should move to the workspace, not a dying peer block',
@@ -3013,7 +3013,7 @@ suite('Blocks', function () {
       child.dispose();
       this.clock.runAll();
 
-      assert.equal(
+      assert.strictEqual(
         Blockly.getFocusManager().getFocusedNode(),
         parent,
         'Focus should move to the parent block when a connected child is deleted',
@@ -3029,7 +3029,7 @@ suite('Blocks', function () {
       b.dispose();
       this.clock.runAll();
 
-      assert.equal(
+      assert.strictEqual(
         Blockly.getFocusManager().getFocusedNode(),
         a,
         'Focus should not change when an unfocused block is deleted',


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #9585

### Proposed Changes
This PR adjusts the focus behavior when a focused block is deleted. Previously, deleting a focused block would focus the workspace, which would in turn focus the first (left/topmost)  block on the workspace. This could cause large jumps in scroll position. Now, when a focused block is deleted, it moves focus to the closest remaining block, resulting in a smaller (or no) workspace movement.

The tests were partially LLM-generated in response to a list of testcases I specified. I reviewed, modified them, and manually added an additional testcase.