### PR TITLE
fix: Increase contrast of active tree focus ring color

### DIFF
--- a/packages/blockly/core/css.ts
+++ b/packages/blockly/core/css.ts
@@ -529,7 +529,7 @@ input[type=number] {
 
 .injectionDiv {
   --blockly-active-node-color: #fff200;
-  --blockly-active-tree-color: #60a5fa;
+  --blockly-active-tree-color: #1379f6;
   --blockly-selection-width: 3px;
 }
 


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #9712

### Proposed Changes
This PR increases the contrast of the default active tree focus ring color to improve accessibility. The new value meets the WCAG AA guidelines for GUI components with a contrast ratio of 3.03:1 against the grey background of the toolbox, and exceeds it with 4.12:1 against the white workspace background.