### PR TITLE
fix: all use closest candidate when moving disconnected blocks

### DIFF
--- a/packages/blockly/core/dragging/block_drag_strategy.ts
+++ b/packages/blockly/core/dragging/block_drag_strategy.ts
@@ -1023,12 +1023,14 @@ export class BlockDragStrategy implements IDragStrategy {
     if (forwardTraversal) {
       if (currentPairIndex === -1) {
         const terminal = this.isInTerminalPosition(this.block, Direction.DOWN);
-        if (navigator.getNavigationLoops()) {
-          return this.pairToCandidate(pairs[0]);
-        } else if (!terminal) {
-          return this.getClosestCandidate(this.block, delta);
+        if (terminal) {
+          if (navigator.getNavigationLoops()) {
+            return this.pairToCandidate(pairs[0]);
+          } else {
+            return null;
+          }
         }
-        return null;
+        return this.getClosestCandidate(this.block, delta);
       } else if (currentPairIndex === pairs.length - 1) {
         return null;
       } else {
@@ -1037,12 +1039,14 @@ export class BlockDragStrategy implements IDragStrategy {
     } else {
       if (currentPairIndex === -1) {
         const terminal = this.isInTerminalPosition(this.block, Direction.UP);
-        if (navigator.getNavigationLoops()) {
-          return this.pairToCandidate(pairs[pairs.length - 1]);
-        } else if (!terminal) {
-          return this.getClosestCandidate(this.block, delta);
+        if (terminal) {
+          if (navigator.getNavigationLoops()) {
+            return this.pairToCandidate(pairs[pairs.length - 1]);
+          } else {
+            return null;
+          }
         }
-        return null;
+        return this.getClosestCandidate(this.block, delta);
       } else if (currentPairIndex === 0) {
         return null;
       } else {

--- a/packages/blockly/tests/mocha/keyboard_movement_test.js
+++ b/packages/blockly/tests/mocha/keyboard_movement_test.js
@@ -1282,7 +1282,6 @@ suite('Keyboard-driven movement', function () {
 
         Blockly.getFocusManager().focusNode(loop);
         startMove(this.workspace);
-        moveRight(this.workspace);
         this.clock.tick(10);
 
         this.moveAndAssert(


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details

### Proposed Changes

This unifies the behavior of selecting the closest connection that is currently reserved for non-looping mode so that it happens in either mode.

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->

### Reason for Changes

Currently, when there is no current connection pair and we are looping, a block is moved to the first or last possible connection, depending on move direction. This causes an unexpected jump in block position for non-screenreader users.

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage

One test needed to be updated as this changes the required move commands to achieve a particular block arrangement.

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->
