### PR TITLE
feat: add optional new shortcuts for block/workspace navigation

### DIFF
--- a/packages/blockly/core/shortcut_items.ts
+++ b/packages/blockly/core/shortcut_items.ts
@@ -1472,13 +1472,9 @@ export function registerJumpBottomStack() {
  * block in the workspace.
  */
 export function registerJumpFirstBlock() {
-  const ctrlHome = ShortcutRegistry.registry.createSerializedKey(
+  const ctrlCmdHome = ShortcutRegistry.registry.createSerializedKey(
     KeyCodes.HOME,
-    [KeyCodes.CTRL],
-  );
-  const metaHome = ShortcutRegistry.registry.createSerializedKey(
-    KeyCodes.HOME,
-    [KeyCodes.META],
+    [KeyCodes.CTRL_CMD],
   );
   const jumpFirstBlockShortcut: KeyboardShortcut = {
     name: names.JUMP_FIRST_BLOCK,
@@ -1493,7 +1489,7 @@ export function registerJumpFirstBlock() {
       getFocusManager().focusNode(topBlocks[0]);
       return true;
     },
-    keyCodes: [ctrlHome, metaHome],
+    keyCodes: [ctrlCmdHome],
     displayText: () => Msg['SHORTCUTS_JUMP_FIRST_BLOCK'],
   };
   ShortcutRegistry.registry.register(jumpFirstBlockShortcut);
@@ -1504,12 +1500,10 @@ export function registerJumpFirstBlock() {
  * block in the workspace.
  */
 export function registerJumpLastBlock() {
-  const ctrlEnd = ShortcutRegistry.registry.createSerializedKey(KeyCodes.END, [
-    KeyCodes.CTRL,
-  ]);
-  const metaEnd = ShortcutRegistry.registry.createSerializedKey(KeyCodes.END, [
-    KeyCodes.META,
-  ]);
+  const ctrlCmdEnd = ShortcutRegistry.registry.createSerializedKey(
+    KeyCodes.END,
+    [KeyCodes.CTRL_CMD],
+  );
   const jumpLastBlockShortcut: KeyboardShortcut = {
     name: names.JUMP_LAST_BLOCK,
     preconditionFn: (workspace) => {
@@ -1523,7 +1517,7 @@ export function registerJumpLastBlock() {
       getFocusManager().focusNode(allBlocks[allBlocks.length - 1]);
       return true;
     },
-    keyCodes: [ctrlEnd, metaEnd],
+    keyCodes: [ctrlCmdEnd],
     displayText: () => Msg['SHORTCUTS_JUMP_LAST_BLOCK'],
   };
   ShortcutRegistry.registry.register(jumpLastBlockShortcut);

--- a/packages/blockly/core/shortcut_items.ts
+++ b/packages/blockly/core/shortcut_items.ts
@@ -11,6 +11,7 @@ import {BlockSvg} from './block_svg.js';
 import * as clipboard from './clipboard.js';
 import {RenderedWorkspaceComment} from './comments.js';
 import * as contextmenu from './contextmenu.js';
+import type {Scope} from './contextmenu_registry.js';
 import * as dropDownDiv from './dropdowndiv.js';
 import * as eventUtils from './events/utils.js';
 import {FlyoutButton} from './flyout_button.js';
@@ -31,6 +32,7 @@ import {isSelectable} from './interfaces/i_selectable.js';
 import {Direction, KeyboardMover} from './keyboard_nav/keyboard_mover.js';
 import {keyboardNavigationController} from './keyboard_navigation_controller.js';
 import {Msg} from './msg.js';
+import {RenderedConnection} from './rendered_connection.js';
 import {KeyboardShortcut, ShortcutRegistry} from './shortcut_registry.js';
 import * as Tooltip from './tooltip.js';
 import {aria} from './utils.js';
@@ -79,6 +81,12 @@ export enum names {
   NEXT_HEADING = 'next_heading',
   PREVIOUS_HEADING = 'previous_heading',
   TOGGLE_SCREENREADER = 'toggle_screenreader',
+  JUMP_TOP_STACK = 'jump_to_top_of_stack',
+  JUMP_BOTTOM_STACK = 'jump_to_bottom_of_stack',
+  JUMP_BLOCK_START = 'jump_to_block_start',
+  JUMP_BLOCK_END = 'jump_to_block_end',
+  JUMP_FIRST_BLOCK = 'jump_to_first_block',
+  JUMP_LAST_BLOCK = 'jump_to_last_block',
 }
 
 /**
@@ -1325,6 +1333,203 @@ export function registerToggleScreenreaderMode() {
 }
 
 /**
+ * @param workspace
+ * @param scope
+ * @returns true if the block navigation shortcuts should be allowed, false otherwise.
+ */
+const shouldDoBlockNavigation = (workspace: WorkspaceSvg, scope: Scope) => {
+  return (
+    !workspace.isFlyout &&
+    !!scope.focusedNode &&
+    !workspace.isDragging() &&
+    !getFocusManager().ephemeralFocusTaken() &&
+    // Either a block or something that has a parent block is focused
+    !!workspace.getNavigator().getSourceBlockFromNode(scope.focusedNode)
+  );
+};
+
+/**
+ * Registers a keyboard shortcut that sets the focus to the block
+ * that owns the current focused node.
+ */
+export function registerJumpBlockStart() {
+  const jumpBlockStartShortcut: KeyboardShortcut = {
+    name: names.JUMP_BLOCK_START,
+    preconditionFn: shouldDoBlockNavigation,
+    callback(workspace, e, shortcut, scope) {
+      if (!scope.focusedNode) return false;
+      let selectedBlock = workspace
+        .getNavigator()
+        .getSourceBlockFromNode(scope.focusedNode);
+      if (selectedBlock?.getFullBlockField() && !!selectedBlock.getParent()) {
+        // Act on the parent block if the current block is a full-block field block.
+        // Because full-block field blocks look like fields, so treat them that way.
+        selectedBlock = selectedBlock.getParent();
+      }
+      if (!selectedBlock) return false;
+
+      getFocusManager().focusNode(selectedBlock);
+      return true;
+    },
+    keyCodes: [KeyCodes.HOME],
+    displayText: () => Msg['SHORTCUTS_JUMP_BLOCK_START'],
+  };
+  ShortcutRegistry.registry.register(jumpBlockStartShortcut);
+}
+
+/**
+ * Registers a keyboard shortcut that sets the focus to the
+ * last input of the block that owns the current focused node.
+ */
+export function registerJumpBlockEnd() {
+  const jumpBlockEndShortcut: KeyboardShortcut = {
+    name: names.JUMP_BLOCK_END,
+    preconditionFn: shouldDoBlockNavigation,
+    callback(workspace, e, shortcut, scope) {
+      if (!scope.focusedNode) return false;
+      let selectedBlock = workspace
+        .getNavigator()
+        .getSourceBlockFromNode(scope.focusedNode);
+      if (selectedBlock?.getFullBlockField() && !!selectedBlock.getParent()) {
+        // Act on the parent block if the current block is a full-block field block.
+        // Because full-block field blocks look like fields, so treat them that way.
+        selectedBlock = selectedBlock.getParent();
+      }
+      if (!selectedBlock) return false;
+      const inputs = selectedBlock.inputList;
+      if (!inputs.length) return false;
+      const connection = inputs[inputs.length - 1].connection;
+      if (!connection || !(connection instanceof RenderedConnection))
+        return false;
+      getFocusManager().focusNode(connection);
+      return true;
+    },
+    keyCodes: [KeyCodes.END],
+    displayText: () => Msg['SHORTCUTS_JUMP_BLOCK_END'],
+  };
+  ShortcutRegistry.registry.register(jumpBlockEndShortcut);
+}
+
+/**
+ * Registers a keyboard shortcut that sets the focus to the top block
+ * in the current stack.
+ */
+export function registerJumpTopStack() {
+  const jumpTopStackShortcut: KeyboardShortcut = {
+    name: names.JUMP_TOP_STACK,
+    preconditionFn: shouldDoBlockNavigation,
+    callback(workspace, e, shortcut, scope) {
+      if (!scope.focusedNode) return false;
+      const selectedBlock = workspace
+        .getNavigator()
+        .getSourceBlockFromNode(scope.focusedNode);
+      if (!selectedBlock) return false;
+      const topOfStack = selectedBlock.getRootBlock();
+      getFocusManager().focusNode(topOfStack);
+      return true;
+    },
+    keyCodes: [KeyCodes.PAGE_UP],
+    displayText: () => Msg['SHORTCUTS_JUMP_TOP_STACK'],
+  };
+  ShortcutRegistry.registry.register(jumpTopStackShortcut);
+}
+
+/**
+ * Registers a keyboard shortcut that sets the focus to the bottom block
+ * in the current stack.
+ */
+export function registerJumpBottomStack() {
+  const jumpBottomStackShortcut: KeyboardShortcut = {
+    name: names.JUMP_BOTTOM_STACK,
+    preconditionFn: shouldDoBlockNavigation,
+    callback(workspace, e, shortcut, scope) {
+      if (!scope.focusedNode) return false;
+      const selectedBlock = workspace
+        .getNavigator()
+        .getSourceBlockFromNode(scope.focusedNode);
+      if (!selectedBlock) return false;
+      // To get the bottom block in a stack, first go to the top of the stack
+      // Then get the last next connection
+      // Then get the last descendant of that block
+      const lastBlock = selectedBlock
+        .getRootBlock()
+        .lastConnectionInStack(false)
+        ?.getSourceBlock();
+      if (!lastBlock) return false;
+      const descendants = lastBlock.getDescendants(true);
+      const bottomOfStack = descendants[descendants.length - 1];
+      getFocusManager().focusNode(bottomOfStack);
+      return true;
+    },
+    keyCodes: [KeyCodes.PAGE_DOWN],
+    displayText: () => Msg['SHORTCUTS_JUMP_BOTTOM_STACK'],
+  };
+  ShortcutRegistry.registry.register(jumpBottomStackShortcut);
+}
+
+/**
+ * Registers a keyboard shortcut that sets the focus to the first
+ * block in the workspace.
+ */
+export function registerJumpFirstBlock() {
+  const ctrlHome = ShortcutRegistry.registry.createSerializedKey(
+    KeyCodes.HOME,
+    [KeyCodes.CTRL],
+  );
+  const metaHome = ShortcutRegistry.registry.createSerializedKey(
+    KeyCodes.HOME,
+    [KeyCodes.META],
+  );
+  const jumpFirstBlockShortcut: KeyboardShortcut = {
+    name: names.JUMP_FIRST_BLOCK,
+    preconditionFn: (workspace) => {
+      return (
+        !workspace.isDragging() && !getFocusManager().ephemeralFocusTaken()
+      );
+    },
+    callback(workspace) {
+      const topBlocks = workspace.getTopBlocks(true);
+      if (!topBlocks.length) return false;
+      getFocusManager().focusNode(topBlocks[0]);
+      return true;
+    },
+    keyCodes: [ctrlHome, metaHome],
+    displayText: () => Msg['SHORTCUTS_JUMP_FIRST_BLOCK'],
+  };
+  ShortcutRegistry.registry.register(jumpFirstBlockShortcut);
+}
+
+/**
+ * Registers a keyboard shortcut that sets the focus to the last
+ * block in the workspace.
+ */
+export function registerJumpLastBlock() {
+  const ctrlEnd = ShortcutRegistry.registry.createSerializedKey(KeyCodes.END, [
+    KeyCodes.CTRL,
+  ]);
+  const metaEnd = ShortcutRegistry.registry.createSerializedKey(KeyCodes.END, [
+    KeyCodes.META,
+  ]);
+  const jumpLastBlockShortcut: KeyboardShortcut = {
+    name: names.JUMP_LAST_BLOCK,
+    preconditionFn: (workspace) => {
+      return (
+        !workspace.isDragging() && !getFocusManager().ephemeralFocusTaken()
+      );
+    },
+    callback(workspace) {
+      const allBlocks = workspace.getAllBlocks(true);
+      if (!allBlocks.length) return false;
+      getFocusManager().focusNode(allBlocks[allBlocks.length - 1]);
+      return true;
+    },
+    keyCodes: [ctrlEnd, metaEnd],
+    displayText: () => Msg['SHORTCUTS_JUMP_LAST_BLOCK'],
+  };
+  ShortcutRegistry.registry.register(jumpLastBlockShortcut);
+}
+
+/**
  * Registers all default keyboard shortcut item. This should be called once per
  * instance of KeyboardShortcutRegistry.
  *
@@ -1366,6 +1571,19 @@ export function registerScreenReaderShortcuts() {
   registerReadInformation();
   registerReadExtendedInformation();
   registerToggleScreenreaderMode();
+}
+
+/**
+ * Registers keyboard shortcuts used to jump between blocks and stacks in the workspace.
+ * Note these are not registered by default, so call this function to enable them if desired.
+ */
+export function registerNavigationShortcuts() {
+  registerJumpBlockStart();
+  registerJumpBlockEnd();
+  registerJumpTopStack();
+  registerJumpBottomStack();
+  registerJumpFirstBlock();
+  registerJumpLastBlock();
 }
 
 registerDefaultShortcuts();

--- a/packages/blockly/msg/json/en.json
+++ b/packages/blockly/msg/json/en.json
@@ -1,7 +1,7 @@
 {
 	"@metadata": {
 		"author": "Ellen Spertus <ellen.spertus@gmail.com>",
-		"lastupdated": "2026-06-12 09:20:03.058537",
+		"lastupdated": "2026-06-29 14:27:29.644968",
 		"locale": "en",
 		"messagedocumentation" : "qqq"
 	},
@@ -488,6 +488,12 @@
 	"SHORTCUTS_CLEANUP": "Clean up workspace",
 	"SHORTCUTS_SHOW_TOOLTIP": "Show tooltip",
 	"SHORTCUTS_TOGGLE_SCREENREADER_MODE": "Toggle screenreader mode",
+	"SHORTCUTS_JUMP_BLOCK_START": "Jump to block start",
+	"SHORTCUTS_JUMP_BLOCK_END": "Jump to block end",
+	"SHORTCUTS_JUMP_TOP_STACK": "Jump to top of stack",
+	"SHORTCUTS_JUMP_BOTTOM_STACK": "Jump to bottom of stack",
+	"SHORTCUTS_JUMP_FIRST_BLOCK": "Jump to first block",
+	"SHORTCUTS_JUMP_LAST_BLOCK": "Jump to last block",
 	"KEYBOARD_NAV_UNCONSTRAINED_MOVE_HINT": "Hold %1 and use arrow keys to move freely, then %2 to accept the position.",
 	"KEYBOARD_NAV_CONSTRAINED_MOVE_HINT": "Use the arrow keys to move, then %1 to accept the position.",
 	"KEYBOARD_NAV_COPIED_HINT": "Copied. Press %1 to paste.",

--- a/packages/blockly/msg/json/qqq.json
+++ b/packages/blockly/msg/json/qqq.json
@@ -1,13 +1,4 @@
 {
-	"@metadata": {
-		"authors": [
-			"Ajeje Brazorf",
-			"Espertus",
-			"Liuxinyu970226",
-			"McDutchie",
-			"Shirayuki"
-		]
-	},
 	"VARIABLES_DEFAULT_NAME": "default name - A simple, general default name for a variable, preferably short. For more context, see [[Translating:Blockly#infrequent_message_types]].\n{{Identical|Item}}",
 	"UNNAMED_KEY": "default name - A simple, default name for an unnamed function or variable. Preferably indicates that the item is unnamed.",
 	"TODAY": "button text - Button that sets a calendar to today's date.\n{{Identical|Today}}",
@@ -491,6 +482,12 @@
 	"SHORTCUTS_CLEANUP": "shortcut display text for the cleanup shortcut, which organizes blocks on the workspace.",
 	"SHORTCUTS_SHOW_TOOLTIP": "shortcut display text for the show tooltip shortcut, which displays a short help text for the focused element.",
 	"SHORTCUTS_TOGGLE_SCREENREADER_MODE": "shortcut display text for a shortcut that toggles various behaviors to improve the experience of individuals using screenreaders.",
+	"SHORTCUTS_JUMP_BLOCK_START": "shortcut display text for a shortcut that jumps focus to the start of the currently focused block.",
+	"SHORTCUTS_JUMP_BLOCK_END": "shortcut display text for a shortcut that jumps focus to the last input of the currently focused block.",
+	"SHORTCUTS_JUMP_TOP_STACK": "shortcut display text for a shortcut that jumps focus to the top block of the current stack.",
+	"SHORTCUTS_JUMP_BOTTOM_STACK": "shortcut display text for a shortcut that jumps focus to the bottom block of the current stack.",
+	"SHORTCUTS_JUMP_FIRST_BLOCK": "shortcut display text for a shortcut that jumps focus to the first block in the workspace.",
+	"SHORTCUTS_JUMP_LAST_BLOCK": "shortcut display text for a shortcut that jumps focus to the last block in the workspace.",
 	"KEYBOARD_NAV_UNCONSTRAINED_MOVE_HINT": "Message shown to inform users how to move blocks to arbitrary locations with the keyboard.",
 	"KEYBOARD_NAV_CONSTRAINED_MOVE_HINT": "Message shown to inform users how to move blocks with the keyboard.",
 	"KEYBOARD_NAV_COPIED_HINT": "Message shown when an item is copied in keyboard navigation mode.",
@@ -599,7 +596,7 @@
 	"FIELD_LABEL_CHECKBOX_UNCHECKED": "Label for an unchecked checkbox field, used by screen readers to identify the state of a checkbox field.",
 	"FIELD_LABEL_VARIABLE": "Label for a variable field option, used by screen readers to identify the options in a variable dropdown field. \n\nParameters:\n* %1 - the name of the variable represented by the option \n\nExamples:\n* 'Variable 'item''\n* 'Variable 'x''",
 	"ARIA_LABEL_BUTTON": "Part of an aria label for an element that indicates it is a button, but for technical reasons cannot be give a role of button. Ideally, this would match the localized name for what screenreaders announce for <button> elements in your language.",
-	"ARIA_LABEL_HEADING": "Part of an aria label for an element that indicates it is a heading, but for technical reasons cannot be given a role of heading. Ideally, this would match the localized name for what screen readers announce for <code><nowiki><h1></nowiki></code> elements in your language.",
+	"ARIA_LABEL_HEADING": "Part of an aria label for an element that indicates it is a heading, but for technial reasons cannot be given a role of heading. Ideally, this would match the localized name for what screenreaders announce for <h1> elements in your language.",
 	"BUBBLE_LABEL_DEFAULT": "Default label for bubbles.  This is only used if a bubble is created without a label provider.",
 	"BUBBLE_LABEL_COMMENT": "Label for a comment bubble. Placeholder corresponds to the content of the comment. \n\nParameters:\n* %1 - the content of the comment \n\nExamples:\n* 'Comment: This block does something important.'",
 	"BUBBLE_LABEL_WARNING": "Label for a warning bubble. Placeholder corresponds to the content of the warning. \n\nParameters:\n* %1 - the content of the warning \n\nExamples:\n* 'Warning: Something went wrong with this block.'",

--- a/packages/blockly/msg/messages.js
+++ b/packages/blockly/msg/messages.js
@@ -1899,6 +1899,24 @@ Blockly.Msg.SHORTCUTS_SHOW_TOOLTIP = 'Show tooltip';
 /// shortcut display text for a shortcut that toggles various behaviors to improve the experience of individuals using screenreaders.
 Blockly.Msg.SHORTCUTS_TOGGLE_SCREENREADER_MODE = 'Toggle screenreader mode';
 /** @type {string} */
+/// shortcut display text for a shortcut that jumps focus to the start of the currently focused block.
+Blockly.Msg.SHORTCUTS_JUMP_BLOCK_START = 'Jump to block start';
+/** @type {string} */
+/// shortcut display text for a shortcut that jumps focus to the last input of the currently focused block.
+Blockly.Msg.SHORTCUTS_JUMP_BLOCK_END = 'Jump to block end';
+/** @type {string} */
+/// shortcut display text for a shortcut that jumps focus to the top block of the current stack.
+Blockly.Msg.SHORTCUTS_JUMP_TOP_STACK = 'Jump to top of stack';
+/** @type {string} */
+/// shortcut display text for a shortcut that jumps focus to the bottom block of the current stack.
+Blockly.Msg.SHORTCUTS_JUMP_BOTTOM_STACK = 'Jump to bottom of stack';
+/** @type {string} */
+/// shortcut display text for a shortcut that jumps focus to the first block in the workspace.
+Blockly.Msg.SHORTCUTS_JUMP_FIRST_BLOCK = 'Jump to first block';
+/** @type {string} */
+/// shortcut display text for a shortcut that jumps focus to the last block in the workspace.
+Blockly.Msg.SHORTCUTS_JUMP_LAST_BLOCK = 'Jump to last block';
+/** @type {string} */
 /// Message shown to inform users how to move blocks to arbitrary locations
 /// with the keyboard.
 Blockly.Msg.KEYBOARD_NAV_UNCONSTRAINED_MOVE_HINT = 'Hold %1 and use arrow keys to move freely, then %2 to accept the position.';

--- a/packages/blockly/tests/mocha/shortcut_items_test.js
+++ b/packages/blockly/tests/mocha/shortcut_items_test.js
@@ -2251,7 +2251,7 @@ suite('Keyboard Shortcut Items', function () {
       const topBlock = this.workspace.getBlockById('controls_repeat_1');
       this.injectionDiv.dispatchEvent(
         createKeyDownEvent(Blockly.utils.KeyCodes.HOME, [
-          Blockly.utils.KeyCodes.CTRL,
+          Blockly.utils.KeyCodes.CTRL_CMD,
         ]),
       );
       sinon.assert.calledWith(this.focusNodeSpy, topBlock);
@@ -2264,7 +2264,7 @@ suite('Keyboard Shortcut Items', function () {
       const topBlock = this.workspace.getBlockById('controls_repeat_1');
       this.injectionDiv.dispatchEvent(
         createKeyDownEvent(Blockly.utils.KeyCodes.HOME, [
-          Blockly.utils.KeyCodes.CTRL,
+          Blockly.utils.KeyCodes.CTRL_CMD,
         ]),
       );
       sinon.assert.calledWith(this.focusNodeSpy, topBlock);
@@ -2275,7 +2275,7 @@ suite('Keyboard Shortcut Items', function () {
       const topBlock = this.workspace.getBlockById('controls_repeat_1');
       this.injectionDiv.dispatchEvent(
         createKeyDownEvent(Blockly.utils.KeyCodes.HOME, [
-          Blockly.utils.KeyCodes.CTRL,
+          Blockly.utils.KeyCodes.CTRL_CMD,
         ]),
       );
       sinon.assert.calledWith(this.focusNodeSpy, topBlock);
@@ -2287,7 +2287,7 @@ suite('Keyboard Shortcut Items', function () {
       const lastBlock = this.workspace.getBlockById('text_2');
       this.injectionDiv.dispatchEvent(
         createKeyDownEvent(Blockly.utils.KeyCodes.END, [
-          Blockly.utils.KeyCodes.CTRL,
+          Blockly.utils.KeyCodes.CTRL_CMD,
         ]),
       );
       sinon.assert.calledWith(this.focusNodeSpy, lastBlock);
@@ -2300,7 +2300,7 @@ suite('Keyboard Shortcut Items', function () {
       const lastBlock = this.workspace.getBlockById('text_2');
       this.injectionDiv.dispatchEvent(
         createKeyDownEvent(Blockly.utils.KeyCodes.END, [
-          Blockly.utils.KeyCodes.CTRL,
+          Blockly.utils.KeyCodes.CTRL_CMD,
         ]),
       );
       sinon.assert.calledWith(this.focusNodeSpy, lastBlock);
@@ -2311,7 +2311,7 @@ suite('Keyboard Shortcut Items', function () {
       const lastBlock = this.workspace.getBlockById('text_2');
       this.injectionDiv.dispatchEvent(
         createKeyDownEvent(Blockly.utils.KeyCodes.END, [
-          Blockly.utils.KeyCodes.CTRL,
+          Blockly.utils.KeyCodes.CTRL_CMD,
         ]),
       );
       sinon.assert.calledWith(this.focusNodeSpy, lastBlock);
@@ -2375,7 +2375,7 @@ suite('Keyboard Shortcut Items', function () {
         const topBlock = this.workspace.getBlockById('controls_repeat_1');
         this.injectionDiv.dispatchEvent(
           createKeyDownEvent(Blockly.utils.KeyCodes.HOME, [
-            Blockly.utils.KeyCodes.CTRL,
+            Blockly.utils.KeyCodes.CTRL_CMD,
           ]),
         );
         sinon.assert.calledWith(this.focusNodeSpy, topBlock);
@@ -2387,7 +2387,7 @@ suite('Keyboard Shortcut Items', function () {
         const lastBlock = this.workspace.getBlockById('text_2');
         this.injectionDiv.dispatchEvent(
           createKeyDownEvent(Blockly.utils.KeyCodes.END, [
-            Blockly.utils.KeyCodes.CTRL,
+            Blockly.utils.KeyCodes.CTRL_CMD,
           ]),
         );
         sinon.assert.calledWith(this.focusNodeSpy, lastBlock);

--- a/packages/blockly/tests/mocha/shortcut_items_test.js
+++ b/packages/blockly/tests/mocha/shortcut_items_test.js
@@ -2037,4 +2037,379 @@ suite('Keyboard Shortcut Items', function () {
       assert.include(this.liveRegion.textContent, 'Screenreader mode is off');
     });
   });
+  const blockJson = {
+    'blocks': {
+      'languageVersion': 0,
+      'blocks': [
+        {
+          'type': 'controls_repeat_ext',
+          'id': 'controls_repeat_1',
+          'x': 63,
+          'y': 88,
+          'inputs': {
+            'TIMES': {
+              'shadow': {
+                'type': 'math_number',
+                'id': 'math_number_1',
+                'fields': {
+                  'NUM': 10,
+                },
+              },
+            },
+            'DO': {
+              'block': {
+                'type': 'controls_forEach',
+                'id': 'controls_forEach_1',
+                'fields': {
+                  'VAR': {
+                    'id': '/wU7DoTDScBz~6hbq-[E',
+                  },
+                },
+                'inputs': {
+                  'LIST': {
+                    'block': {
+                      'type': 'lists_repeat',
+                      'id': 'lists_repeat_1',
+                      'inputs': {
+                        'ITEM': {
+                          'block': {
+                            'type': 'lists_getIndex',
+                            'id': 'lists_getIndex_1',
+                            'fields': {
+                              'MODE': 'GET',
+                              'WHERE': 'FROM_START',
+                            },
+                            'inputs': {
+                              'VALUE': {
+                                'block': {
+                                  'type': 'variables_get',
+                                  'id': 'Lhk_B9iVsV%BhhJ%h]m$',
+                                  'fields': {
+                                    'VAR': {
+                                      'id': '.*~ZjUJ#Sua{h6xyVp7`',
+                                    },
+                                  },
+                                },
+                              },
+                            },
+                          },
+                        },
+                        'NUM': {
+                          'shadow': {
+                            'type': 'math_number',
+                            'id': 'math_number_2',
+                            'fields': {
+                              'NUM': 5,
+                            },
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+        {
+          'type': 'controls_forEach',
+          'id': 'controls_forEach_2',
+          'x': 63,
+          'y': 288,
+          'fields': {
+            'VAR': {
+              'id': '+rcR|2HqfZ=vK}N8L{RU',
+            },
+          },
+          'inputs': {
+            'DO': {
+              'block': {
+                'type': 'controls_repeat_ext',
+                'id': 'controls_repeat_2',
+                'inputs': {
+                  'TIMES': {
+                    'shadow': {
+                      'type': 'math_number',
+                      'id': 'math_number_3',
+                      'fields': {
+                        'NUM': 10,
+                      },
+                    },
+                  },
+                },
+                'next': {
+                  'block': {
+                    'type': 'text_print',
+                    'id': 'text_print_1',
+                    'inputs': {
+                      'TEXT': {
+                        'block': {
+                          'type': 'text',
+                          'id': 'text_1',
+                          'fields': {
+                            'TEXT': 'last block inside a loop',
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+          'next': {
+            'block': {
+              'type': 'text_print',
+              'id': 'text_print_2',
+              'inputs': {
+                'TEXT': {
+                  'block': {
+                    'type': 'text',
+                    'id': 'text_2',
+                    'fields': {
+                      'TEXT': 'last block on workspace',
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      ],
+    },
+  };
+
+  suite('Jump shortcuts', function () {
+    setup(function () {
+      this.getFocusedNodeStub = sinon.stub(
+        Blockly.getFocusManager(),
+        'getFocusedNode',
+      );
+      this.focusNodeSpy = sinon.stub(Blockly.getFocusManager(), 'focusNode');
+      Blockly.serialization.workspaces.load(blockJson, this.workspace);
+    });
+
+    suiteSetup(function () {
+      Blockly.ShortcutItems.registerNavigationShortcuts();
+    });
+
+    suiteTeardown(function () {
+      for (const shortcut of [
+        'jump_to_top_of_stack',
+        'jump_to_bottom_of_stack',
+        'jump_to_block_start',
+        'jump_to_block_end',
+        'jump_to_first_block',
+        'jump_to_last_block',
+      ]) {
+        Blockly.ShortcutRegistry.registry.unregister(shortcut);
+      }
+    });
+
+    test('Home focuses current block if block is focused', function () {
+      const inListBlock = this.workspace.getBlockById('lists_getIndex_1');
+      this.getFocusedNodeStub.returns(inListBlock);
+      this.injectionDiv.dispatchEvent(
+        createKeyDownEvent(Blockly.utils.KeyCodes.HOME),
+      );
+      sinon.assert.calledWith(this.focusNodeSpy, inListBlock);
+    });
+
+    test('Home focuses owning block if field is focused', function () {
+      const inListBlock = this.workspace.getBlockById('lists_getIndex_1');
+      const fieldToFocus = inListBlock.getField('MODE');
+      this.getFocusedNodeStub.returns(fieldToFocus);
+      this.injectionDiv.dispatchEvent(
+        createKeyDownEvent(Blockly.utils.KeyCodes.HOME),
+      );
+      sinon.assert.calledWith(this.focusNodeSpy, inListBlock);
+    });
+
+    test('End focuses last input on owning block', function () {
+      const inListBlock = this.workspace.getBlockById('lists_getIndex_1');
+      const fieldToFocus = inListBlock.getField('MODE');
+      this.getFocusedNodeStub.returns(fieldToFocus);
+      this.injectionDiv.dispatchEvent(
+        createKeyDownEvent(Blockly.utils.KeyCodes.END),
+      );
+      const expectedFocus = inListBlock.getInput('AT').connection;
+      sinon.assert.calledWith(this.focusNodeSpy, expectedFocus);
+    });
+
+    test('End has no effect if block has no inputs', function () {
+      const textBlock = this.workspace.getBlockById('text_1');
+      this.getFocusedNodeStub.returns(textBlock);
+      this.injectionDiv.dispatchEvent(
+        createKeyDownEvent(Blockly.utils.KeyCodes.END),
+      );
+      sinon.assert.notCalled(this.focusNodeSpy);
+    });
+
+    test('CtrlHome focuses top block in workspace if block is focused', function () {
+      const inListBlock = this.workspace.getBlockById('lists_getIndex_1');
+      this.getFocusedNodeStub.returns(inListBlock);
+      const topBlock = this.workspace.getBlockById('controls_repeat_1');
+      this.injectionDiv.dispatchEvent(
+        createKeyDownEvent(Blockly.utils.KeyCodes.HOME, [
+          Blockly.utils.KeyCodes.CTRL,
+        ]),
+      );
+      sinon.assert.calledWith(this.focusNodeSpy, topBlock);
+    });
+
+    test('CtrlHome focuses top block in workspace if field is focused', function () {
+      const inListBlock = this.workspace.getBlockById('lists_getIndex_1');
+      const fieldToFocus = inListBlock.getField('MODE');
+      this.getFocusedNodeStub.returns(fieldToFocus);
+      const topBlock = this.workspace.getBlockById('controls_repeat_1');
+      this.injectionDiv.dispatchEvent(
+        createKeyDownEvent(Blockly.utils.KeyCodes.HOME, [
+          Blockly.utils.KeyCodes.CTRL,
+        ]),
+      );
+      sinon.assert.calledWith(this.focusNodeSpy, topBlock);
+    });
+
+    test('CtrlHome focuses top block in workspace if workspace is focused', function () {
+      this.getFocusedNodeStub.returns(this.workspace);
+      const topBlock = this.workspace.getBlockById('controls_repeat_1');
+      this.injectionDiv.dispatchEvent(
+        createKeyDownEvent(Blockly.utils.KeyCodes.HOME, [
+          Blockly.utils.KeyCodes.CTRL,
+        ]),
+      );
+      sinon.assert.calledWith(this.focusNodeSpy, topBlock);
+    });
+
+    test('CtrlEnd focuses last block in workspace if block is focused', function () {
+      const inListBlock = this.workspace.getBlockById('lists_getIndex_1');
+      this.getFocusedNodeStub.returns(inListBlock);
+      const lastBlock = this.workspace.getBlockById('text_2');
+      this.injectionDiv.dispatchEvent(
+        createKeyDownEvent(Blockly.utils.KeyCodes.END, [
+          Blockly.utils.KeyCodes.CTRL,
+        ]),
+      );
+      sinon.assert.calledWith(this.focusNodeSpy, lastBlock);
+    });
+
+    test('CtrlEnd focuses last block in workspace if field is focused', function () {
+      const inListBlock = this.workspace.getBlockById('lists_getIndex_1');
+      const fieldToFocus = inListBlock.getField('MODE');
+      this.getFocusedNodeStub.returns(fieldToFocus);
+      const lastBlock = this.workspace.getBlockById('text_2');
+      this.injectionDiv.dispatchEvent(
+        createKeyDownEvent(Blockly.utils.KeyCodes.END, [
+          Blockly.utils.KeyCodes.CTRL,
+        ]),
+      );
+      sinon.assert.calledWith(this.focusNodeSpy, lastBlock);
+    });
+
+    test('CtrlEnd focuses last block in workspace if workspace is focused', function () {
+      this.getFocusedNodeStub.returns(this.workspace);
+      const lastBlock = this.workspace.getBlockById('text_2');
+      this.injectionDiv.dispatchEvent(
+        createKeyDownEvent(Blockly.utils.KeyCodes.END, [
+          Blockly.utils.KeyCodes.CTRL,
+        ]),
+      );
+      sinon.assert.calledWith(this.focusNodeSpy, lastBlock);
+    });
+
+    test('PageUp focuses on first block in stack', function () {
+      const inListBlock = this.workspace.getBlockById('lists_getIndex_1');
+      const fieldToFocus = inListBlock.getField('MODE');
+      this.getFocusedNodeStub.returns(fieldToFocus);
+      this.injectionDiv.dispatchEvent(
+        createKeyDownEvent(Blockly.utils.KeyCodes.PAGE_UP),
+      );
+      const expectedFocus = this.workspace.getBlockById('controls_repeat_1');
+      sinon.assert.calledWith(this.focusNodeSpy, expectedFocus);
+    });
+
+    test('PageDown focuses on last block in stack with nested row blocks', function () {
+      const inListBlock = this.workspace.getBlockById('lists_getIndex_1');
+      const fieldToFocus = inListBlock.getField('MODE');
+      this.getFocusedNodeStub.returns(fieldToFocus);
+      this.injectionDiv.dispatchEvent(
+        createKeyDownEvent(Blockly.utils.KeyCodes.PAGE_DOWN),
+      );
+      const expectedFocus = this.workspace.getBlockById('math_number_2');
+      sinon.assert.calledWith(this.focusNodeSpy, expectedFocus);
+    });
+
+    test('PageDown focuses on last block in stack with many stack blocks', function () {
+      const blockToFocus = this.workspace.getBlockById('text_1');
+      this.getFocusedNodeStub.returns(blockToFocus);
+      this.injectionDiv.dispatchEvent(
+        createKeyDownEvent(Blockly.utils.KeyCodes.PAGE_DOWN),
+      );
+      const expectedFocus = this.workspace.getBlockById('text_2');
+      sinon.assert.calledWith(this.focusNodeSpy, expectedFocus);
+    });
+
+    suite('in flyout', function () {
+      test('Home has no effect', function () {
+        this.workspace.internalIsFlyout = true;
+        const inListBlock = this.workspace.getBlockById('lists_getIndex_1');
+        this.getFocusedNodeStub.returns(inListBlock);
+        this.injectionDiv.dispatchEvent(
+          createKeyDownEvent(Blockly.utils.KeyCodes.HOME),
+        );
+        sinon.assert.notCalled(this.focusNodeSpy);
+      });
+      test('End has no effect', function () {
+        this.workspace.internalIsFlyout = true;
+        const inListBlock = this.workspace.getBlockById('lists_getIndex_1');
+        this.getFocusedNodeStub.returns(inListBlock);
+        this.injectionDiv.dispatchEvent(
+          createKeyDownEvent(Blockly.utils.KeyCodes.END),
+        );
+        sinon.assert.notCalled(this.focusNodeSpy);
+      });
+      test('CtrlHome focuses top block in flyout workspace', function () {
+        this.workspace.internalIsFlyout = true;
+        const inListBlock = this.workspace.getBlockById('lists_getIndex_1');
+        this.getFocusedNodeStub.returns(inListBlock);
+        const topBlock = this.workspace.getBlockById('controls_repeat_1');
+        this.injectionDiv.dispatchEvent(
+          createKeyDownEvent(Blockly.utils.KeyCodes.HOME, [
+            Blockly.utils.KeyCodes.CTRL,
+          ]),
+        );
+        sinon.assert.calledWith(this.focusNodeSpy, topBlock);
+      });
+      test('CtrlEnd focuses last block in flyout workspace', function () {
+        this.workspace.internalIsFlyout = true;
+        const inListBlock = this.workspace.getBlockById('lists_getIndex_1');
+        this.getFocusedNodeStub.returns(inListBlock);
+        const lastBlock = this.workspace.getBlockById('text_2');
+        this.injectionDiv.dispatchEvent(
+          createKeyDownEvent(Blockly.utils.KeyCodes.END, [
+            Blockly.utils.KeyCodes.CTRL,
+          ]),
+        );
+        sinon.assert.calledWith(this.focusNodeSpy, lastBlock);
+      });
+      test('PageUp has no effect', function () {
+        this.workspace.internalIsFlyout = true;
+        const inListBlock = this.workspace.getBlockById('lists_getIndex_1');
+        this.getFocusedNodeStub.returns(inListBlock);
+        this.injectionDiv.dispatchEvent(
+          createKeyDownEvent(Blockly.utils.KeyCodes.PAGE_UP),
+        );
+        sinon.assert.notCalled(this.focusNodeSpy);
+      });
+      test('PageDown has no effect', function () {
+        this.workspace.internalIsFlyout = true;
+        const inListBlock = this.workspace.getBlockById('lists_getIndex_1');
+        this.getFocusedNodeStub.returns(inListBlock);
+        this.injectionDiv.dispatchEvent(
+          createKeyDownEvent(Blockly.utils.KeyCodes.PAGE_DOWN),
+        );
+        sinon.assert.notCalled(this.focusNodeSpy);
+      });
+    });
+  });
 });

--- a/packages/docs/docs/guides/configure/keyboard-nav.mdx
+++ b/packages/docs/docs/guides/configure/keyboard-nav.mdx
@@ -82,6 +82,27 @@ shortcuts are displayed in the context menu.
 Press **C** to clean up the workspace by moving all block stacks into a single
 column with no overlaps, preserving their order on the page. 
 
+## Optional navigation shortcuts
+
+We also provide optional navigation shortcuts to make navigating the workspace easier:
+
+| Key | Action |
+| --- | --- |
+| Home | Jump to block start |
+| End | Jump to block end |
+| Page Up | Jump to top of stack |
+| Page Down | Jump to bottom of stack |
+| Ctrl/Cmd + Home | Jump to first block |
+| Ctrl/Cmd + End | Jump to last block |
+
+We recommend that you enable these for your application by calling:
+
+```js
+Blockly.ShortcutItems.registerNavigationShortcuts()
+```
+
+These shortcuts may become enabled by default in future versions of Blockly.
+
 ## Technical details
 
 Blockly keyboard navigation uses the [focus system](/guides/configure/web/focus)


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

Backports the navigation shortcuts from [here](https://github.com/RaspberryPiFoundation/blockly/blob/add-screen-reader-support-experimental/tests/mocha/shortcut_items_test.js) with changes for v13 APIs
Fixes #9997 while we're at it (for certain problems with full-block fields, did not change behavior for end as per my last comment there)
Updates docs

### Proposed Changes

Adds new navigation shortcuts for jumping around to start/end of block/workspace/stack. These are optional and can be installed by calling `Blockly.ShortcutItems.registerNavigationShortcuts()`

### Reason for Changes

missing them from the beta test

### Test Coverage

Added tests

### Documentation

Added docs

### Additional Information

<!-- Anything else we should know? -->
