### PR TITLE
chore: Update dependabot config file

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,7 @@ version: 2
 updates:
   - package-ecosystem: 'npm' # See documentation for possible values
     directory: '/' # Location of package manifests
-    target-branch: 'develop'
+    target-branch: 'main'
     schedule:
       interval: 'weekly'
     commit-message:
@@ -17,13 +17,13 @@ updates:
       - 'PR: dependencies'
   - package-ecosystem: 'github-actions' # See documentation for possible values
     directory: '/'
-    target-branch: 'develop'
+    target-branch: 'main'
     schedule:
       interval: 'weekly'
     ignore:
       # See notes in welcome_new_contributors.yml for details on this.
       - dependency-name: 'actions/first-interaction'
-        versions: ['*']
+        versions: ['> 1.3.0']
     commit-message:
       prefix: 'chore(deps)'
     labels:


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Proposed Changes
This PR updates the dependabot config file to (a) target `main` rather than the now-defunct `develop` branch and (b) remove the * wildcard for the first-interaction package, which is not supported syntax and was causing it to fail to parse the config file. Instead we tell it to ignore versions newer than the one that dep is pinned to.