### PR TITLE
fix: Avoid issue with toolbox search plugin

### DIFF
--- a/packages/blockly/core/shortcut_items.ts
+++ b/packages/blockly/core/shortcut_items.ts
@@ -778,11 +778,12 @@ export function registerFocusToolbox() {
   const focusToolboxShortcut: KeyboardShortcut = {
     name: names.FOCUS_TOOLBOX,
     preconditionFn: (workspace) => !workspace.isDragging(),
-    callback: (workspace) => {
+    callback: (workspace, event) => {
       const toolbox = workspace.getToolbox();
       if (toolbox) {
         keyboardNavigationController.setIsActive(true);
         getFocusManager().focusTree(toolbox);
+        event.preventDefault();
         return true;
       } else {
         const flyout = workspace.getFlyout();
@@ -790,6 +791,7 @@ export function registerFocusToolbox() {
 
         keyboardNavigationController.setIsActive(true);
         getFocusManager().focusTree(flyout.getWorkspace());
+        event.preventDefault();
         return true;
       }
     },


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Proposed Changes
This PR avoids an issue with the toolbox search plugin where focusing the toolbox would cause a t to be entered into the search field when the search category was the previously-selected category.