### PR TITLE
fix: nested category with blocks in parent 

### DIFF
--- a/packages/blockly/core/dragging/block_drag_strategy.ts
+++ b/packages/blockly/core/dragging/block_drag_strategy.ts
@@ -245,24 +245,6 @@ export class BlockDragStrategy implements IDragStrategy {
         eventUtils.setRecordUndo(false);
         this.positionNewBlock(this.block, newBlock);
 
-        // If the block came from a flyout, collapse open categories to avoid
-        // weirdness with reopening categories
-        const selectedCategory = this.block.workspace.targetWorkspace?.getToolbox()?.getSelectedItem();
-        if(selectedCategory && selectedCategory.isCollapsible()) {
-          const collapsibleCategory = selectedCategory as CollapsibleToolboxCategory;
-          collapsibleCategory.setExpanded(false);
-        }
-        
-        // Code for closing the collapsible category if you drag out a child
-        // prob don't want this
-
-        // const selectedCategoryParent = selectedCategory?.getParent();
-        // //AND the parent opens a flyout-- how do I check for that from here???
-        // if(selectedCategoryParent && selectedCategoryParent.isCollapsible()) {
-        //   const collapsibleCategory = selectedCategoryParent as CollapsibleToolboxCategory;
-        //   collapsibleCategory.setExpanded(false);
-        // }
-
         eventUtils.setRecordUndo(true);
 
         return newBlock;

--- a/packages/blockly/core/dragging/block_drag_strategy.ts
+++ b/packages/blockly/core/dragging/block_drag_strategy.ts
@@ -8,6 +8,7 @@ import type {Block} from '../block.js';
 import * as blockAnimation from '../block_animations.js';
 import {computeMoveLabel} from '../block_aria_composer.js';
 import type {BlockSvg} from '../block_svg.js';
+import { CollapsibleToolboxCategory } from '../blockly.js';
 import * as bumpObjects from '../bump_objects.js';
 import {config} from '../config.js';
 import {Connection} from '../connection.js';
@@ -243,6 +244,25 @@ export class BlockDragStrategy implements IDragStrategy {
         ) as BlockSvg;
         eventUtils.setRecordUndo(false);
         this.positionNewBlock(this.block, newBlock);
+
+        // If the block came from a flyout, collapse open categories to avoid
+        // weirdness with reopening categories
+        const selectedCategory = this.block.workspace.targetWorkspace?.getToolbox()?.getSelectedItem();
+        if(selectedCategory && selectedCategory.isCollapsible()) {
+          const collapsibleCategory = selectedCategory as CollapsibleToolboxCategory;
+          collapsibleCategory.setExpanded(false);
+        }
+        
+        // Code for closing the collapsible category if you drag out a child
+        // prob don't want this
+
+        // const selectedCategoryParent = selectedCategory?.getParent();
+        // //AND the parent opens a flyout-- how do I check for that from here???
+        // if(selectedCategoryParent && selectedCategoryParent.isCollapsible()) {
+        //   const collapsibleCategory = selectedCategoryParent as CollapsibleToolboxCategory;
+        //   collapsibleCategory.setExpanded(false);
+        // }
+
         eventUtils.setRecordUndo(true);
 
         return newBlock;

--- a/packages/blockly/core/dragging/block_drag_strategy.ts
+++ b/packages/blockly/core/dragging/block_drag_strategy.ts
@@ -8,7 +8,6 @@ import type {Block} from '../block.js';
 import * as blockAnimation from '../block_animations.js';
 import {computeMoveLabel} from '../block_aria_composer.js';
 import type {BlockSvg} from '../block_svg.js';
-import { CollapsibleToolboxCategory } from '../blockly.js';
 import * as bumpObjects from '../bump_objects.js';
 import {config} from '../config.js';
 import {Connection} from '../connection.js';
@@ -244,7 +243,6 @@ export class BlockDragStrategy implements IDragStrategy {
         ) as BlockSvg;
         eventUtils.setRecordUndo(false);
         this.positionNewBlock(this.block, newBlock);
-
         eventUtils.setRecordUndo(true);
 
         return newBlock;

--- a/packages/blockly/core/toolbox/collapsible_category.ts
+++ b/packages/blockly/core/toolbox/collapsible_category.ts
@@ -237,44 +237,29 @@ export class CollapsibleToolboxCategory
   }
 
   override onClick(_e: Event) {
-    //TODO: figure out what the behavior should be, then properly refactor
-    //Separate the logic for category expansion and the flyout
-    const parentToolbox = this.getParentToolbox();
-    const thisFlyoutVisible = parentToolbox.getSelectedItem() === this && parentToolbox.getFlyout()?.isVisible();
-    const isExpanded = this.isExpanded();
+    // Check for special case where the category has its own flyout items. 
+    if(this.flyoutItems_.length > 0) {
+      const parentToolbox = this.getParentToolbox();
+      const thisFlyoutVisible = 
+        parentToolbox.getSelectedItem() === this &&
+        parentToolbox.getFlyout()?.isVisible();
 
-    // if expanded && flyout showing, then close both.
-    if(isExpanded && thisFlyoutVisible) {
-      this.parentToolbox_.getFlyout()?.setVisible(false);
-      this.setExpanded(false);
-      return;
+      if(this.expanded_ && !thisFlyoutVisible) {
+        this.toggleFlyout();
+        return;
+      }
     }
 
-    // if expanded && flyout not showing, then just open flyout. 
-    if(isExpanded && !thisFlyoutVisible) {
-      this.parentToolbox_.getFlyout()?.setVisible(true);
-      return;
-    }
-
-    // if not expanded && flyout showing, then just expand OR close flyout??? 
-    // as it currently stands the code makes this one imposssible
-    if(!isExpanded && thisFlyoutVisible) {
-     //this.parentToolbox_.getFlyout()?.setVisible(false);
-      this.setExpanded(true);
-      return;
-    }
-
-    // if not expanded && flyout not showing, then open both
-    if(!isExpanded && !thisFlyoutVisible) {
-      this.setExpanded(true);
-      this.parentToolbox_.getFlyout()?.setVisible(true);
-      return;
-    }
-    //this.toggleExpanded();
+    this.toggleExpanded();
   }
 
+  /** Toggles the parent toolbox's flyout. */
   toggleFlyout() {
-    this.parentToolbox_.getFlyout()?.setVisible(false);
+    if(this.parentToolbox_.getFlyout()?.isVisible()) {
+      this.parentToolbox_.getFlyout()?.setVisible(false);
+    } else {
+      this.parentToolbox_.getFlyout()?.setVisible(true);
+    }
   }
 
   /** Toggles whether or not the category is expanded. */

--- a/packages/blockly/core/toolbox/collapsible_category.ts
+++ b/packages/blockly/core/toolbox/collapsible_category.ts
@@ -237,7 +237,44 @@ export class CollapsibleToolboxCategory
   }
 
   override onClick(_e: Event) {
-    this.toggleExpanded();
+    //TODO: figure out what the behavior should be, then properly refactor
+    //Separate the logic for category expansion and the flyout
+    const parentToolbox = this.getParentToolbox();
+    const thisFlyoutVisible = parentToolbox.getSelectedItem() === this && parentToolbox.getFlyout()?.isVisible();
+    const isExpanded = this.isExpanded();
+
+    // if expanded && flyout showing, then close both.
+    if(isExpanded && thisFlyoutVisible) {
+      this.parentToolbox_.getFlyout()?.setVisible(false);
+      this.setExpanded(false);
+      return;
+    }
+
+    // if expanded && flyout not showing, then just open flyout. 
+    if(isExpanded && !thisFlyoutVisible) {
+      this.parentToolbox_.getFlyout()?.setVisible(true);
+      return;
+    }
+
+    // if not expanded && flyout showing, then just expand OR close flyout??? 
+    // as it currently stands the code makes this one imposssible
+    if(!isExpanded && thisFlyoutVisible) {
+     //this.parentToolbox_.getFlyout()?.setVisible(false);
+      this.setExpanded(true);
+      return;
+    }
+
+    // if not expanded && flyout not showing, then open both
+    if(!isExpanded && !thisFlyoutVisible) {
+      this.setExpanded(true);
+      this.parentToolbox_.getFlyout()?.setVisible(true);
+      return;
+    }
+    //this.toggleExpanded();
+  }
+
+  toggleFlyout() {
+    this.parentToolbox_.getFlyout()?.setVisible(false);
   }
 
   /** Toggles whether or not the category is expanded. */

--- a/packages/blockly/core/toolbox/collapsible_category.ts
+++ b/packages/blockly/core/toolbox/collapsible_category.ts
@@ -195,7 +195,7 @@ export class CollapsibleToolboxCategory
       this.subcategoriesDiv_!.style.display = 'block';
       this.openIcon_(this.iconDom_);
     } else {
-      this.setFlyout(false);
+      this.setFlyoutVisible(false);
       this.subcategoriesDiv_!.style.display = 'none';
       this.closeIcon_(this.iconDom_);
     }
@@ -245,7 +245,7 @@ export class CollapsibleToolboxCategory
         parentToolbox.getFlyout()?.isVisible();
 
       if (this.expanded_ && !thisFlyoutVisible) {
-        this.setFlyout(true);
+        this.setFlyoutVisible(true);
         return;
       }
     }
@@ -254,7 +254,7 @@ export class CollapsibleToolboxCategory
   }
 
   /** Sets the visibility of the parent toolbox's flyout. */
-  setFlyout(isVisible: boolean) {
+  private setFlyoutVisible(isVisible: boolean) {
     this.parentToolbox_.getFlyout()?.setVisible(isVisible);
   }
 

--- a/packages/blockly/core/toolbox/collapsible_category.ts
+++ b/packages/blockly/core/toolbox/collapsible_category.ts
@@ -195,7 +195,7 @@ export class CollapsibleToolboxCategory
       this.subcategoriesDiv_!.style.display = 'block';
       this.openIcon_(this.iconDom_);
     } else {
-      this.parentToolbox_.getFlyout()?.setVisible(false);
+      this.setFlyout(false);
       this.subcategoriesDiv_!.style.display = 'none';
       this.closeIcon_(this.iconDom_);
     }
@@ -237,15 +237,15 @@ export class CollapsibleToolboxCategory
   }
 
   override onClick(_e: Event) {
-    // Check for special case where the category has its own flyout items. 
-    if(this.flyoutItems_.length > 0) {
+    // Check for special case where the category has its own flyout items.
+    if (this.flyoutItems_.length > 0) {
       const parentToolbox = this.getParentToolbox();
-      const thisFlyoutVisible = 
+      const thisFlyoutVisible =
         parentToolbox.getSelectedItem() === this &&
         parentToolbox.getFlyout()?.isVisible();
 
-      if(this.expanded_ && !thisFlyoutVisible) {
-        this.toggleFlyout();
+      if (this.expanded_ && !thisFlyoutVisible) {
+        this.setFlyout(true);
         return;
       }
     }
@@ -253,13 +253,9 @@ export class CollapsibleToolboxCategory
     this.toggleExpanded();
   }
 
-  /** Toggles the parent toolbox's flyout. */
-  toggleFlyout() {
-    if(this.parentToolbox_.getFlyout()?.isVisible()) {
-      this.parentToolbox_.getFlyout()?.setVisible(false);
-    } else {
-      this.parentToolbox_.getFlyout()?.setVisible(true);
-    }
+  /** Sets the visibility of the parent toolbox's flyout. */
+  setFlyout(isVisible: boolean) {
+    this.parentToolbox_.getFlyout()?.setVisible(isVisible);
   }
 
   /** Toggles whether or not the category is expanded. */

--- a/packages/blockly/tests/mocha/toolbox_test.js
+++ b/packages/blockly/tests/mocha/toolbox_test.js
@@ -306,7 +306,7 @@ suite('Toolbox', function () {
       });
       test('if category expanded and flyout hidden, click should open flyout', function () {
         this.parentCategory.setExpanded(true);
-        this.flyout.getWorkspace().hideChaff();
+        this.flyout.hide();
 
         this.parentCategory.onClick(new Event('click'));
         this.toolbox.selectItemByPosition(0);
@@ -316,7 +316,6 @@ suite('Toolbox', function () {
       });
       test('category expanded and flyout visible, click should collapse and close', function () {
         this.parentCategory.setExpanded(true);
-        this.parentCategory.setFlyout(true);
         this.toolbox.selectItemByPosition(0);
 
         this.parentCategory.onClick(new Event('click'));

--- a/packages/blockly/tests/mocha/toolbox_test.js
+++ b/packages/blockly/tests/mocha/toolbox_test.js
@@ -283,84 +283,47 @@ suite('Toolbox', function () {
                     {
                       kind: 'block',
                       type: 'text_join',
-                    }
-                  ]
-                }
-              ]
-            }
+                    },
+                  ],
+                },
+              ],
+            },
           ],
         };
-
-        this.flyoutWorkspace = Blockly.inject(this.div, {
-          toolbox: collapsibleCategoryWithFlyout,
-        });
-        this.flyoutToolbox = this.flyoutWorkspace.getToolbox();
-        this.flyout = this.flyoutToolbox.getFlyout();
-        this.parentCategory = this.flyoutToolbox.getToolboxItems()[0];
+        this.toolbox.render(collapsibleCategoryWithFlyout);
+        this.flyout = this.toolbox.getFlyout();
+        this.parentCategory = this.toolbox.getToolboxItems()[0];
       });
 
-      teardown(function () {
-        this.flyoutWorkspace.dispose();
-      });
+      test('if category collapsed and flyout hidden, click should uncollapse and open flyout', function () {
+        this.parentCategory.setExpanded(false);
 
-      test('collapsed and flyout hidden, click should uncollapse and open flyout',
-        function () {
-          assert.isFalse(this.parentCategory.isExpanded());
-          assert.isFalse(this.flyout.isVisible());
-
-          this.parentCategory.onClick(new Event('click'));
-
-          assert.isTrue(this.parentCategory.isExpanded());
-          assert.equal(
-            this.toolbox.getSelectedItem(),
-            this.parentCategory,
-          );
-          assert.isTrue(this.flyout.isVisible());
-        },
-      );
-      test('expanded and flyout hidden, click should open flyout',
-        function () {
-          // First click opens both.
-          this.parentCategory.onClick(new Event('click'));
-
-          assert.isTrue(this.parentCategory.isExpanded());
-          assert.isTrue(this.flyout.isVisible());
-
-          this.toolbox.setSelectedItem(null);
-
-          assert.isTrue(this.parentCategory.isExpanded());
-          assert.isFalse(this.flyout.isVisible());
-
-          this.parentCategory.onClick(new Event('click'));
-
-          assert.isTrue(this.parentCategory.isExpanded());
-          assert.equal(
-            this.toolbox.getSelectedItem(),
-            this.parentCategory,
-          );
-          assert.isTrue(this.flyout.isVisible());
-        },
-      );
-      test('expanded and flyout visible, click should collapse and close',
-      function () {
         this.parentCategory.onClick(new Event('click'));
+        this.toolbox.selectItemByPosition(0);
 
         assert.isTrue(this.parentCategory.isExpanded());
         assert.isTrue(this.flyout.isVisible());
+      });
+      test('if category expanded and flyout hidden, click should open flyout', function () {
+        this.parentCategory.setExpanded(true);
+        this.flyout.getWorkspace().hideChaff();
 
         this.parentCategory.onClick(new Event('click'));
+        this.toolbox.selectItemByPosition(0);
+
+        assert.isTrue(this.parentCategory.isExpanded());
+        assert.isTrue(this.flyout.isVisible());
+      });
+      test('category expanded and flyout visible, click should collapse and close', function () {
+        this.parentCategory.setExpanded(true);
+        this.parentCategory.setFlyout(true);
+        this.toolbox.selectItemByPosition(0);
+
+        this.parentCategory.onClick(new Event('click'));
+        this.parentCategory.getParentToolbox().clearSelection();
 
         assert.isFalse(this.parentCategory.isExpanded());
-        assert.notEqual(
-          this.toolbox.getSelectedItem(),
-          this.parentCategory,
-        );
         assert.isFalse(this.flyout.isVisible());
-        assert.isTrue(this.flyout.isVisible());
-
-      },
-    );
-
       });
     });
   });

--- a/packages/blockly/tests/mocha/toolbox_test.js
+++ b/packages/blockly/tests/mocha/toolbox_test.js
@@ -261,6 +261,8 @@ suite('Toolbox', function () {
       sinon.assert.calledOnce(setSelectedSpy);
       sinon.assert.calledOnce(onClickSpy);
     });
+    //add tests here
+    
   });
 
   suite('on key down', function () {

--- a/packages/blockly/tests/mocha/toolbox_test.js
+++ b/packages/blockly/tests/mocha/toolbox_test.js
@@ -294,12 +294,14 @@ suite('Toolbox', function () {
         this.flyout = this.toolbox.getFlyout();
         this.parentCategory = this.toolbox.getToolboxItems()[0];
       });
-
+      function clickCategory(category) {
+        const target = category.getClickTarget();
+        const event = new PointerEvent('pointerdown', {bubbles: true});
+        target.dispatchEvent(event);
+      }
       test('if category collapsed and flyout hidden, click should uncollapse and open flyout', function () {
         this.parentCategory.setExpanded(false);
-
-        this.parentCategory.onClick(new Event('click'));
-        this.toolbox.selectItemByPosition(0);
+        clickCategory(this.parentCategory);
 
         assert.isTrue(this.parentCategory.isExpanded());
         assert.isTrue(this.flyout.isVisible());
@@ -307,19 +309,15 @@ suite('Toolbox', function () {
       test('if category expanded and flyout hidden, click should open flyout', function () {
         this.parentCategory.setExpanded(true);
         this.flyout.hide();
-
-        this.parentCategory.onClick(new Event('click'));
-        this.toolbox.selectItemByPosition(0);
+        clickCategory(this.parentCategory);
 
         assert.isTrue(this.parentCategory.isExpanded());
         assert.isTrue(this.flyout.isVisible());
       });
       test('category expanded and flyout visible, click should collapse and close', function () {
-        this.parentCategory.setExpanded(true);
-        this.toolbox.selectItemByPosition(0);
-
-        this.parentCategory.onClick(new Event('click'));
-        this.parentCategory.getParentToolbox().clearSelection();
+        // Click in to expand, then click again to close
+        clickCategory(this.parentCategory);
+        clickCategory(this.parentCategory);
 
         assert.isFalse(this.parentCategory.isExpanded());
         assert.isFalse(this.flyout.isVisible());

--- a/packages/blockly/tests/mocha/toolbox_test.js
+++ b/packages/blockly/tests/mocha/toolbox_test.js
@@ -261,8 +261,108 @@ suite('Toolbox', function () {
       sinon.assert.calledOnce(setSelectedSpy);
       sinon.assert.calledOnce(onClickSpy);
     });
-    //add tests here
-    
+    suite('collapsible category with flyout', function () {
+      setup(function () {
+        const collapsibleCategoryWithFlyout = {
+          kind: 'categoryToolbox',
+          contents: [
+            {
+              kind: 'category',
+              name: 'Parent',
+              categorystyle: 'text_category',
+              contents: [
+                {
+                  kind: 'block',
+                  type: 'text',
+                },
+                {
+                  kind: 'category',
+                  name: 'Child',
+                  categorystyle: 'text_category',
+                  contents: [
+                    {
+                      kind: 'block',
+                      type: 'text_join',
+                    }
+                  ]
+                }
+              ]
+            }
+          ],
+        };
+
+        this.flyoutWorkspace = Blockly.inject(this.div, {
+          toolbox: collapsibleCategoryWithFlyout,
+        });
+        this.flyoutToolbox = this.flyoutWorkspace.getToolbox();
+        this.flyout = this.flyoutToolbox.getFlyout();
+        this.parentCategory = this.flyoutToolbox.getToolboxItems()[0];
+      });
+
+      teardown(function () {
+        this.flyoutWorkspace.dispose();
+      });
+
+      test('collapsed and flyout hidden, click should uncollapse and open flyout',
+        function () {
+          assert.isFalse(this.parentCategory.isExpanded());
+          assert.isFalse(this.flyout.isVisible());
+
+          this.parentCategory.onClick(new Event('click'));
+
+          assert.isTrue(this.parentCategory.isExpanded());
+          assert.equal(
+            this.toolbox.getSelectedItem(),
+            this.parentCategory,
+          );
+          assert.isTrue(this.flyout.isVisible());
+        },
+      );
+      test('expanded and flyout hidden, click should open flyout',
+        function () {
+          // First click opens both.
+          this.parentCategory.onClick(new Event('click'));
+
+          assert.isTrue(this.parentCategory.isExpanded());
+          assert.isTrue(this.flyout.isVisible());
+
+          this.toolbox.setSelectedItem(null);
+
+          assert.isTrue(this.parentCategory.isExpanded());
+          assert.isFalse(this.flyout.isVisible());
+
+          this.parentCategory.onClick(new Event('click'));
+
+          assert.isTrue(this.parentCategory.isExpanded());
+          assert.equal(
+            this.toolbox.getSelectedItem(),
+            this.parentCategory,
+          );
+          assert.isTrue(this.flyout.isVisible());
+        },
+      );
+      test('expanded and flyout visible, click should collapse and close',
+      function () {
+        this.parentCategory.onClick(new Event('click'));
+
+        assert.isTrue(this.parentCategory.isExpanded());
+        assert.isTrue(this.flyout.isVisible());
+
+        this.parentCategory.onClick(new Event('click'));
+
+        assert.isFalse(this.parentCategory.isExpanded());
+        assert.notEqual(
+          this.toolbox.getSelectedItem(),
+          this.parentCategory,
+        );
+        assert.isFalse(this.flyout.isVisible());
+        assert.isTrue(this.flyout.isVisible());
+
+      },
+    );
+
+      });
+    });
   });
 
   suite('on key down', function () {


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #9392 

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
Adjusts handling of toolboxes when a collapsible category has its own flyout items. Now, when a block is dragged out of an expanded parent, the categories all remain expanded even if the flyout automatically closes. When the user clicks back into the parent category, the parent flyout opens without collapsing the child category. Another click on the parent category will collapse the category and flyout. 

### Test Coverage

Includes 3 unit tests for covering different combinations of flyout/category open. Note that the category closed/flyout open combination was not included bc it shouldn't be possible to enter this state with the current setup. 

### Additional Information

Note that the updated behavior doesn't precisely match the expected behavior described in the original issue, this is an intentional choice made after discussing the issue!
