### PR TITLE
fix: Improve accuracy of block navigability detection

### DIFF
--- a/packages/blockly/core/block_svg.ts
+++ b/packages/blockly/core/block_svg.ts
@@ -1926,7 +1926,7 @@ export class BlockSvg
       }
     }
 
-    if (this.workspace.getNavigator().getFirstChild(this)) {
+    if (this.workspace.getNavigator().getInNode(this)) {
       hints.showBlockNavigationHint(this.workspace);
     } else {
       hints.showHelpHint(this.workspace);


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #9714

### Proposed Changes
This PR uses `getInNode()` in place of `getFirstChild()` to correctly determine if a block has any navigable locations. `getInNode()` corresponds directly to the right arrow key, whereas `getFirstChild()` could return child nodes that were on subsequent rows and thus unreachable via right arrow, which the hint toast suggests using.