### PR TITLE
chore: remove incorrect overrides

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,10 +23,6 @@
     "@commitlint/cli": "^21.0.2",
     "@commitlint/config-conventional": "^21.0.2"
   },
-  "overrides": {
-    "eslint": "10.3.0",
-    "prettier": "3.8.3"
-  },
   "scripts": {
     "test": "npm run test --ws --if-present",
     "lint": "npm run lint --ws --if-present",


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [ ] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Might fix the package-lock problem?

We added overrides to force both `blockly` and `docs` to use the same version of eslint and prettier, but we already pin those versions and this was out of date so I don't think we need it?

