### PR TITLE
fix: Fix count of toolbox items in Voiceover

### DIFF
--- a/packages/blockly/core/block_flyout_inflater.ts
+++ b/packages/blockly/core/block_flyout_inflater.ts
@@ -91,8 +91,11 @@ export class BlockFlyoutInflater implements IFlyoutInflater {
       .filter((icon) => icon.isClickableInFlyout?.(flyout.autoClose))
       .map((icon) => icon.getFocusableElement().id)
       .filter((id) => !!id);
-    if (ownedIconIds.length) {
-      aria.setState(focusableElement, aria.State.OWNS, ownedIconIds);
+    // Likewise for connections.
+    const ownedConnectionIds = block.getConnections_(true).map((c) => c.id);
+    const ownedChildIds = [...ownedIconIds, ...ownedConnectionIds];
+    if (ownedChildIds.length) {
+      aria.setState(focusableElement, aria.State.OWNS, ownedChildIds);
     }
 
     this.addBlockListeners(block);


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Proposed Changes
This PR fixes an issue introduced by the fixes in #10073 that caused Voiceover to read out inflated counts of toolbox items. Applying the same pattern as was used to avoid this with icons to connections resolves the issue.