### PR TITLE
fix: reset initial connections before storing new ones

### DIFF
--- a/packages/blockly/core/dragging/block_drag_strategy.ts
+++ b/packages/blockly/core/dragging/block_drag_strategy.ts
@@ -916,6 +916,10 @@ export class BlockDragStrategy implements IDragStrategy {
     }
 
     this.allConnectionPairs = [];
+    this.startParentConn = null;
+    this.startChildConn = null;
+    this.connectionCandidate = null;
+    this.dragging = false;
   }
 
   /** Disposes of any state at the end of the drag. */

--- a/packages/blockly/core/dragging/block_drag_strategy.ts
+++ b/packages/blockly/core/dragging/block_drag_strategy.ts
@@ -485,6 +485,8 @@ export class BlockDragStrategy implements IDragStrategy {
    * the initial connection pair is also used as the first connection candidate.
    */
   private storeInitialConnections(healStack: boolean) {
+    this.startParentConn = null;
+    this.startChildConn = null;
     // Prioritize the block's parent connection (output or previous) if one exists.
     let localParentConn: RenderedConnection | null = null;
     let parentTargetConn: RenderedConnection | null = null;

--- a/packages/blockly/tests/mocha/keyboard_movement_test.js
+++ b/packages/blockly/tests/mocha/keyboard_movement_test.js
@@ -779,6 +779,61 @@ suite('Keyboard-driven movement', function () {
         assert.isFalse(ifBlock.isEnabled());
       });
 
+      test('Cancel after committed keyboard move does not throw', function () {
+        // if block with repeat block in next connection
+        const json = {
+          'blocks': {
+            'languageVersion': 0,
+            'blocks': [
+              {
+                'type': 'controls_if',
+                'id': 'ifBlock',
+                'x': 25,
+                'y': 10,
+                'next': {
+                  'block': {
+                    'type': 'controls_repeat_ext',
+                    'id': 'repeatBlock',
+                    'inputs': {
+                      'TIMES': {
+                        'shadow': {
+                          'type': 'math_number',
+                          'fields': {
+                            'NUM': 10,
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            ],
+          },
+        };
+        this.workspace.clear();
+        Blockly.serialization.workspaces.load(json, this.workspace);
+        const ifBlock = this.workspace.getBlockById('ifBlock');
+        const repeatBlock = this.workspace.getBlockById('repeatBlock');
+
+        // Move the if block down twice so it connects to the repeat block statement input.
+        Blockly.getFocusManager().focusNode(ifBlock);
+        startMove(this.workspace);
+        moveDown(this.workspace);
+        moveDown(this.workspace);
+        endMove(this.workspace);
+
+        assert.strictEqual(ifBlock.getParent(), repeatBlock);
+
+        // Start a second keyboard move and cancel before committing.
+        assert.doesNotThrow(() => {
+          Blockly.getFocusManager().focusNode(ifBlock);
+          startMove(this.workspace);
+          moveUp(this.workspace);
+          moveUp(this.workspace);
+          cancelMove(this.workspace);
+        });
+      });
+
       suite('Statement move tests', function () {
         // Clear the workspace and load start blocks.
         setup(function () {


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [ ] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes: 
1. With two connected blocks on the workspace, move one to a different connection and commit the move.
2. Start moving the same block again, but hit escape before committing.
```
block_svg.ts:313 Uncaught HierarchyRequestError: Failed to execute 'appendChild' on 'Node': The new child element contains the parent.
    at BlockSvg.setParent (block_svg.ts:313:44)
```


### Proposed Changes
This change guarantees that we clear any stored initial connections before storing new ones.
<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->

### Reason for Changes

The workspace could become completely unresponsive if a revert fails.  In this case, after storing an initial child connection, the block was moved to a parent connection on the same block. When the next move occurs, the initial child connection was not cleared, resulting in two conflicting initial connections. Revert would then try to "re-connect" the blocks in two conflicting ways.

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage

Thanks to @maribethb for writing a new test that ensures we don't throw when a block move is reverted after storing both a child and parent connection for two different moves.

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->

### Additional Information

<!-- Anything else we should know? -->
Alternative to https://github.com/RaspberryPiFoundation/blockly/pull/9980

It still seems like there is some cleanup that is missing (that `endDrag` does but `revertDrag` doesn't, but this can wait for now.