### PR TITLE
feat: Stop on workspace during constrained move

### DIFF
--- a/packages/blockly/core/dragging/block_drag_strategy.ts
+++ b/packages/blockly/core/dragging/block_drag_strategy.ts
@@ -573,18 +573,13 @@ export class BlockDragStrategy implements IDragStrategy {
       const direction = this.getDirectionToNewLocation(
         Coordinate.sum(this.startLoc!, delta),
       );
-      const candidate = this.findTraversalCandidate(direction);
-      if (candidate) {
-        return candidate;
-      }
-
-      delta = new Coordinate(0, 0);
+      return this.findTraversalCandidate(direction);
     }
 
     // If we do not have a candidate yet, we fallback to the closest one nearby.
     let radius = this.getSearchRadius();
     const localConns = this.getLocalConnections(this.block);
-    let candidate = null;
+    let candidate: ConnectionCandidate | null = null;
 
     for (const conn of localConns) {
       const {connection: neighbour, radius: rad} = conn.closest(radius, delta);
@@ -775,30 +770,40 @@ export class BlockDragStrategy implements IDragStrategy {
    * @returns A candidate connection and radius, or null if none was found.
    */
   findTraversalCandidate(direction: Direction): ConnectionCandidate | null {
-    const currentPairIndex = this.allConnectionPairs.findIndex(
+    const pairs = this.allConnectionPairs;
+    if (direction === Direction.NONE || !pairs.length) {
+      return this.connectionCandidate;
+    }
+    const forwardTraversal =
+      direction === Direction.RIGHT || direction === Direction.DOWN;
+    const currentPairIndex = pairs.findIndex(
       (pair) =>
         this.connectionCandidate?.local === pair.local &&
         this.connectionCandidate?.neighbour === pair.neighbour,
     );
-    if (currentPairIndex !== -1) {
-      if (direction === Direction.UP || direction === Direction.LEFT) {
-        const nextPair =
-          this.allConnectionPairs[currentPairIndex - 1] ??
-          this.allConnectionPairs[this.allConnectionPairs.length - 1];
-        return {...nextPair, distance: 0};
-      } else if (
-        direction === Direction.DOWN ||
-        direction === Direction.RIGHT
-      ) {
-        const nextPair =
-          this.allConnectionPairs[currentPairIndex + 1] ??
-          this.allConnectionPairs[0];
-        return {...nextPair, distance: 0};
+
+    if (forwardTraversal) {
+      if (currentPairIndex === -1) {
+        return this.pairToCandidate(pairs[0]);
+      } else if (currentPairIndex === pairs.length - 1) {
+        return null;
+      } else {
+        return this.pairToCandidate(pairs[currentPairIndex + 1]);
+      }
+    } else {
+      if (currentPairIndex === -1) {
+        return this.pairToCandidate(pairs[pairs.length - 1]);
+      } else if (currentPairIndex === 0) {
+        return null;
+      } else {
+        return this.pairToCandidate(pairs[currentPairIndex - 1]);
       }
     }
-    return null;
   }
 
+  private pairToCandidate(pair: ConnectionPair): ConnectionCandidate {
+    return {...pair, distance: 0};
+  }
   /**
    * Returns the cardinal direction that the block being dragged would have to
    * move in to reach the given location.

--- a/packages/blockly/tests/mocha/keyboard_movement_test.js
+++ b/packages/blockly/tests/mocha/keyboard_movement_test.js
@@ -583,6 +583,7 @@ suite('Keyboard-driven movement', function () {
           {id: 'controls_if', index: 6, ownIndex: 0}, // "Else" statement input.
           {id: 'controls_if', index: 1, ownIndex: 0}, // Next.
           {id: 'p5_draw', index: 0, ownIndex: 0}, // Statement input.
+          null, // Disconnected on workspace
         ];
         /**
          * Expected connection candidates when moving STATEMENT_SIMPLE after
@@ -653,6 +654,7 @@ suite('Keyboard-driven movement', function () {
           {id: 'controls_if', index: 6, ownIndex: 0}, // "Else" statement input.
           {id: 'controls_if', index: 1, ownIndex: 0}, // Next.
           {id: 'p5_draw', index: 0, ownIndex: 0}, // Statement input.
+          null, // Disconnected on workspace
         ];
         /**
          * Expected connection candidates when moving STATEMENT_COMPLEX after
@@ -761,6 +763,7 @@ suite('Keyboard-driven movement', function () {
           {id: 'join2', index: 1, ownIndex: 0}, // Join block ADD0 input.
           {id: 'join2', index: 2, ownIndex: 0}, // Join block ADD1 input.
           // Skip input of unattached join block.
+          null, // Disconnected on workspace
         ];
         /**
          * Expected connection candidates when moving BLOCK_SIMPLE, after


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes https://github.com/RaspberryPiFoundation/blockly/issues/9619

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
This updates traversal logic during constrained move mode by adding a disconnected-on-workspace (ie. `null`) stop to the end of the list. As the user uses the arrow keys to traverse valid connections between the dragging block and compatible neighbors, they can/will eventually find the block disconnected. At that point, we will be provide the hint for unconstrained move mode. If the user continues to use the (unmodified) arrow keys, we will wrap to the other end of the list of connection pairs.

With this change, it's now expected that a block might be disconnected on the workspace during traversal. As such, we will no longer attempt to immediately find a nearby connections for a disconnected block that begins moving. 

I considered adding `null` or some sentinel value to the list of `allConnectionPairs`. This could simplify some of the traversal logic, but would make other parts harder to reason about. The approach presented here keeps logic delegated to `findTraversalCandidate`.

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
As stated in the linked issue:
> Constrained moves should offer a possible "connection" point as being disconnected as a top level block.

### Test Coverage

Tests were updated to reflect the additional traversal stop, represented again as `null`.

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->

### Documentation

N/A
<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
We will not attempt to find a perfect disconnected location (e.g. positioned beside other blocks, avoid overlaps on a cluttered workspace. Instead we simply keep the block at its previous location - either before or after all the blocks normally reachable during traversal.