### PR TITLE
chore: remove unused gulp helpers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1564,7 +1564,6 @@
         "gulp-concat": "^2.6.1",
         "gulp-gzip": "^1.4.2",
         "gulp-header": "^2.0.9",
-        "gulp-insert": "^0.5.0",
         "gulp-rename": "^2.0.0",
         "gulp-replace": "^1.0.0",
         "gulp-series": "^1.0.2",
@@ -6254,36 +6253,6 @@
         "xtend": "~4.0.1"
       }
     },
-    "packages/blockly/node_modules/gulp-insert": {
-      "version": "0.5.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "readable-stream": "^1.0.26-4",
-        "streamqueue": "0.0.6"
-      }
-    },
-    "packages/blockly/node_modules/gulp-insert/node_modules/isarray": {
-      "version": "0.0.1",
-      "dev": true,
-      "license": "MIT"
-    },
-    "packages/blockly/node_modules/gulp-insert/node_modules/readable-stream": {
-      "version": "1.1.14",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.1",
-        "isarray": "0.0.1",
-        "string_decoder": "~0.10.x"
-      }
-    },
-    "packages/blockly/node_modules/gulp-insert/node_modules/string_decoder": {
-      "version": "0.10.31",
-      "dev": true,
-      "license": "MIT"
-    },
     "packages/blockly/node_modules/gulp-rename": {
       "version": "2.1.0",
       "dev": true,
@@ -8995,37 +8964,6 @@
       "dependencies": {
         "any-promise": "^1.1.0"
       }
-    },
-    "packages/blockly/node_modules/streamqueue": {
-      "version": "0.0.6",
-      "dev": true,
-      "dependencies": {
-        "readable-stream": "^1.0.26-2"
-      },
-      "engines": {
-        "node": ">= 0.10.0"
-      }
-    },
-    "packages/blockly/node_modules/streamqueue/node_modules/isarray": {
-      "version": "0.0.1",
-      "dev": true,
-      "license": "MIT"
-    },
-    "packages/blockly/node_modules/streamqueue/node_modules/readable-stream": {
-      "version": "1.1.14",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.1",
-        "isarray": "0.0.1",
-        "string_decoder": "~0.10.x"
-      }
-    },
-    "packages/blockly/node_modules/streamqueue/node_modules/string_decoder": {
-      "version": "0.10.31",
-      "dev": true,
-      "license": "MIT"
     },
     "packages/blockly/node_modules/string_decoder": {
       "version": "1.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1566,7 +1566,6 @@
         "gulp-header": "^2.0.9",
         "gulp-rename": "^2.0.0",
         "gulp-replace": "^1.0.0",
-        "gulp-shell": "^0.8.0",
         "gulp-sourcemaps": "^3.0.0",
         "gulp-umd": "^2.0.0",
         "http-server": "^14.0.0",
@@ -6275,43 +6274,6 @@
         "node": ">=10"
       }
     },
-    "packages/blockly/node_modules/gulp-shell": {
-      "version": "0.8.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "chalk": "^3.0.0",
-        "fancy-log": "^1.3.3",
-        "lodash.template": "^4.5.0",
-        "plugin-error": "^1.0.1",
-        "through2": "^3.0.1",
-        "tslib": "^1.10.0"
-      },
-      "engines": {
-        "node": ">=10.0.0"
-      }
-    },
-    "packages/blockly/node_modules/gulp-shell/node_modules/chalk": {
-      "version": "3.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "packages/blockly/node_modules/gulp-shell/node_modules/through2": {
-      "version": "3.0.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "inherits": "^2.0.4",
-        "readable-stream": "2 || 3"
-      }
-    },
     "packages/blockly/node_modules/gulp-sourcemaps": {
       "version": "3.0.0",
       "dev": true,
@@ -9229,11 +9191,6 @@
       "peerDependencies": {
         "typescript": ">=4.8.4"
       }
-    },
-    "packages/blockly/node_modules/tslib": {
-      "version": "1.14.1",
-      "dev": true,
-      "license": "0BSD"
     },
     "packages/blockly/node_modules/type": {
       "version": "1.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1566,7 +1566,6 @@
         "gulp-header": "^2.0.9",
         "gulp-rename": "^2.0.0",
         "gulp-replace": "^1.0.0",
-        "gulp-series": "^1.0.2",
         "gulp-shell": "^0.8.0",
         "gulp-sourcemaps": "^3.0.0",
         "gulp-umd": "^2.0.0",
@@ -6275,11 +6274,6 @@
       "engines": {
         "node": ">=10"
       }
-    },
-    "packages/blockly/node_modules/gulp-series": {
-      "version": "1.0.2",
-      "dev": true,
-      "license": "MIT"
     },
     "packages/blockly/node_modules/gulp-shell": {
       "version": "0.8.0",

--- a/packages/blockly/package.json
+++ b/packages/blockly/package.json
@@ -128,7 +128,6 @@
     "gulp-header": "^2.0.9",
     "gulp-rename": "^2.0.0",
     "gulp-replace": "^1.0.0",
-    "gulp-series": "^1.0.2",
     "gulp-shell": "^0.8.0",
     "gulp-sourcemaps": "^3.0.0",
     "gulp-umd": "^2.0.0",

--- a/packages/blockly/package.json
+++ b/packages/blockly/package.json
@@ -128,7 +128,6 @@
     "gulp-header": "^2.0.9",
     "gulp-rename": "^2.0.0",
     "gulp-replace": "^1.0.0",
-    "gulp-shell": "^0.8.0",
     "gulp-sourcemaps": "^3.0.0",
     "gulp-umd": "^2.0.0",
     "http-server": "^14.0.0",

--- a/packages/blockly/package.json
+++ b/packages/blockly/package.json
@@ -126,7 +126,6 @@
     "gulp-concat": "^2.6.1",
     "gulp-gzip": "^1.4.2",
     "gulp-header": "^2.0.9",
-    "gulp-insert": "^0.5.0",
     "gulp-rename": "^2.0.0",
     "gulp-replace": "^1.0.0",
     "gulp-series": "^1.0.2",


### PR DESCRIPTION

## The basics

Cleanup.

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves
Removes unused dev dependencies.

### Proposed Changes

Removes:
- `gulp-insert`
- `gulp-series`
- `gulp-shell`

### Reason for Changes

No longer in use.
