### PR TITLE
fix: remove redundant labels for child blocks of parent input

### DIFF
--- a/packages/blockly/core/block_aria_composer.ts
+++ b/packages/blockly/core/block_aria_composer.ts
@@ -318,7 +318,7 @@ export function getInputLabels(
     }
   }
 
-  return inputsToLabel.map((input) => input.getLabel(verbosity, true));
+  return inputsToLabel.map((input) => input.getLabel(verbosity));
 }
 
 /**

--- a/packages/blockly/core/block_aria_composer.ts
+++ b/packages/blockly/core/block_aria_composer.ts
@@ -205,6 +205,9 @@ export function computeFieldRowLabel(
  * wrapped in the "Begin %1" prefix so the readout indicates that the child
  * block starts the body of the statement input.
  *
+ * Labels for child blocks of inputs are excluded because they are included
+ * with {@link getInputLabels} already.
+ *
  * @internal
  * @param block The block to generate a parent input label for.
  * @returns A description of the block's parent statement input, or undefined
@@ -242,6 +245,7 @@ function getParentInputLabel(block: BlockSvg) {
     const sectionLabels = getInputLabelsSubset(
       parentBlock as BlockSvg,
       parentInput,
+      false, // Exclude labels from child blocks.
     );
     if (!sectionLabels.length) {
       return undefined;
@@ -314,7 +318,7 @@ export function getInputLabels(
     }
   }
 
-  return inputsToLabel.map((input) => input.getLabel(verbosity));
+  return inputsToLabel.map((input) => input.getLabel(verbosity, true));
 }
 
 /**
@@ -338,17 +342,23 @@ export function getInputLabels(
  *
  * @internal
  * @param block The block to retrieve a list of field/input labels for.
- * @param input The input that defines the end of the subset.
+ * @param endInput The input that defines the end of the subset.
+ * @param includeEndInputChildren Whether to include labels for child blocks
+ *    connected to the end input.
  * @returns A list of field/input labels for the given block.
  */
-export function getInputLabelsSubset(block: BlockSvg, input: Input): string[] {
-  const inputIndex = block.inputList.indexOf(input);
+export function getInputLabelsSubset(
+  block: BlockSvg,
+  endInput: Input,
+  includeEndInputChildren: boolean,
+): string[] {
+  const inputIndex = block.inputList.indexOf(endInput);
   if (inputIndex === -1) {
     throw new Error(
-      `Input with name "${input.name}" not found on block with id "${block.id}".`,
+      `Input with name "${endInput.name}" not found on block with id "${block.id}".`,
     );
   }
-  const isStatementTarget = input.type === inputTypes.STATEMENT;
+  const isStatementTarget = endInput.type === inputTypes.STATEMENT;
 
   const startIndex = isStatementTarget
     ? findStartOfStatementSection(block.inputList, inputIndex)
@@ -362,9 +372,13 @@ export function getInputLabelsSubset(block: BlockSvg, input: Input): string[] {
     .filter((subsetInput) => subsetInput.isVisible());
 
   // The derived labels are based on the field row and any connected child
-  // blocks.
+  // blocks. Labels for child blocks are potentially skipped if they would be
+  // redundant within the overall block label.
   const derivedLabels = inputsInSubset.map((subsetInput) =>
-    subsetInput.getLabel(Verbosity.TERSE),
+    subsetInput.getLabel(
+      Verbosity.TERSE,
+      subsetInput !== endInput || includeEndInputChildren,
+    ),
   );
 
   // For statement inputs, we only include the fallback label ("input %1")
@@ -529,7 +543,7 @@ function computeMoveConnectionLabel(
   let inputLabel = input.getAriaLabelText();
 
   if (!inputLabel) {
-    const labels = getInputLabelsSubset(conn.getSourceBlock(), input);
+    const labels = getInputLabelsSubset(conn.getSourceBlock(), input, true);
     if (!labels.length) return baseLabel;
 
     inputLabel = labels.join(', ');

--- a/packages/blockly/core/inputs/input.ts
+++ b/packages/blockly/core/inputs/input.ts
@@ -400,18 +400,21 @@ export class Input {
 
   /**
    * Returns a derived accessibility label for this input: field row text plus
-   * labels of any connected child blocks. Does not include custom labels from
-   * {@link getAriaLabelText}; those are used in move-mode and parent-input
-   * context only.
+   * labels of any connected child blocks (unless excluded). Does not include
+   * custom labels from {@link getAriaLabelText}; those are used in move-mode
+   * and parent-input context only.
    *
    * @internal
    */
-  getLabel(verbosity = Verbosity.STANDARD): string {
+  getLabel(verbosity = Verbosity.STANDARD, includeChildren: boolean): string {
     if (!this.isVisible()) return '';
 
     const labels = computeFieldRowLabel(this, false, verbosity);
 
-    if (this.connection?.type === ConnectionType.INPUT_VALUE) {
+    if (
+      includeChildren &&
+      this.connection?.type === ConnectionType.INPUT_VALUE
+    ) {
       const childBlock = this.connection.targetBlock();
       if (childBlock && !childBlock.isInsertionMarker()) {
         labels.push(

--- a/packages/blockly/core/inputs/input.ts
+++ b/packages/blockly/core/inputs/input.ts
@@ -406,7 +406,7 @@ export class Input {
    *
    * @internal
    */
-  getLabel(verbosity = Verbosity.STANDARD, includeChildren: boolean): string {
+  getLabel(verbosity = Verbosity.STANDARD, includeChildren = true): string {
     if (!this.isVisible()) return '';
 
     const labels = computeFieldRowLabel(this, false, verbosity);

--- a/packages/blockly/core/rendered_connection.ts
+++ b/packages/blockly/core/rendered_connection.ts
@@ -360,6 +360,7 @@ export class RenderedConnection
       getInputLabelsSubset(
         parentInput.getSourceBlock() as BlockSvg,
         parentInput,
+        true,
       ).join(', ');
     if (this.type === ConnectionType.NEXT_STATEMENT) {
       aria.setState(


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes https://github.com/RaspberryPiFoundation/blockly/issues/9966

### Proposed Changes

This prevents labels of child blocks being included for parent inputs  (see `getParentInputLabel)` as part of the main `computeAriaLabel` composer function. This was causing redundancy as the block being labeled is also the child block of its parent input. With this change, blocks with parent inputs will only have their labels included once:

<img width="614" height="319" alt="image" src="https://github.com/user-attachments/assets/8074995a-4587-4fcd-9bb5-9595057e33a6" />

This adds a new optional parameter to `Input.getLabel`. Unfortunately, I wasn't able to just use `verbosity` here as there are times when we want the child blocks to be read even when `verbosity` is `TERSE`, such as for move mode announcements and the extended information shortcut. Making this parameter optional prevents introducing a breaking change for any v13 beta users.

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->

### Reason for Changes

Blocks with parent inputs were having their own labels read twice. See linked issue for examples.

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
