### PR TITLE
fix: Improve fallback for getInitialCandidate

### DIFF
--- a/packages/blockly/core/dragging/block_drag_strategy.ts
+++ b/packages/blockly/core/dragging/block_drag_strategy.ts
@@ -1238,6 +1238,19 @@ export class BlockDragStrategy implements IDragStrategy {
       return this.pairToCandidate(parentPair);
     }
 
+    // Fall back to the nearest parent block that has a compatible connection.
+    // This handles the case where a nested value block (e.g. a number input)
+    // has passive focus but the dragged block is a statement block that should
+    // be inserted after the containing statement block.
+    let ancestorBlock = passiveBlock.getSurroundParent();
+    while (ancestorBlock) {
+      const pair = this.allConnectionPairs.find(
+        (pair) => pair.neighbour.getSourceBlock() === ancestorBlock,
+      );
+      if (pair) return this.pairToCandidate(pair);
+      ancestorBlock = ancestorBlock.getSurroundParent();
+    }
+
     return null;
   }
 

--- a/packages/blockly/core/dragging/block_drag_strategy.ts
+++ b/packages/blockly/core/dragging/block_drag_strategy.ts
@@ -1242,13 +1242,13 @@ export class BlockDragStrategy implements IDragStrategy {
     // This handles the case where a nested value block (e.g. a number input)
     // has passive focus but the dragged block is a statement block that should
     // be inserted after the containing statement block.
-    let ancestorBlock = passiveBlock.getSurroundParent();
-    while (ancestorBlock) {
+    let parentBlock = passiveBlock.getSurroundParent();
+    while (parentBlock) {
       const pair = this.allConnectionPairs.find(
-        (pair) => pair.neighbour.getSourceBlock() === ancestorBlock,
+        (pair) => pair.neighbour.getSourceBlock() === parentBlock,
       );
       if (pair) return this.pairToCandidate(pair);
-      ancestorBlock = ancestorBlock.getSurroundParent();
+      parentBlock = parentBlock.getSurroundParent();
     }
 
     return null;


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

This PR improves the `getInitialCandidate` fallback to the nearest parent block that has a compatible connection. This handles the case where a nested value block (e.g. a number input) has passive focus but the dragged block (inserted via keyboard from the flyout) is a statement block that should be inserted after the containing statement block.

This PR would benefit from thorough review and testing to ensure that there aren't any unintended consequences.

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes https://github.com/RaspberryPiFoundation/blockly/issues/9899

### Test Coverage

None

### Documentation

No

### Additional Information

N/A
