### PR TITLE
fix: improve terminal position detection

### DIFF
--- a/packages/blockly/core/dragging/block_drag_strategy.ts
+++ b/packages/blockly/core/dragging/block_drag_strategy.ts
@@ -1075,19 +1075,26 @@ export class BlockDragStrategy implements IDragStrategy {
     }
 
     const topBlocks = block.workspace.getTopBlocks(true);
+    const blockRect = block.getBoundingRectangle();
 
-    const index = topBlocks.indexOf(block);
-    const delta = direction === Direction.UP ? -1 : 1;
-    const start = index + delta;
+    // A block is terminal if it is above (moving up) or below (moving down) all other blocks
+    // that have valid connections with it. We need to consider the full shape of the blocks,
+    // not just their top-left origins.
+    const isMovingUp = direction === Direction.UP;
+    const edge = isMovingUp ? 'top' : 'bottom';
+    const directionalCompare = isMovingUp
+      ? (a: number, b: number) => a <= b
+      : (a: number, b: number) => a >= b;
+    const blocksToConsider = topBlocks.filter(
+      (b) =>
+        b.id !== block.id &&
+        directionalCompare(b.getBoundingRectangle()[edge], blockRect[edge]),
+    );
 
-    // Generally terminal blocks will be at the start or end of the sorted list
-    // of top blocks, but it still counts if all of the blocks before/after it
-    // have no valid connection points for the block in question.
     const blockConnections = block.getConnections_(false);
-    for (let i = start; i >= 0 && i < topBlocks.length; i += delta) {
-      const topBlock = topBlocks[i];
+    for (const topBlock of blocksToConsider) {
+      const stackConnections = this.getAllConnections(topBlock);
       for (const a of blockConnections) {
-        const stackConnections = this.getAllConnections(topBlock);
         for (const b of stackConnections) {
           if (
             block.workspace.connectionChecker.canConnect(a, b, true, Infinity)

--- a/packages/blockly/tests/mocha/keyboard_movement_test.js
+++ b/packages/blockly/tests/mocha/keyboard_movement_test.js
@@ -1440,6 +1440,7 @@ suite('Keyboard-driven movement', function () {
         const boolean = this.workspace.newBlock('logic_boolean');
         boolean.initSvg();
         boolean.render();
+        this.workspace.cleanUp();
 
         Blockly.getFocusManager().focusNode(boolean);
         startMove(this.workspace);
@@ -1523,6 +1524,7 @@ suite('Keyboard-driven movement', function () {
         const boolean = this.workspace.newBlock('logic_boolean');
         boolean.initSvg();
         boolean.render();
+        this.workspace.cleanUp();
 
         Blockly.getFocusManager().focusNode(boolean);
         startMove(this.workspace);


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details


### Proposed Changes

Refactors `isInTerminalPosition` to use full block bounding rectangles and directional comparison when determining whether a top-level block is at the start or end of the workspace layout. The logic now filters candidate blocks based on vertical ordering and evaluates connectivity against all relevant connection pairs rather than relying on top-left block origin alone.

The moving block in this screenshot was previously considered to be terminal because the `repeat` block is above it, based on origin. With this change, it is no longer considered terminal, based on the bottom of each top block. This means users in screen reader mode can connect to it by pressing 'down'.

<img width="297" height="256" alt="image" src="https://github.com/user-attachments/assets/1a01aaea-4b14-4b1b-90ad-bafc8c8d58db" />

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->

### Reason for Changes

The previous implementation did not properly account for the full spatial extent of blocks, which could cause non-looping moves to fail/beep when moving down. This update makes terminal detection more accurate.

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage
This change slightly alters move connection order in some cases. Two tests were updated to make sure that blocks were laid out at expected locations.
<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->
