### PR TITLE
fix: Use dominant axis for keyboard move direction

### DIFF
--- a/packages/blockly/core/dragging/block_drag_strategy.ts
+++ b/packages/blockly/core/dragging/block_drag_strategy.ts
@@ -1142,11 +1142,15 @@ export class BlockDragStrategy implements IDragStrategy {
     const actualPosition = this.block.getRelativeToSurfaceXY();
     const delta = Coordinate.difference(newLocation, actualPosition);
     const {x, y} = delta;
-
-    if (x < 0) return Direction.LEFT;
-    if (x > 0) return Direction.RIGHT;
-    if (y < 0) return Direction.UP;
-    if (y > 0) return Direction.DOWN;
+    // Pick the dominant axis rather than testing x before y. A keyboard move is
+    // single-axis by intent, but the delta is round-tripped through pixels
+    // (KeyboardMover scales up by workspace.scale, Dragger scales back down), so
+    // at any zoom != 1 the axis that should be zero carries ~1e-14 of
+    // floating-point residue. Comparing magnitudes keeps that residue from
+    // outranking the real movement and flipping e.g. a DOWN press to RIGHT.
+    if (Math.abs(x) > Math.abs(y))
+      return x < 0 ? Direction.LEFT : Direction.RIGHT;
+    if (Math.abs(y) > 0) return y < 0 ? Direction.UP : Direction.DOWN;
     return Direction.NONE;
   }
 


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

In keyboard move mode, getDirectionToNewLocation decided the move direction by testing the horizontal delta before the vertical one and treating any non-zero x as a sideways move. The move delta is round-tripped through pixels (KeyboardMover scales up by the workspace scale, Dragger scales back down), and at any zoom other than 100% that conversion leaves ~1e-14 of floating-point residue on the axis that should be exactly zero. In real terms, `x` could be 0.0...01 and `y` could be ~20, but because we checked `x` first, it was interpreted as a horizontal move rather than vertical. At a scale of 1, the conversions are exact, so there is no floating point result.

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes https://github.com/RaspberryPiFoundation/blockly/issues/10029

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->

Choose the axis with the larger absolute delta instead, so the genuine movement always wins and sub-pixel rounding noise can't flip the direction. Behaviour at scale 1 is unchanged.

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

This addresses unexpected keyboard move behaviour raised in https://github.com/RaspberryPiFoundation/blockly/issues/10029

### Test Coverage

This could do with a test case or two, but it's not straight forward to reproduce so would need quite a complicated test setup

### Documentation

N/A

### Additional Information

Behaviour after change:
https://github.com/user-attachments/assets/e3a12b98-5651-4f4a-9bd1-7f727fcb078b




