### PR TITLE
fix: Make dialog handling of ephemeral focus more robust

### DIFF
--- a/packages/blockly/core/dialog.ts
+++ b/packages/blockly/core/dialog.ts
@@ -251,7 +251,11 @@ function displayDialog(
 
   let restoreFocus: (() => void) | undefined;
   if (activeDialogCount === 0) {
-    restoreFocus = getFocusManager().takeEphemeralFocus(dialog);
+    if (getFocusManager().ephemeralFocusTaken()) {
+      restoreFocus = undefined;
+    } else {
+      restoreFocus = getFocusManager().takeEphemeralFocus(dialog);
+    }
   }
 
   activeDialogCount++;


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Proposed Changes
This PR makes the dialog system check to ensure that nothing else is holding ephemeral focus before attempting to claim it itself. Claiming ephemeral focus when it is already held throws, and this could be triggered by e.g. showing a dialog from content in a widgetdiv (which already/also claims ephemeral focus). Now, if ephemeral focus is held, the dialog system doesn't claim it, and when the dialog reference count reaches 0, it will not attempt to restore focus since it won't hold a callback to invoke. 