### PR TITLE
fix: Fix bug that caused blocks inserted via Enter to not attach

### DIFF
--- a/packages/blockly/core/block_svg.ts
+++ b/packages/blockly/core/block_svg.ts
@@ -1911,9 +1911,9 @@ export class BlockSvg
    * main workspace. If this block has a single full-block field, that field
    * will be focused. Otherwise, this is a no-op.
    */
-  performAction() {
+  performAction(e?: KeyboardEvent) {
     if (this.workspace.isFlyout) {
-      KeyboardMover.mover.startMove(this);
+      KeyboardMover.mover.startMove(this, e);
       return;
     } else if (this.isSimpleReporter()) {
       for (const input of this.inputList) {

--- a/packages/blockly/core/interfaces/i_focusable_node.ts
+++ b/packages/blockly/core/interfaces/i_focusable_node.ts
@@ -104,8 +104,10 @@ export interface IFocusableNode {
    * Optional method invoked when this node has focus and the user acts on it by
    * pressing Enter or Space. Behavior should generally be similar to the node
    * being clicked on.
+   *
+   * @param e The event that triggered this action, if any.
    */
-  performAction?(): void;
+  performAction?(e?: Event): void;
 }
 
 /**

--- a/packages/blockly/core/shortcut_items.ts
+++ b/packages/blockly/core/shortcut_items.ts
@@ -859,7 +859,7 @@ export function registerPerformAction() {
       const focusedNode = getFocusManager().getFocusedNode();
       if (focusedNode && 'performAction' in focusedNode) {
         e.preventDefault();
-        focusedNode.performAction?.();
+        focusedNode.performAction?.(e);
         return true;
       }
       return false;

--- a/packages/blockly/tests/mocha/shortcut_items_test.js
+++ b/packages/blockly/tests/mocha/shortcut_items_test.js
@@ -1037,6 +1037,10 @@ suite('Keyboard Shortcut Items', function () {
     });
 
     test('Inserts blocks from the flyout in move mode', function () {
+      const first = this.workspace.newBlock('stack_block');
+      first.initSvg();
+      first.render();
+
       this.workspace.getToolbox().selectItemByPosition(0);
       const block = this.workspace
         .getNavigator()
@@ -1052,6 +1056,12 @@ suite('Keyboard Shortcut Items', function () {
       assert.instanceOf(movingBlock, Blockly.BlockSvg);
       assert.isTrue(movingBlock.isDragging());
       assert.isFalse(movingBlock.workspace.isFlyout);
+
+      const hasInsertionMarker = this.workspace
+        .getTopBlocks()
+        .flatMap((b) => b.getChildren())
+        .some((b) => b.isInsertionMarker());
+      assert.isTrue(hasInsertionMarker);
 
       Blockly.KeyboardMover.mover.abortMove();
     });


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves
This PR fixes a bug where inserting a block from the flyout using Enter (but not M) would insert it in move mode but with no potential candidate connections, meaning it could only be positioned via unconstrained move mode. The behavior is now identical whether you're using M or Enter. I also updated a test to ensure that inserting a block with Enter results in an insertion marker being displayed, meaning that the insertion is in constrained move mode.