### PR TITLE
fix: delete-area hit testing at non-default zoom (#10095)

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,8 +24,8 @@
     "@commitlint/config-conventional": "^21.0.2"
   },
   "overrides": {
-    "eslint": "10.5.0",
-    "prettier": "3.8.4"
+    "eslint": "10.3.0",
+    "prettier": "3.8.3"
   },
   "scripts": {
     "test": "npm run test --ws --if-present",

--- a/package.json
+++ b/package.json
@@ -24,8 +24,8 @@
     "@commitlint/config-conventional": "^21.0.2"
   },
   "overrides": {
-    "eslint": "10.3.0",
-    "prettier": "3.8.3"
+    "eslint": "10.5.0",
+    "prettier": "3.8.4"
   },
   "scripts": {
     "test": "npm run test --ws --if-present",

--- a/packages/blockly/core/dragging/dragger.ts
+++ b/packages/blockly/core/dragging/dragger.ts
@@ -16,7 +16,6 @@ import type {IDragger} from '../interfaces/i_dragger.js';
 import {isFocusableNode} from '../interfaces/i_focusable_node.js';
 import * as registry from '../registry.js';
 import {Coordinate} from '../utils/coordinate.js';
-import {screenToWsCoordinates} from '../utils/svg_math.js';
 
 export class Dragger implements IDragger {
   protected startLoc: Coordinate;
@@ -50,7 +49,10 @@ export class Dragger implements IDragger {
     const pointerEvent = e instanceof PointerEvent ? e : null;
     if (!pointerEvent) return;
 
-    const coordinate = this.pointerToWorkspaceCoordinate(pointerEvent);
+    const coordinate = new Coordinate(
+      pointerEvent.clientX,
+      pointerEvent.clientY,
+    );
     // Must check `wouldDelete` before calling other hooks on drag targets
     // since we have documented that we would do so.
     if (isDeletable(this.draggable)) {
@@ -122,7 +124,10 @@ export class Dragger implements IDragger {
       return;
     }
 
-    const coordinate = this.pointerToWorkspaceCoordinate(pointerEvent);
+    const coordinate = new Coordinate(
+      pointerEvent.clientX,
+      pointerEvent.clientY,
+    );
     const dragTarget = this.draggable.workspace.getDragTarget(coordinate);
 
     if (dragTarget) {
@@ -180,17 +185,6 @@ export class Dragger implements IDragger {
     const dragTarget = this.draggable.workspace.getDragTarget(coordinate);
     if (!dragTarget) return false;
     return dragTarget.shouldPreventMove(rootDraggable);
-  }
-
-  /**
-   * Returns the workspace coordinate for a pointer position, for delete-area
-   * hit testing.
-   */
-  private pointerToWorkspaceCoordinate(e: PointerEvent): Coordinate {
-    return screenToWsCoordinates(
-      this.draggable.workspace,
-      new Coordinate(e.clientX, e.clientY),
-    );
   }
 
   protected pixelsToWorkspaceUnits(pixelCoord: Coordinate): Coordinate {

--- a/packages/blockly/core/workspace_svg.ts
+++ b/packages/blockly/core/workspace_svg.ts
@@ -1517,17 +1517,16 @@ export class WorkspaceSvg
   /* eslint-enable */
 
   /**
-   * Returns the drag target the pointer event is over.
+   * Returns the drag target at the given point.
    *
-   * @param e Pointer move event or a workspace coordinate.
-   * @returns Null if not over a drag target, or the drag target the event is
-   *     over.
+   * @param point A pointer event, or a point in client/viewport coordinates.
+   * @returns Null if not over a drag target, or the drag target at that point.
    */
-  getDragTarget(e: PointerEvent | Coordinate): IDragTarget | null {
+  getDragTarget(point: PointerEvent | Coordinate): IDragTarget | null {
     const coordinate =
-      e instanceof Coordinate
-        ? svgMath.wsToScreenCoordinates(this, e)
-        : new Coordinate(e.clientX, e.clientY);
+      point instanceof Coordinate
+        ? point
+        : new Coordinate(point.clientX, point.clientY);
     for (let i = 0, targetArea; (targetArea = this.dragTargetAreas[i]); i++) {
       if (targetArea.clientRect.contains(coordinate.x, coordinate.y)) {
         return targetArea.component;
@@ -2139,7 +2138,6 @@ export class WorkspaceSvg
     const flyout = this.getFlyout(false);
     if (flyout && flyout.isVisible()) {
       flyout.reflow();
-      this.recordDragTargets();
     }
     if (this.grid) {
       this.grid.update(this.scale);
@@ -2165,6 +2163,7 @@ export class WorkspaceSvg
         this.scrollbar.resizeContent(metrics);
       }
     }
+    this.recordDragTargets();
   }
 
   /**

--- a/packages/blockly/core/workspace_svg.ts
+++ b/packages/blockly/core/workspace_svg.ts
@@ -2138,6 +2138,7 @@ export class WorkspaceSvg
     const flyout = this.getFlyout(false);
     if (flyout && flyout.isVisible()) {
       flyout.reflow();
+      this.recordDragTargets();
     }
     if (this.grid) {
       this.grid.update(this.scale);
@@ -2163,7 +2164,6 @@ export class WorkspaceSvg
         this.scrollbar.resizeContent(metrics);
       }
     }
-    this.recordDragTargets();
   }
 
   /**

--- a/packages/blockly/tests/mocha/dragger_test.js
+++ b/packages/blockly/tests/mocha/dragger_test.js
@@ -32,10 +32,12 @@ suite('Dragger', function () {
    * @returns {{x: number, y: number}} Viewport coordinates at the block origin.
    */
   function blockOriginClient(block) {
-    const screenCoords = Blockly.utils.svgMath.wsToScreenCoordinates(
-      block.workspace,
-      block.getRelativeToSurfaceXY(),
-    );
+    const ws = block.workspace;
+    let point = block.getRelativeToSurfaceXY();
+    if (ws.isMutator) {
+      point = point.scale(ws.options.parentWorkspace.scale);
+    }
+    const screenCoords = Blockly.utils.svgMath.wsToScreenCoordinates(ws, point);
     return {x: screenCoords.x, y: screenCoords.y};
   }
 
@@ -65,12 +67,28 @@ suite('Dragger', function () {
   }
 
   /**
+   * @param {!Blockly.WorkspaceSvg} workspace The workspace with a trashcan.
+   * @returns {boolean} Whether the trashcan lid open style is applied.
+   */
+  function hasTrashLidOpen(workspace) {
+    return workspace.trashcan.svgGroup.classList.contains('blocklyTrashOpen');
+  }
+
+  /**
+   * @param {!Blockly.WorkspaceSvg} workspace The workspace to zoom.
+   * @param {number} scale The target zoom factor.
+   */
+  function setWorkspaceScale(workspace, scale) {
+    workspace.setScale(scale);
+  }
+
+  /**
    * Simulates pressing on the block center and dragging to a viewport point.
    *
    * @param {!Blockly.BlockSvg} block The block to drag.
    * @param {{x: number, y: number}} pointerEnd The viewport point to drag to.
-   * @returns {{dragger: !Blockly.dragging.Dragger, dragEvent: !PointerEvent}}
-   *     The dragger and final pointer event from the simulated drag.
+   * @returns {{dragger: !Blockly.dragging.Dragger, dragEvent: !PointerEvent, block: !Blockly.BlockSvg}}
+   *     The dragger, final pointer event, and block being dragged.
    */
   function dragBlock(block, pointerEnd) {
     const start = blockCenterClient(block);
@@ -86,7 +104,7 @@ suite('Dragger', function () {
     dragger.onDragStart(dragStartEvent);
     dragger.onDrag(dragEvent, totalDelta);
 
-    return {dragger, dragEvent};
+    return {dragger, dragEvent, block: dragger.draggable};
   }
 
   setup(function () {
@@ -110,25 +128,45 @@ suite('Dragger', function () {
     sharedTestTeardown.call(this);
   });
 
-  [
-    {name: 'trashcan', rectKey: 'trashRect'},
-    {name: 'toolbox', rectKey: 'toolboxRect'},
-  ].forEach(({name, rectKey}) => {
-    test(`applies delete styling and deletes when dragged to ${name}`, function () {
-      const deleteRect = this[rectKey];
-      const {dragger, dragEvent} = dragBlock(
-        this.block,
-        rectCenterClient(deleteRect),
-      );
+  const zoomLevels = [
+    {name: 'default scale', scale: null},
+    {name: 'zoomed in', scale: 1.5},
+    {name: 'zoomed out', scale: 0.7},
+  ];
 
-      assert.isTrue(
-        deleteRect.contains(dragEvent.clientX, dragEvent.clientY),
-        `Expected cursor to be inside ${name} delete area`,
-      );
-      assert.isTrue(hasDeleteStyle(this.block));
+  zoomLevels.forEach(({name: zoomName, scale}) => {
+    [
+      {name: 'trashcan', rectKey: 'trashRect', checkLid: true},
+      {name: 'toolbox', rectKey: 'toolboxRect', checkLid: false},
+    ].forEach(({name, rectKey, checkLid}) => {
+      test(`applies delete styling and deletes when dragged to ${name} at ${zoomName}`, function () {
+        if (scale !== null) {
+          setWorkspaceScale(this.workspace, scale);
+          this.trashRect = this.workspace.trashcan.getClientRect();
+          this.toolboxRect = this.workspace.toolbox.getClientRect();
+        }
 
-      dragger.onDragEnd(dragEvent);
-      assert.isTrue(this.block.isDeadOrDying());
+        const deleteRect = this[rectKey];
+        const {dragger, dragEvent, block} = dragBlock(
+          this.block,
+          rectCenterClient(deleteRect),
+        );
+
+        assert.isTrue(
+          deleteRect.contains(dragEvent.clientX, dragEvent.clientY),
+          `Expected cursor to be inside ${name} delete area`,
+        );
+        assert.isTrue(hasDeleteStyle(block));
+        if (checkLid) {
+          assert.isTrue(
+            hasTrashLidOpen(this.workspace),
+            'Expected trashcan lid to be open',
+          );
+        }
+
+        dragger.onDragEnd(dragEvent);
+        assert.isTrue(block.isDeadOrDying());
+      });
     });
   });
 
@@ -140,12 +178,12 @@ suite('Dragger', function () {
       x: deleteAreaRect.right - 5,
       y: originBefore.y,
     };
-    const {dragger, dragEvent} = dragBlock(this.block, {
+    const {dragger, dragEvent, block} = dragBlock(this.block, {
       x: start.x + desiredOrigin.x - originBefore.x,
       y: start.y + desiredOrigin.y - originBefore.y,
     });
 
-    const originAfter = blockOriginClient(this.block);
+    const originAfter = blockOriginClient(block);
     assert.isTrue(
       deleteAreaRect.contains(originAfter.x, originAfter.y),
       'Expected block origin to overlap delete area',
@@ -154,9 +192,112 @@ suite('Dragger', function () {
       deleteAreaRect.contains(dragEvent.clientX, dragEvent.clientY),
       'Expected cursor to be outside delete area',
     );
-    assert.isFalse(hasDeleteStyle(this.block));
+    assert.isFalse(hasDeleteStyle(block));
 
     dragger.onDragEnd(dragEvent);
-    assert.isFalse(this.block.isDeadOrDying());
+    assert.isFalse(block.isDeadOrDying());
+  });
+
+  suite('Mutator', function () {
+    /**
+     * Opens a mutator on a controls_if block and returns the mutator workspace.
+     *
+     * @param {!Blockly.WorkspaceSvg} workspace The main workspace.
+     * @returns {!Promise<!Blockly.WorkspaceSvg>} The mutator workspace.
+     */
+    async function openMutator(workspace) {
+      const block = Blockly.serialization.blocks.append(
+        {
+          'type': 'controls_if',
+          'extraState': {
+            'elseIfCount': 0,
+          },
+        },
+        workspace,
+      );
+      block.initSvg();
+      block.render();
+      const icon = block.getIcon(Blockly.icons.MutatorIcon.TYPE);
+      await icon.setBubbleVisible(true);
+      return icon.getWorkspace();
+    }
+
+    test('deletes flyout block when pointer is over flyout delete area at zoomed scale', async function () {
+      for (let i = 0; i < 3; i++) {
+        this.workspace.zoomCenter(1);
+      }
+
+      const mutatorWorkspace = await openMutator(this.workspace);
+      this.clock.runAll();
+      mutatorWorkspace.recordDragTargets();
+
+      const flyout = mutatorWorkspace.getFlyout();
+      const flyoutRect = flyout.getClientRect();
+      assert.isNotNull(flyoutRect);
+
+      const flyoutBlock = flyout
+        .getWorkspace()
+        .getBlocksByType('controls_if_elseif')[0];
+      flyoutBlock.initSvg();
+      flyoutBlock.render();
+
+      const {dragger, dragEvent, block} = dragBlock(
+        flyoutBlock,
+        rectCenterClient(flyoutRect),
+      );
+
+      assert.isTrue(
+        flyoutRect.contains(dragEvent.clientX, dragEvent.clientY),
+        'Expected cursor to be inside flyout delete area',
+      );
+      assert.isTrue(hasDeleteStyle(block));
+
+      dragger.onDragEnd(dragEvent);
+      assert.isTrue(block.isDeadOrDying());
+    });
+
+    test('does not apply delete styling when only block origin overlaps flyout delete area at zoomed scale', async function () {
+      for (let i = 0; i < 3; i++) {
+        this.workspace.zoomCenter(1);
+      }
+
+      const mutatorWorkspace = await openMutator(this.workspace);
+      this.clock.runAll();
+      mutatorWorkspace.recordDragTargets();
+
+      const flyout = mutatorWorkspace.getFlyout();
+      const flyoutRect = flyout.getClientRect();
+      assert.isNotNull(flyoutRect);
+
+      const workspaceBlock = mutatorWorkspace.newBlock('controls_if_elseif');
+      workspaceBlock.initSvg();
+      workspaceBlock.render();
+      workspaceBlock.moveBy(200, 50);
+
+      const start = blockCenterClient(workspaceBlock);
+      const originBefore = blockOriginClient(workspaceBlock);
+      const desiredOrigin = {
+        x: flyoutRect.right - 5,
+        y: originBefore.y,
+      };
+      const {dragger, dragEvent, block} = dragBlock(workspaceBlock, {
+        x: start.x + desiredOrigin.x - originBefore.x,
+        y: start.y + desiredOrigin.y - originBefore.y,
+      });
+
+      const originAfter = blockOriginClient(block);
+      assert.isTrue(
+        flyoutRect.contains(originAfter.x, originAfter.y),
+        'Expected block origin to overlap flyout delete area',
+      );
+      assert.isFalse(
+        flyoutRect.contains(dragEvent.clientX, dragEvent.clientY),
+        'Expected cursor to be outside flyout delete area',
+      );
+      assert.isFalse(hasDeleteStyle(block));
+
+      dragger.onDragEnd(dragEvent);
+      assert.isFalse(block.isDeadOrDying());
+    });
   });
 });


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [ ] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes https://github.com/RaspberryPiFoundation/blockly/issues/10095

### Proposed Changes

Hit-test delete areas now us client/viewport coordinates (`clientX`/`clientY`) instead of a client-to-workspace-to-client round-trip

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->

### Reason for Changes

After #10078, delete styling would still appear at non-default zoom but blocks were not reliably deleted and the trashcan lid did not animate. The coordinate round-trip misaligned hit tests with `getBoundingClientRect()` at certain zoom levels, but using client coordinates fixes that. 

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage

- Extended `dragger_test.js` with generated trashcan/toolbox delete tests at zoom 0.7 and 1.5 (delete style, trashcan lid, disposal)
- Generated extra mutator workspace tests with a zoomed parent workspace (delete on pointer-over-area; no false positive on origin-only overlap). Unrelated to bug report, but felt useful enough to add.

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->
