### PR TITLE
fix: re-establish touch identifier when a gesture restarts after a missed pointerup

### DIFF
--- a/packages/blockly/core/gesture.ts
+++ b/packages/blockly/core/gesture.ts
@@ -418,6 +418,14 @@ export class Gesture {
 
     this.mouseDownXY = new Coordinate(e.clientX, e.clientY);
 
+    // Re-establish the touch identifier for this gesture's starting pointer.
+    // If getGesture() cancelled a stale gesture for this pointer (a missed
+    // pointerup), that cancel() cleared the global touch identifier via
+    // dispose(). Without restoring it here, this gesture's terminating
+    // pointerup is rejected by Touch.shouldHandleEvent and the gesture is
+    // never disposed, permanently locking the workspace.
+    Touch.checkTouchIdentifier(e);
+
     this.bindMouseEvents(e);
 
     if (!this.isEnding_) {

--- a/packages/blockly/tests/mocha/gesture_test.js
+++ b/packages/blockly/tests/mocha/gesture_test.js
@@ -130,4 +130,26 @@ suite('Gesture', function () {
       this.workspace.id,
     );
   });
+
+  test('Duplicate pointerdown (missed pointerup) does not lock the workspace', function () {
+    // Some touch environments emit a pointerdown for a pointer that is already
+    // down (a missed pointerup). getGesture() handles this by cancelling the
+    // stale gesture and starting a new one; that new gesture must still be
+    // disposable so the workspace does not lock up permanently.
+    const target = this.workspace.getSvgGroup();
+    dispatchPointerEvent(target, 'pointerdown', {pointerId: 1});
+    assert.isTrue(
+      Blockly.Gesture.inProgress(),
+      'Precondition: first pointerdown must start a gesture.',
+    );
+    // Duplicate pointerdown for the same pointer id (missed pointerup).
+    dispatchPointerEvent(target, 'pointerdown', {pointerId: 1});
+    // Releasing the pointer must end the gesture.
+    dispatchPointerEvent(document, 'pointerup', {pointerId: 1});
+
+    assert.isFalse(
+      Blockly.Gesture.inProgress(),
+      'Gesture should not remain in progress after the pointer is released.',
+    );
+  });
 });


### PR DESCRIPTION
Resolves #9955

### Summary
When `getGesture` discards a stale gesture (missed pointerup) and starts a fresh one for the same `pointerdown`, the cleared global touch identifier is never restored, so the new gesture's terminating `pointerup` is filtered out by `Touch.shouldHandleEvent` and the gesture is never disposed — permanently locking the workspace (regression since v12.0.0). Re-establish the identifier when the gesture starts.

### Fix (`core/gesture.ts`, in `doStart`; `Touch` is already imported)
```diff
     this.gestureHasStarted = true;
 
     blockAnimations.disconnectUiStop();
@@
     this.mouseDownXY = new Coordinate(e.clientX, e.clientY);
 
+    // Re-establish the touch identifier for this gesture's starting pointer.
+    // If getGesture() cancelled a stale gesture for this pointer (a missed
+    // pointerup), that cancel() cleared the global touch identifier via
+    // dispose(). Without restoring it here, this gesture's terminating
+    // pointerup is rejected by Touch.shouldHandleEvent and the gesture is
+    // never disposed, permanently locking the workspace.
+    Touch.checkTouchIdentifier(e);
+
     this.bindMouseEvents(e);
 
     if (!this.isEnding_) {
       this.handleTouchStart(e);
     }
```
**Why this is safe (by construction):** `e` in `doStart` is always this gesture's *own* originating `pointerdown`, so setting `touchIdentifier_` to its id can never select the **wrong** pointer — it is always correct, on every start path. A genuine concurrent second finger has a **different** pointer id and never reaches `doStart` (it is routed to the existing gesture's `handleStart`); the bug requires a **duplicate same-id** `pointerdown`. `checkTouchIdentifier` mutates state only when `touchIdentifier_ === null && e.type === 'pointerdown'`, so the call is a strict **no-op on the workspace `onMouseDown` path** (whose capture-gated binding at `workspace_svg.ts:806`, `noCaptureIdentifier = false`, already set the identifier before `doStart` runs); on the cancel-and-recreate path it restores the identifier that the prior `cancel()` → `dispose()` cleared. Right-click (`gesture.ts:410`) and target-input (`gesture.ts:383`) early-return **before** this line. Empirically confirmed on a built master HEAD: a normal 2-finger pinch still reaches `cachedPoints.size === 2` / `isMultiTouch()`.

### Regression test (append to existing `packages/blockly/tests/mocha/gesture_test.js`)
Dispatch on the workspace's **`svgGroup_`** (where `onMouseDown` is bound), not `getParentSvg()` (an *ancestor* — a bubbling listener on a descendant never sees it, so the gesture would never start and the test would pass vacuously). A precondition assert guards against exactly that.
```js
test('Duplicate pointerdown (missed pointerup) does not lock the workspace', function () {
  const target = this.workspace.getSvgGroup();
  // First pointerdown starts a gesture.
  dispatchPointerEvent(target, 'pointerdown', {pointerId: 1});
  assert.isTrue(
    Blockly.Gesture.inProgress(),
    'Precondition: first pointerdown must start a gesture.',
  );
  // A second pointerdown for the SAME pointer id arrives (missed pointerup);
  // getGesture cancels the stale gesture and starts a new one.
  dispatchPointerEvent(target, 'pointerdown', {pointerId: 1});
  // Releasing the pointer must end the gesture.
  dispatchPointerEvent(document, 'pointerup', {pointerId: 1});

  assert.isFalse(
    Blockly.Gesture.inProgress(),
    'Gesture should not remain in progress after the pointer is released.',
  );
});
```
**Verified fail-before / pass-after on Blockly's own mocha runner** (`gulp build` + `tests/mocha`, master HEAD `c531405`): on the unpatched build this test fails (`inProgress() === true`) while the other 5 `Gesture` suite tests pass; on the patched build all **6/6 `Gesture` tests pass** (no regression). The precondition assert holds in both runs.

### Alternative fix locations (for maintainer preference)
- `WorkspaceSvg.getGesture`: after `this.currentGesture_ = new Gesture(e, this)`, call `Touch.checkTouchIdentifier(e)` (requires importing `Touch` into `workspace_svg.ts`). Also validated.
- `Gesture.handleUp`: dispose a started gesture even when `shouldHandleEvent` is false, so a started gesture can never become permanently undisposable. Broader behavioral change; not preferred.

### Verification
- Repro + fix exercised against a built **master `c531405`** `blockly_compressed.js` (headless Chrome): unpatched → locked; with `doStart` fix → recovers; normal pinch unaffected.
- **Regression test run on Blockly's own mocha runner** (`gulp build` + `tests/mocha`, master `c531405`): unpatched build → the new test fails (5/6 Gesture pass); patched build → **6/6 Gesture tests pass**.
- Real-device capture (Android 10 Chrome, Blockly 12.5.1): freeze preceded by `"Tried to start the same gesture twice." ×9` and 5 duplicate-active `pointerdown`s.