### PR TITLE
Guard deepMerge against prototype pollution

### DIFF
--- a/packages/blockly/core/utils/object.ts
+++ b/packages/blockly/core/utils/object.ts
@@ -21,6 +21,12 @@ export function deepMerge(
   source: AnyDuringMigration,
 ): AnyDuringMigration {
   for (const x in source) {
+    // Skip prototype-pollution vectors so a source object with an own
+    // enumerable `__proto__`, `constructor`, or `prototype` key cannot mutate
+    // Object.prototype during the recursive merge.
+    if (x === '__proto__' || x === 'constructor' || x === 'prototype') {
+      continue;
+    }
     if (source[x] !== null && Array.isArray(source[x])) {
       target[x] = deepMerge(target[x] || [], source[x]);
     } else if (source[x] !== null && typeof source[x] === 'object') {

--- a/packages/blockly/tests/mocha/utils_test.js
+++ b/packages/blockly/tests/mocha/utils_test.js
@@ -598,5 +598,15 @@ suite('Utils', function () {
 
       assert.deepEqual(expected, actual);
     });
+    test('Does not pollute Object.prototype via __proto__', function () {
+      delete Object.prototype.blocklyPolluted;
+      const payload = JSON.parse('{"__proto__": {"blocklyPolluted": "yes"}}');
+
+      Blockly.utils.object.deepMerge({}, payload);
+
+      assert.isUndefined(Object.prototype.blocklyPolluted);
+      assert.isUndefined(({}).blocklyPolluted);
+      delete Object.prototype.blocklyPolluted;
+    });
   });
 });


### PR DESCRIPTION
## The basics

- [x] I validated my changes

## The details
### Resolves

Fixes #10048

### Proposed Changes

`deepMerge` walks `source` with `for...in` and never skips the prototype-pollution keys, so a source object with an own enumerable `__proto__` (which is exactly what `JSON.parse` produces) gets written onto `Object.prototype` during the recursive merge. This adds a small guard that skips `__proto__`, `constructor`, and `prototype` before merging each key.

### Reason for Changes

`Blockly.utils.object.deepMerge` is a public, package-root-reachable API. If a host app passes any user-influenced data through it, `deepMerge({}, JSON.parse('{"__proto__":{"x":"y"}}'))` sets `Object.prototype.x`, which then leaks onto every plain object in the process (CWE-1321). The guard is minimal and leaves behavior unchanged for all normal keys.

### Test Coverage

Added a case to the existing `deepMerge` mocha suite in `utils_test.js`: it merges a `JSON.parse('{"__proto__": {"blocklyPolluted": "yes"}}')` payload into `{}` and asserts `Object.prototype.blocklyPolluted` stays `undefined`. It fails before the guard and passes after. I don't have the Blockly build toolchain set up locally, so I leaned on the added test plus CI rather than a local full run.

### Documentation

None needed, behavior is unchanged for normal keys.

### Additional Information

On #10048 a maintainer mentioned you might prefer to drop `deepMerge` in favor of the spread operator. Happy to do that instead if you'd rather remove the function than harden it; this guard is the minimal fix in the meantime.
