### PR TITLE
fix: Make `ShadowRoot` checks more robust

### DIFF
--- a/packages/blockly/core/css.ts
+++ b/packages/blockly/core/css.ts
@@ -55,7 +55,10 @@ export function inject(
   // stylesheet declared later wins by document order. Style elements appended
   // to the light DOM don't apply inside shadow roots, so for the shadow DOM
   // case we prepend the style element to the shadow root itself.
-  (root instanceof ShadowRoot ? root : document.head).prepend(styleEl);
+  (typeof globalThis.ShadowRoot !== 'undefined' && root instanceof ShadowRoot
+    ? root
+    : document.head
+  ).prepend(styleEl);
 }
 
 /**

--- a/packages/blockly/core/renderers/common/constants.ts
+++ b/packages/blockly/core/renderers/common/constants.ts
@@ -1134,7 +1134,10 @@ export class ConstantProvider {
     styleEl.textContent = this.getCSS_(selector).join('\n');
     // See css.ts inject() for the rationale on prepending and shadow root
     // handling.
-    (root instanceof ShadowRoot ? root : document.head).prepend(styleEl);
+    (typeof globalThis.ShadowRoot !== 'undefined' && root instanceof ShadowRoot
+      ? root
+      : document.head
+    ).prepend(styleEl);
 
     const sitesForSelector =
       injectionSites.get(selector) ?? new WeakSet<Document | ShadowRoot>();


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Proposed Changes
This PR ensures that `ShadowRoot` is defined before performing an `instanceof` check against it. This shouldn't be a problem for browsers in practice, but it was tripping up JSDom, which does not define `ShadowRoot`.