### PR TITLE
fix(docs): fix typo in workspace reference

### DIFF
--- a/packages/docs/docs/guides/create-custom-blocks/procedures/creating-custom-procedure-blocks.mdx
+++ b/packages/docs/docs/guides/create-custom-blocks/procedures/creating-custom-procedure-blocks.mdx
@@ -54,7 +54,7 @@ Blockly.Blocks['my_procedure_def'] = {
 
     // Insertion markers reference the model of the original block.
     if (this.isInsertionMarker()) return;
-    this.workpace.getProcedureMap().delete(model.getId());
+    this.workspace.getProcedureMap().delete(model.getId());
   }
 }
 ```


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [ ] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

I did not follow the guide there entirely, because this is a docs change. I only run `cd packages/docs && npm run lint`. Tell me if that's not enough.

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes no issues (probably).

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
Fix typo in method call `workpace.getProcedureMap()` to `workspace`.

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
There was a typo in the docs.

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->
Probably no unit tests needed for docs. Tell me if I'm wrong.

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->
This is a docs-only change.

### Additional Information

<!-- Anything else we should know? -->
Nothing.
