### PR TITLE
fix: forward shadow block context menu to parent

### DIFF
--- a/packages/blockly/core/block_svg.ts
+++ b/packages/blockly/core/block_svg.ts
@@ -709,6 +709,18 @@ export class BlockSvg
    * @internal
    */
   showContextMenu(e: Event) {
+    // Forward to the nearest non-shadow ancestor and focus it for keyboard users.
+    if (this.isShadow()) {
+      let parent = this.getParent();
+      while (parent && parent.isShadow()) {
+        parent = parent.getParent();
+      }
+      if (parent) {
+        getFocusManager().focusNode(parent);
+        parent.showContextMenu(e);
+      }
+      return;
+    }
     const menuOptions = this.generateContextMenu(e);
 
     const location = this.calculateContextMenuLocation(e);

--- a/packages/blockly/tests/mocha/contextmenu_test.js
+++ b/packages/blockly/tests/mocha/contextmenu_test.js
@@ -8,6 +8,10 @@ import {callbackFactory} from '../../build/src/core/contextmenu.js';
 import * as xmlUtils from '../../build/src/core/utils/xml.js';
 import {assert} from '../../node_modules/chai/index.js';
 import {
+  defineRowBlock,
+  defineStackBlock,
+} from './test_helpers/block_definitions.js';
+import {
   sharedTestSetup,
   sharedTestTeardown,
 } from './test_helpers/setup_teardown.js';
@@ -89,6 +93,90 @@ suite('Context Menu', function () {
 
       Blockly.ContextMenu.hide();
       assert.isNull(Blockly.ContextMenu.getMenu());
+    });
+  });
+
+  suite('Block showContextMenu', function () {
+    setup(function () {
+      defineRowBlock();
+      defineStackBlock();
+      Blockly.ContextMenuRegistry.registry.reset();
+      Blockly.ContextMenuItems.registerDefaultOptions();
+      this.pointerEvent = new PointerEvent('pointerdown');
+    });
+
+    teardown(function () {
+      if (Blockly.ContextMenu.getMenu()) {
+        Blockly.ContextMenu.hide();
+      }
+    });
+
+    /**
+     * Initializes and renders the given blocks.
+     * @param {...Blockly.BlockSvg} blocks The blocks to initialize.
+     */
+    function initAndRender(...blocks) {
+      for (const block of blocks) {
+        block.initSvg();
+        block.render();
+      }
+    }
+
+    /**
+     * Asserts that the given block's context menu is shown and it has focus.
+     * @param {!Blockly.BlockSvg} block The block that should own the menu.
+     */
+    function assertBlockContextMenu(block) {
+      assert.strictEqual(Blockly.getFocusManager().getFocusedNode(), block);
+      assert.instanceOf(
+        Blockly.ContextMenu.getMenu(),
+        Blockly.Menu,
+        'Context menu should be shown',
+      );
+      assert.strictEqual(Blockly.ContextMenu.getCurrentBlock(), block);
+    }
+
+    test('value shadow forwards context menu to parent and focuses parent', function () {
+      const parent = this.workspace.newBlock('row_block');
+      parent.getInput('INPUT').connection.setShadowState({type: 'row_block'});
+      const shadow = parent.getInput('INPUT').connection.targetBlock();
+      assert.isTrue(shadow.isShadow());
+      initAndRender(parent, shadow);
+
+      Blockly.getFocusManager().focusNode(shadow);
+      shadow.showContextMenu(this.pointerEvent);
+
+      assertBlockContextMenu(parent);
+    });
+
+    test('nested shadows forward to the first non-shadow ancestor', function () {
+      const parent = this.workspace.newBlock('row_block');
+      parent.getInput('INPUT').connection.setShadowState({type: 'row_block'});
+      const middleShadow = parent.getInput('INPUT').connection.targetBlock();
+      middleShadow
+        .getInput('INPUT')
+        .connection.setShadowState({type: 'row_block'});
+      const childShadow = middleShadow
+        .getInput('INPUT')
+        .connection.targetBlock();
+      assert.isTrue(middleShadow.isShadow());
+      assert.isTrue(childShadow.isShadow());
+      initAndRender(parent, middleShadow, childShadow);
+
+      Blockly.getFocusManager().focusNode(childShadow);
+      childShadow.showContextMenu(this.pointerEvent);
+
+      assertBlockContextMenu(parent);
+    });
+
+    test('non-shadow block shows its own context menu', function () {
+      const block = this.workspace.newBlock('stack_block');
+      initAndRender(block);
+      Blockly.getFocusManager().focusNode(block);
+
+      block.showContextMenu(this.pointerEvent);
+
+      assertBlockContextMenu(block);
     });
   });
 });


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [ ] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes https://github.com/RaspberryPiFoundation/blockly/issues/9999

### Proposed Changes

- Update `BlockSvg.showContextMenu` so shadow blocks forward to the nearest non-shadow ancestor instead of opening their own menu.
- Focus that ancestor before delegating


### Reason for Changes

Shadow blocks do not have context menus for mouse users, but keyboard users can still focus them and trigger one (e.g. Ctrl/Cmd+Enter). Forwarding to the owning block matches mouse/pointer behavior and exposes the parent’s relevant actions.
<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage

Added a `Block showContextMenu` suite in `contextmenu_test.js` covering value-input shadow forwarding, nested input shadows, and a non-shadow regression case.
