### PR TITLE
fix: Improve VoiceOver experience when using Safari

### DIFF
--- a/packages/blockly/core/block_svg.ts
+++ b/packages/blockly/core/block_svg.ts
@@ -1397,6 +1397,7 @@ export class BlockSvg
       return;
     }
     requestAnimationFrame(() => {
+      if (this.dragging) return;
       /* eslint-disable-next-line @typescript-eslint/no-this-alias */
       let block: this | null = this;
       do {

--- a/packages/blockly/core/block_svg.ts
+++ b/packages/blockly/core/block_svg.ts
@@ -1393,25 +1393,28 @@ export class BlockSvg
    * @internal
    */
   moveSvgRootToFront(blockOnly = false) {
-    /* eslint-disable-next-line @typescript-eslint/no-this-alias */
-    let block: this | null = this;
-    if (block.isDeadOrDying()) {
+    if (this.isDeadOrDying()) {
       return;
     }
-    do {
-      const root = block.getSvgRoot();
-      const parent = root.parentNode;
-      if (!parent) return;
-      const childNodes = parent.childNodes;
-      // Avoid moving the block if it's already at the bottom.
-      if (childNodes[childNodes.length - 1] !== root) {
-        while (root.nextSibling) {
-          parent.insertBefore(root.nextSibling, root);
+    requestAnimationFrame(() => {
+      /* eslint-disable-next-line @typescript-eslint/no-this-alias */
+      let block: this | null = this;
+      do {
+        if (block.isDeadOrDying()) return;
+        const root = block.getSvgRoot();
+        const parent = root.parentNode;
+        if (!parent) return;
+        const childNodes = parent.childNodes;
+        // Avoid moving the block if it's already at the bottom.
+        if (childNodes[childNodes.length - 1] !== root) {
+          while (root.nextSibling) {
+            parent.insertBefore(root.nextSibling, root);
+          }
         }
-      }
-      if (blockOnly) break;
-      block = block.getParent();
-    } while (block);
+        if (blockOnly) break;
+        block = block.getParent();
+      } while (block);
+    });
   }
 
   /**

--- a/packages/blockly/core/block_svg.ts
+++ b/packages/blockly/core/block_svg.ts
@@ -1405,7 +1405,9 @@ export class BlockSvg
       const childNodes = parent.childNodes;
       // Avoid moving the block if it's already at the bottom.
       if (childNodes[childNodes.length - 1] !== root) {
-        parent.appendChild(root);
+        while (root.nextSibling) {
+          parent.insertBefore(root.nextSibling, root);
+        }
       }
       if (blockOnly) break;
       block = block.getParent();

--- a/packages/blockly/core/css.ts
+++ b/packages/blockly/core/css.ts
@@ -162,6 +162,9 @@ const content = `
 
 .blocklyHighlightedConnectionPath {
   fill: none;
+}
+
+.blocklyHighlightedConnectionPathVisible {
   stroke: #fc3;
   stroke-width: 4px;
 }
@@ -602,12 +605,6 @@ input[type=number] {
   stroke: var(--blockly-active-node-color);
   stroke-dasharray: 5px 3px;
   stroke-width: var(--blockly-selection-width);
-}
-
-/* Workaround for unexpectedly hidden connection path due to core style. */
-.blocklyKeyboardNavigation
-  .blocklyPassiveFocus.blocklyHighlightedConnectionPath {
-  display: unset !important;
 }
 
 /* Different ways for toolbox/flyout to be the active tree: */

--- a/packages/blockly/core/rendered_connection.ts
+++ b/packages/blockly/core/rendered_connection.ts
@@ -322,11 +322,11 @@ export class RenderedConnection
   }
 
   /**
-   * Sets the aria role, label, and other state for this connection.
+   * Sets the aria role and role description for this connection.
    *
    * @param highlightSvg The focusable element for this connection.
    */
-  recomputeAriaContext(highlightSvg: SVGElement) {
+  setAriaRole(highlightSvg: SVGElement) {
     // Note that output connections don't have highlights so this doesn't need to take them into account.
     const roleDescription =
       this.type === ConnectionType.INPUT_VALUE
@@ -335,6 +335,15 @@ export class RenderedConnection
 
     aria.setRole(highlightSvg, aria.Role.FIGURE);
     aria.setState(highlightSvg, aria.State.ROLEDESCRIPTION, roleDescription);
+  }
+
+  /**
+   * Sets the aria role, label, and other state for this connection.
+   *
+   * @param highlightSvg The focusable element for this connection.
+   */
+  private recomputeAriaContext(highlightSvg: SVGElement) {
+    this.setAriaRole(highlightSvg);
 
     // 'Next' connections are only focusable if they're the last connection
     // inside a statement input. The label for these connections comes from

--- a/packages/blockly/core/rendered_connection.ts
+++ b/packages/blockly/core/rendered_connection.ts
@@ -28,6 +28,7 @@ import * as internalConstants from './internal_constants.js';
 import {Msg} from './msg.js';
 import * as aria from './utils/aria.js';
 import {Coordinate} from './utils/coordinate.js';
+import * as dom from './utils/dom.js';
 import * as svgMath from './utils/svg_math.js';
 import {WorkspaceSvg} from './workspace_svg.js';
 
@@ -394,8 +395,14 @@ export class RenderedConnection
     // draw pass).
     const highlightSvg = this.findHighlightSvg();
     if (highlightSvg) {
-      highlightSvg.style.display = '';
-      highlightSvg.parentElement?.appendChild(highlightSvg);
+      dom.addClass(highlightSvg, 'blocklyHighlightedConnectionPathVisible');
+      requestAnimationFrame(() => {
+        const parent = highlightSvg.parentElement;
+        if (!parent) return;
+        while (highlightSvg.nextSibling) {
+          parent.insertBefore(highlightSvg.nextSibling, highlightSvg);
+        }
+      });
       this.recomputeAriaContext(highlightSvg);
     }
   }
@@ -407,7 +414,7 @@ export class RenderedConnection
     // Note that this is done synchronously for parity with highlight().
     const highlightSvg = this.findHighlightSvg();
     if (highlightSvg) {
-      highlightSvg.style.display = 'none';
+      dom.removeClass(highlightSvg, 'blocklyHighlightedConnectionPathVisible');
     }
   }
 

--- a/packages/blockly/core/rendered_connection.ts
+++ b/packages/blockly/core/rendered_connection.ts
@@ -326,7 +326,7 @@ export class RenderedConnection
    *
    * @param highlightSvg The focusable element for this connection.
    */
-  private recomputeAriaContext(highlightSvg: SVGElement) {
+  recomputeAriaContext(highlightSvg: SVGElement) {
     // Note that output connections don't have highlights so this doesn't need to take them into account.
     const roleDescription =
       this.type === ConnectionType.INPUT_VALUE

--- a/packages/blockly/core/renderers/common/constants.ts
+++ b/packages/blockly/core/renderers/common/constants.ts
@@ -1208,7 +1208,7 @@ export class ConstantProvider {
       `}`,
 
       // Connection highlight.
-      `${selector} .blocklyHighlightedConnectionPath {`,
+      `${selector} .blocklyHighlightedConnectionPathVisible {`,
         `stroke: #fc3;`,
       `}`,
 

--- a/packages/blockly/core/renderers/common/drawer.ts
+++ b/packages/blockly/core/renderers/common/drawer.ts
@@ -440,8 +440,11 @@ export class Drawer {
 
         const highlightSvg = this.drawConnectionHighlightPath(elem);
         if (highlightSvg) {
-          highlightSvg.style.display = elem.highlighted ? '' : 'none';
           elem.connectionModel.setAriaRole(highlightSvg);
+          highlightSvg.classList.toggle(
+            'blocklyHighlightedConnectionPathVisible',
+            elem.highlighted,
+          );
         }
       }
     }

--- a/packages/blockly/core/renderers/common/drawer.ts
+++ b/packages/blockly/core/renderers/common/drawer.ts
@@ -441,7 +441,7 @@ export class Drawer {
         const highlightSvg = this.drawConnectionHighlightPath(elem);
         if (highlightSvg) {
           highlightSvg.style.display = elem.highlighted ? '' : 'none';
-          elem.connectionModel.recomputeAriaContext(highlightSvg);
+          elem.connectionModel.setAriaRole(highlightSvg);
         }
       }
     }

--- a/packages/blockly/core/renderers/common/drawer.ts
+++ b/packages/blockly/core/renderers/common/drawer.ts
@@ -441,6 +441,7 @@ export class Drawer {
         const highlightSvg = this.drawConnectionHighlightPath(elem);
         if (highlightSvg) {
           highlightSvg.style.display = elem.highlighted ? '' : 'none';
+          elem.connectionModel.recomputeAriaContext(highlightSvg);
         }
       }
     }

--- a/packages/blockly/core/renderers/common/path_object.ts
+++ b/packages/blockly/core/renderers/common/path_object.ts
@@ -226,7 +226,6 @@ export class PathObject implements IPathObject {
       {
         'id': connection.id,
         'class': 'blocklyHighlightedConnectionPath',
-        'style': 'display: none;',
         'd': connectionPath,
         'transform': transformation,
       },

--- a/packages/blockly/core/renderers/zelos/constants.ts
+++ b/packages/blockly/core/renderers/zelos/constants.ts
@@ -789,7 +789,7 @@ export class ConstantProvider extends BaseConstantProvider {
       `}`,
 
       // Connection highlight.
-      `${selector} .blocklyHighlightedConnectionPath {`,
+      `${selector} .blocklyHighlightedConnectionPathVisible {`,
       `stroke: ${this.SELECTED_GLOW_COLOUR};`,
       `}`,
 


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

Fixes https://github.com/RaspberryPiFoundation/blockly/issues/10066

### Proposed Changes

This PR consists of many small changes that combine to improve the VoiceOver in Safari experience:

- Do not append the element to the DOM that is about to be focused (causes VoiceOver cursor / focus decoupling). Instead move other elements before it. This is applied to blocks and rendered connections
- Reorder blocks / connections inside requestAnimationFrame to avoid VoiceOver cursor flickers
- Compute basic aria role and roledescription for rendered connections at draw time. This ensures that the element is focusable and understood by Safari to be focusable. The aria-label is still only calculated on focus.
- Ensure that rendered connections are always visible. Toggling the display style causes real issues with Safari and VoiceOver. Instead, a class is used to manage the stroke highlighting and toggled where display was previously.
- Ensures that the move mode icon stays at the front after the above changes

### Reason for Changes

Maintains the '[bring to the front'](https://github.com/RaspberryPiFoundation/blockly/pull/10032) fix for blocks focused via keyboard and improves VoiceOver in Safari. 

### Test Coverage

Manual testing in Safari with VoiceOver. Existing tests still pass.

### Documentation

None

### Additional Information

This change would really benefit from testing with different screen readers on different browsers to ensure that are no regressions.
