### PR TITLE
fix: use translated 'bubble' string for ARIA label fallback

### DIFF
--- a/packages/blockly/core/bubbles/bubble.ts
+++ b/packages/blockly/core/bubbles/bubble.ts
@@ -15,6 +15,7 @@ import type {IFocusableTree} from '../interfaces/i_focusable_tree.js';
 import type {IHasBubble} from '../interfaces/i_has_bubble.js';
 import {ISelectable} from '../interfaces/i_selectable.js';
 import {ContainerRegion} from '../metrics_manager.js';
+import {Msg} from '../msg.js';
 import {Scrollbar} from '../scrollbar.js';
 import {aria} from '../utils.js';
 import {Coordinate} from '../utils/coordinate.js';
@@ -791,7 +792,11 @@ export abstract class Bubble
 
     const label = this.getAriaLabel()?.trim();
 
-    aria.setState(element, aria.State.LABEL, label ? label : 'Bubble');
+    aria.setState(
+      element,
+      aria.State.LABEL,
+      label ? label : Msg['BUBBLE_LABEL_DEFAULT'],
+    );
   }
 
   /**


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes https://github.com/RaspberryPiFoundation/blockly/issues/9953

### Proposed Changes

This replaces a hard-coded English string literal with a translatable one.  No functional changes.
<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->

### Reason for Changes

> The [bubble implementation](https://github.com/RaspberryPiFoundation/blockly/blob/1cac226a19594d805d3bcc194106a10ac3ad1ddc/packages/blockly/core/bubbles/bubble.ts#L794) hardcodes the English 'Bubble' as the fallback label. https://github.com/RaspberryPiFoundation/blockly/commit/9a01417400bec54496bd3ce49160d7612a544c3f introduced BUBBLE_LABEL_DEFAULT for this purpose but didn't actually use it.

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
