### PR TITLE
feat: add block role description to verbose block labels

### DIFF
--- a/packages/blockly/core/block.ts
+++ b/packages/blockly/core/block.ts
@@ -46,6 +46,7 @@ import type {
   IVariableModel,
   IVariableState,
 } from './interfaces/i_variable_model.js';
+import {Msg} from './msg.js';
 import * as registry from './registry.js';
 import * as Tooltip from './tooltip.js';
 import * as arrayUtils from './utils/array.js';
@@ -1567,15 +1568,27 @@ export class Block {
   }
 
   /**
-   * @returns The custom string to use as the role description for this block,
-   *   or undefined if no custom description is set.
+   * @returns The string to use as the role description for this block. If a
+   *    custom provider has been set, use that. Otherwise, return a default
+   *    description based on the block's properties.
    */
-  getAriaRoleDescription(): string | undefined {
-    if (!this.ariaRoleDescriptionProvider) return undefined;
-    if (typeof this.ariaRoleDescriptionProvider === 'function') {
-      return this.ariaRoleDescriptionProvider();
+  getAriaRoleDescription(): string {
+    if (this.ariaRoleDescriptionProvider) {
+      if (typeof this.ariaRoleDescriptionProvider === 'function') {
+        return this.ariaRoleDescriptionProvider();
+      }
+      return replaceMessageReferences(this.ariaRoleDescriptionProvider);
     }
-    return replaceMessageReferences(this.ariaRoleDescriptionProvider);
+
+    let roleDescription: string;
+    if (this.statementInputCount) {
+      roleDescription = Msg['BLOCK_LABEL_CONTAINER'];
+    } else if (this.outputConnection) {
+      roleDescription = Msg['BLOCK_LABEL_VALUE'];
+    } else {
+      roleDescription = Msg['BLOCK_LABEL_STATEMENT'];
+    }
+    return roleDescription;
   }
 
   /**

--- a/packages/blockly/core/block_aria_composer.ts
+++ b/packages/blockly/core/block_aria_composer.ts
@@ -79,6 +79,7 @@ export function computeAriaLabel(
     verbosity >= Verbosity.STANDARD && getCollapsedLabel(block),
     verbosity >= Verbosity.LOQUACIOUS && getShadowBlockLabel(block),
     verbosity >= Verbosity.STANDARD && getInputCountLabel(block),
+    verbosity >= Verbosity.LOQUACIOUS && block.getAriaRoleDescription(),
   ]
     .filter((label) => !!label)
     .join(', ');
@@ -100,18 +101,11 @@ export function configureAriaRole(block: BlockSvg) {
     setRole(focusableElement, Role.FIGURE);
   }
 
-  let roleDescription;
-  const customDescription = block.getAriaRoleDescription();
-  if (customDescription) {
-    roleDescription = customDescription;
-  } else if (block.statementInputCount) {
-    roleDescription = Msg['BLOCK_LABEL_CONTAINER'];
-  } else if (block.outputConnection) {
-    roleDescription = Msg['BLOCK_LABEL_VALUE'];
-  } else {
-    roleDescription = Msg['BLOCK_LABEL_STATEMENT'];
-  }
-  setState(focusableElement, State.ROLEDESCRIPTION, roleDescription);
+  setState(
+    focusableElement,
+    State.ROLEDESCRIPTION,
+    block.getAriaRoleDescription(),
+  );
 }
 
 /**


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes https://github.com/RaspberryPiFoundation/blockly/issues/9959

### Proposed Changes

This prepares a change to add the block's role description ('container', 'value', 'statement', or custom) to the end of a block's `LOQUACIOUS` labels, ie. when using the "information" shortcut.  This aligns to the design doc's examples of Block labels: https://docs.google.com/document/d/1-q0paWfV9qYWoZKWb9BpcfYOy3xYZtvcLyuuD61qHXw/edit?pli=1&tab=t.0#bookmark=id.cfg03e73jnno


<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
<img width="626" height="223" alt="image" src="https://github.com/user-attachments/assets/362951f0-51d4-4bdb-a716-a79d8345f7fe" />

This was never implemented in the composer, so we should confirm whether it's actually desired or not before merging.