### PR TITLE
fix: focus the workspace itself on first focus

### DIFF
--- a/packages/blockly/core/workspace_svg.ts
+++ b/packages/blockly/core/workspace_svg.ts
@@ -2789,22 +2789,25 @@ export class WorkspaceSvg
   getRestoredFocusableNode(
     previousNode: IFocusableNode | null,
   ): IFocusableNode | null {
-    if (!previousNode) {
-      const flyout = this.targetWorkspace?.getFlyout();
-      if (this.isFlyout && flyout) {
-        // Return the first focusable item of the flyout.
-        return (
-          flyout
-            .getContents()
-            .find((flyoutItem) => {
-              const element = flyoutItem.getElement();
-              return isFocusableNode(element) && element.canBeFocused();
-            })
-            ?.getElement() ?? null
-        );
-      }
-      return this.getTopBlocks(true)[0] ?? null;
-    } else return null;
+    if (previousNode) {
+      return previousNode;
+    }
+    const flyout = this.targetWorkspace?.getFlyout();
+    if (this.isFlyout && flyout) {
+      // Return the first focusable item of the flyout.
+      return (
+        flyout
+          .getContents()
+          .find((flyoutItem) => {
+            const element = flyoutItem.getElement();
+            return isFocusableNode(element) && element.canBeFocused();
+          })
+          ?.getElement() ?? null
+      );
+    }
+    // This workspace has never been focused before, so return null to use
+    // the default focusing behavior (focus the workspace itself).
+    return null;
   }
 
   /** See IFocusableTree.getNestedTrees. */

--- a/packages/blockly/core/workspace_svg.ts
+++ b/packages/blockly/core/workspace_svg.ts
@@ -2753,7 +2753,7 @@ export class WorkspaceSvg
 
   /** See IFocusableNode.getFocusableTree. */
   getFocusableTree(): IFocusableTree {
-    return (this.isMutator && this.options.parentWorkspace) || this;
+    return this;
   }
 
   /** See IFocusableNode.onNodeFocus. */
@@ -2804,6 +2804,10 @@ export class WorkspaceSvg
           })
           ?.getElement() ?? null
       );
+    }
+    if (this.isMutator) {
+      // Return the first block in the mutator workspace, if it exists.
+      return this.getTopBlocks(true)[0] ?? null;
     }
     // This workspace has never been focused before, so return null to use
     // the default focusing behavior (focus the workspace itself).

--- a/packages/blockly/tests/mocha/keyboard_navigation_test.js
+++ b/packages/blockly/tests/mocha/keyboard_navigation_test.js
@@ -153,7 +153,8 @@ suite('Keyboard navigation on Blocks', function () {
   });
 
   test('Selected block', function () {
-    Blockly.getFocusManager().focusTree(this.workspace);
+    // first block in workspace
+    focusBlock(this.workspace, 'p5_setup_1');
     pressKeyN(this.workspace, Blockly.utils.KeyCodes.DOWN, 13);
     assert.equal(getFocusedBlockId(), 'controls_repeat_ext_1');
   });

--- a/packages/blockly/tests/mocha/shortcut_items_test.js
+++ b/packages/blockly/tests/mocha/shortcut_items_test.js
@@ -1855,6 +1855,10 @@ suite('Keyboard Shortcut Items', function () {
     test('Displays new tooltip on a block using the keyboard shortcut if tooltip for another block is already displayed', function () {
       const block1 = this.workspace.newBlock('controls_if');
       const block2 = this.workspace.newBlock('logic_compare');
+      for (const block of [block1, block2]) {
+        block.initSvg();
+        block.render();
+      }
 
       block1.setTooltip('block1');
       block2.setTooltip('block2');

--- a/packages/blockly/tests/mocha/workspace_svg_test.js
+++ b/packages/blockly/tests/mocha/workspace_svg_test.js
@@ -149,6 +149,36 @@ suite('WorkspaceSvg', function () {
     );
   });
 
+  suite('getRestoredFocusableNode', function () {
+    test('restores focus to the workspace itself for a non-mutator non-flyout workspace', function () {
+      Blockly.getFocusManager().focusTree(this.workspace);
+      assert.strictEqual(
+        Blockly.getFocusManager().getFocusedNode(),
+        this.workspace,
+      );
+    });
+
+    test('restores focus to the first block for a mutator workspace', async function () {
+      const block = this.workspace.newBlock('controls_if');
+      block.initSvg();
+      block.render();
+      const icon = block.getIcon(Blockly.icons.MutatorIcon.TYPE);
+      await icon.setBubbleVisible(true);
+      const mutatorWorkspace = icon.getWorkspace();
+      const firstBlock = mutatorWorkspace.getTopBlocks(true)[0];
+
+      assert.strictEqual(
+        mutatorWorkspace.getRestoredFocusableNode(null),
+        firstBlock,
+      );
+      Blockly.getFocusManager().focusTree(mutatorWorkspace);
+      assert.strictEqual(
+        Blockly.getFocusManager().getFocusedNode(),
+        firstBlock,
+      );
+    });
+  });
+
   suite('updateToolbox', function () {
     test('Passes in null when toolbox exists', function () {
       assert.throws(


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #9969 

### Proposed Changes

- For non-mutator, non-flyout workspaces, focuses the workspace itself on first focus, not the first block. reduces cognitive overload for screenreader users and actually reads the screenreader mode hint we added.
- No change for mutators and flyouts: focuses the first block or focusable item
- Added new tests for the above behavior
- Previously, mutator workspaces said that their focusable tree was actually the parent workspace. This causes problems. Changed it so they return themselves. See next section for details.
- Fixed an issue with a tooltip test not rendering the blocks, causing the test to pass by luck of the way previous things worked

### Reason for Changes

See issue description for why the first change.

As to why the change to `getFocusableTree` in `workspace_svg`:

At an intermediate step in this PR, I had mutator workspaces also returning the workspace itself for initial focus rather than the first block. This revealed problems with `getFocusableTree` returning the parent workspace. It caused the escape shortcut to behave incorrectly, T to open the main workspace toolbox instead of the flyout toolbox, etc. Basically there was almost no way previously to actually put the focus on the mutator workspace itself (since mutator workspaces are never empty) and so the condition where `workspace.getFocusableTree` was actually hitting the mutator case never occurred. blocks on the mutator workspace did not participate in the same lie where they said that their tree was the main workspace tree. they correctly reported the mutator workspace tree.

I audited the cases where the mutator workspace being focused and `getFocusableTree` is called. Here are the results:


Consumer | Effect of returning parent for mutator root
-- | --
FocusManager.getFocusedTree() | Wrong tree (main workspace)
globalShortcutHandler | Routes shortcuts to main workspace instead of mutator
Navigator.getTopLevelItems() | Lists main workspace blocks instead of mutator blocks
FocusManager tree-switching / highlight logic | Treats mutator root as belonging to parent tree

All of these are actually the wrong behavior. It just never mattered before since the mutator workspace was never focused.

Then after I fixed these problems, I realized it actually made more sense for mutator workspaces to continue focusing their first block, unlike the main workspace. So this again goes back to not mattering since it is very difficult to actually focus the mutator workspace again. But, this behavior is more correct, and if we change our mind in the future about focusing the first block for mutator workspaces, we can easily change that without hitting these same problems.

### Test Coverage

added unit tests, fixed existing ones (that were relying on implementation details to pass). manually tested main workspaces, flyout workspaces, and mutator workspaces.

### Documentation

n/a

### Additional Information

<!-- Anything else we should know? -->
