### PR TITLE
feat: Add keyboard shortcut to clean up the workspace

### DIFF
--- a/packages/blockly/core/shortcut_items.ts
+++ b/packages/blockly/core/shortcut_items.ts
@@ -60,6 +60,7 @@ export enum names {
   PREVIOUS_STACK = 'previous_stack',
   INFORMATION = 'information',
   PERFORM_ACTION = 'perform_action',
+  CLEANUP = 'cleanup',
 }
 
 /**
@@ -871,6 +872,25 @@ export function registerPerformAction() {
 }
 
 /**
+ * Registers keyboard shortcut to clean up the workspace.
+ */
+export function registerCleanup() {
+  const cleanupShortcut: KeyboardShortcut = {
+    name: names.CLEANUP,
+    preconditionFn: (workspace) =>
+      !workspace.isDragging() && !workspace.isReadOnly(),
+    callback: (workspace) => {
+      keyboardNavigationController.setIsActive(true);
+      workspace.cleanUp();
+      return true;
+    },
+    keyCodes: [KeyCodes.C],
+    allowCollision: true,
+  };
+  ShortcutRegistry.registry.register(cleanupShortcut);
+}
+
+/**
  * Registers all default keyboard shortcut item. This should be called once per
  * instance of KeyboardShortcutRegistry.
  *
@@ -899,6 +919,7 @@ export function registerKeyboardNavigationShortcuts() {
   registerDisconnectBlock();
   registerStackNavigation();
   registerPerformAction();
+  registerCleanup();
 }
 
 /**

--- a/packages/blockly/tests/mocha/shortcut_items_test.js
+++ b/packages/blockly/tests/mocha/shortcut_items_test.js
@@ -1231,4 +1231,43 @@ suite('Keyboard Shortcut Items', function () {
       this.workspace.registerButtonCallback('CREATE_VARIABLE', oldCallback);
     });
   });
+
+  suite('Clean up workspace (C)', function () {
+    test('Arranges all blocks in a vertical column', function () {
+      this.workspace.newBlock('controls_if');
+      const block2 = this.workspace.newBlock('controls_if');
+      block2.moveBy(300, 20);
+      const block3 = this.workspace.newBlock('controls_if');
+      block3.moveBy(-75, -60);
+
+      const event = createKeyDownEvent(Blockly.utils.KeyCodes.C);
+      this.workspace.getInjectionDiv().dispatchEvent(event);
+
+      for (const block of this.workspace.getTopBlocks()) {
+        assert.equal(block.relativeCoords.x, 0);
+      }
+    });
+
+    test('Does nothing on a readonly workspace', function () {
+      this.workspace.newBlock('controls_if');
+      const block2 = this.workspace.newBlock('controls_if');
+      block2.moveBy(300, 20);
+      const block3 = this.workspace.newBlock('controls_if');
+      block3.moveBy(-75, -60);
+
+      this.workspace.setIsReadOnly(true);
+
+      const oldBounds = this.workspace
+        .getTopBlocks(true)
+        .map((b) => b.getBoundingRectangle());
+
+      const event = createKeyDownEvent(Blockly.utils.KeyCodes.C);
+      this.workspace.getInjectionDiv().dispatchEvent(event);
+
+      const newBounds = this.workspace
+        .getTopBlocks(true)
+        .map((b) => b.getBoundingRectangle());
+      assert.deepEqual(oldBounds, newBounds);
+    });
+  });
 });


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes part of #9703

### Proposed Changes
This PR adds a keyboard shortcut that cleans up the workspace by arranging all block stacks in a vertical column, bound to C.