### PR TITLE
feat: Indicate the Blockly version number on the playground

### DIFF
--- a/packages/blockly/tests/playground.html
+++ b/packages/blockly/tests/playground.html
@@ -94,6 +94,8 @@
         }
 
         addEventHandlers();
+
+        document.querySelector('#version').innerText = Blockly.VERSION;
       }
 
       /**
@@ -527,7 +529,7 @@
   <body>
     <div id="blocklyDiv"></div>
 
-    <h1>Blockly Playground</h1>
+    <h1>Blockly Playground (<span id="version"></span>)</h1>
 
     <p>
       <input id="show" type="button" value="Show" /> -


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Proposed Changes
This PR adds the Blockly version number to the title of the playground. There was recently a discussion in the forum resulting from confusion about what version of Blockly the playground was using, and in general it'd be helpful to see this information at a glance as a reminder that e.g. we need to deploy the latest release to GitHub pages.