### PR TITLE
feat: ctrl/cmd+v pastes near focused block

### DIFF
--- a/packages/blockly/core/clipboard/block_paster.ts
+++ b/packages/blockly/core/clipboard/block_paster.ts
@@ -37,7 +37,7 @@ export class BlockPaster implements IPaster<BlockCopyData, BlockSvg> {
     // However, the algorithm for deciding where to paste a block depends on
     // the starting position of the copied block, so we'll pass those coordinates along
     const initialCoordinates =
-      coordinate ||
+      coordinate ??
       new Coordinate(
         copyData.blockState['x'] || 0,
         copyData.blockState['y'] || 0,

--- a/packages/blockly/core/keyboard_nav/navigators/navigator.ts
+++ b/packages/blockly/core/keyboard_nav/navigators/navigator.ts
@@ -5,6 +5,7 @@
  */
 
 import {BlockSvg} from '../../block_svg.js';
+import {CommentEditor} from '../../comments/comment_editor.js';
 import {Field} from '../../field.js';
 import {getFocusManager} from '../../focus_manager.js';
 import {Icon} from '../../icons/icon.js';
@@ -499,6 +500,9 @@ export class Navigator {
       return node.getSourceBlock();
     } else if (node instanceof Icon) {
       return node.getSourceBlock() as BlockSvg;
+    } else if (node instanceof CommentEditor) {
+      const parent = node.getParent();
+      return parent instanceof BlockSvg ? parent : null;
     }
 
     return null;

--- a/packages/blockly/core/shortcut_items.ts
+++ b/packages/blockly/core/shortcut_items.ts
@@ -297,6 +297,27 @@ export function registerCut() {
 }
 
 /**
+ * Returns workspace coordinates to use as the paste origin when focus is on a
+ * block or one of its children (fields, connections, icons, block comments).
+ *
+ * @param focusedNode The node that currently has focus.
+ * @param targetWorkspace The workspace where the paste will occur.
+ * @returns The parent block's location in workspace coordinates, or undefined
+ *     if focus is not on a block or one of its children.
+ */
+function getPasteOriginFromFocus(
+  focusedNode: IFocusableNode | null,
+  targetWorkspace: WorkspaceSvg,
+): Coordinate | undefined {
+  const block = targetWorkspace
+    .getNavigator()
+    .getSourceBlockFromNode(focusedNode);
+  if (!block) return undefined;
+
+  return block.getRelativeToSurfaceXY();
+}
+
+/**
  * Keyboard shortcut to paste a block on ctrl+v, cmd+v, or alt+v.
  */
 export function registerPaste() {
@@ -330,6 +351,7 @@ export function registerPaste() {
     },
     callback(workspace: WorkspaceSvg, e: Event) {
       const copyData = clipboard.getLastCopiedData();
+      const focusedNode = getFocusManager().getFocusedNode();
       if (!copyData) return false;
 
       const copyWorkspace = clipboard.getLastCopiedWorkspace();
@@ -355,6 +377,15 @@ export function registerPaste() {
         return !!clipboard.paste(copyData, targetWorkspace, mouseCoords);
       }
 
+      const pasteOrigin = getPasteOriginFromFocus(
+        focusedNode,
+        targetWorkspace,
+      );
+      if (pasteOrigin) {
+        return !!clipboard.paste(copyData, targetWorkspace, pasteOrigin);
+      }
+
+      // No spatial focus target (e.g. workspace root) — use copy-location behavior.
       const copyCoords = clipboard.getLastCopiedLocation();
       if (!copyCoords) {
         // If we don't have location data about the original copyable, let the

--- a/packages/blockly/core/shortcut_items.ts
+++ b/packages/blockly/core/shortcut_items.ts
@@ -356,7 +356,8 @@ export function registerPaste() {
         return !!clipboard.paste(copyData, targetWorkspace, mouseCoords);
       }
 
-      // If the focused node is a block, paste relative to that block's position.
+      // If the focused node is a block, or part of a block (connection, field, etc.),
+      // paste relative to that block's position.
       const block = targetWorkspace
         .getNavigator()
         .getSourceBlockFromNode(focusedNode);

--- a/packages/blockly/core/shortcut_items.ts
+++ b/packages/blockly/core/shortcut_items.ts
@@ -377,10 +377,7 @@ export function registerPaste() {
         return !!clipboard.paste(copyData, targetWorkspace, mouseCoords);
       }
 
-      const pasteOrigin = getPasteOriginFromFocus(
-        focusedNode,
-        targetWorkspace,
-      );
+      const pasteOrigin = getPasteOriginFromFocus(focusedNode, targetWorkspace);
       if (pasteOrigin) {
         return !!clipboard.paste(copyData, targetWorkspace, pasteOrigin);
       }

--- a/packages/blockly/core/shortcut_items.ts
+++ b/packages/blockly/core/shortcut_items.ts
@@ -297,27 +297,6 @@ export function registerCut() {
 }
 
 /**
- * Returns workspace coordinates to use as the paste origin when focus is on a
- * block or one of its children (fields, connections, icons, block comments).
- *
- * @param focusedNode The node that currently has focus.
- * @param targetWorkspace The workspace where the paste will occur.
- * @returns The parent block's location in workspace coordinates, or undefined
- *     if focus is not on a block or one of its children.
- */
-function getPasteOriginFromFocus(
-  focusedNode: IFocusableNode | null,
-  targetWorkspace: WorkspaceSvg,
-): Coordinate | undefined {
-  const block = targetWorkspace
-    .getNavigator()
-    .getSourceBlockFromNode(focusedNode);
-  if (!block) return undefined;
-
-  return block.getRelativeToSurfaceXY();
-}
-
-/**
  * Keyboard shortcut to paste a block on ctrl+v, cmd+v, or alt+v.
  */
 export function registerPaste() {
@@ -377,7 +356,11 @@ export function registerPaste() {
         return !!clipboard.paste(copyData, targetWorkspace, mouseCoords);
       }
 
-      const pasteOrigin = getPasteOriginFromFocus(focusedNode, targetWorkspace);
+      // If the focused node is a block, paste relative to that block's position.
+      const block = targetWorkspace
+        .getNavigator()
+        .getSourceBlockFromNode(focusedNode);
+      const pasteOrigin = block?.getRelativeToSurfaceXY();
       if (pasteOrigin) {
         return !!clipboard.paste(copyData, targetWorkspace, pasteOrigin);
       }

--- a/packages/blockly/tests/mocha/shortcut_items_test.js
+++ b/packages/blockly/tests/mocha/shortcut_items_test.js
@@ -429,6 +429,79 @@ suite('Keyboard Shortcut Items', function () {
       sinon.assert.calledWith(toastSpy, this.workspace, 'copiedHint');
       toastSpy.restore();
     });
+
+    test('Pastes near focused block instead of copy origin', function () {
+      this.workspace.clear();
+      const blockA = setSelectedBlock(this.workspace);
+
+      this.injectionDiv.dispatchEvent(
+        createKeyDownEvent(Blockly.utils.KeyCodes.C, [
+          Blockly.utils.KeyCodes.CTRL_CMD,
+        ]),
+      );
+
+      const blockB = Blockly.serialization.blocks.append(
+        {type: 'stack_block', x: 300, y: 300},
+        this.workspace,
+      );
+      Blockly.getFocusManager().focusNode(blockB);
+
+      this.injectionDiv.dispatchEvent(
+        createKeyDownEvent(Blockly.utils.KeyCodes.V, [
+          Blockly.utils.KeyCodes.CTRL_CMD,
+        ]),
+      );
+
+      const pastedBlock = this.workspace
+        .getAllBlocks(false)
+        .find((b) => ![blockA, blockB].includes(b));
+      assert.isDefined(pastedBlock);
+
+      const pastedXY = pastedBlock.getRelativeToSurfaceXY();
+      // Check that the pasted block is closer to blockB than blockA, which means
+      // it used the focus location instead of the copy origin.
+      assert.isBelow(
+        Blockly.utils.Coordinate.distance(
+          pastedXY,
+          blockB.getRelativeToSurfaceXY(),
+        ),
+        Blockly.utils.Coordinate.distance(
+          pastedXY,
+          blockA.getRelativeToSurfaceXY(),
+        ),
+      );
+    });
+
+    test('Uses copy origin when workspace has focus', function () {
+      const blockA = setSelectedBlock(this.workspace);
+      this.injectionDiv.dispatchEvent(
+        createKeyDownEvent(Blockly.utils.KeyCodes.C, [
+          Blockly.utils.KeyCodes.CTRL_CMD,
+        ]),
+      );
+
+      Blockly.getFocusManager().focusNode(this.workspace);
+      this.injectionDiv.dispatchEvent(
+        createKeyDownEvent(Blockly.utils.KeyCodes.V, [
+          Blockly.utils.KeyCodes.CTRL_CMD,
+        ]),
+      );
+
+      const pastedBlock = this.workspace
+        .getAllBlocks(false)
+        .find((b) => b.id !== blockA.id);
+      assert.isDefined(pastedBlock);
+
+      const copyOrigin = blockA.getRelativeToSurfaceXY();
+      const pastedXY = pastedBlock.getRelativeToSurfaceXY();
+      assert.isBelow(
+        Blockly.utils.Coordinate.distance(pastedXY, copyOrigin),
+        Blockly.utils.Coordinate.distance(
+          pastedXY,
+          new Blockly.utils.Coordinate(300, 300),
+        ),
+      );
+    });
   });
 
   suite('Undo', function () {


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes https://github.com/RaspberryPiFoundation/blockly/issues/9091

### Proposed Changes

This updates the `'paste'` shortcut to use a currently focused block's position instead of the position included in the `copyData`. If a block's child is focused (e.g., connection, comment editor, etc.), the source block's position is used. If the workspace is focused, there is no change to the behavior.

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->

### Reason for Changes

Previously, if the user copied in one location with the keyboard and then moved to a different block, the paste would occur near the original copied block's location.

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage

Added new relevant tests.
<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->
