### PR TITLE
chore: Remove the keyboard-navigation plugin from the advanced playground

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1986,7 +1986,6 @@
       "devDependencies": {
         "@blockly/block-test": "^7.0.2",
         "@blockly/dev-tools": "^9.0.2",
-        "@blockly/keyboard-navigation": "^3.0.1",
         "@blockly/theme-modern": "^7.0.1",
         "@hyperjump/browser": "^1.1.4",
         "@hyperjump/json-schema": "^1.5.0",
@@ -2143,14 +2142,6 @@
       "license": "MIT",
       "engines": {
         "node": "*"
-      }
-    },
-    "packages/blockly/node_modules/@blockly/keyboard-navigation": {
-      "version": "3.0.1",
-      "dev": true,
-      "license": "Apache-2.0",
-      "peerDependencies": {
-        "blockly": "^12.3.0"
       }
     },
     "packages/blockly/node_modules/@blockly/theme-dark": {

--- a/packages/blockly/package.json
+++ b/packages/blockly/package.json
@@ -105,7 +105,6 @@
   "devDependencies": {
     "@blockly/block-test": "^7.0.2",
     "@blockly/dev-tools": "^9.0.2",
-    "@blockly/keyboard-navigation": "^3.0.1",
     "@blockly/theme-modern": "^7.0.1",
     "@hyperjump/browser": "^1.1.4",
     "@hyperjump/json-schema": "^1.5.0",

--- a/packages/blockly/tests/playgrounds/advanced_playground.html
+++ b/packages/blockly/tests/playgrounds/advanced_playground.html
@@ -18,9 +18,6 @@
       await loadScript(
         '../../node_modules/@blockly/theme-modern/dist/index.js',
       );
-      await loadScript(
-        '../../node_modules/@blockly/keyboard-navigation/dist/index.js',
-      );
 
       let kbNavigation;
 
@@ -52,28 +49,6 @@
             // Refresh theme.
             ws.setTheme(ws.getTheme());
           });
-
-        // Keyboard navigation options.
-        const kbOptions = {
-          'Enable keyboard navigation': false,
-        };
-        gui.remember(kbOptions);
-        gui.add(kbOptions, 'Enable keyboard navigation').onChange((enabled) => {
-          setupKeyboardNav(enabled, playground);
-        });
-
-        // Set up keyboard navigation on page load
-        setupKeyboardNav(kbOptions['Enable keyboard navigation'], playground);
-      }
-
-      function setupKeyboardNav(enabled, playground) {
-        if (enabled) {
-          kbNavigation = new KeyboardNavigation(playground.getWorkspace());
-        } else {
-          if (kbNavigation) {
-            kbNavigation.dispose();
-          }
-        }
       }
 
       function initPlayground() {
@@ -128,8 +103,6 @@
         };
 
         Blockly.ContextMenuItems.registerCommentOptions();
-        KeyboardNavigation.registerKeyboardNavigationStyles();
-        // TODO: register the navigation-deferring toolbox.
 
         createPlayground(
           document.getElementById('root'),


### PR DESCRIPTION

<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves
Now that keyboard navigation is being backported into core, the keyboard navigation plugin is unnecessary and actively conflicts with the built-in behavior in the advanced playground. This PR removes the dependency on the plugin in favor of the built-in behavior, which is available by default in the advanced playground, as well as the normal and multi variants.