### PR TITLE
fix: Fix bug that caused blocks to become disconnected when undoing deletions

### DIFF
--- a/packages/blockly/core/connection.ts
+++ b/packages/blockly/core/connection.ts
@@ -291,10 +291,7 @@ export class Connection {
     }
 
     let event;
-    if (
-      eventUtils.isEnabled() &&
-      !childConnection.getSourceBlock().isDeadOrDying()
-    ) {
+    if (eventUtils.isEnabled()) {
       event = new (eventUtils.get(EventType.BLOCK_MOVE))(
         childConnection.getSourceBlock(),
       ) as BlockMove;


### PR DESCRIPTION

<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #9616

### Proposed Changes
This PR reverts part of #9563 which turns out to have been unnecessary and caused a bug whereby blocks would appear disconnected when deleting a block that was connected to another and then undoing. The original issue remains fixed with these changes.