### PR TITLE
chore: chain Input.setAriaLabelProvider calls

### DIFF
--- a/packages/blockly/blocks/lists.ts
+++ b/packages/blockly/blocks/lists.ts
@@ -279,13 +279,14 @@ const LISTS_CREATE_WITH = {
     // Add new inputs.
     for (let i = 0; i < this.itemCount_; i++) {
       if (!this.getInput('ADD' + i)) {
-        const input = this.appendValueInput('ADD' + i).setAlign(Align.RIGHT);
-        input.setAriaLabelProvider(
-          Msg['INPUT_LABEL_LISTS_CREATE_WITH_ITEM'].replace(
-            '%1',
-            String(i + 1),
-          ),
-        );
+        const input = this.appendValueInput('ADD' + i)
+          .setAlign(Align.RIGHT)
+          .setAriaLabelProvider(
+            Msg['INPUT_LABEL_LISTS_CREATE_WITH_ITEM'].replace(
+              '%1',
+              String(i + 1),
+            ),
+          );
         if (i === 0) {
           input.appendField(Msg['LISTS_CREATE_WITH_INPUT_WITH']);
         }

--- a/packages/blockly/blocks/text.ts
+++ b/packages/blockly/blocks/text.ts
@@ -885,10 +885,11 @@ const JOIN_MUTATOR_MIXIN = {
     // Add new inputs.
     for (let i = 0; i < this.itemCount_; i++) {
       if (!this.getInput('ADD' + i)) {
-        const input = this.appendValueInput('ADD' + i).setAlign(Align.RIGHT);
-        input.setAriaLabelProvider(
-          Msg['INPUT_LABEL_TEXT_JOIN_ITEM'].replace('%1', (i + 1).toString()),
-        );
+        const input = this.appendValueInput('ADD' + i)
+          .setAlign(Align.RIGHT)
+          .setAriaLabelProvider(
+            Msg['INPUT_LABEL_TEXT_JOIN_ITEM'].replace('%1', (i + 1).toString()),
+          );
         if (i === 0) {
           input.appendField(Msg['TEXT_JOIN_TITLE_CREATEWITH']);
         }


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Proposed Changes

Now that `Input.setAriaLabelProvider` returns `this`, it can be chained with other `Input` methods. (https://github.com/RaspberryPiFoundation/blockly/pull/9913).
This updates the two previous call sites  to use chaining where it wasn't originally possible.

### Reason for Changes

Aligns to the conventions of other `Input` methods (such as `appendField`, `setAlign`, and `setCheck`).

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
