### PR TITLE
chore: add a deploy key to allow pushing to main

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -79,6 +79,7 @@ jobs:
         uses: actions/checkout@v5
         with:
           fetch-depth: 0
+          ssh-key: ${{ secrets.DEPLOY_PRIVATE_KEY }}
 
       - name: Download versioned files
         uses: actions/download-artifact@v4


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [ ] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->


### Proposed Changes

- Adds a deploy key to the publish workflow
- 
### Reason for Changes

I've added a private deploy key to the environment secrets, and allowed the deploy key to be exempt from the ruleset that says PRs are required.

Thanks to this github discussion for the idea:

https://github.com/orgs/community/discussions/25305#discussioncomment-10728028

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
