### PR TITLE
fix: Fix bug that caused blocks in flyout to disappear on click in Chrome

### DIFF
--- a/packages/blockly/core/gesture.ts
+++ b/packages/blockly/core/gesture.ts
@@ -1004,8 +1004,8 @@ export class Gesture {
       this.setTargetBlock(block.getParent()!);
     } else {
       this.targetBlock = block;
-      getFocusManager().focusNode(this.targetBlock);
       this.targetBlock.bringToFront();
+      getFocusManager().focusNode(this.targetBlock);
     }
   }
 


### PR DESCRIPTION

<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #9705

### Proposed Changes
This PR fixes a bug where, when clicking on a block in an autoclosing flyout in Chrome, the block would disappear until the mouse moved. Now, the block remains visible and spawns on the main workspace, which is the intended behavior and consistent with Safari and Firefox.