### PR TITLE
feat: Add support for going to the beginning of a block

### DIFF
--- a/packages/blockly/core/block_svg.ts
+++ b/packages/blockly/core/block_svg.ts
@@ -1819,6 +1819,36 @@ export class BlockSvg
     return this.dragStrategy.isMovable();
   }
 
+  /** Returns whether the block fully fits within the boundaries of the workspace */
+  isBlockFullyInBounds(): boolean {
+    let blockLeft;
+    let blockRight;
+    const {left, top, width, height} = this.workspace
+      .getMetricsManager()
+      .getViewMetrics(true);
+
+    const xy = this.getRelativeToSurfaceXY();
+    const {width: blockWidth, height: blockHeight} = this.getHeightWidth();
+
+    if (this.RTL) {
+      blockLeft = xy.x - blockWidth;
+      blockRight = xy.x;
+    } else {
+      blockLeft = xy.x;
+      blockRight = xy.x + blockWidth;
+    }
+
+    const blockTop = xy.y;
+    const blockBottom = xy.y + blockHeight;
+
+    return (
+      blockLeft >= left &&
+      blockRight <= left + width &&
+      blockTop >= top &&
+      blockBottom <= top + height
+    );
+  }
+
   /** Starts a drag on the block. */
   startDrag(e?: PointerEvent): void {
     this.dragStrategy.startDrag(e);

--- a/packages/blockly/core/workspace_svg.ts
+++ b/packages/blockly/core/workspace_svg.ts
@@ -1987,9 +1987,8 @@ export class WorkspaceSvg
    *
    * @param id ID of block center on.
    * @param blockOnly True to center only on the block itself, not its stack.
-   * @param centerOnBlockStart It is correct to center only on the block itself at its beginning.
    */
-  centerOnBlock(id: string | null, blockOnly?: boolean, centerOnBlockStart?: boolean) {
+  centerOnBlock(id: string | null, blockOnly?: boolean) {
     if (!this.isMovable()) {
       console.warn(
         'Tried to move a non-movable workspace. This could result' +
@@ -2011,9 +2010,9 @@ export class WorkspaceSvg
       : block.getHeightWidth();
 
     // Find the enter of the block in workspace units.
-    const blockCenterY = centerOnBlockStart
-      ? xy.y
-      : xy.y + heightWidth.height / 2;
+    const blockCenterY = block.isBlockFullyInBounds()
+      ? xy.y + heightWidth.height / 2
+      : xy.y;
 
     // In RTL the block's position is the top right of the block, not top left.
     const multiplier = this.RTL ? -1 : 1;

--- a/packages/blockly/core/workspace_svg.ts
+++ b/packages/blockly/core/workspace_svg.ts
@@ -1987,8 +1987,9 @@ export class WorkspaceSvg
    *
    * @param id ID of block center on.
    * @param blockOnly True to center only on the block itself, not its stack.
+   * @param centerOnBlockStart It is correct to center only on the block itself at its beginning.
    */
-  centerOnBlock(id: string | null, blockOnly?: boolean) {
+  centerOnBlock(id: string | null, blockOnly?: boolean, centerOnBlockStart?: boolean) {
     if (!this.isMovable()) {
       console.warn(
         'Tried to move a non-movable workspace. This could result' +
@@ -2010,7 +2011,9 @@ export class WorkspaceSvg
       : block.getHeightWidth();
 
     // Find the enter of the block in workspace units.
-    const blockCenterY = xy.y + heightWidth.height / 2;
+    const blockCenterY = centerOnBlockStart
+      ? xy.y
+      : xy.y + heightWidth.height / 2;
 
     // In RTL the block's position is the top right of the block, not top left.
     const multiplier = this.RTL ? -1 : 1;

--- a/packages/blockly/tests/mocha/workspace_svg_test.js
+++ b/packages/blockly/tests/mocha/workspace_svg_test.js
@@ -314,6 +314,21 @@ suite('WorkspaceSvg', function () {
           this.clock,
         );
       });
+      test('centerOnBlock when block partially out of bounds', function () {
+        const block = this.workspace.newBlock('stack_block');
+        block.initSvg();
+        block.render();
+
+        sinon.stub(block, 'getRelativeToSurfaceXY').returns({x: 10, y: 80});
+        sinon.stub(block, 'getHeightWidth').returns({width: 40, height: 40});
+
+        runViewportEventTest(
+          () => this.workspace.centerOnBlock(block.id),
+          this.changeListenerSpy,
+          this.workspace,
+          this.clock,
+        );
+      });
     });
     suite('Blocks triggering viewport changes', function () {
       test('block move that triggers scroll', function () {


### PR DESCRIPTION
## The basics

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

Fixes https://github.com/RaspberryPiFoundation/blockly/issues/9628

### Proposed Changes

Allows you to center a block at its beginning.

### Reason for Changes

Centering takes place in the center of the block, which is inconvenient, for example, when switching to defining a procedure.
<img width="1227" height="535" alt="image" src="https://github.com/user-attachments/assets/6c1b3e75-1ca5-4fee-9eb0-6e94a3a511cd" />

You can use the changes to go to the beginning.
<img width="1230" height="532" alt="image" src="https://github.com/user-attachments/assets/9e41f407-02f9-434a-bc78-fe3dfd6a3062" />





### Test Coverage

The changes do not affect existing tests and do not require writing new ones.

### Documentation

JSDoc has been updated
https://developers.google.com/blockly/reference/js/blockly.workspacesvg_class.centeronblock_1_method?hl=it

### Additional Information

No
