### PR TITLE
chore: Remove unused imports

### DIFF
--- a/packages/blockly/core/block.ts
+++ b/packages/blockly/core/block.ts
@@ -11,13 +11,6 @@
  */
 // Former goog.module ID: Blockly.Block
 
-// Unused import preserved for side-effects. Remove if unneeded.
-import './events/events_block_change.js';
-// Unused import preserved for side-effects. Remove if unneeded.
-import './events/events_block_create.js';
-// Unused import preserved for side-effects. Remove if unneeded.
-import './events/events_block_delete.js';
-
 import {Blocks} from './blocks.js';
 import * as common from './common.js';
 import {Connection} from './connection.js';

--- a/packages/blockly/core/block_svg.ts
+++ b/packages/blockly/core/block_svg.ts
@@ -11,9 +11,6 @@
  */
 // Former goog.module ID: Blockly.BlockSvg
 
-// Unused import preserved for side-effects. Remove if unneeded.
-import './events/events_selected.js';
-
 import {Block} from './block.js';
 import * as blockAnimations from './block_animations.js';
 import {computeAriaLabel, configureAriaRole} from './block_aria_composer.js';

--- a/packages/blockly/core/blockly.ts
+++ b/packages/blockly/core/blockly.ts
@@ -6,15 +6,6 @@
 
 // Former goog.module ID: Blockly
 
-// Unused import preserved for side-effects. Remove if unneeded.
-import './events/events_block_create.js';
-// Unused import preserved for side-effects. Remove if unneeded.
-import './events/workspace_events.js';
-// Unused import preserved for side-effects. Remove if unneeded.
-import './events/events_ui_base.js';
-// Unused import preserved for side-effects. Remove if unneeded.
-import './events/events_var_create.js';
-
 import {Block} from './block.js';
 import * as blockAnimations from './block_animations.js';
 import {BlockFlyoutInflater} from './block_flyout_inflater.js';

--- a/packages/blockly/core/field.ts
+++ b/packages/blockly/core/field.ts
@@ -13,9 +13,6 @@
  */
 // Former goog.module ID: Blockly.Field
 
-// Unused import preserved for side-effects. Remove if unneeded.
-import './events/events_block_change.js';
-
 import type {Block} from './block.js';
 import {computeAriaLabel} from './block_aria_composer.js';
 import type {BlockSvg} from './block_svg.js';

--- a/packages/blockly/core/field_checkbox.ts
+++ b/packages/blockly/core/field_checkbox.ts
@@ -10,10 +10,6 @@
  * @class
  */
 // Former goog.module ID: Blockly.FieldCheckbox
-
-// Unused import preserved for side-effects. Remove if unneeded.
-import './events/events_block_change.js';
-
 import {Field, FieldConfig, FieldValidator} from './field.js';
 import * as fieldRegistry from './field_registry.js';
 import {Msg} from './msg.js';

--- a/packages/blockly/core/field_input.ts
+++ b/packages/blockly/core/field_input.ts
@@ -11,9 +11,6 @@
  */
 // Former goog.module ID: Blockly.FieldInput
 
-// Unused import preserved for side-effects. Remove if unneeded.
-import './events/events_block_change.js';
-
 import {computeAriaLabel, getBeginStackLabel} from './block_aria_composer.js';
 import {BlockSvg} from './block_svg.js';
 import * as browserEvents from './browser_events.js';

--- a/packages/blockly/core/field_textinput.ts
+++ b/packages/blockly/core/field_textinput.ts
@@ -11,9 +11,6 @@
  */
 // Former goog.module ID: Blockly.FieldTextInput
 
-// Unused import preserved for side-effects. Remove if unneeded.
-import './events/events_block_change.js';
-
 import {Field} from './field.js';
 import {
   FieldInput,

--- a/packages/blockly/core/field_variable.ts
+++ b/packages/blockly/core/field_variable.ts
@@ -11,9 +11,6 @@
  */
 // Former goog.module ID: Blockly.FieldVariable
 
-// Unused import preserved for side-effects. Remove if unneeded.
-import './events/events_block_change.js';
-
 import type {Block} from './block.js';
 import {Field, FieldConfig, UnattachedFieldError} from './field.js';
 import {

--- a/packages/blockly/core/gesture.ts
+++ b/packages/blockly/core/gesture.ts
@@ -12,9 +12,6 @@
  */
 // Former goog.module ID: Blockly.Gesture
 
-// Unused import preserved for side-effects. Remove if unneeded.
-import './events/events_click.js';
-
 import * as blockAnimations from './block_animations.js';
 import type {BlockSvg} from './block_svg.js';
 import * as browserEvents from './browser_events.js';

--- a/packages/blockly/core/inputs/input.ts
+++ b/packages/blockly/core/inputs/input.ts
@@ -11,9 +11,6 @@
  */
 // Former goog.module ID: Blockly.Input
 
-// Unused import preserved for side-effects. Remove if unneeded.
-import '../field_label.js';
-
 import type {Block} from '../block.js';
 import {computeFieldRowLabel, getInputLabels} from '../block_aria_composer.js';
 import type {BlockSvg} from '../block_svg.js';

--- a/packages/blockly/core/procedures.ts
+++ b/packages/blockly/core/procedures.ts
@@ -6,9 +6,6 @@
 
 // Former goog.module ID: Blockly.Procedures
 
-// Unused import preserved for side-effects. Remove if unneeded.
-import './events/events_block_change.js';
-
 import type {Block} from './block.js';
 import type {BlockSvg} from './block_svg.js';
 import {Blocks} from './blocks.js';

--- a/packages/blockly/core/variable_map.ts
+++ b/packages/blockly/core/variable_map.ts
@@ -11,11 +11,6 @@
  */
 // Former goog.module ID: Blockly.VariableMap
 
-// Unused import preserved for side-effects. Remove if unneeded.
-import './events/events_var_delete.js';
-// Unused import preserved for side-effects. Remove if unneeded.
-import './events/events_var_rename.js';
-
 import type {Block} from './block.js';
 import {EventType} from './events/type.js';
 import * as eventUtils from './events/utils.js';

--- a/packages/blockly/core/variable_model.ts
+++ b/packages/blockly/core/variable_model.ts
@@ -11,9 +11,6 @@
  */
 // Former goog.module ID: Blockly.VariableModel
 
-// Unused import preserved for side-effects. Remove if unneeded.
-import './events/events_var_create.js';
-
 import {EventType} from './events/type.js';
 import * as eventUtils from './events/utils.js';
 import {IVariableModel, IVariableState} from './interfaces/i_variable_model.js';

--- a/packages/blockly/core/workspace.ts
+++ b/packages/blockly/core/workspace.ts
@@ -11,9 +11,6 @@
  */
 // Former goog.module ID: Blockly.Workspace
 
-// Unused import preserved for side-effects. Remove if unneeded.
-import './connection_checker.js';
-
 import type {Block} from './block.js';
 import type {BlocklyOptions} from './blockly_options.js';
 import {WorkspaceComment} from './comments/workspace_comment.js';

--- a/packages/blockly/core/workspace_svg.ts
+++ b/packages/blockly/core/workspace_svg.ts
@@ -11,13 +11,6 @@
  */
 // Former goog.module ID: Blockly.WorkspaceSvg
 
-// Unused import preserved for side-effects. Remove if unneeded.
-import './events/events_block_create.js';
-// Unused import preserved for side-effects. Remove if unneeded.
-import './events/events_theme_change.js';
-// Unused import preserved for side-effects. Remove if unneeded.
-import './events/events_viewport.js';
-
 import type {Block} from './block.js';
 import type {BlockSvg} from './block_svg.js';
 import type {BlocklyOptions} from './blockly_options.js';

--- a/packages/blockly/core/zoom_controls.ts
+++ b/packages/blockly/core/zoom_controls.ts
@@ -11,9 +11,6 @@
  */
 // Former goog.module ID: Blockly.ZoomControls
 
-// Unused import preserved for side-effects. Remove if unneeded.
-import './events/events_click.js';
-
 import * as browserEvents from './browser_events.js';
 import {ComponentManager} from './component_manager.js';
 import * as Css from './css.js';


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Proposed Changes
This PR removes a variety of unused imports left over from the goog.module or Typescript migrations, almost all related to events. While the events do have side effects of registering themselves, the top-level events.ts imports all of them, and is in turn imported in blockly.ts. I verified that Blockly still builds, all tests pass, and the mirror demo (dependent on events) still works. 