### PR TITLE
fix: dont show input number in connection labels

### DIFF
--- a/packages/blockly/core/block_aria_composer.ts
+++ b/packages/blockly/core/block_aria_composer.ts
@@ -328,7 +328,11 @@ export function getInputLabels(
  * @param input The input that defines the end of the subset.
  * @returns A list of field/input labels for the given block.
  */
-export function getInputLabelsSubset(block: BlockSvg, input: Input): string[] {
+export function getInputLabelsSubset(
+  block: BlockSvg,
+  input: Input,
+  includeFallbackLabels = true,
+): string[] {
   const inputIndex = block.inputList.indexOf(input);
   if (inputIndex === -1) {
     throw new Error(
@@ -347,11 +351,14 @@ export function getInputLabelsSubset(block: BlockSvg, input: Input): string[] {
     .map(
       (input) =>
         input.getLabel(Verbosity.TERSE, false) ||
-        Msg['INPUT_LABEL_INDEX'].replace(
-          '%1',
-          (input.getIndex() + 1).toString(),
-        ),
-    );
+        (includeFallbackLabels
+          ? Msg['INPUT_LABEL_INDEX'].replace(
+              '%1',
+              (input.getIndex() + 1).toString(),
+            )
+          : undefined),
+    )
+    .filter((label) => label !== undefined);
 }
 
 /**

--- a/packages/blockly/core/rendered_connection.ts
+++ b/packages/blockly/core/rendered_connection.ts
@@ -355,11 +355,14 @@ export class RenderedConnection
 
     // Use the custom label for an input if it exists, otherwise use the
     // "field row" approach to get the default label for the input.
+    // Don't include the "input 1" fallback for default labels, since
+    // the input is already being described as a statement or value input.
     const parentInputLabel =
       parentInput?.getAriaLabelText() ??
       getInputLabelsSubset(
         parentInput.getSourceBlock() as BlockSvg,
         parentInput,
+        false,
       ).join(', ');
     if (this.type === ConnectionType.NEXT_STATEMENT) {
       aria.setState(

--- a/packages/blockly/tests/mocha/aria_test.js
+++ b/packages/blockly/tests/mocha/aria_test.js
@@ -626,6 +626,21 @@ suite('ARIA', function () {
       );
     });
 
+    test('statement input connection label does not include the placeholder "input"', function () {
+      const block = this.renderBlock('controls_repeat_ext');
+      const doInput = block.getInput('DO');
+      doInput.connection.highlight();
+      try {
+        const label = Blockly.utils.aria.getState(
+          doInput.connection.getFocusableElement(),
+          Blockly.utils.aria.State.LABEL,
+        );
+        assert.notInclude(label, 'input');
+      } finally {
+        doInput.connection.unhighlight();
+      }
+    });
+
     test('last next connection in a populated statement stack uses statement role description and end label', function () {
       const repeat = this.renderBlock('controls_repeat_ext');
       const printBlock = this.renderBlock('text_print');


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #9909 

### Proposed Changes

- removes "input x" from input labels, it's confusing.

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage

added test

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
