### PR TITLE
chore: add copilot instructions for code reviews

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,38 @@
+# Code review guidelines
+
+## General principles
+- **Style:** Suggest `npm run format` or `npm run lint:fix` for formatting issues; do not comment on individual style nits.
+- **Patterns:** Enforce existing Blockly patterns and official docs over new conventions.
+- **Documentation:** Prefer linking to [Blockly Dev Docs](https://developers.google.com/blockly) over duplicating content in comments.
+- **TSDoc:** Public APIs require TSDoc for behavior, params, and returns. Do not include implementation details or historical context unless essential.
+
+## Localization
+- All user-visible strings must use `Blockly.Msg`.
+- New strings must be added to `msg/messages.js`, `msg/json/qqq.json`, and `msg/json/en.json`.
+- Link [this guide](https://developers.google.com/blockly/guides/contribute/core/add_localization_token) if strings are missing or misplaced.
+- PRs that attempt to add translations for non-English strings should be redirected to TranslateWiki via the ([translation guide](hhttps://developers.google.com/blockly/guides/contribute/core/translating)).
+
+## Breaking changes
+### Policy
+- A breaking change is any non-backwards-compatible change to public APIs, behavior, UI, or browser requirements.
+- **Avoid:** Prefer deprecation with migration paths over removal. 
+- **Compatibility:** Must support Safari 15.4+, latest Chrome, and latest Firefox.
+- **Identification:** Flag breaking changes unless all of the following are true:
+  1. PR description explicitly notes it.
+  2. Commit type includes `!` (e.g., `feat!:`).
+  3. Target branch is not `main`.
+
+### Breaking
+- Removing/renaming public methods, properties, or classes.
+- Changing signatures or behavior of existing public methods.
+- Adding required methods to public interfaces.
+- New keyboard shortcuts or context menu items (potential developer conflicts).
+- DOM restructures affecting external CSS/JS.
+- Changes to build output/consumption (e.g., ESM-only).
+- Changes that affect the output of serialization.
+
+### Non-breaking (do not flag)
+- Additive changes (new methods/properties).
+- Internal refactoring (including items marked `@internal`).
+- Tooling/workflow changes.
+- Changes to unreleased code (non-`main` feature branches).


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves



### Proposed Changes

Adds some copilot instructions to hopefully help copilot give better code reviews.

### Reason for Changes

Copilot kinda sucks at reviewing blockly PRs right now. Added some instructions but I'm just guessing on what works here.

Copilot reviewer is limited to the first 4000 characters of instructions, so this is pretty terse and there is not a lot of background info about the repo, etc. We could put some of that in `agents.md` files instead to help people using copilot for authoring code. This is focused on code review.

There is definitely some recency bias in issues we've seen lately with PRs from contributors (breaking changes, translation, etc) so feel free to suggest things I'm missing

### Test Coverage

n/a

### Documentation

n/a

### Additional Information

<!-- Anything else we should know? -->
