### PR TITLE
fix: Fix Github pages publishing

### DIFF
--- a/packages/blockly/package.json
+++ b/packages/blockly/package.json
@@ -47,7 +47,7 @@
     "test:generators": "gulp testGenerators",
     "test:mocha:interactive": "npm run build && concurrently -n tsc,server \"tsc --watch --preserveWatchOutput --outDir \"build/src\" --declarationDir \"build/declarations\"\" \"gulp interactiveMocha\"",
     "test:compile:advanced": "gulp buildAdvancedCompilationTest --debug",
-    "updateGithubPages": "npm ci && gulp updateGithubPages --upstream",
+    "updateGithubPages": "npm ci && node ./tests/scripts/magic_symlink.js && gulp updateGithubPages --upstream",
     "updateGithubPages:staging": "npm ci && gulp updateGithubPages --use-local"
   },
   "exports": {

--- a/packages/blockly/package.json
+++ b/packages/blockly/package.json
@@ -47,7 +47,7 @@
     "test:generators": "gulp testGenerators",
     "test:mocha:interactive": "npm run build && concurrently -n tsc,server \"tsc --watch --preserveWatchOutput --outDir \"build/src\" --declarationDir \"build/declarations\"\" \"gulp interactiveMocha\"",
     "test:compile:advanced": "gulp buildAdvancedCompilationTest --debug",
-    "updateGithubPages": "npm ci && node ./tests/scripts/magic_symlink.js && gulp updateGithubPages --upstream",
+    "updateGithubPages": "npm ci && cp -R ../../node_modules/@blockly node_modules/ && gulp updateGithubPages --upstream",
     "updateGithubPages:staging": "npm ci && gulp updateGithubPages --use-local"
   },
   "exports": {


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Proposed Changes
This PR fixes the `npm run updateGithubPages` command by copying various Blockly-related packages that the playgrounds depend on out of the root node_modules folder before publishing the pages.