### PR TITLE
fix: export JSON block definition type

### DIFF
--- a/packages/blockly/core/blockly.ts
+++ b/packages/blockly/core/blockly.ts
@@ -426,6 +426,7 @@ Names.prototype.populateProcedures = function (
 };
 // clang-format on
 
+export * from './interfaces/i_json_block_definition.js';
 export * from './interfaces/i_navigation_policy.js';
 export * from './keyboard_nav/navigation_policies/block_navigation_policy.js';
 export * from './keyboard_nav/navigation_policies/bubble_navigation_policy.js';

--- a/packages/blockly/tests/typescript/src/field/json_block_custom_args.ts
+++ b/packages/blockly/tests/typescript/src/field/json_block_custom_args.ts
@@ -4,8 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {defineBlocksWithJsonArray} from 'blockly-test/core';
-import type {JsonBlockDefinition} from 'blockly-test/core/interfaces/i_json_block_definition';
+import {
+  defineBlocksWithJsonArray,
+  type JsonBlockDefinition,
+} from 'blockly-test/core';
 
 import './different_user_input';
 


### PR DESCRIPTION
## The basics

  - [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

  ## The details
  ### Resolves

  Fixes #10086

  ### Proposed Changes

  Exports `JsonBlockDefinition` from `blockly.ts` so it is available through the public `blockly/core` entry point.

  Also updates the TypeScript test fixture to import `JsonBlockDefinition` from `blockly-test/core` instead of the internal `interfaces/i_json_block_definition`
  path.

  ### Reason for Changes

  `JsonBlockDefinition` was added in #9613, but it was not re-exported from `blockly.ts`. As a result, users could not access the type from the expected public
  Blockly core export.

  This PR adds the missing re-export.

  ### Test Coverage

  Updated the TypeScript test fixture for JSON block custom args to verify that `JsonBlockDefinition` can be imported from `blockly-test/core`.

  Validated with `npm.cmd run tsc -w packages/blockly`

  ### Documentation

  No documentation changes needed.
