### PR TITLE
fix: scope passive block focus to keyboard navigation

### DIFF
--- a/packages/blockly/core/css.ts
+++ b/packages/blockly/core/css.ts
@@ -571,6 +571,12 @@ input[type=number] {
 
 /* Passive focus cases: */
 /* Blocks with passive focus except when widget/dropdown div in use. */
+.blocklyKeyboardNavigation:not(
+        :has(
+            .blocklyDropDownDiv:focus-within,
+            .blocklyWidgetDiv:focus-within
+          )
+      )
   .blocklyPassiveFocus:is(
     .blocklyPath:not(.blocklyFlyout .blocklyPath),
     .blocklyHighlightedConnectionPath


### PR DESCRIPTION
The passive-focus selector for blocks and connection paths lacked the .blocklyKeyboardNavigation gate that the sibling field and icon selectors in the same rule already have, so passive block outlines leaked into mouse-only usage. It also never honored the dropdown/widget-div guard its own comment promised. Scope it identically to the field/icon selectors.

<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

Fixes #10062

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
