### PR TITLE
chore: add option to publish the package without bumping version

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,7 +4,14 @@ on:
   workflow_dispatch:
     inputs:
       dry_run:
-        description: 'Dry run'
+        description: 'Dry run - print the version that would be published, but do not commit or publish anything.'
+        required: false
+        default: false
+        type: boolean
+      skip_versioning:
+        description: >
+          Skip version bump - use the version already in the repo
+          (e.g. retry after npm publish failed but the release commit is already pushed).
         required: false
         default: false
         type: boolean
@@ -36,10 +43,12 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
 
       - name: Install dependencies
+        if: ${{ !inputs.skip_versioning }}
         run: npm ci
 
       - name: Determine version bump
         id: bump
+        if: ${{ !inputs.skip_versioning }}
         working-directory: packages/blockly
         run: |
           RELEASE_TYPE=$(npx conventional-recommended-bump --preset conventionalcommits -t blockly-)
@@ -47,21 +56,20 @@ jobs:
           echo "Recommended bump: $RELEASE_TYPE"
 
       - name: Apply version bump
+        if: ${{ !inputs.skip_versioning }}
         working-directory: packages/blockly
         run: npm version ${{ steps.bump.outputs.release_type }} --no-git-tag-version
 
-      - name: Read new version
+      - name: Read package version
         id: version
         working-directory: packages/blockly
         run: |
           VERSION=$(node -p "require('./package.json').version")
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-          echo "New version: $VERSION"
-
-      - name: Update lockfile
-        run: npm install
+          echo "Version: $VERSION"
 
       - name: Upload versioned files
+        if: ${{ !inputs.skip_versioning }}
         uses: actions/upload-artifact@v4
         with:
           name: versioned-files
@@ -82,11 +90,13 @@ jobs:
           ssh-key: ${{ secrets.DEPLOY_PRIVATE_KEY }}
 
       - name: Download versioned files
+        if: ${{ !inputs.skip_versioning }}
         uses: actions/download-artifact@v4
         with:
           name: versioned-files
 
       - name: Commit and push version bump
+        if: ${{ !inputs.skip_versioning }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
@@ -109,7 +119,7 @@ jobs:
 
       - name: Publish to npm
         working-directory: packages/blockly/dist
-        run: npm publish
+        run: npm publish --verbose
 
       - name: Create tarball
         working-directory: packages/blockly


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [ ] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes 

### Proposed Changes

- Adds a workflow option to skip versioning step. This is used when committing a version bump has succeeded, but publishing hasn't. You can retry just publishing without bumping the version number again.
- Adds a description to dry run param
- Removes the `npm install` step after running `npm version`. Ostensibly it was to update the `package-lock.json` file with the new version number, but I verified that that is already done by `npm version`, and running `npm install` might update the versions of dependencies unnecessarily since we weren't using `npm ci`.
- publish in verbose mode to hopefully figure out why publishing failed

### Reason for Changes

Attempting to publish again

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
