### PR TITLE
fix: Fix a bug that could cause menus to scroll incorrectly on mouseover

### DIFF
--- a/packages/blockly/core/css.ts
+++ b/packages/blockly/core/css.ts
@@ -456,6 +456,7 @@ input[type=number] {
   height: 16px;
   position: absolute;
   width: 16px;
+  display: none;
 }
 
 .blocklyMenuItemSelected .blocklyMenuItemCheckbox {
@@ -463,6 +464,7 @@ input[type=number] {
   float: left;
   margin-left: -24px;
   position: static;  /* Scroll with the menu. */
+  display: block;
 }
 
 .blocklyMenuItemRtl .blocklyMenuItemCheckbox {

--- a/packages/blockly/core/css.ts
+++ b/packages/blockly/core/css.ts
@@ -452,17 +452,12 @@ input[type=number] {
 }
 
 /* State: selected/checked. */
-.blocklyMenuItemCheckbox {
-  height: 16px;
-  position: absolute;
-  width: 16px;
-  display: none;
-}
-
 .blocklyMenuItemSelected .blocklyMenuItemCheckbox {
   background: url(<<<PATH>>>/sprites.png) no-repeat -48px -16px;
   float: left;
   margin-left: -24px;
+  width: 16px;
+  height: 16px;
   position: static;  /* Scroll with the menu. */
   display: block;
 }


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Proposed Changes
This PR resolves an issue that caused lengthy dropdown menus to jump/scroll and momentarily display the wrong item as selected on mouseover. Scratch reported this in the variable dropdown, but it affected core as well.