### PR TITLE
fix: Field text hidden from ARIA

### DIFF
--- a/packages/blockly/core/field.ts
+++ b/packages/blockly/core/field.ts
@@ -476,15 +476,18 @@ export abstract class Field<T = any>
   }
 
   /**
-   * Create a field text element. Not to be overridden by subclasses. Instead
+   * Create a field text element. Not to be overridden by subclasses. Instead,
    * modify the result of the function inside initView, or create a separate
-   * function to call.
+   * function to call. Aria state is hidden; use the aria label for the field
+   * and/or containing block to expose content to screen readers. Text content
+   * for custom blocks can be set after creation.
    */
   protected createTextElement_() {
     this.textElement_ = dom.createSvgElement(
       Svg.TEXT,
       {
         'class': 'blocklyText blocklyFieldText',
+        'aria-hidden': 'true',
       },
       this.fieldGroup_,
     );

--- a/packages/blockly/tests/mocha/field_test.js
+++ b/packages/blockly/tests/mocha/field_test.js
@@ -944,5 +944,14 @@ suite('Abstract Fields', function () {
         assert.equal(field.computeAriaLabel(true), 'custom type: custom value');
       });
     });
+
+    suite('Field text elements are hidden', function () {
+      test('Field text element has aria-hidden=true', function () {
+        const field = new TestField();
+        field.constants_ = {FIELD_BORDER_RECT_RADIUS: 5};
+        field.initView();
+        assert(field.getTextElement().ariaHidden === 'true');
+      });
+    });
   });
 });


### PR DESCRIPTION
## The basics

- [ x ] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

Fixes https://github.com/RaspberryPiFoundation/blockly/issues/9655

### Proposed Changes

Field text elements are `aria-hidden` by default.

### Reason for Changes
With the aria label changes in place we no longer need text on the elements to be visible to assistive technology. With these changes, the accessibility tree goes from looking like this:
<img width="404" height="293" alt="Screenshot 2026-04-16 at 10 58 31 AM" src="https://github.com/user-attachments/assets/17dbadf8-451b-43bd-a373-b71991a069d8" />
to looking like this:
<img width="376" height="200" alt="Screenshot 2026-04-16 at 10 59 27 AM" src="https://github.com/user-attachments/assets/5b1ee7bc-45e4-4e2f-9f5d-b5ec57739c25" />

### Test Coverage

Added a unit test which ensures field text elements get the `aria-hidden=true` attribute.

### Documentation

Changes to the `Field.createTextElement_()` method documentation are included in this PR.

