### PR TITLE
fix: Do not bump neighbours mid-drag

### DIFF
--- a/packages/blockly/core/block_svg.ts
+++ b/packages/blockly/core/block_svg.ts
@@ -1615,6 +1615,7 @@ export class BlockSvg
     if (
       this.isDeadOrDying() ||
       this.workspace.isDragging() ||
+      this.isDragging() ||
       root.isInFlyout
     ) {
       return;
@@ -1636,7 +1637,7 @@ export class BlockSvg
 
         if (conn.isSuperior()) {
           neighbour.bumpAwayFrom(conn, /* initiatedByThis = */ false);
-        } else {
+        } else if (!neighbour.getSourceBlock().isDragging()) {
           conn.bumpAwayFrom(neighbour, /* initiatedByThis = */ true);
         }
       }

--- a/packages/blockly/core/dragging/block_drag_strategy.ts
+++ b/packages/blockly/core/dragging/block_drag_strategy.ts
@@ -358,21 +358,7 @@ export class BlockDragStrategy implements IDragStrategy {
         new Coordinate(0, 0),
       );
       if (neighbour) {
-        let offset: Coordinate;
-        if (neighbour.type === ConnectionType.PREVIOUS_STATEMENT) {
-          offset = new Coordinate(
-            neighbour.x,
-            neighbour.y -
-              this.block.getHeightWidth().height -
-              this.BLOCK_CONNECTION_OFFSET,
-          );
-        } else {
-          offset = new Coordinate(
-            neighbour.x + this.BLOCK_CONNECTION_OFFSET,
-            neighbour.y + this.BLOCK_CONNECTION_OFFSET,
-          );
-        }
-        this.block.moveDuringDrag(offset);
+        this.block.moveDuringDrag(this.determineConnectionOffset());
       }
 
       if (this.allConnectionPairs.length) {
@@ -587,35 +573,7 @@ export class BlockDragStrategy implements IDragStrategy {
     // Handle the case where the drag has reached a possible connection.
     if (this.connectionCandidate) {
       if (this.moveMode === MoveMode.CONSTRAINED) {
-        const {local, neighbour} = this.connectionCandidate;
-
-        const dx = neighbour.x - local.x;
-        const dy = neighbour.y - local.y;
-
-        // Base aligned position
-        let x = this.startLoc!.x + dx;
-        let y = this.startLoc!.y + dy;
-
-        // Decide offset direction
-        const becomingChild =
-          local.type === ConnectionType.PREVIOUS_STATEMENT ||
-          local.type === ConnectionType.OUTPUT_VALUE;
-
-        const offset = this.BLOCK_CONNECTION_OFFSET;
-
-        // An offset is used to distinguish the block from insertion marker,
-        // while keeping the connection point visible. The offset direction
-        // changes based on the parent/child relationship of the blocks
-        // being connected.
-        if (becomingChild) {
-          x += offset;
-          y += offset;
-        } else {
-          x -= offset;
-          y -= offset;
-        }
-
-        this.block.moveDuringDrag(new Coordinate(x, y));
+        this.block.moveDuringDrag(this.determineConnectionOffset());
       }
     } else {
       // No connection was available or adequately close to the dragged block;
@@ -633,6 +591,44 @@ export class BlockDragStrategy implements IDragStrategy {
       }
     }
     this.announceMove();
+  }
+
+  /**
+   * Determines the offset to apply to the dragged block's position
+   * based on the current connection candidate.
+   *
+   * @returns coordinates representing the offset
+   */
+  private determineConnectionOffset(): Coordinate {
+    const {local, neighbour} = this.connectionCandidate!;
+
+    const dx = neighbour.x - local.x;
+    const dy = neighbour.y - local.y;
+
+    // Base aligned position
+    let x = this.startLoc!.x + dx;
+    let y = this.startLoc!.y + dy;
+
+    // Decide offset direction
+    const becomingChild =
+      local.type === ConnectionType.PREVIOUS_STATEMENT ||
+      local.type === ConnectionType.OUTPUT_VALUE;
+
+    const offset = this.BLOCK_CONNECTION_OFFSET;
+
+    // An offset is used to distinguish the block from insertion marker,
+    // while keeping the connection point visible. The offset direction
+    // changes based on the parent/child relationship of the blocks
+    // being connected.
+    if (becomingChild) {
+      x += offset;
+      y += offset;
+    } else {
+      x -= offset;
+      y -= offset;
+    }
+
+    return new Coordinate(x, y);
   }
 
   /**


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [ ] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes 

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
This makes me two adjustments to how blocks are positioned during `startDrag`, at the start of a keyboard move:
1. Dragging blocks will no longer be bumped or have their neighbours bumped. If a top block is moved off of its stack, the other blocks will stay put; similar to command+dragging a single block off the top of a stack.

<img width="378" height="198" alt="image" src="https://github.com/user-attachments/assets/f6e9cf5d-d3e1-4cd6-85b1-16db6495007d" />
<img width="379" height="197" alt="image" src="https://github.com/user-attachments/assets/31bf37f4-6bbd-439a-a47e-a4c5bd8a851d" />

2. Newly dragging blocks will use the same offset/positioning logic as blocks that are mid-drag. We offset the location so that it reveals both the insertion marker and candidate connecting block. If the dragging block is becoming a child, we offset to the lower right. If the dragging block is becoming a parent, we offset to the upper left.
<img width="215" height="257" alt="image" src="https://github.com/user-attachments/assets/4a059bce-5a29-46bf-9e42-da101c2ba7ea" /><img width="252" height="203" alt="image" src="https://github.com/user-attachments/assets/5e4b5e81-f749-4a3f-9d74-b80fb6b2fb40" />


### Reason for Changes

As of the latest v13 beta.9, pressing M to move a block causes the selected block and any neighbour to move in unexpected ways due to bumping. The preview position of the dragging block was also inconsistent with later moves within the same "drag". 

<img width="377" height="220" alt="image" src="https://github.com/user-attachments/assets/c87514eb-18bd-4e37-b586-26dda846e152" />
<img width="381" height="220" alt="image" src="https://github.com/user-attachments/assets/61e13ec6-121f-4df7-9c9c-b830e576e533" />

