### PR TITLE
chore: add ability to publish prereleases

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,6 +27,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
         with:
+          ref: ${{ github.ref }}
           persist-credentials: false
 
       - name: Reconfigure git to use HTTP authentication
@@ -58,6 +59,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
+        with:
+          ref: ${{ github.ref }}
 
       - name: Use Node.js 20.x
         uses: actions/setup-node@v5
@@ -75,6 +78,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
+        with:
+          ref: ${{ github.ref }}
 
       - name: Use Node.js 20.x
         uses: actions/setup-node@v5

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -93,8 +93,8 @@ jobs:
               minor) npm version preminor --preid=beta --no-git-tag-version ;;
               patch) npm version prepatch --preid=beta --no-git-tag-version ;;
               *)
-                echo "Unexpected release_type='${RELEASE_TYPE}', defaulting to prepatch"
-                npm version prepatch --preid=beta --no-git-tag-version
+                echo "::error title=Invalid release bump::conventional-recommended-bump returned '${RELEASE_TYPE}' (expected major, minor, or patch). Fix commits/tags or set version_override." >&2
+                exit 1
                 ;;
             esac
           fi

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,17 +4,27 @@ on:
   workflow_dispatch:
     inputs:
       dry_run:
-        description: 'Dry run - print the version that would be published, but do not commit or publish anything.'
+        description: >
+          Dry run — print the version and npm dist-tag that would be used; no commit or publish.
+          Pick the branch to publish from with the "Use workflow from" dropdown.
+          Non-default branches publish to the npm dist-tag `beta` (not `latest`).
         required: false
         default: false
         type: boolean
       skip_versioning:
         description: >
-          Skip version bump - use the version already in the repo
+          Skip version bump — use the version already in the repo
           (e.g. retry after npm publish failed but the release commit is already pushed).
         required: false
         default: false
         type: boolean
+      version_override:
+        description: >
+          Optional. Full semver to publish (e.g. 12.6.0-beta.2). Skips conventional bump when set.
+          Leave empty for automatic versioning.
+        required: false
+        default: ''
+        type: string
 
 permissions:
   contents: write
@@ -34,6 +44,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
         with:
+          ref: ${{ github.ref }}
           fetch-depth: 0
 
       - name: Setup Node.js
@@ -48,7 +59,7 @@ jobs:
 
       - name: Determine version bump
         id: bump
-        if: ${{ !inputs.skip_versioning }}
+        if: ${{ !inputs.skip_versioning && inputs.version_override == '' }}
         working-directory: packages/blockly
         run: |
           RELEASE_TYPE=$(npx conventional-recommended-bump --preset conventionalcommits -t blockly-)
@@ -58,7 +69,35 @@ jobs:
       - name: Apply version bump
         if: ${{ !inputs.skip_versioning }}
         working-directory: packages/blockly
-        run: npm version ${{ steps.bump.outputs.release_type }} --no-git-tag-version
+        env:
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          REF_NAME: ${{ github.ref_name }}
+          RELEASE_TYPE: ${{ steps.bump.outputs.release_type }}
+          VERSION_OVERRIDE: ${{ inputs.version_override }}
+        run: |
+          set -euo pipefail
+          if [ -n "${VERSION_OVERRIDE}" ]; then
+            npm version "${VERSION_OVERRIDE}" --no-git-tag-version
+            exit 0
+          fi
+          if [ "${REF_NAME}" = "${DEFAULT_BRANCH}" ]; then
+            npm version "${RELEASE_TYPE}" --no-git-tag-version
+            exit 0
+          fi
+          VERSION=$(node -p "require('./package.json').version")
+          if [[ "${VERSION}" == *"-beta."* ]]; then
+            npm version prerelease --preid=beta --no-git-tag-version
+          else
+            case "${RELEASE_TYPE}" in
+              major) npm version premajor --preid=beta --no-git-tag-version ;;
+              minor) npm version preminor --preid=beta --no-git-tag-version ;;
+              patch) npm version prepatch --preid=beta --no-git-tag-version ;;
+              *)
+                echo "Unexpected release_type='${RELEASE_TYPE}', defaulting to prepatch"
+                npm version prepatch --preid=beta --no-git-tag-version
+                ;;
+            esac
+          fi
 
       - name: Read package version
         id: version
@@ -67,6 +106,15 @@ jobs:
           VERSION=$(node -p "require('./package.json').version")
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "Version: $VERSION"
+
+      - name: Dry run summary
+        if: ${{ inputs.dry_run }}
+        run: |
+          DIST_TAG="${{ github.ref_name == github.event.repository.default_branch && 'latest' || 'beta' }}"
+          echo "Dry run: would publish version ${{ steps.version.outputs.version }} to npm dist-tag: ${DIST_TAG}"
+          if [ "${{ github.ref_name }}" != "${{ github.event.repository.default_branch }}" ]; then
+            echo "GitHub release would be created as prerelease."
+          fi
 
       - name: Upload versioned files
         if: ${{ !inputs.skip_versioning }}
@@ -82,10 +130,13 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ !inputs.dry_run }}
     environment: release
+    env:
+      NPM_DIST_TAG: ${{ github.ref_name == github.event.repository.default_branch && 'latest' || 'beta' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v5
         with:
+          ref: ${{ github.ref }}
           fetch-depth: 0
           ssh-key: ${{ secrets.DEPLOY_PRIVATE_KEY }}
 
@@ -119,7 +170,7 @@ jobs:
 
       - name: Publish to npm
         working-directory: packages/blockly/dist
-        run: npm publish --verbose
+        run: npm publish --tag "${NPM_DIST_TAG}" --verbose
 
       - name: Create tarball
         working-directory: packages/blockly
@@ -131,7 +182,15 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           TARBALL="blockly-${{ needs.version.outputs.version }}.tgz"
-          gh release create "blockly-v${{ needs.version.outputs.version }}" "$TARBALL" \
-            --repo "$GITHUB_REPOSITORY" \
-            --title "blockly-v${{ needs.version.outputs.version }}" \
-            --generate-notes
+          if [ "${{ github.ref_name }}" != "${{ github.event.repository.default_branch }}" ]; then
+            gh release create "blockly-v${{ needs.version.outputs.version }}" "$TARBALL" \
+              --repo "$GITHUB_REPOSITORY" \
+              --title "blockly-v${{ needs.version.outputs.version }}" \
+              --generate-notes \
+              --prerelease
+          else
+            gh release create "blockly-v${{ needs.version.outputs.version }}" "$TARBALL" \
+              --repo "$GITHUB_REPOSITORY" \
+              --title "blockly-v${{ needs.version.outputs.version }}" \
+              --generate-notes
+          fi


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [ ] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->


### Proposed Changes

Allows publishing from non-main branches:
- you select the branch to publish from from the built-in dropdown that lets you pick which version of the workflow to run. that means we'll need to merge this change into the v13 branch before we can publish from there.
- if the branch is not the default branch, then we'll bump the version using conventional commits with the `beta` naming convention. so for v13 it should detect that we're doing a beta for a major release. if the beta part of the version is already there then it bumps the beta number.
- if the branch is not the default branch, publish the npm package with tag `beta` and also publish the github release as a prerelease
- also adds a version override input we can use to do special beta versions, but it should work fine by default if you leave this out
- changes the `build` workflows to use the versions in the branch being checked out explicitly, this means when we publish from v13 branch we'll use the CI from v13 instead of from main.

### Reason for Changes

Make it possible to publish a beta with trusted publishing

Note that things might have been clearer if we just had a separate workflow for publishing betas, but trusted publishing only allows you to specify a single workflow and single environment.

Also note you can't just put a general description for a workflow that is manually invoked, so added the instructions about using the branch dropdown to the description for dry run for lack of a better place to put the instructions in the UI.

### Test Coverage

We'll do a dry run of this after it's merged

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

Also need to update the github release environment settings. I think I had it set up so it could only publish on the `main` branch but we'll have to disable that unfortunately because trusted publishing only lets you set up one environment
