### PR TITLE
chore: add example to JSDoc for getAriaValue

### DIFF
--- a/packages/blockly/core/field.ts
+++ b/packages/blockly/core/field.ts
@@ -329,6 +329,11 @@ export abstract class Field<T = any>
    * entirely when there may be a better contextual placeholder to use, instead,
    * specific to the field.
    *
+   * For example, a text input field may have a value of null when empty. To
+   * avoid hiding this field from screen reader, implementations should ensure
+   * that if the value is null, this function would return an appropriate,
+   * localized value such as "empty text".
+   *
    * Implementations are responsible for, and encouraged to, return a localized
    * version of the ARIA representation of the field's value.
    *


### PR DESCRIPTION
In a previous PR, I prepped adding an example comment to a JSDoc for a new Field method, but I accidentally forgot to push the change before merging. This adds that example.
- https://github.com/RaspberryPiFoundation/blockly/pull/9683#discussion_r3047596668

<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details


### Proposed Changes

No functional changes

### Reason for Changes

https://github.com/RaspberryPiFoundation/blockly/pull/9683#discussion_r3047596668

### Test Coverage

N/A
