### PR TITLE
fix: Fix loss of focus when deleting blocks via context menu

### DIFF
--- a/packages/blockly/core/contextmenu_items.ts
+++ b/packages/blockly/core/contextmenu_items.ts
@@ -545,6 +545,7 @@ export function registerDelete() {
     },
     callback(scope: Scope) {
       if (scope.block) {
+        getFocusManager().focusNode(scope.block);
         scope.block.checkAndDelete();
       }
     },


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Proposed Changes
This PR fixes a loss of focus when blocks were deleted from the context menu. Blocks find and focus the next-best neighbor in their `dispose()` method, but only when they are currently focused. When deletion is triggered by the context menu, the context menu is focused, so the check was bypassed. The context menu handler now focuses the block before invoking `dispose()`.