### PR TITLE
fix: use placeholder for empty inputs in block labels

### DIFF
--- a/packages/blockly/core/block_aria_composer.ts
+++ b/packages/blockly/core/block_aria_composer.ts
@@ -172,6 +172,13 @@ export function computeFieldRowLabel(
       return computeFieldRowLabel(inputs[index - 1], lookback, verbosity);
     }
   }
+  if (
+    input.type === inputTypes.VALUE &&
+    input.connection?.targetConnection === null &&
+    verbosity >= Verbosity.STANDARD
+  ) {
+    fieldRowLabel.push(Msg['INPUT_LABEL_EMPTY']);
+  }
   return fieldRowLabel.filter((label) => !!label);
 }
 

--- a/packages/blockly/tests/mocha/shortcut_items_test.js
+++ b/packages/blockly/tests/mocha/shortcut_items_test.js
@@ -843,7 +843,9 @@ suite('Keyboard Shortcut Items', function () {
       block.initSvg();
       block.render();
       Blockly.getFocusManager().focusNode(block);
-      this.assertAnnouncement('Begin stack, if, Empty, do, First category, has input');
+      this.assertAnnouncement(
+        'Begin stack, if, Empty, do, First category, has input',
+      );
     });
 
     test('Icon', function () {
@@ -853,7 +855,9 @@ suite('Keyboard Shortcut Items', function () {
       Blockly.getFocusManager().focusNode(
         block.getIcon(Blockly.icons.IconType.MUTATOR),
       );
-      this.assertAnnouncement('Begin stack, if, Empty, do, First category, has input');
+      this.assertAnnouncement(
+        'Begin stack, if, Empty, do, First category, has input',
+      );
     });
 
     test('Field', function () {
@@ -869,7 +873,9 @@ suite('Keyboard Shortcut Items', function () {
       block.initSvg();
       block.render();
       Blockly.getFocusManager().focusNode(block.getInput('DO0').connection);
-      this.assertAnnouncement('Begin stack, if, Empty, do, First category, has input');
+      this.assertAnnouncement(
+        'Begin stack, if, Empty, do, First category, has input',
+      );
     });
   });
 

--- a/packages/blockly/tests/mocha/shortcut_items_test.js
+++ b/packages/blockly/tests/mocha/shortcut_items_test.js
@@ -843,7 +843,7 @@ suite('Keyboard Shortcut Items', function () {
       block.initSvg();
       block.render();
       Blockly.getFocusManager().focusNode(block);
-      this.assertAnnouncement('Begin stack, if, do, First category, has input');
+      this.assertAnnouncement('Begin stack, if, Empty, do, First category, has input');
     });
 
     test('Icon', function () {
@@ -853,7 +853,7 @@ suite('Keyboard Shortcut Items', function () {
       Blockly.getFocusManager().focusNode(
         block.getIcon(Blockly.icons.IconType.MUTATOR),
       );
-      this.assertAnnouncement('Begin stack, if, do, First category, has input');
+      this.assertAnnouncement('Begin stack, if, Empty, do, First category, has input');
     });
 
     test('Field', function () {
@@ -869,7 +869,7 @@ suite('Keyboard Shortcut Items', function () {
       block.initSvg();
       block.render();
       Blockly.getFocusManager().focusNode(block.getInput('DO0').connection);
-      this.assertAnnouncement('Begin stack, if, do, First category, has input');
+      this.assertAnnouncement('Begin stack, if, Empty, do, First category, has input');
     });
   });
 


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes https://github.com/RaspberryPiFoundation/blockly/issues/9924

### Proposed Changes

When computing a block label, if we encounter an empty value input, insert a placeholder so something is read. Use the existing `INPUT_LABEL_EMPTY` translation string, or `'Empty'` in English. This is restricted for standard or greater verbosity so that it's not also included when focusing the input or when disambiguating inputs for move mode announcements.
<img width="624" height="215" alt="image" src="https://github.com/user-attachments/assets/75b4bc69-195b-4367-81ea-432a1eb7e81d" />
<img width="619" height="178" alt="image" src="https://github.com/user-attachments/assets/cc429074-d7f8-4f90-a753-90c9bcdcf99b" />

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->

### Reason for Changes

Empty value inputs are not exposed to screen readers effectively, either as `, ` or nothing at all.
<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage

Existing tests for the Information (I) shortcut were updated as the placeholder is now expected to be used for the empty boolean value input on a new `controls_if` block.

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->
