### PR TITLE
fix: only show paste hint toast on keyboard copy/cut

### DIFF
--- a/packages/blockly/core/shortcut_items.ts
+++ b/packages/blockly/core/shortcut_items.ts
@@ -230,7 +230,7 @@ export function registerCopy() {
           ? focused.getRelativeToSurfaceXY()
           : undefined;
       const copied = !!clipboard.copy(focused, copyCoords);
-      if (copied) {
+      if (copied && e instanceof KeyboardEvent) {
         showCopiedHint(workspace);
       }
       return copied;
@@ -284,7 +284,7 @@ export function registerCut() {
         workspace.getAudioManager().play('delete');
         e.preventDefault();
       }
-      if (copyData) {
+      if (copyData && e instanceof KeyboardEvent) {
         showCutHint(workspace);
       }
       return !!copyData;


### PR DESCRIPTION
This differs from the keyboard nav plugin but I think it's correct for an on-by-default world as it's very weird to encounter this toast on a touch device with and not helpful for mouse usage (e.g. in MakeCode's context menu).

<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes https://github.com/RaspberryPiFoundation/blockly/issues/9961

(newly raised, check the team agree)

### Proposed Changes

Gate the cut/copy toasts on the event being a KeyboardEvent (could be context menu via keyboard or the shortcut).

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
