### PR TITLE
docs: fix typos, broken links, and license

### DIFF
--- a/packages/docs/docs/codelabs/custom-renderer/setup.mdx
+++ b/packages/docs/docs/codelabs/custom-renderer/setup.mdx
@@ -10,7 +10,7 @@ This codelab will add code to the Blockly sample app to create and use a new cus
 
 ### The application
 
-Use the Use the [`npx @blockly/create-package`](https://www.npmjs.com/package/@blockly/create-package) command to create a standalone application that contains a sample setup of Blockly, including custom blocks and a display of the generated code and output.
+Use the [`npx @blockly/create-package`](https://www.npmjs.com/package/@blockly/create-package) command to create a standalone application that contains a sample setup of Blockly, including custom blocks and a display of the generated code and output.
 
 1. Run `npx @blockly/create-package app custom-renderer-codelab`. This will create a blockly application in the folder `custom-renderer-codelab`.
 1. `cd` into the new directory: `cd custom-renderer-codelab`.

--- a/packages/docs/docs/guides/app-integration/accessibility/compliance.mdx
+++ b/packages/docs/docs/guides/app-integration/accessibility/compliance.mdx
@@ -62,7 +62,7 @@ readers and other assistive technology. By default, descriptions are computed
 based on block definitions. Developers are encouraged to further customize their
 labels with language that is appropriate for their audiences. Screen reader
 label generation can take advantage of Blockly's 
-[localization system](/guides/configure/web/translations).
+[localization system](/guides/configure/translations).
 
 ### Standard interfaces
 

--- a/packages/docs/docs/guides/configure/events.mdx
+++ b/packages/docs/docs/guides/configure/events.mdx
@@ -133,7 +133,7 @@ and causing side effects.
 
 ## Event types
 
-Refer to the [reference documentation](/reference/blockly.events)
+Refer to the [reference documentation](/reference/blockly.events_namespace)
 for information about individual events.
 
 ## Demo

--- a/packages/docs/docs/guides/contribute/core/index.mdx
+++ b/packages/docs/docs/guides/contribute/core/index.mdx
@@ -7,7 +7,7 @@ image: images/blockly_banner.png
 # Contribute to core
 
 The [Blockly](https://github.com/RaspberryPiFoundation/blockly) core repository contains the
-code that is needed to run any Blackly-based application. It also contains the documentation, including codelabs.
+code that is needed to run any Blockly-based application. It also contains the documentation, including codelabs.
 
 ## Need to Know
 
@@ -32,7 +32,7 @@ to create a PR.
   ```js
   /**
    *   @license
-   *   Copyright <Current YYYY> Google LLC
+   *   Copyright <Current YYYY> Raspberry Pi Foundation
    *   SPDX-License-Identifier: Apache-2.0
    */
   ```

--- a/packages/docs/docs/guides/contribute/samples/index.mdx
+++ b/packages/docs/docs/guides/contribute/samples/index.mdx
@@ -33,7 +33,7 @@ order to create a PR.
   ```js
   /**
    *   @license
-   *   Copyright <Current YYYY> Google LLC
+   *   Copyright <Current YYYY> Raspberry Pi Foundation
    *   SPDX-License-Identifier: Apache-2.0
    */
   ```


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

Addresses a small series of typos and broken/incorrect links in docs. 
Also updates license statement in contributing docs from Google to RPF.

