### PR TITLE
fix: Do not use custom input labels for connection positions and move start

### DIFF
--- a/packages/blockly/core/block_aria_composer.ts
+++ b/packages/blockly/core/block_aria_composer.ts
@@ -346,7 +346,7 @@ export function getInputLabelsSubset(block: BlockSvg, input: Input): string[] {
     .filter((input) => input.isVisible())
     .map(
       (input) =>
-        input.getLabel(Verbosity.TERSE) ||
+        input.getLabel(Verbosity.TERSE, false) ||
         Msg['INPUT_LABEL_INDEX'].replace(
           '%1',
           (input.getIndex() + 1).toString(),

--- a/packages/blockly/core/block_svg.ts
+++ b/packages/blockly/core/block_svg.ts
@@ -2051,7 +2051,7 @@ export class BlockSvg
       block = block.getNextBlock();
     }
     if (count <= 1) {
-      return computeAriaLabel(this, aria.Verbosity.TERSE);
+      return computeAriaLabel(this, aria.Verbosity.TERSE, false);
     }
 
     const labelTemplate = Msg['BLOCK_LABEL_STACK_BLOCKS'];


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes https://github.com/RaspberryPiFoundation/blockly/issues/9922

### Proposed Changes

Stop using custom input labels when computing block ARIA labels for the start of a move announcement.

Before:

<img width="637" height="371" alt="image" src="https://github.com/user-attachments/assets/d70da208-008d-41fa-ac44-b5e6f0527b69" />

After:
<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
<img width="633" height="315" alt="image" src="https://github.com/user-attachments/assets/ad9a26f3-d4ff-41ed-a4ff-d45cc06da5d8" />

Stop using custom input labels when using a subset of input labels, for example, when focusing a statement input on a container block.

Before:

<img width="635" height="304" alt="image" src="https://github.com/user-attachments/assets/df3eef64-d8a4-4096-a9b4-9032fdd8124c" />

After:

<img width="624" height="282" alt="image" src="https://github.com/user-attachments/assets/8679b7b0-18e8-41d3-8437-c3d41ea17d76" />


### Reason for Changes

Fixes two bugs where custom input labels are used in place of more useful computed labels from fields.

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Additional Information

I think it would be worth considering making `useCustomLabels` default to `false`.
