### PR TITLE
chore: rename commit lint job

### DIFF
--- a/.github/workflows/conventional-label.yml
+++ b/.github/workflows/conventional-label.yml
@@ -5,7 +5,7 @@ on:
       - edited
 name: commit lint & label
 jobs:
-  lint:
+  commit-lint:
     runs-on: ubuntu-latest
     env:
       PR_TITLE: ${{ github.event.pull_request.title }}


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [ ] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

The commit-lint workflow had a job called `lint` which clashed with the `lint` job from Node.js CI workflow. Because they were both called `lint`, it made both of the checks required in order to merge a PR, but this one prob shouldn't be required because as seen it can incorrectly hang and it would also need to re-run on synchronize or some other trigger.