### PR TITLE
fix: Treat the flyout as a listbox with options

### DIFF
--- a/packages/blockly/core/block_flyout_inflater.ts
+++ b/packages/blockly/core/block_flyout_inflater.ts
@@ -80,7 +80,21 @@ export class BlockFlyoutInflater implements IFlyoutInflater {
     // to correct the role and hidden state for it.
     const focusableElement = block.getFocusableElement();
     aria.clearState(focusableElement, aria.State.HIDDEN);
-    aria.setRole(focusableElement, aria.Role.LISTITEM);
+    aria.setRole(focusableElement, aria.Role.OPTION);
+
+    // Clickable icons in the flyout are owned by their parent block.
+    // This ensures that clickable icons are not included in the option
+    // count when screen readers assess the number of options in the
+    // flyout listbox.
+    const ownedIconIds = block
+      .getIcons()
+      .filter((icon) => icon.isClickableInFlyout?.(flyout.autoClose))
+      .map((icon) => icon.getFocusableElement().id)
+      .filter((id) => !!id);
+    if (ownedIconIds.length) {
+      aria.setState(focusableElement, aria.State.OWNS, ownedIconIds);
+    }
+
     this.addBlockListeners(block);
 
     return new FlyoutItem(block, BLOCK_TYPE);

--- a/packages/blockly/core/flyout_base.ts
+++ b/packages/blockly/core/flyout_base.ts
@@ -697,9 +697,9 @@ export abstract class Flyout
       .trim();
     aria.setState(this.getWorkspace().getCanvas(), aria.State.LABEL, ariaLabel);
 
-    // The block canvas is a list. The list items must be direct descendants of the list,
+    // The block canvas is a listbox. The options must be direct descendants of the listbox,
     // and the flyout may or may not be a region, so we set the role on the block canvas rather than the svgGroup_.
-    aria.setRole(this.getWorkspace().getCanvas(), aria.Role.LIST);
+    aria.setRole(this.getWorkspace().getCanvas(), aria.Role.LISTBOX);
   }
 
   /**

--- a/packages/blockly/core/flyout_button.ts
+++ b/packages/blockly/core/flyout_button.ts
@@ -177,10 +177,10 @@ export class FlyoutButton
     aria.setRole(svgText, aria.Role.PRESENTATION);
 
     // We add the word "heading" or "button" to the label so that they give appropriate hints
-    // we can't use the corresponding roles because that overwrites the context of it being a list item.
+    // we can't use the corresponding roles because that overwrites the context of it being an option.
     const ariaLabel = `${text}, ${this.isFlyoutLabel ? Msg['ARIA_LABEL_HEADING'] : Msg['ARIA_LABEL_BUTTON']}`;
     aria.setState(this.getFocusableElement(), aria.State.LABEL, ariaLabel);
-    aria.setRole(this.getFocusableElement(), aria.Role.LISTITEM);
+    aria.setRole(this.getFocusableElement(), aria.Role.OPTION);
 
     const fontSize = style.getComputedStyle(svgText, 'fontSize');
     const fontWeight = style.getComputedStyle(svgText, 'fontWeight');

--- a/packages/blockly/core/icons/icon.ts
+++ b/packages/blockly/core/icons/icon.ts
@@ -231,6 +231,16 @@ export abstract class Icon implements IIcon, IContextMenu {
   protected recomputeAriaContext(): void {
     const element = this.getFocusableElement();
     if (!element) return;
+    const flyout = (
+      this.sourceBlock.workspace as WorkspaceSvg
+    ).targetWorkspace?.getFlyout();
+    if (flyout && !this.isClickableInFlyout(flyout.autoClose)) {
+      // Icons that can't be used in the flyout are removed from the
+      // accessibility tree, like non-interactive fields.
+      aria.setState(element, aria.State.HIDDEN, true);
+      return;
+    }
+    aria.clearState(element, aria.State.HIDDEN);
     aria.setRole(element, aria.Role.BUTTON);
     const label = this.getAriaLabel() ?? Msg['ICON_LABEL_DEFAULT'];
     aria.setState(element, aria.State.LABEL, label);

--- a/packages/blockly/tests/mocha/aria_test.js
+++ b/packages/blockly/tests/mocha/aria_test.js
@@ -348,7 +348,7 @@ suite('ARIA', function () {
       );
       const block = this.workspace.getFlyout().getWorkspace().getTopBlocks()[0];
       const role = Blockly.utils.aria.getRole(block.getFocusableElement());
-      assert.equal(role, Blockly.utils.aria.Role.LISTITEM);
+      assert.equal(role, Blockly.utils.aria.Role.OPTION);
     });
 
     test('Root workspace blocks indicate that in their labels', function () {


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

Fixes https://github.com/RaspberryPiFoundation/blockly/issues/10058

### Proposed Changes

Change the flyout from a list to listbox and flyout items from listitems to options.

Subsequently, clickable icons in the flyout need to be owned (using aria-owns) by their parent block to avoid inflating the number of options that the screen reader counts. This PR also introduces more safety with icons by making them inert in the flyout when they are not clickable.

### Reason for Changes

This fixes compatibility with Windows narrator without regressing other screen readers (VoiceOver, NVDA, JAWS, ChromeVox)

### Test Coverage

Updated one existing change to assert option instead of listitem.

### Documentation

None

### Additional Information

An alternative fix could be to avoid using aria-label in the flyout, and instead use a visually hidden element that contains the aria-label text, but I have not explored or test this version.
