### PR TITLE
chore: sync eslint/prettier overrides with package-lock.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,8 +24,8 @@
     "@commitlint/config-conventional": "^21.0.2"
   },
   "overrides": {
-    "eslint": "10.3.0",
-    "prettier": "3.8.3"
+    "eslint": "10.5.0",
+    "prettier": "3.8.4"
   },
   "scripts": {
     "test": "npm run test --ws --if-present",


### PR DESCRIPTION
## Summary

Root `package.json` overrides pinned `eslint@10.3.0` and `prettier@3.8.3`, but `package-lock.json` and workspace packages already resolve `eslint@10.5.0` and `prettier@3.8.4`. That drift causes `npm ci` to fail on `main` and blocks PR CI.

This updates the overrides to match the lockfile and workspace versions.
