### PR TITLE
fix: Add visual invalid input handling beyond color

### DIFF
--- a/packages/blockly/core/field_input.ts
+++ b/packages/blockly/core/field_input.ts
@@ -30,6 +30,7 @@ import {getFocusManager} from './focus_manager.js';
 import type {IFocusableNode} from './interfaces/i_focusable_node.js';
 import {Msg} from './msg.js';
 import * as renderManagement from './render_management.js';
+import {Svg} from './utils.js';
 import * as aria from './utils/aria.js';
 import {Verbosity} from './utils/aria.js';
 import * as dom from './utils/dom.js';
@@ -82,7 +83,7 @@ export abstract class FieldInput<T extends InputTypes> extends Field<
   /**
    * The warning icon to display on invalid input
    */
-  protected warningIcon: HTMLImageElement | null = null;
+  protected warningIcon: SVGElement | null = null;
 
   /**
    * The intial value of the field when the user opened an editor to change its
@@ -202,29 +203,52 @@ export abstract class FieldInput<T extends InputTypes> extends Field<
   }
 
   /** Creates the DOM elements for the invalid input warning icon. */
-  private createWarningIcon(parent?: Element | null): HTMLImageElement | null {
+  protected createWarningIcon(): SVGElement | null {
     const sourceBlock = this.sourceBlock_ as BlockSvg;
     if (!sourceBlock) {
       return null;
     }
-
     const bBox = this.getScaledBBox();
     const bBoxHeight = bBox.bottom - bBox.top;
-    const e = document.createElement('img');
-    e.setAttribute('class', 'blocklyInputWarning');
-    e.setAttribute(
-      'src',
-      `${sourceBlock.workspace.options.pathToMedia}input-warning-icon.svg`,
-    );
-    e.setAttribute('x', `0`);
-    e.setAttribute('y', `0`);
-    e.setAttribute('height', `${bBoxHeight}px`);
-    e.setAttribute('width', `${bBoxHeight}px`);
-    e.setAttribute('float', 'inline-start');
 
-    if (parent) {
-      parent.appendChild(e);
-    }
+    const e = dom.createSvgElement(Svg.SVG, {
+      'class': 'blocklyInputWarning',
+      'viewBox': '-4 0 24 16',
+      'x': '0',
+      'y': '0',
+      'height': `${bBoxHeight}px`,
+      'width': `${bBoxHeight}px`,
+      'float': 'inline-start',
+    });
+    dom.createSvgElement(
+      Svg.PATH,
+      {
+        'd': 'M2,15Q-1,15 0.5,12L6.5,1.7Q8,-1 9.5,1.7L15.5,12Q17,15 14,15z',
+        'stroke': '#1f1f1f',
+        'stroke-width': '1px',
+        'fill': 'none',
+      },
+      e,
+    );
+    dom.createSvgElement(
+      Svg.PATH,
+      {
+        'd': 'm7,4.8v3.16l0.27,2.27h1.46l0.27,-2.27v-3.16z',
+        'fill': '#1f1f1f',
+      },
+      e,
+    );
+    dom.createSvgElement(
+      Svg.RECT,
+      {
+        'x': '7',
+        'y': '11',
+        'height': '2',
+        'width': '2',
+        'fill': '#1f1f1f',
+      },
+      e,
+    );
 
     return e;
   }
@@ -353,41 +377,12 @@ export abstract class FieldInput<T extends InputTypes> extends Field<
     // doValueUpdate_ so that the code is more centralized.
     if (this.isBeingEdited_) {
       const htmlInput = this.htmlInput_ as HTMLElement;
+      this.renderWarningIcon(block.RTL, this.isTextValid_);
       if (!this.isTextValid_) {
         dom.addClass(htmlInput, 'blocklyInvalidInput');
         aria.setState(htmlInput, aria.State.INVALID, true);
-        // insert the icon
-        if (this.warningIcon && htmlInput) {
-          const bBox = this.getScaledBBox();
-          const hasBorder = !!this.borderRect_;
-          const xPadding = hasBorder
-            ? this.getConstants()!.FIELD_BORDER_RECT_X_PADDING
-            : (bBox.bottom - bBox.top) / 2;
-          dom.addClass(this.warningIcon, 'blocklyInputWarningInvalid');
-          htmlInput.setAttribute(
-            'width',
-            `${htmlInput.offsetWidth + this.warningIcon.width}px`,
-          );
-          // If we pad by the whole icon width, it looks too far from the
-          // text, and half the width looks too close.
-          const iconPadding = this.warningIcon.width / 1.5;
-          if (block.RTL) {
-            htmlInput.style.paddingRight = `${iconPadding}px`;
-          } else {
-            htmlInput.style.paddingLeft = `${iconPadding}px`;
-          }
-          this.size_.width = this.warningIcon.width;
-          const iconOffset = hasBorder
-            ? this.getConstants()!.FIELD_TEXT_HEIGHT -
-              this.getConstants()!.FIELD_BORDER_RECT_X_PADDING
-            : 0;
-          this.updateSize_(xPadding + iconOffset);
-        }
       } else {
         dom.removeClass(htmlInput, 'blocklyInvalidInput');
-        if (this.warningIcon) {
-          dom.removeClass(this.warningIcon, 'blocklyInputWarningInvalid');
-        }
         aria.setState(htmlInput, aria.State.INVALID, false);
       }
     }
@@ -400,6 +395,44 @@ export abstract class FieldInput<T extends InputTypes> extends Field<
     if (this.getConstants()!.FULL_BLOCK_FIELDS) block.applyColour();
   }
 
+  protected renderWarningIcon(rtl: boolean, isValid: boolean) {
+    const htmlInput = this.htmlInput_ as HTMLElement;
+
+    if (this.warningIcon) {
+      if (isValid) {
+        htmlInput.style.paddingRight = '';
+        htmlInput.style.paddingLeft = '';
+        dom.removeClass(this.warningIcon, 'blocklyInputWarningInvalid');
+      } else {
+        const bBox = this.getScaledBBox();
+        const bBoxHeight = bBox.bottom - bBox.top;
+        const hasBorder = !!this.borderRect_;
+        const xPadding = hasBorder
+          ? this.getConstants()!.FIELD_BORDER_RECT_X_PADDING
+          : bBoxHeight / 2;
+        dom.addClass(this.warningIcon, 'blocklyInputWarningInvalid');
+        const iconWidth = this.warningIcon.getBoundingClientRect().width;
+        htmlInput.setAttribute(
+          'width',
+          `${htmlInput.offsetWidth + iconWidth}px`,
+        );
+        // If we pad by the whole icon width, it looks too far from the
+        // text, and half the width looks too close.
+        const iconPadding = iconWidth / 1.5;
+        if (rtl) {
+          htmlInput.style.paddingRight = `${iconPadding}px`;
+        } else {
+          htmlInput.style.paddingLeft = `${iconPadding}px`;
+        }
+        this.size_.width = iconWidth;
+        const iconOffset = hasBorder
+          ? this.getConstants()!.FIELD_TEXT_HEIGHT -
+            this.getConstants()!.FIELD_BORDER_RECT_X_PADDING
+          : 0;
+        this.updateSize_(xPadding + iconOffset);
+      }
+    }
+  }
   /**
    * Set whether this field is spellchecked by the browser.
    *

--- a/packages/blockly/core/field_input.ts
+++ b/packages/blockly/core/field_input.ts
@@ -15,6 +15,7 @@ import {computeAriaLabel, getBeginStackLabel} from './block_aria_composer.js';
 import {BlockSvg} from './block_svg.js';
 import * as browserEvents from './browser_events.js';
 import * as bumpObjects from './bump_objects.js';
+import * as css from './css.js';
 import * as dialog from './dialog.js';
 import * as dropDownDiv from './dropdowndiv.js';
 import {EventType} from './events/type.js';
@@ -77,6 +78,11 @@ export abstract class FieldInput<T extends InputTypes> extends Field<
    * True if the value currently displayed in the field's editory UI is valid.
    */
   protected isTextValid_ = false;
+
+  /**
+   * The warning icon to display on invalid input
+   */
+  protected warningIcon: HTMLImageElement | null = null;
 
   /**
    * The intial value of the field when the user opened an editor to change its
@@ -193,6 +199,34 @@ export abstract class FieldInput<T extends InputTypes> extends Field<
     this.fullBlockClickTarget_ =
       !!this.getConstants()?.FULL_BLOCK_FIELDS && block.isSimpleReporter();
     return this.fullBlockClickTarget_;
+  }
+
+  /** Creates the DOM elements for the invalid input warning icon. */
+  private createWarningIcon(parent?: Element | null): HTMLImageElement | null {
+    const sourceBlock = this.sourceBlock_ as BlockSvg;
+    if (!sourceBlock) {
+      return null;
+    }
+
+    const bBox = this.getScaledBBox();
+    const bBoxHeight = bBox.bottom - bBox.top;
+    const e = document.createElement('img');
+    e.setAttribute('class', 'blocklyInputWarning');
+    e.setAttribute(
+      'src',
+      `${sourceBlock.workspace.options.pathToMedia}input-warning-icon.svg`,
+    );
+    e.setAttribute('x', `0`);
+    e.setAttribute('y', `0`);
+    e.setAttribute('height', `${bBoxHeight}px`);
+    e.setAttribute('width', `${bBoxHeight}px`);
+    e.setAttribute('float', 'inline-start');
+
+    if (parent) {
+      parent.appendChild(e);
+    }
+
+    return e;
   }
 
   /**
@@ -312,6 +346,9 @@ export abstract class FieldInput<T extends InputTypes> extends Field<
    */
   protected override render_() {
     super.render_();
+    const block = this.getSourceBlock() as BlockSvg | null;
+    if (!block) throw new UnattachedFieldError();
+
     // This logic is done in render_ rather than doValueInvalid_ or
     // doValueUpdate_ so that the code is more centralized.
     if (this.isBeingEdited_) {
@@ -319,14 +356,42 @@ export abstract class FieldInput<T extends InputTypes> extends Field<
       if (!this.isTextValid_) {
         dom.addClass(htmlInput, 'blocklyInvalidInput');
         aria.setState(htmlInput, aria.State.INVALID, true);
+        // insert the icon
+        if (this.warningIcon && htmlInput) {
+          const bBox = this.getScaledBBox();
+          const hasBorder = !!this.borderRect_;
+          const xPadding = hasBorder
+            ? this.getConstants()!.FIELD_BORDER_RECT_X_PADDING
+            : (bBox.bottom - bBox.top) / 2;
+          dom.addClass(this.warningIcon, 'blocklyInputWarningInvalid');
+          htmlInput.setAttribute(
+            'width',
+            `${htmlInput.offsetWidth + this.warningIcon.width}px`,
+          );
+          // If we pad by the whole icon width, it looks too far from the
+          // text, and half the width looks too close.
+          const iconPadding = this.warningIcon.width / 1.5;
+          if (block.RTL) {
+            htmlInput.style.paddingRight = `${iconPadding}px`;
+          } else {
+            htmlInput.style.paddingLeft = `${iconPadding}px`;
+          }
+          this.size_.width = this.warningIcon.width;
+          const iconOffset = hasBorder
+            ? this.getConstants()!.FIELD_TEXT_HEIGHT -
+              this.getConstants()!.FIELD_BORDER_RECT_X_PADDING
+            : 0;
+          this.updateSize_(xPadding + iconOffset);
+        }
       } else {
         dom.removeClass(htmlInput, 'blocklyInvalidInput');
+        if (this.warningIcon) {
+          dom.removeClass(this.warningIcon, 'blocklyInputWarningInvalid');
+        }
         aria.setState(htmlInput, aria.State.INVALID, false);
       }
     }
 
-    const block = this.getSourceBlock() as BlockSvg | null;
-    if (!block) throw new UnattachedFieldError();
     // In general, do *not* let fields control the color of blocks. Having the
     // field control the color is unexpected, and could have performance
     // impacts.
@@ -462,6 +527,8 @@ export abstract class FieldInput<T extends InputTypes> extends Field<
       'spellcheck',
       this.spellcheck_ as AnyDuringMigration,
     );
+    this.warningIcon = this.createWarningIcon();
+
     const scale = this.workspace_!.getAbsoluteScale();
     const fontSize = this.getConstants()!.FIELD_TEXT_FONTSIZE * scale + 'pt';
     div!.style.fontSize = fontSize;
@@ -484,9 +551,15 @@ export abstract class FieldInput<T extends InputTypes> extends Field<
         div!.style.boxShadow =
           'rgba(255, 255, 255, 0.3) 0 0 0 ' + 4 * scale + 'px';
       }
+      // Adjust invalid input warning icon for full block style
+      const paddingX = (bBox.bottom - bBox.top) / 4;
+      this.warningIcon!.style.paddingLeft = `${paddingX}px`;
+      this.warningIcon!.style.paddingRight = `${paddingX}px`;
     }
     htmlInput.style.borderRadius = borderRadius;
-
+    if (this.warningIcon) {
+      div!.appendChild(this.warningIcon);
+    }
     div!.appendChild(htmlInput);
 
     htmlInput.value = htmlInput.defaultValue = this.getEditorText_(this.value_);
@@ -921,3 +994,13 @@ export interface FieldInputConfig extends FieldConfig {
 export type FieldInputValidator<T extends InputTypes> = FieldValidator<
   string | T
 >;
+
+css.register(`
+  .blocklyInputWarning {
+    display: none;
+    position: absolute;
+  }
+  .blocklyInputWarning.blocklyInputWarningInvalid {
+    display: inline;
+  }
+`);

--- a/packages/blockly/core/field_input.ts
+++ b/packages/blockly/core/field_input.ts
@@ -30,11 +30,11 @@ import {getFocusManager} from './focus_manager.js';
 import type {IFocusableNode} from './interfaces/i_focusable_node.js';
 import {Msg} from './msg.js';
 import * as renderManagement from './render_management.js';
-import {Svg} from './utils.js';
 import * as aria from './utils/aria.js';
 import {Verbosity} from './utils/aria.js';
 import * as dom from './utils/dom.js';
 import {Size} from './utils/size.js';
+import {Svg} from './utils/svg.js';
 import * as userAgent from './utils/useragent.js';
 import * as WidgetDiv from './widgetdiv.js';
 import type {WorkspaceSvg} from './workspace_svg.js';
@@ -218,34 +218,31 @@ export abstract class FieldInput<T extends InputTypes> extends Field<
       'y': '0',
       'height': `${bBoxHeight}px`,
       'width': `${bBoxHeight}px`,
-      'float': 'inline-start',
     });
     dom.createSvgElement(
       Svg.PATH,
       {
+        'class': 'blocklyInputWarningIconShape',
         'd': 'M2,15Q-1,15 0.5,12L6.5,1.7Q8,-1 9.5,1.7L15.5,12Q17,15 14,15z',
-        'stroke': '#1f1f1f',
-        'stroke-width': '1px',
-        'fill': 'none',
       },
       e,
     );
     dom.createSvgElement(
       Svg.PATH,
       {
+        'class': 'blocklyInputWarningIconSymbol',
         'd': 'm7,4.8v3.16l0.27,2.27h1.46l0.27,-2.27v-3.16z',
-        'fill': '#1f1f1f',
       },
       e,
     );
     dom.createSvgElement(
       Svg.RECT,
       {
+        'class': 'blocklyInputWarningIconSymbol',
         'x': '7',
         'y': '11',
         'height': '2',
         'width': '2',
-        'fill': '#1f1f1f',
       },
       e,
     );
@@ -1029,6 +1026,14 @@ export type FieldInputValidator<T extends InputTypes> = FieldValidator<
 >;
 
 css.register(`
+  .blocklyInputWarningIconShape {
+    stroke: #1f1f1f;
+    stroke-width: 1px;
+    fill: none;
+  }
+  .blocklyInputWarningIconSymbol {
+    fill: #1f1f1f;
+  }
   .blocklyInputWarning {
     display: none;
     position: absolute;

--- a/packages/blockly/media/input-warning-icon.svg
+++ b/packages/blockly/media/input-warning-icon.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-4 0 24 16">
+  <path d="M2,15Q-1,15 0.5,12L6.5,1.7Q8,-1 9.5,1.7L15.5,12Q17,15 14,15z" stroke="#1f1f1f" stroke-width="1px" fill="none"/>
+  <path d="m7,4.8v3.16l0.27,2.27h1.46l0.27,-2.27v-3.16z" fill="#1f1f1f"/>
+  <rect x="7" y="11" height="2" width="2" fill="#1f1f1f"></rect>
+</svg>

--- a/packages/blockly/media/input-warning-icon.svg
+++ b/packages/blockly/media/input-warning-icon.svg
@@ -1,5 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="-4 0 24 16">
-  <path d="M2,15Q-1,15 0.5,12L6.5,1.7Q8,-1 9.5,1.7L15.5,12Q17,15 14,15z" stroke="#1f1f1f" stroke-width="1px" fill="none"/>
-  <path d="m7,4.8v3.16l0.27,2.27h1.46l0.27,-2.27v-3.16z" fill="#1f1f1f"/>
-  <rect x="7" y="11" height="2" width="2" fill="#1f1f1f"></rect>
-</svg>

--- a/packages/blockly/tests/mocha/field_number_test.js
+++ b/packages/blockly/tests/mocha/field_number_test.js
@@ -569,6 +569,30 @@ suite('Number Fields', function () {
       assert.notInclude(label, 'dog');
       assert.include(label, '5');
     });
+    test('Invalid input has ARIA invalid state', function () {
+      this.field.setValue(5);
+      this.field.showEditor();
+
+      this.field.htmlInput_.value = 'a';
+      this.field.onHtmlInputChange(null);
+
+      // Move forward a few ticks to give the render_() a chance to run
+      this.clock.tick(16);
+      const ariaInvalid = this.field.htmlInput_.getAttribute('aria-invalid');
+      assert.equal(ariaInvalid, 'true');
+    });
+    test('Invalid input displays warning icon', function () {
+      this.field.setValue(5);
+      this.field.showEditor();
+
+      this.field.htmlInput_.value = 'a';
+      this.field.onHtmlInputChange(null);
+
+      // Move forward a few ticks to give the render_() a chance to run
+      this.clock.tick(16);
+      const warningIconDisplay = this.field.warningIcon.checkVisibility();
+      assert.isTrue(warningIconDisplay);
+    });
     suite('Full block fields', function () {
       setup(function () {
         this.workspace = Blockly.inject('blocklyDiv', {

--- a/packages/blockly/tests/mocha/field_textinput_test.js
+++ b/packages/blockly/tests/mocha/field_textinput_test.js
@@ -224,6 +224,7 @@ suite('Text Input Fields', function () {
             FIELD_TEXT_FONTFAMILY: 'sans-serif',
           };
           field.clickTarget_ = document.createElement('div');
+          field.createWarningIcon = () => {};
           Blockly.common.setMainWorkspace(workspace);
           Blockly.WidgetDiv.createDom();
           this.stub = sinon.stub(field, 'resizeEditor_');
@@ -510,6 +511,29 @@ suite('Text Input Fields', function () {
           rightField.getFocusableElement(),
         );
       });
+      test('Invalid input displays warning icon', async function () {
+        const validator = function () {
+          return null;
+        };
+        const block = this.workspace.getBlockById('left_input_block');
+        const field = this.getFieldFromShadowBlock(block);
+        field.setValidator(validator);
+        const stub = sinon.stub(field, 'resizeEditor_');
+
+        Blockly.getFocusManager().focusNode(field);
+        field.showEditor();
+        // This must be called to avoid editor resize logic throwing an error.
+        await Blockly.renderManagement.finishQueuedRenders();
+
+        // Change the value of the field's input through its editor.
+        const fieldEditor = document.querySelector('.blocklyHtmlInput');
+        this.simulateTypingIntoInput(fieldEditor, 'a');
+
+        // Move forward a few ticks to give the render_() a chance to run
+        this.clock.tick(16);
+        const warningIconDisplay = field.warningIcon.checkVisibility();
+        assert.isTrue(warningIconDisplay);
+      });
     });
 
     // The block being tested uses full-block fields in Zelos.
@@ -644,6 +668,28 @@ suite('Text Input Fields', function () {
       this.field.setValue('new value');
       const updatedLabel = this.focusableElement.getAttribute('aria-label');
       assert.isTrue(updatedLabel.includes('new value'));
+    });
+    test('Invalid input has ARIA invalid state', async function () {
+      const validator = function () {
+        return null;
+      };
+      this.field.setValidator(validator);
+      const stub = sinon.stub(this.field, 'resizeEditor_');
+
+      Blockly.getFocusManager().focusNode(this.field);
+      this.field.showEditor();
+      // This must be called to avoid editor resize logic throwing an error.
+      await Blockly.renderManagement.finishQueuedRenders();
+
+      // Change the value of the field's input through its editor.
+      const fieldEditor = document.querySelector('.blocklyHtmlInput');
+      fieldEditor.value = 'a';
+      fieldEditor.dispatchEvent(new InputEvent('input'));
+
+      // Move forward a few ticks to give the render_() a chance to run
+      this.clock.tick(16);
+      const ariaInvalid = fieldEditor.getAttribute('aria-invalid');
+      assert.equal(ariaInvalid, 'true');
     });
   });
 });


### PR DESCRIPTION
## The basics
- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

Fixes https://github.com/RaspberryPiFoundation/blockly/issues/9684

### Proposed Changes

Added a warning icon which is displayed when a field's input is invalid. This is to address the [Use of Color](https://www.w3.org/WAI/WCAG22/Understanding/use-of-color) WCAG guidelines.

#### Zelos Renderer

<img width="275" height="81" alt="Screenshot 2026-07-02 at 3 12 37 PM" src="https://github.com/user-attachments/assets/9e671867-43ba-452e-be49-47f0810ab5a1" />
<img width="260" height="82" alt="Screenshot 2026-07-02 at 3 13 20 PM" src="https://github.com/user-attachments/assets/f27e487f-1cc1-47e2-bbff-b9b9c45d6b78" />
<img width="119" height="67" alt="Screenshot 2026-07-02 at 3 13 49 PM" src="https://github.com/user-attachments/assets/acb38b6d-fe40-4eb0-911c-77fdf85ad8c2" />
<img width="122" height="72" alt="Screenshot 2026-07-02 at 3 14 01 PM" src="https://github.com/user-attachments/assets/d36d0ef4-0450-4146-8e84-d06ab1d7e1ef" />

Zoomed in:
<img width="336" height="126" alt="Screenshot 2026-07-02 at 3 19 08 PM" src="https://github.com/user-attachments/assets/ccc1ea65-ce05-43c9-bd0a-90c8303226bf" />
<img width="338" height="136" alt="Screenshot 2026-07-02 at 3 19 18 PM" src="https://github.com/user-attachments/assets/e17f5db4-4968-4fee-9422-1ed413d04850" />
<img width="477" height="151" alt="Screenshot 2026-07-02 at 3 20 58 PM" src="https://github.com/user-attachments/assets/57e0be82-dc48-4094-8e72-171e5b3ea808" />
<img width="373" height="112" alt="Screenshot 2026-07-02 at 3 36 51 PM" src="https://github.com/user-attachments/assets/f592f0fe-f2a4-4369-800a-fbb1ba26ddea" />

Zoomed out:
<img width="65" height="44" alt="Screenshot 2026-07-02 at 3 23 11 PM" src="https://github.com/user-attachments/assets/c30b2dad-d90c-40d6-a0ef-15eb88ae05e0" />
<img width="68" height="43" alt="Screenshot 2026-07-02 at 3 23 18 PM" src="https://github.com/user-attachments/assets/0917bd00-4919-4e94-a4b5-28a755552202" />
<img width="139" height="45" alt="Screenshot 2026-07-02 at 3 23 54 PM" src="https://github.com/user-attachments/assets/8191901c-b052-434d-a19e-23e79a1b7090" />
<img width="147" height="51" alt="Screenshot 2026-07-02 at 3 24 02 PM" src="https://github.com/user-attachments/assets/bdd911b9-9bfd-47ca-aacd-2ec5b4ea345c" />

RTL:
<img width="120" height="68" alt="Screenshot 2026-07-02 at 3 26 47 PM" src="https://github.com/user-attachments/assets/d19634b0-72b5-436e-bab0-9d51a0ac1771" />
<img width="126" height="67" alt="Screenshot 2026-07-02 at 3 26 52 PM" src="https://github.com/user-attachments/assets/30a63ea6-3509-4796-80c8-7b2e736bad86" />
<img width="251" height="80" alt="Screenshot 2026-07-02 at 3 26 59 PM" src="https://github.com/user-attachments/assets/31bad0a3-df8c-41f5-bd9d-43ebef6ee552" />
<img width="263" height="79" alt="Screenshot 2026-07-02 at 3 27 07 PM" src="https://github.com/user-attachments/assets/60e6f592-4fcf-42af-a901-9308d2fb3c0a" />

#### Geras Renderer
<img width="110" height="50" alt="Screenshot 2026-07-02 at 3 17 06 PM" src="https://github.com/user-attachments/assets/4e72efc3-27f4-4a6b-91c3-a25bb3d0029f" />
<img width="104" height="47" alt="Screenshot 2026-07-02 at 3 40 22 PM" src="https://github.com/user-attachments/assets/25e46dd3-2e82-45d3-994d-5955c256c45d" />
<img width="241" height="55" alt="Screenshot 2026-07-02 at 3 17 41 PM" src="https://github.com/user-attachments/assets/714086a2-639c-49a1-872d-aac9355cdc54" />
<img width="214" height="55" alt="Screenshot 2026-07-02 at 3 17 55 PM" src="https://github.com/user-attachments/assets/a8bfdb6b-9b81-435f-b7f9-c5ff8f9d0034" />

Zoomed in:
<img width="211" height="96" alt="Screenshot 2026-07-02 at 3 22 12 PM" src="https://github.com/user-attachments/assets/762536cf-5cb2-4634-99fa-c4e28d0b49f4" />
<img width="220" height="103" alt="Screenshot 2026-07-02 at 3 22 18 PM" src="https://github.com/user-attachments/assets/432f424b-c98f-42e0-91c5-edf025023213" />
<img width="422" height="100" alt="Screenshot 2026-07-02 at 3 21 52 PM" src="https://github.com/user-attachments/assets/73e60954-d8d8-4a39-a708-a4752f3234b6" />
<img width="444" height="88" alt="Screenshot 2026-07-02 at 3 22 00 PM" src="https://github.com/user-attachments/assets/bf7ce4d0-bc3b-499e-a0ce-00e9f8d99f01" />

Zoomed out:
<img width="67" height="31" alt="Screenshot 2026-07-02 at 3 24 35 PM" src="https://github.com/user-attachments/assets/9f725ab6-a4bc-44b7-a52b-57a683a395e2" />
<img width="66" height="34" alt="Screenshot 2026-07-02 at 3 24 43 PM" src="https://github.com/user-attachments/assets/f7e8e81b-ddcb-4c6f-a610-243a73f4fe55" />
<img width="138" height="31" alt="Screenshot 2026-07-02 at 3 24 51 PM" src="https://github.com/user-attachments/assets/eca82a93-a02a-4072-b20f-9b23e4c4a129" />
<img width="145" height="32" alt="Screenshot 2026-07-02 at 3 24 58 PM" src="https://github.com/user-attachments/assets/efed1882-73c8-4c00-bd72-d554f35cfbc1" />

RTL:

<img width="109" height="61" alt="Screenshot 2026-07-02 at 3 25 46 PM" src="https://github.com/user-attachments/assets/87ca9296-1f0c-4286-a2a8-386ffc83d434" />
<img width="106" height="52" alt="Screenshot 2026-07-02 at 3 25 54 PM" src="https://github.com/user-attachments/assets/54c62893-b440-42f1-aa24-98929240eec3" />
<img width="216" height="51" alt="Screenshot 2026-07-02 at 3 26 01 PM" src="https://github.com/user-attachments/assets/90b5c42b-de58-4a8e-9fdd-4205103fe792" />
<img width="236" height="50" alt="Screenshot 2026-07-02 at 3 26 08 PM" src="https://github.com/user-attachments/assets/37d5ebcd-ccc7-4579-a5eb-57b7ad3e6b13" />

### Test Coverage

Tests added to ensure icon is added appropriately and aria-invalid state is set.
