### PR TITLE
fix: use a better shortcut for screenreader mode

### DIFF
--- a/packages/blockly/core/shortcut_items.ts
+++ b/packages/blockly/core/shortcut_items.ts
@@ -1293,9 +1293,9 @@ export function registerShowTooltip() {
  * improve the experience for individuals using screenreaders.
  */
 export function registerToggleScreenreaderMode() {
-  const shortcut = ShortcutRegistry.registry.createSerializedKey(KeyCodes.Z, [
-    KeyCodes.CTRL_CMD,
+  const shortcut = ShortcutRegistry.registry.createSerializedKey(KeyCodes.A, [
     KeyCodes.ALT,
+    KeyCodes.SHIFT,
   ]);
 
   let enabled = false;

--- a/packages/blockly/tests/mocha/shortcut_items_test.js
+++ b/packages/blockly/tests/mocha/shortcut_items_test.js
@@ -1972,10 +1972,10 @@ suite('Keyboard Shortcut Items', function () {
     });
   });
 
-  suite('Toggle screenreader mode (Ctrl+Alt+Z / Cmd+Option+Z)', function () {
-    const event = createKeyDownEvent(Blockly.utils.KeyCodes.Z, [
-      Blockly.utils.KeyCodes.CTRL_CMD,
+  suite('Toggle screenreader mode (Alt+Shift+A / Option+Shift+A)', function () {
+    const event = createKeyDownEvent(Blockly.utils.KeyCodes.A, [
       Blockly.utils.KeyCodes.ALT,
+      Blockly.utils.KeyCodes.SHIFT,
     ]);
 
     setup(function () {


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #10060 

### Proposed Changes

Changes the "toggle screenreader mode" shortcut from cmd+shift+z to alt+shift+a

### Reason for Changes

Conflicts with ChromeVox shortcut for previous

### Test Coverage

Updated

### Documentation

Needs callout in release notes

### Additional Information

<!-- Anything else we should know? -->
