### PR TITLE
fix: recompute field ARIA when editor is closed

### DIFF
--- a/packages/blockly/core/field_input.ts
+++ b/packages/blockly/core/field_input.ts
@@ -551,6 +551,8 @@ export abstract class FieldInput<T extends InputTypes> extends Field<
     const clickTarget = this.getClickTarget_();
     if (!clickTarget) throw new Error('A click target has not been set.');
     dom.removeClass(clickTarget, 'blocklyEditing');
+
+    this.recomputeAriaContext();
   }
 
   /**

--- a/packages/blockly/tests/mocha/field_number_test.js
+++ b/packages/blockly/tests/mocha/field_number_test.js
@@ -551,6 +551,24 @@ suite('Number Fields', function () {
       const updatedLabel = this.focusableElement.getAttribute('aria-label');
       assert.isTrue(updatedLabel.includes('1'));
     });
+    test('ARIA label resets after closing editor with invalid input', function () {
+      this.field.setValue(5);
+      this.field.showEditor();
+
+      this.field.htmlInput_.value = 'dog';
+      this.field.onHtmlInputChange(null);
+      assert.equal(this.field.getValue(), 5);
+
+      const labelWhileInvalid =
+        this.focusableElement.getAttribute('aria-label');
+      assert.include(labelWhileInvalid, 'dog');
+
+      Blockly.WidgetDiv.hideIfOwner(this.field);
+
+      const label = this.focusableElement.getAttribute('aria-label');
+      assert.notInclude(label, 'dog');
+      assert.include(label, '5');
+    });
     suite('Full block fields', function () {
       setup(function () {
         this.workspace = Blockly.inject('blocklyDiv', {


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes https://github.com/RaspberryPiFoundation/blockly/issues/10050

### Proposed Changes

Recomputes ARIA context for `FieldInput` classes after the editor is closed.

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->

### Reason for Changes

Previously, we were not doing this, which allowed outdated invalid values to persist on labels for number fields:
<img width="532" height="168" alt="image" src="https://github.com/user-attachments/assets/d635bb3f-87ed-4cef-82e3-b93549cfbdb4" />

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage

Added a test to cover this scenario.
<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->
