### PR TITLE
chore: Add tagging for blockly releases in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -154,6 +154,9 @@ jobs:
           git add packages/blockly/package.json package-lock.json
           git commit -m "release: v${{ needs.version.outputs.version }}"
           git push
+          TAG="blockly-v${{ needs.version.outputs.version }}"
+          git tag "$TAG"
+          git push origin "refs/tags/$TAG"
 
       - name: Setup Node.js
         uses: actions/setup-node@v5


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes issue where prereleases were not tagged correctly (i hope)

### Proposed Changes

- Manually creates and pushes a tag after the versioning step. Will not create a tag if skip-versioning is true, because that is intended to be used if this workflow has already succeeded at the version commit step but failed at the publish step, so it's assumed the tag already exists.

### Reason for Changes

github releases were auto-creating tags from the default branch, which is correct if that's where you published from but wrong if you're publishing e.g. a v13 beta.

### Test Coverage

YOLO (it's impossible to test this but i asked a robot and it said it would work)

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
