### PR TITLE
fix: dont crash after reverting move

### DIFF
--- a/packages/blockly/core/dragging/block_drag_strategy.ts
+++ b/packages/blockly/core/dragging/block_drag_strategy.ts
@@ -971,14 +971,6 @@ export class BlockDragStrategy implements IDragStrategy {
       }
     } else {
       this.block.moveDuringDrag(this.startLoc!);
-      this.workspace
-        .getLayerManager()
-        ?.moveOffDragLayer(this.block, layers.BLOCK);
-      this.getVisibleBubbles(this.block).forEach((bubble) =>
-        this.workspace
-          .getLayerManager()
-          ?.moveOffDragLayer(bubble, layers.BUBBLE, false),
-      );
 
       // Blocks dragged directly from a flyout may need to be bumped into
       // bounds.

--- a/packages/blockly/core/dragging/dragger.ts
+++ b/packages/blockly/core/dragging/dragger.ts
@@ -156,8 +156,9 @@ export class Dragger implements IDragger {
   }
 
   /** Handles a drag being reverted. */
-  onDragRevert() {
+  onDragRevert(e?: PointerEvent | KeyboardEvent) {
     this.draggable.revertDrag();
+    this.draggable.endDrag(e, DragDisposition.REVERT);
     if (isFocusableNode(this.draggable)) {
       getFocusManager().focusNode(this.draggable);
     }

--- a/packages/blockly/tests/mocha/keyboard_movement_test.js
+++ b/packages/blockly/tests/mocha/keyboard_movement_test.js
@@ -533,6 +533,33 @@ suite('Keyboard-driven movement', function () {
       assert.strictEqual(this.block1.nextConnection.targetBlock(), this.block2);
       assert.strictEqual(this.block2.nextConnection.targetBlock(), this.block3);
     });
+
+    test('Cancel after committed keyboard move does not throw', function () {
+      this.workspace.clear();
+      const ifBlock = this.workspace.newBlock('controls_if');
+      ifBlock.initSvg();
+      ifBlock.render();
+      this.drawBlock = this.workspace.newBlock('draw_emoji');
+      this.drawBlock.initSvg();
+      this.drawBlock.render();
+      this.workspace.cleanUp();
+
+      // Commit moving draw block from the stack into the if block's DO input.
+      Blockly.getFocusManager().focusNode(this.drawBlock);
+      startMove(this.workspace);
+      // move the block down to connect it to the do input.
+      moveUp(this.workspace);
+      endMove(this.workspace);
+
+      assert.strictEqual(this.drawBlock.getParent(), ifBlock);
+
+      // Start a second keyboard move and cancel before committing.
+      assert.doesNotThrow(() => {
+        Blockly.getFocusManager().focusNode(this.drawBlock);
+        startMove(this.workspace);
+        cancelMove(this.workspace);
+      });
+    });
   });
 
   suite('of blocks', function () {


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes 
With two connected blocks on the workspace, move one to a different connection and commit the move.
Start moving the same block again, but hit escape before committing.
block_svg.ts:313 Uncaught HierarchyRequestError: Failed to execute 'appendChild' on 'Node': The new child element contains the parent.
    at BlockSvg.setParent (block_svg.ts:313:44)3. Hit escape again
Keyboard shortcut named "commitMove" not found.
(anonymous) @ shortcut_registry.ts:80
dom.ts:119 Uncaught RangeError: Maximum call stack size exceeded
    at dom.ts:119:24

### Proposed Changes

- cleans up after a reverted keyboard move
- removes redundant cleanup code from `revertDrag` since it's handled in `endDrag`

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage

added test for this

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
