### PR TITLE
fix: Fix bug that could prevent dismissing field editors on Enter

### DIFF
--- a/packages/blockly/core/field_input.ts
+++ b/packages/blockly/core/field_input.ts
@@ -506,8 +506,6 @@ export abstract class FieldInput<T extends InputTypes> extends Field<
    */
   protected widgetDispose_() {
     // Non-disposal related things that we do when the editor closes.
-    console.log('widget dispose');
-    console.trace();
     this.isBeingEdited_ = false;
     this.isTextValid_ = true;
     // Make sure the field's node matches the field's internal value.

--- a/packages/blockly/core/field_input.ts
+++ b/packages/blockly/core/field_input.ts
@@ -506,6 +506,8 @@ export abstract class FieldInput<T extends InputTypes> extends Field<
    */
   protected widgetDispose_() {
     // Non-disposal related things that we do when the editor closes.
+    console.log('widget dispose');
+    console.trace();
     this.isBeingEdited_ = false;
     this.isTextValid_ = true;
     // Make sure the field's node matches the field's internal value.
@@ -601,6 +603,9 @@ export abstract class FieldInput<T extends InputTypes> extends Field<
     if (e.key === 'Enter') {
       WidgetDiv.hideIfOwner(this);
       dropDownDiv.hideWithoutAnimation();
+      // Prevent this from also being handled by the Enter keyboard shortcut,
+      // which can re-show the field editor after we just dismissed it.
+      e.stopPropagation();
     } else if (e.key === 'Escape') {
       this.setValue(
         this.htmlInput_!.getAttribute('data-untyped-default-value'),


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Proposed Changes
This PR prevents propagation of the Enter event in a field editor. For `FieldDate`, this prevented Enter from dismissing the date picker; although Enter committed the change and hid the picker, the global Enter keyboard shortcut was subsequently invoked and put the field back into editing mode. By stopping propagation, we prevent the keyboard shortcut from being invoked and causing unexpected side effects.