### PR TITLE
fix: dont activate base delete areas for keyboard moves

### DIFF
--- a/packages/blockly/core/delete_area.ts
+++ b/packages/blockly/core/delete_area.ts
@@ -17,6 +17,7 @@ import {DragTarget} from './drag_target.js';
 import {isDeletable} from './interfaces/i_deletable.js';
 import type {IDeleteArea} from './interfaces/i_delete_area.js';
 import type {IDraggable} from './interfaces/i_draggable.js';
+import {KeyboardMover} from './keyboard_nav/keyboard_mover.js';
 
 /**
  * Abstract class for a component that can delete a block or bubble that is
@@ -56,7 +57,10 @@ export class DeleteArea extends DragTarget implements IDeleteArea {
    *     area.
    */
   wouldDelete(element: IDraggable): boolean {
-    if (element instanceof BlockSvg) {
+    // don't delete things if we're doing a keyboard move
+    if (KeyboardMover.mover.isMoving()) {
+      this.updateWouldDelete_(false);
+    } else if (element instanceof BlockSvg) {
       const block = element;
       const couldDeleteBlock = !block.getParent() && block.isDeletable();
       this.updateWouldDelete_(couldDeleteBlock);

--- a/packages/blockly/core/toolbox/toolbox.ts
+++ b/packages/blockly/core/toolbox/toolbox.ts
@@ -11,7 +11,6 @@
  */
 // Former goog.module ID: Blockly.Toolbox
 
-import {BlockSvg} from '../block_svg.js';
 import * as browserEvents from '../browser_events.js';
 import * as common from '../common.js';
 import {ComponentManager} from '../component_manager.js';
@@ -26,7 +25,6 @@ import {
   isCollapsibleToolboxItem,
   type ICollapsibleToolboxItem,
 } from '../interfaces/i_collapsible_toolbox_item.js';
-import {isDeletable} from '../interfaces/i_deletable.js';
 import type {IDraggable} from '../interfaces/i_draggable.js';
 import type {IFlyout} from '../interfaces/i_flyout.js';
 import type {IFocusableNode} from '../interfaces/i_focusable_node.js';
@@ -37,6 +35,7 @@ import {isSelectableToolboxItem} from '../interfaces/i_selectable_toolbox_item.j
 import type {IStyleable} from '../interfaces/i_styleable.js';
 import type {IToolbox} from '../interfaces/i_toolbox.js';
 import type {IToolboxItem} from '../interfaces/i_toolbox_item.js';
+import {KeyboardMover} from '../keyboard_nav/keyboard_mover.js';
 import {ToolboxNavigator} from '../keyboard_nav/navigators/toolbox_navigator.js';
 import * as registry from '../registry.js';
 import type {KeyboardShortcut} from '../shortcut_registry.js';
@@ -509,31 +508,13 @@ export class Toolbox
   }
 
   /**
-   * Returns whether the provided block or bubble would be deleted if dropped on
-   * this area.
-   * This method should check if the element is deletable and is always called
-   * before onDragEnter/onDragOver/onDragExit.
-   *
-   * @param element The block or bubble currently being dragged.
-   * @returns Whether the element provided would be deleted if dropped on this
-   *     area.
-   */
-  override wouldDelete(element: IDraggable): boolean {
-    if (element instanceof BlockSvg) {
-      const block = element;
-      this.updateWouldDelete_(!block.getParent() && block.isDeletable());
-    } else {
-      this.updateWouldDelete_(isDeletable(element) && element.isDeletable());
-    }
-    return this.wouldDelete_;
-  }
-
-  /**
    * Handles when a cursor with a block or bubble enters this drag target.
    *
    * @param _dragElement The block or bubble currently being dragged.
    */
   override onDragEnter(_dragElement: IDraggable) {
+    // don't trigger for keyboard moves
+    if (KeyboardMover.mover.isMoving()) return;
     this.updateCursorDeleteStyle_(true);
   }
 
@@ -543,6 +524,8 @@ export class Toolbox
    * @param _dragElement The block or bubble currently being dragged.
    */
   override onDragExit(_dragElement: IDraggable) {
+    // don't trigger for keyboard moves
+    if (KeyboardMover.mover.isMoving()) return;
     this.updateCursorDeleteStyle_(false);
   }
 
@@ -553,6 +536,8 @@ export class Toolbox
    * @param _dragElement The block or bubble currently being dragged.
    */
   override onDrop(_dragElement: IDraggable) {
+    // don't trigger for keyboard moves
+    if (KeyboardMover.mover.isMoving()) return;
     this.updateCursorDeleteStyle_(false);
   }
 

--- a/packages/blockly/core/trashcan.ts
+++ b/packages/blockly/core/trashcan.ts
@@ -24,6 +24,7 @@ import type {IAutoHideable} from './interfaces/i_autohideable.js';
 import type {IDraggable} from './interfaces/i_draggable.js';
 import type {IFlyout} from './interfaces/i_flyout.js';
 import type {IPositionable} from './interfaces/i_positionable.js';
+import {KeyboardMover} from './keyboard_nav/keyboard_mover.js';
 import type {UiMetrics} from './metrics_manager.js';
 import * as uiPosition from './positionable_helpers.js';
 import * as registry from './registry.js';
@@ -426,6 +427,8 @@ export class Trashcan
    * @param _dragElement The block or bubble currently being dragged.
    */
   override onDragOver(_dragElement: IDraggable) {
+    // don't trigger for keyboard moves
+    if (KeyboardMover.mover.isMoving()) return;
     this.setLidOpen(this.wouldDelete_);
   }
 
@@ -435,6 +438,8 @@ export class Trashcan
    * @param _dragElement The block or bubble currently being dragged.
    */
   override onDragExit(_dragElement: IDraggable) {
+    // don't trigger for keyboard moves
+    if (KeyboardMover.mover.isMoving()) return;
     this.setLidOpen(false);
   }
 
@@ -445,6 +450,8 @@ export class Trashcan
    * @param _dragElement The block or bubble currently being dragged.
    */
   override onDrop(_dragElement: IDraggable) {
+    // don't trigger for keyboard moves
+    if (KeyboardMover.mover.isMoving()) return;
     setTimeout(this.setLidOpen.bind(this, false), 100);
   }
 

--- a/packages/blockly/tests/mocha/toolbox_test.js
+++ b/packages/blockly/tests/mocha/toolbox_test.js
@@ -5,7 +5,10 @@
  */
 
 import {assert} from '../../node_modules/chai/index.js';
-import {defineStackBlock} from './test_helpers/block_definitions.js';
+import {
+  defineBasicBlockWithField,
+  defineStackBlock,
+} from './test_helpers/block_definitions.js';
 import {
   sharedTestSetup,
   sharedTestTeardown,
@@ -810,6 +813,30 @@ suite('Toolbox', function () {
         innerCategory.isVisible(),
         'Not all ancestors are expanded, so category should not be visible',
       );
+    });
+  });
+  suite('delete area', function () {
+    test('Keyboard drag - wouldDelete returns false', function () {
+      // Create a deletable block
+      defineBasicBlockWithField();
+      const block = this.toolbox.getWorkspace().newBlock('test_field_block');
+      block.initSvg();
+      block.render();
+
+      // Stub KeyboardMover.mover.isMoving() to return true
+      const isMovingStub = sinon
+        .stub(Blockly.KeyboardMover.mover, 'isMoving')
+        .returns(true);
+
+      try {
+        const result = this.toolbox.wouldDelete(block);
+        assert.isFalse(
+          result,
+          'wouldDelete should return false during keyboard move',
+        );
+      } finally {
+        isMovingStub.restore();
+      }
     });
   });
 });

--- a/packages/blockly/tests/mocha/trashcan_test.js
+++ b/packages/blockly/tests/mocha/trashcan_test.js
@@ -373,4 +373,27 @@ suite('Trashcan', function () {
       this.workspace.options.maxTrashcanContents = Infinity;
     });
   });
+  suite('delete area', function () {
+    test('Keyboard drag - wouldDelete returns false', function () {
+      // Create a deletable block
+      const block = this.workspace.newBlock('test_field_block');
+      block.initSvg();
+      block.render();
+
+      // Stub KeyboardMover.mover.isMoving() to return true
+      const isMovingStub = sinon
+        .stub(Blockly.KeyboardMover.mover, 'isMoving')
+        .returns(true);
+
+      try {
+        const result = this.trashcan.wouldDelete(block);
+        assert.isFalse(
+          result,
+          'wouldDelete should return false during keyboard move',
+        );
+      } finally {
+        isMovingStub.restore();
+      }
+    });
+  });
 });


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #9721 

### Proposed Changes

- updates the default delete area implementation to not delete things if a keyboard move is in progress
- removes the toolbox's override of `wouldDelete` since it was not different than the base implementation (please double check me on that)
- updates the toolbox and trashcan various onDragEnter/Exit/etc to not fire if it's a keyboard drag 

### Reason for Changes

The reason I chose this approach is it updates the default delete area to not trigger for keyboard moves, but allows developers to customize it if they do want their delete areas to trigger for keyboard moves

An alternative was to have the dragger just not fire any of the drag target methods if the drag target was also a delete area. but that was actually more complicated due to various factors (e.g. if you are moving from a regular drag target to a delete area, you have to make sure to trigger the `onDragExit` for the regular drag target but NOT trigger the `onDragEnter` for the delete area). And it's less customizable and explainable for developers implementing their own drag targets.

### Test Coverage

i will add a test case for this before i merge this but wanted to get review on the approach first because i have another commitment today before i can write the test

### Documentation

we don't have any documentation for delete areas but if we did we should tell developers they should probably not activate them for keyboard moves

### Additional Information

<!-- Anything else we should know? -->
