### PR TITLE
fix: typo in `unregisterWorkspace`

### DIFF
--- a/packages/blockly/core/common.ts
+++ b/packages/blockly/core/common.ts
@@ -15,6 +15,7 @@ import * as eventUtils from './events/utils.js';
 import {getFocusManager} from './focus_manager.js';
 import {ISelectable, isSelectable} from './interfaces/i_selectable.js';
 import {ShortcutRegistry} from './shortcut_registry.js';
+import { deprecation } from './utils.js';
 import type {Workspace} from './workspace.js';
 import type {WorkspaceSvg} from './workspace_svg.js';
 
@@ -60,6 +61,23 @@ export function registerWorkspace(workspace: Workspace) {
  */
 export function unregisterWorkspace(workspace: Workspace) {
   delete WorkspaceDB_[workspace.id];
+}
+
+/**
+ * Unregister a workspace from the workspace db.
+ *
+ * @deprecated v12: use Blockly.common.unregisterWorkspace
+ * @param workspace
+ */
+export function unregisterWorkpace(workspace: Workspace) {
+  deprecation.warn(
+    'Blockly.common.unregisterWorkpace',
+    'v12',
+    'v13',
+    'Blockly.common.unregisterWorkspace',
+  );
+
+  unregisterWorkspace(workspace);
 }
 
 /**

--- a/packages/blockly/core/common.ts
+++ b/packages/blockly/core/common.ts
@@ -58,7 +58,7 @@ export function registerWorkspace(workspace: Workspace) {
  *
  * @param workspace
  */
-export function unregisterWorkpace(workspace: Workspace) {
+export function unregisterWorkspace(workspace: Workspace) {
   delete WorkspaceDB_[workspace.id];
 }
 

--- a/packages/blockly/core/common.ts
+++ b/packages/blockly/core/common.ts
@@ -15,7 +15,7 @@ import * as eventUtils from './events/utils.js';
 import {getFocusManager} from './focus_manager.js';
 import {ISelectable, isSelectable} from './interfaces/i_selectable.js';
 import {ShortcutRegistry} from './shortcut_registry.js';
-import {deprecation} from './utils.js';
+import * as deprecation from './utils/deprecation.js';
 import type {Workspace} from './workspace.js';
 import type {WorkspaceSvg} from './workspace_svg.js';
 

--- a/packages/blockly/core/common.ts
+++ b/packages/blockly/core/common.ts
@@ -15,7 +15,7 @@ import * as eventUtils from './events/utils.js';
 import {getFocusManager} from './focus_manager.js';
 import {ISelectable, isSelectable} from './interfaces/i_selectable.js';
 import {ShortcutRegistry} from './shortcut_registry.js';
-import { deprecation } from './utils.js';
+import {deprecation} from './utils.js';
 import type {Workspace} from './workspace.js';
 import type {WorkspaceSvg} from './workspace_svg.js';
 
@@ -66,14 +66,14 @@ export function unregisterWorkspace(workspace: Workspace) {
 /**
  * Unregister a workspace from the workspace db.
  *
- * @deprecated v12: use Blockly.common.unregisterWorkspace
+ * @deprecated v13: use Blockly.common.unregisterWorkspace
  * @param workspace
  */
 export function unregisterWorkpace(workspace: Workspace) {
   deprecation.warn(
     'Blockly.common.unregisterWorkpace',
-    'v12',
     'v13',
+    'v14',
     'Blockly.common.unregisterWorkspace',
   );
 

--- a/packages/blockly/core/workspace.ts
+++ b/packages/blockly/core/workspace.ts
@@ -167,7 +167,7 @@ export class Workspace {
     this.listeners.length = 0;
     this.clear();
     // Remove from workspace database.
-    common.unregisterWorkpace(this);
+    common.unregisterWorkspace(this);
   }
 
   /**

--- a/packages/blockly/scripts/migration/renamings.json5
+++ b/packages/blockly/scripts/migration/renamings.json5
@@ -1600,7 +1600,7 @@
       oldName: 'Blockly.common',
       exports: {
         unregisterWorkpace: {
-          newExport: 'unregisterWorkspace'.
+          newExport: 'unregisterWorkspace',
         },
       },
     },

--- a/packages/blockly/scripts/migration/renamings.json5
+++ b/packages/blockly/scripts/migration/renamings.json5
@@ -1595,5 +1595,16 @@
     },
   ],
 
+  '13.0.0': [
+    {
+      oldName: 'Blockly.common',
+      exports: {
+        unregisterWorkpace: {
+          newExport: 'unregisterWorkspace'.
+        },
+      },
+    },
+  ],
+
   'develop': [],
 }


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Updates #9559

Thanks @suk-6 for fixing this!

### Proposed Changes

- Fixes typo in `unregisterWorkspace`, adds deprecation warning to old name, adds rename to database.

### Additional Information

If you previously called `Blockly.common.unregisterWorkpace` (with typo) please correct the name or run the renamings script to automatically fix the name.
