### PR TITLE
fix: Keep workspace stack count fresh instead of hiding it on Mac/VoiceOver

### DIFF
--- a/packages/blockly/core/workspace_svg.ts
+++ b/packages/blockly/core/workspace_svg.ts
@@ -745,17 +745,6 @@ export class WorkspaceSvg
    * Updates the label on the workspace to reflect the number of top-level stacks in the workspace.
    */
   private updateAriaLabel() {
-    if (userAgent.APPLE) {
-      // VoiceOver is reading this label inappropriately, so don't show the
-      // stack count because it might be inaccurate.
-      // https://github.com/RaspberryPiFoundation/blockly/issues/9885
-      aria.setState(
-        this.svgGroup_,
-        aria.State.LABEL,
-        Msg['WORKSPACE_LABEL_PLAIN'],
-      );
-      return;
-    }
     const numStacks = this.getTopBlocks(false).length;
     if (numStacks == 1) {
       aria.setState(
@@ -2975,7 +2964,14 @@ export class WorkspaceSvg
   onTreeFocus(
     _node: IFocusableNode,
     _previousTree: IFocusableTree | null,
-  ): void {}
+  ): void {
+    // Screen readers read this label as the enclosing region when workspace
+    // contents are focused, so refresh it here to keep the stack count from
+    // going stale.
+    if (!this.isFlyout && !this.isMutator) {
+      this.updateAriaLabel();
+    }
+  }
 
   /** See IFocusableTree.onTreeBlur. */
   onTreeBlur(nextTree: IFocusableTree | null): void {


### PR DESCRIPTION
Screen readers read the workspace's region label when its contents are focused, but updateAriaLabel only ran on the workspace node's own focus. When a child block took focus on first entry the label was never refreshed, so a stale stack count (e.g. "0 stacks") was announced. The previous workaround dropped the count entirely on Apple.

Refresh the label in onTreeFocus, which fires whenever focus enters the workspace tree (including via a child), before the element is focused, so the announced count is current. This lets us restore the informative stack count on all platforms.

<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

This fixes only part 1 of this issue as described in this comment https://github.com/RaspberryPiFoundation/blockly/issues/9885#issuecomment-4719643883

### Proposed Changes

Refresh the label in onTreeFocus, which fires whenever focus enters the workspace tree (including via a child), before the element is focused, so the announced count is current. This lets us restore the informative stack count on all platforms.

### Reason for Changes

This isn't Mac specific, other screen readers also output region context when focusing  nodes in the region.

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
