### PR TITLE
fix: don't allow disconnecting shadow blocks

### DIFF
--- a/packages/blockly/core/shortcut_items.ts
+++ b/packages/blockly/core/shortcut_items.ts
@@ -940,10 +940,12 @@ export function registerDisconnectBlock() {
   const disconnectShortcut: ShortcutRegistry.KeyboardShortcut = {
     name: names.DISCONNECT,
     preconditionFn: (workspace, scope) => {
+      const focused = scope.focusedNode;
       const result =
         !workspace.isDragging() &&
         !workspace.isReadOnly() &&
-        scope.focusedNode instanceof BlockSvg;
+        focused instanceof BlockSvg &&
+        !focused.isShadow();
 
       if (!result) {
         workspace.getAudioManager().playErrorBeep();

--- a/packages/blockly/tests/mocha/shortcut_items_test.js
+++ b/packages/blockly/tests/mocha/shortcut_items_test.js
@@ -1036,6 +1036,23 @@ suite('Keyboard Shortcut Items', function () {
       assert.deepEqual(bounds, this.blockE.getBoundingRectangle());
     });
 
+    test('Does nothing for a shadow block', function () {
+      this.blockH.setShadow(true);
+      Blockly.getFocusManager().focusNode(this.blockH);
+      assert.isTrue(this.blockH.outputConnection.isConnected());
+
+      this.injectionDiv.dispatchEvent(
+        createKeyDownEvent(Blockly.utils.KeyCodes.X),
+      );
+
+      // The shadow should remain connected to its parent input.
+      assert.isTrue(this.blockH.outputConnection.isConnected());
+      assert.strictEqual(
+        Blockly.getFocusManager().getFocusedNode(),
+        this.blockH,
+      );
+    });
+
     test('Disconnects child blocks when triggered on top stack block', function () {
       Blockly.getFocusManager().focusNode(this.blockB);
       assert.isTrue(this.blockB.nextConnection.isConnected());


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes https://github.com/RaspberryPiFoundation/blockly/issues/9963 (newly raised)

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage

Added webdriver coverage.

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
