### PR TITLE
chore: fix outdated style in getting started codelab

### DIFF
--- a/packages/docs/docs/codelabs/getting-started/complete-code/index.html
+++ b/packages/docs/docs/codelabs/getting-started/complete-code/index.html
@@ -9,7 +9,7 @@
 
     <link
       rel="stylesheet"
-      href="https://code.getmdl.io/1.2.1/material.indigo-pink.min.css" />
+      href="https://unpkg.com/material-design-lite@1.3.0/dist/material.indigo-pink.min.css" />
     <link rel="stylesheet" href="styles/index.css" />
   </head>
 

--- a/packages/docs/docs/codelabs/getting-started/starter-code/index.html
+++ b/packages/docs/docs/codelabs/getting-started/starter-code/index.html
@@ -9,7 +9,7 @@
 
     <link
       rel="stylesheet"
-      href="https://code.getmdl.io/1.2.1/material.indigo-pink.min.css" />
+      href="https://unpkg.com/material-design-lite@1.3.0/dist/material.indigo-pink.min.css" />
     <link rel="stylesheet" href="styles/index.css" />
   </head>
 


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details

Fixes issue where old styles could not be fetched. Copied from the same fix in blockly-samples repo 

