### PR TITLE
fix: position dragging block above/below all blocks

### DIFF
--- a/packages/blockly/core/dragging/block_drag_strategy.ts
+++ b/packages/blockly/core/dragging/block_drag_strategy.ts
@@ -665,7 +665,7 @@ export class BlockDragStrategy implements IDragStrategy {
         if (!bounds) return;
 
         const blockRects = draggingBlock.workspace
-          .getTopBlocks(true)
+          .getTopBlocks()
           .map((block) => block.getBoundingRectangle());
         const blocksLeft = Math.min(...blockRects.map((rect) => rect.left));
 

--- a/packages/blockly/core/dragging/block_drag_strategy.ts
+++ b/packages/blockly/core/dragging/block_drag_strategy.ts
@@ -670,13 +670,14 @@ export class BlockDragStrategy implements IDragStrategy {
         const blocksLeft = Math.min(...blockRects.map((rect) => rect.left));
 
         let destination: Coordinate;
+        let blockBound: number;
         switch (direction) {
           case Direction.LEFT:
           case Direction.UP:
-            const blocksTop = Math.min(...blockRects.map((rect) => rect.top));
+            blockBound = Math.min(...blockRects.map((rect) => rect.top));
             destination = new Coordinate(
               blocksLeft,
-              blocksTop -
+              blockBound -
                 this.BLOCK_CONNECTION_OFFSET * 2 -
                 draggingBlock.getHeightWidth().height,
             );
@@ -684,12 +685,10 @@ export class BlockDragStrategy implements IDragStrategy {
           case Direction.RIGHT:
           case Direction.DOWN:
           default:
-            const blocksBottom = Math.max(
-              ...blockRects.map((rect) => rect.bottom),
-            );
+            blockBound = Math.max(...blockRects.map((rect) => rect.bottom));
             destination = new Coordinate(
               blocksLeft,
-              blocksBottom + this.BLOCK_CONNECTION_OFFSET * 2,
+              blockBound + this.BLOCK_CONNECTION_OFFSET * 2,
             );
             break;
         }

--- a/packages/blockly/core/dragging/block_drag_strategy.ts
+++ b/packages/blockly/core/dragging/block_drag_strategy.ts
@@ -664,13 +664,19 @@ export class BlockDragStrategy implements IDragStrategy {
         const bounds = root?.getBoundingRectangle();
         if (!bounds) return;
 
+        const blockRects = draggingBlock.workspace
+          .getTopBlocks(true)
+          .map((block) => block.getBoundingRectangle());
+        const blocksLeft = Math.min(...blockRects.map((rect) => rect.left));
+
         let destination: Coordinate;
         switch (direction) {
           case Direction.LEFT:
           case Direction.UP:
+            const blocksTop = Math.min(...blockRects.map((rect) => rect.top));
             destination = new Coordinate(
-              bounds.getOrigin().x,
-              bounds.getOrigin().y -
+              blocksLeft,
+              blocksTop -
                 this.BLOCK_CONNECTION_OFFSET * 2 -
                 draggingBlock.getHeightWidth().height,
             );
@@ -678,11 +684,12 @@ export class BlockDragStrategy implements IDragStrategy {
           case Direction.RIGHT:
           case Direction.DOWN:
           default:
+            const blocksBottom = Math.max(
+              ...blockRects.map((rect) => rect.bottom),
+            );
             destination = new Coordinate(
-              bounds.getOrigin().x,
-              bounds.getOrigin().y +
-                bounds.getHeight() +
-                this.BLOCK_CONNECTION_OFFSET * 2,
+              blocksLeft,
+              blocksBottom + this.BLOCK_CONNECTION_OFFSET * 2,
             );
             break;
         }


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [ ] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details

### Proposed Changes

When a block is moved to the workspace in constrained move mode, we will now move it above or below all blocks on the workspace.
<img width="166" height="144" alt="image" src="https://github.com/user-attachments/assets/aba6a51a-4ade-42d2-a600-e2d70862fb09" />

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->

### Reason for Changes

Previously, the fallback placement (above or below the block) was based on the bounding rectangle of a single “root” connected block. This could lead to the dragging block being placed on top of other blocks.

<img width="180" height="107" alt="image" src="https://github.com/user-attachments/assets/2857b5fe-a1af-430d-bb3c-3ca5ce07b484" />

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
