### PR TITLE
feat: add docs as conventional commit option

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -20,9 +20,11 @@ changelog:
     - title: Bug fixes 🐛
       labels:
         - 'PR: fix'
-    - title: Cleanup ♻️
+    - title: Documentation updates 📄
       labels:
         - 'PR: docs'
+    - title: Cleanup ♻️
+      labels:
         - 'PR: refactor'
     - title: Reverted changes ⎌
       labels:

--- a/packages/docs/docs/guides/contribute/get-started/commits.mdx
+++ b/packages/docs/docs/guides/contribute/get-started/commits.mdx
@@ -42,6 +42,8 @@ accepted types.
 
 - **`fix`:** For commits that fix bugs/errors in Blockly.
 
+- **`docs`:** For commits that update or add documentation.
+
 - **`release`:** For commits that relate to the release of a new version.
 
 #### Breaking changes


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details

### Proposed Changes

Adding "docs" as a valid conventional commit. "docs" is already a valid option in `commitlint.config.mjs` and `conventional-label.yml` so the only change is adjusting how releases show docs changes (and updating the documentation). 
