### PR TITLE
chore: remove unused statuses

### DIFF
--- a/packages/blockly/core/utils/aria.ts
+++ b/packages/blockly/core/utils/aria.ts
@@ -123,19 +123,13 @@ export enum State {
    *
    * Value: one of {true, false}.
    */
-  ATOMIC = 'ATOMIC',
+  ATOMIC = 'atomic',
   /**
    * See https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-checked.
    *
    * Value: one of {true, false, mixed, undefined}.
    */
   CHECKED = 'checked',
-  /**
-   * See https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-colcount.
-   *
-   * Value: an integer representing the number of columns in a grid.
-   */
-  COLCOUNT = 'colcount',
   /**
    * See https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-controls.
    *
@@ -197,83 +191,17 @@ export enum State {
    */
   LIVE = 'live',
   /**
-   * See https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-orientation.
-   *
-   * Value: one of {horizontal, vertical, undefined}.
-   */
-  ORIENTATION = 'orientation',
-  /**
-   * See https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-posinset.
-   *
-   * Value: an integer representing the position of the element within a set of related elements.
-   */
-  POSINSET = 'posinset',
-  /**
-   * See https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-pressed.
-   *
-   * Value: one of {true, false, mixed, undefined}.
-   */
-  PRESSED = 'pressed',
-  /**
-   * See https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-readonly.
-   *
-   * Value: one of {true, false}.
-   */
-  READONLY = 'readonly',
-  /**
-   * See https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-required.
-   *
-   * Value: one of {true, false}.
-   */
-  REQUIRED = 'required',
-  /**
    * See https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-roledescription.
    *
    * Value: a string.
    */
   ROLEDESCRIPTION = 'roledescription',
   /**
-   * See https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-rowcount.
-   *
-   * Value: an integer representing the number of rows in a grid or table.
-   */
-  ROWCOUNT = 'rowcount',
-  /**
-   * See https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-rowindex.
-   *
-   * Value: an integer representing the index of the element within a set of related elements.
-   */
-  ROWINDEX = 'rowindex',
-  /**
-   * See https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-rowspan.
-   *
-   * Value: an integer representing the number of rows a cell spans in a grid or table.
-   */
-  ROWSPAN = 'rowspan',
-  /**
    * See https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-selected.
    *
    * Value:one of {true, false, undefined}.
    */
   SELECTED = 'selected',
-  /**
-   * See https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-setsize.
-   *
-   * Value: an integer representing the total number of elements in a set of related elements.
-   */
-  SETSIZE = 'setsize',
-  /**
-   * See https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-valuemax.
-   *
-   * Value: a number representing the maximum allowed value for a range widget.
-   */
-  VALUEMAX = 'valuemax',
-  /**
-   * See https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-valuemin.
-   *
-   * Value: a number representing the minimum allowed value for a range widget.
-   */
-  VALUEMIN = 'valuemin',
 }
 
 /**

--- a/packages/blockly/core/utils/aria.ts
+++ b/packages/blockly/core/utils/aria.ts
@@ -202,6 +202,18 @@ export enum State {
    * Value:one of {true, false, undefined}.
    */
   SELECTED = 'selected',
+  /**
+   * See https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-valuemax.
+   *
+   * Value: a number representing the maximum allowed value for a range widget.
+   */
+  VALUEMAX = 'valuemax',
+  /**
+   * See https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-valuemin.
+   *
+   * Value: a number representing the minimum allowed value for a range widget.
+   */
+  VALUEMIN = 'valuemin',
 }
 
 /**


### PR DESCRIPTION


## The basics

This removes some unused ARIA status options in order to better align the `enum` with the design. See comment from @BenHenning: https://docs.google.com/document/d/1-q0paWfV9qYWoZKWb9BpcfYOy3xYZtvcLyuuD61qHXw/edit?disco=AAAB3FpvXj4
<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->

### Proposed Changes

Remove statuses that aren't expected to be needed for screen reader work.
<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->
n/a

### Documentation

n/a
<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
