### PR TITLE
fix: constrained move mode improvements

### DIFF
--- a/packages/blockly/core/dragging/block_drag_strategy.ts
+++ b/packages/blockly/core/dragging/block_drag_strategy.ts
@@ -653,7 +653,8 @@ export class BlockDragStrategy implements IDragStrategy {
     if (!newCandidate) {
       // Position above or below the first/last block.
       if (this.moveMode === MoveMode.CONSTRAINED) {
-        const connectedBlock = currCandidate?.neighbour.getSourceBlock() ?? null;
+        const connectedBlock =
+          currCandidate?.neighbour.getSourceBlock() ?? null;
         let root = connectedBlock?.getRootBlock() ?? connectedBlock;
         if (root === draggingBlock) root = connectedBlock;
         if (!root) return;
@@ -677,17 +678,16 @@ export class BlockDragStrategy implements IDragStrategy {
         switch (direction) {
           case Direction.LEFT:
           case Direction.UP:
-            const blocksTop = Math.min(...blockRects.map((rect) => rect.top));
             destinationY =
-              blocksTop - offset - draggingBlock.getHeightWidth().height;
+              Math.min(...blockRects.map((rect) => rect.top)) -
+              offset -
+              draggingBlock.getHeightWidth().height;
             break;
           case Direction.RIGHT:
           case Direction.DOWN:
           default:
-            const blocksBottom = Math.max(
-              ...blockRects.map((rect) => rect.bottom),
-            );
-            destinationY = blocksBottom + offset;
+            destinationY =
+              Math.max(...blockRects.map((rect) => rect.bottom)) + offset;
             break;
         }
         draggingBlock.moveDuringDrag(

--- a/packages/blockly/core/dragging/block_drag_strategy.ts
+++ b/packages/blockly/core/dragging/block_drag_strategy.ts
@@ -604,12 +604,10 @@ export class BlockDragStrategy implements IDragStrategy {
   private determineConnectionOffset(): Coordinate {
     const {local, neighbour} = this.connectionCandidate!;
 
-    const dx = neighbour.x - local.x;
-    const dy = neighbour.y - local.y;
+    const connOffset = local.getOffsetInBlock();
 
-    // Base aligned position
-    let x = this.startLoc!.x + dx;
-    let y = this.startLoc!.y + dy;
+    let x = neighbour.x - connOffset.x;
+    let y = neighbour.y - connOffset.y;
 
     // Decide offset direction
     const becomingChild =
@@ -650,51 +648,52 @@ export class BlockDragStrategy implements IDragStrategy {
     const newCandidate =
       this.getInitialCandidate() ?? this.getConnectionCandidate(delta);
 
+    this.connectionPreviewer?.hidePreview();
+    this.connectionCandidate = null;
     if (!newCandidate) {
       // Position above or below the first/last block.
       if (this.moveMode === MoveMode.CONSTRAINED) {
-        const connectedBlock = currCandidate?.neighbour.getSourceBlock();
+        const connectedBlock = currCandidate?.neighbour.getSourceBlock() ?? null;
         let root = connectedBlock?.getRootBlock() ?? connectedBlock;
         if (root === draggingBlock) root = connectedBlock;
-        const direction = this.getDirectionToNewLocation(
-          Coordinate.sum(this.startLoc!, delta),
-        );
-        const bounds = root?.getBoundingRectangle();
-        if (!bounds) return;
+        if (!root) return;
 
         const blockRects = draggingBlock.workspace
           .getTopBlocks()
+          .filter((block) => block !== draggingBlock.getRootBlock())
           .map((block) => block.getBoundingRectangle());
-        const blocksLeft = Math.min(...blockRects.map((rect) => rect.left));
+        if (!blockRects.length) return;
 
-        let destination: Coordinate;
-        let blockBound: number;
+        // If the block was previously connected, position the block near its previous connection.
+        const destinationX =
+          currCandidate?.neighbour.x ??
+          draggingBlock.getRelativeToSurfaceXY().x;
+        let destinationY: number;
+        const offset = this.BLOCK_CONNECTION_OFFSET * 2;
+
+        const direction = this.getDirectionToNewLocation(
+          Coordinate.sum(this.startLoc!, delta),
+        );
         switch (direction) {
           case Direction.LEFT:
           case Direction.UP:
-            blockBound = Math.min(...blockRects.map((rect) => rect.top));
-            destination = new Coordinate(
-              blocksLeft,
-              blockBound -
-                this.BLOCK_CONNECTION_OFFSET * 2 -
-                draggingBlock.getHeightWidth().height,
-            );
+            const blocksTop = Math.min(...blockRects.map((rect) => rect.top));
+            destinationY =
+              blocksTop - offset - draggingBlock.getHeightWidth().height;
             break;
           case Direction.RIGHT:
           case Direction.DOWN:
           default:
-            blockBound = Math.max(...blockRects.map((rect) => rect.bottom));
-            destination = new Coordinate(
-              blocksLeft,
-              blockBound + this.BLOCK_CONNECTION_OFFSET * 2,
+            const blocksBottom = Math.max(
+              ...blockRects.map((rect) => rect.bottom),
             );
+            destinationY = blocksBottom + offset;
             break;
         }
-        draggingBlock.moveDuringDrag(destination);
+        draggingBlock.moveDuringDrag(
+          new Coordinate(destinationX, destinationY),
+        );
       }
-
-      this.connectionPreviewer?.hidePreview();
-      this.connectionCandidate = null;
       return;
     }
     const candidate =


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes https://github.com/RaspberryPiFoundation/blockly/issues/10023 https://github.com/RaspberryPiFoundation/blockly/issues/10024 https://github.com/RaspberryPiFoundation/blockly/issues/10025

### Proposed Changes
This updates `determineConnectionOffset()` and `updateConnectionPreview()` in order to resolve three separate bugs.

1. When determine the connection offset for a drag, use `local.getOffsetInBlock()` instead of `local.x`/`local.y`.
2. Hide connection previews and reset `connectionCandidate` before calculating block position on workspace.
3. Ignore dragging block when considering bounds of other blocks when calculating the same position.
4. Horizontally align blocks moved to workspace with their most recent connection instead of the left edge of all blocks.
<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->

### Reason for Changes

1. When blocks are inserted from the toolbox, their `RenderedConnection.x` and `RenderedConenction.y` values have not been set and are equal to the coordinates of the block itself. This causes the block to be positioned incorrectly. See https://github.com/RaspberryPiFoundation/blockly/issues/10023

<img width="207" height="198" alt="image" src="https://github.com/user-attachments/assets/595e7ab8-e9c8-4d3d-8c9a-176f68042008" />

2-3. Blocks were being moved onto the workspace further down than was necessary because the size of the content was influenced by the prior block position. By first hiding the preview and filtering out the dragging block from the content, we can get accurate bounds. See https://github.com/RaspberryPiFoundation/blockly/issues/10025

<img width="200" height="200" alt="Image" src="https://github.com/user-attachments/assets/ba2576e9-42bd-4d97-a73d-68c91b0c5af5" /><img width="200" height="200" alt="image" src="https://github.com/user-attachments/assets/5f7141ae-4a75-483e-9534-f2e014b57f8a" />

4. By moving the block below the previous connection, we effectively guarantee that moving the block back up will result in moving to the last connection as expected. This solution is consistent screen reader mode enabled and disabled. See https://github.com/RaspberryPiFoundation/blockly/issues/10024

<img width="410" height="150" alt="image" src="https://github.com/user-attachments/assets/032cab71-2173-46a8-b78c-8c5985479ce7" />
<img width="410" height="150" alt="image" src="https://github.com/user-attachments/assets/3314e918-958d-413f-9573-232ac524c150" />

This also adds a slight indent to the position of statements as the `nextConnection` of a block is slightly offset:
<img width="203" height="108" alt="image" src="https://github.com/user-attachments/assets/93db57a5-58f1-48b9-ab78-3c4d6bcd5855" />


