### PR TITLE
fix: Fix bug that prevented opening dropdowns on Chrome

### DIFF
--- a/packages/blockly/core/dropdowndiv.ts
+++ b/packages/blockly/core/dropdowndiv.ts
@@ -706,6 +706,9 @@ export function hideIfOwner<T>(
 
 /** Hide the menu, triggering animation. */
 export function hide() {
+  if (!isVisible()) {
+    return;
+  }
   getFocusManager().unregisterPopoverFocusLossHandler(handleFocusLoss);
   // Start the animation by setting the translation and fading out.
   // Reset to (initialX, initialY) - i.e., no translation.


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #9957

### Proposed Changes
This PR fixes a bug that caused dropdowns to immediately close when shown on Chrome after focusing a textfield -> dropdown -> textfield. `WidgetDiv` has an early return in its `hide()` method in cases where it is not currently being shown; this prevents some teardown code from running. This test was not present in `DropDownDiv`, which could cause the animate-out handler to run when the dropdown was being shown.