### PR TITLE
fix: Bring blocks to the front when focused via keyboard

### DIFF
--- a/packages/blockly/core/block_svg.ts
+++ b/packages/blockly/core/block_svg.ts
@@ -1385,10 +1385,11 @@ export class BlockSvg
     do {
       const root = block.getSvgRoot();
       const parent = root.parentNode;
-      const childNodes = parent!.childNodes;
+      if (!parent) return;
+      const childNodes = parent.childNodes;
       // Avoid moving the block if it's already at the bottom.
       if (childNodes[childNodes.length - 1] !== root) {
-        parent!.appendChild(root);
+        parent.appendChild(root);
       }
       if (blockOnly) break;
       block = block.getParent();

--- a/packages/blockly/core/block_svg.ts
+++ b/packages/blockly/core/block_svg.ts
@@ -1354,6 +1354,29 @@ export class BlockSvg
    */
   bringToFront(blockOnly = false) {
     const previouslyFocused = getFocusManager().getFocusedNode();
+    this.moveSvgRootToFront(blockOnly);
+    if (previouslyFocused) {
+      // Bringing a block to the front of the stack doesn't fundamentally change
+      // the logical structure of the page, but it does change element ordering
+      // which can take automatically take away focus from a node. Ensure focus
+      // is restored to avoid a discontinuity.
+      getFocusManager().focusNode(previouslyFocused);
+    }
+  }
+
+  /**
+   * Reorders this block's SVG root and those of its parents (unless
+   * `blockOnly`` is set to `true`) to the end of their respective parents so
+   * they render on top of their siblings.
+   *
+   * Unlike `bringToFront`, this does not preserve focus across the reorder, so
+   * it is safe to call from within a focus callback
+   *
+   * @param blockOnly True to only move this block to the front without
+   * adjusting its parents.
+   * @internal
+   */
+  moveSvgRootToFront(blockOnly = false) {
     /* eslint-disable-next-line @typescript-eslint/no-this-alias */
     let block: this | null = this;
     if (block.isDeadOrDying()) {
@@ -1370,13 +1393,6 @@ export class BlockSvg
       if (blockOnly) break;
       block = block.getParent();
     } while (block);
-    if (previouslyFocused) {
-      // Bringing a block to the front of the stack doesn't fundamentally change
-      // the logical structure of the page, but it does change element ordering
-      // which can take automatically take away focus from a node. Ensure focus
-      // is restored to avoid a discontinuity.
-      getFocusManager().focusNode(previouslyFocused);
-    }
   }
 
   /**
@@ -1909,6 +1925,9 @@ export class BlockSvg
   onNodeFocus(): void {
     this.recomputeAriaContext();
     this.select();
+    if (!this.workspace.isFlyout) {
+      this.moveSvgRootToFront();
+    }
     const focusedNode = getFocusManager().getFocusedNode();
     if (focusedNode && focusedNode !== this) {
       renderManagement.finishQueuedRenders().then(() => {

--- a/packages/blockly/core/rendered_connection.ts
+++ b/packages/blockly/core/rendered_connection.ts
@@ -700,8 +700,12 @@ export class RenderedConnection
   /** See IFocusableNode.onNodeFocus. */
   onNodeFocus(): void {
     this.highlight();
-    this.getSourceBlock().workspace.scrollBoundsIntoView(
-      this.getSourceBlock().getBoundingRectangleWithoutChildren(),
+    const sourceBlock = this.getSourceBlock();
+    if (!sourceBlock.workspace.isFlyout) {
+      sourceBlock.moveSvgRootToFront();
+    }
+    sourceBlock.workspace.scrollBoundsIntoView(
+      sourceBlock.getBoundingRectangleWithoutChildren(),
     );
   }
 


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

Brings blocks to the front when focused by keyboard navigation.

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes https://github.com/RaspberryPiFoundation/blockly/issues/9907

### Proposed Changes

Moves out a separate `moveSvgRootToFront` method from the existing `bringToFront` method and calls it inside `onNodeFocus` for blocks and rendered connections. The `moveSvgRootToFront` is safe to call inside the `onNodeFocus` callbacks.

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

Aligns mouse and keyboard behaviour. Avoids situations when focused blocks are visually hidden by other blocks on top of them when using keyboard navigation.

### Test Coverage

Not covered.

### Documentation

N/A