### PR TITLE
chore: Remove the build size check from `npm run test`

### DIFF
--- a/packages/blockly/scripts/gulpfiles/test_tasks.mjs
+++ b/packages/blockly/scripts/gulpfiles/test_tasks.mjs
@@ -394,7 +394,6 @@ const tasks = [
   // Build must run before the remaining tasks
   build,
   renamings,
-  metadata,
   mocha,
   generators,
   node,


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
This PR removes the "metadata" build size check from the `npm run test` command. This is currently failing CI for PRs against v13.