### PR TITLE
fix: Consolidate select events

### DIFF
--- a/packages/blockly/core/dragging/block_drag_strategy.ts
+++ b/packages/blockly/core/dragging/block_drag_strategy.ts
@@ -232,7 +232,7 @@ export class BlockDragStrategy implements IDragStrategy {
     } else if (this.block.isInFlyout && this.block.workspace.targetWorkspace) {
       const rootBlock = this.block.getRootBlock();
 
-      const json = blocks.save(rootBlock);
+      const json = blocks.save(rootBlock, {saveIds: false});
       if (json) {
         const newBlock = blocks.appendInternal(
           json,

--- a/packages/blockly/core/dragging/block_drag_strategy.ts
+++ b/packages/blockly/core/dragging/block_drag_strategy.ts
@@ -232,7 +232,7 @@ export class BlockDragStrategy implements IDragStrategy {
     } else if (this.block.isInFlyout && this.block.workspace.targetWorkspace) {
       const rootBlock = this.block.getRootBlock();
 
-      const json = blocks.save(rootBlock, {saveIds: false});
+      const json = blocks.save(rootBlock);
       if (json) {
         const newBlock = blocks.appendInternal(
           json,

--- a/packages/blockly/core/events/utils.ts
+++ b/packages/blockly/core/events/utils.ts
@@ -26,6 +26,7 @@ import {
   isBlockMove,
   isBubbleOpen,
   isClick,
+  isSelected,
   isViewportChange,
 } from './predicates.js';
 
@@ -276,6 +277,33 @@ export function filter(queue: Abstract[]): Abstract[] {
       lastEvent.oldScale = event.oldScale;
     } else if (isClick(event) && isBubbleOpen(lastEvent)) {
       // Drop click events caused by opening/closing bubbles.
+    } else if (
+      isSelected(event) &&
+      isSelected(lastEvent) &&
+      lastEvent.newElementId === undefined
+    ) {
+      // Selection events are a bit quirky; they are fired by both the item
+      // losing selection and the one gaining selection. This means that if item
+      // A is selected, and item B is then clicked, A will fire a selection
+      // event from A to undefined when it is unselected, and B will fire an
+      // event from A to B when it becomes selected. In this case, condense the
+      // event steam to a single event from A to B. Note that the A to undefined
+      // event must be fired, because it's possible for an element to be
+      // unselected without another becoming selected, e.g. clicking on the
+      // workspace while a block is selected. In that case, the A to undefined
+      // event should remain in the event stream.
+      lastEvent.newElementId = event.newElementId;
+      // Selection events have an additional quirk in that, because moving
+      // elements in the DOM causes them to lose focus, various parts of Blockly
+      // refocus an element after moving it to preserve selection. This results
+      // in selected item A firing an A to undefined event when it loses
+      // selection due to the DOM move, and then firing an A to A event when it
+      // is refocused. In that case, we would have condensed this down to one
+      // event above, but that event is now a no-op, so pop it off the event
+      // queue.
+      if (lastEvent.oldElementId === lastEvent.newElementId) {
+        mergedQueue.pop();
+      }
     } else {
       mergedQueue.push(event);
     }

--- a/packages/blockly/tests/mocha/event_selected_test.js
+++ b/packages/blockly/tests/mocha/event_selected_test.js
@@ -6,6 +6,7 @@
 
 import {assert} from '../../node_modules/chai/index.js';
 import {defineRowBlock} from './test_helpers/block_definitions.js';
+import {createChangeListenerSpy} from './test_helpers/events.js';
 import {
   sharedTestSetup,
   sharedTestTeardown,
@@ -13,9 +14,10 @@ import {
 
 suite('Selected Event', function () {
   setup(function () {
-    sharedTestSetup.call(this);
+    sharedTestSetup.call(this, {fireEventsNow: false});
     defineRowBlock();
-    this.workspace = new Blockly.Workspace();
+    this.workspace = new Blockly.inject('blocklyDiv', {});
+    this.eventSpy = createChangeListenerSpy(this.workspace);
   });
 
   teardown(function () {
@@ -37,5 +39,49 @@ suite('Selected Event', function () {
 
       assert.deepEqual(newEvent, origEvent);
     });
+  });
+
+  test('Moving selection between two blocks fires one select event', function () {
+    const block1 = this.workspace.newBlock('row_block', 'test_id1');
+    const block2 = this.workspace.newBlock('row_block', 'test_id2');
+    block1.initSvg();
+    block2.initSvg();
+
+    Blockly.getFocusManager().focusNode(block1);
+    this.clock.runAll();
+    this.eventSpy.resetHistory();
+
+    // Selecting block2 results in block1 becoming unselected; that should not
+    // trigger a select event from block1 to nothing. There should only be one
+    // select event from block1 to block2.
+    Blockly.getFocusManager().focusNode(block2);
+    this.clock.runAll();
+
+    const calls = this.eventSpy.getCalls();
+    assert.lengthOf(calls, 1);
+    const event = calls[0].firstArg;
+    assert.equal(event.oldElementId, block1.id);
+    assert.equal(event.newElementId, block2.id);
+  });
+
+  test('Refocusing the focused element post-DOM move does not fire a select event', function () {
+    const block1 = this.workspace.newBlock('row_block', 'test_id1');
+    const block2 = this.workspace.newBlock('row_block', 'test_id2');
+    block1.initSvg();
+    block2.initSvg();
+
+    Blockly.getFocusManager().focusNode(block1);
+    block2.bringToFront();
+    this.clock.runAll();
+    assert.equal(Blockly.getFocusManager().getFocusedNode(), block1);
+    this.eventSpy.resetHistory();
+    // `bringToFront` moves the block in the DOM, which ordinarily would cause
+    // it to lose focus; however, the implementation re-focuses it post-move.
+    // Since the block was selected before, this should not trigger a select
+    // event to be fired, as the selection has not actually changed.
+    block1.bringToFront();
+    this.clock.runAll();
+    const calls = this.eventSpy.getCalls();
+    assert.lengthOf(calls, 0);
   });
 });


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #9087

### Proposed Changes
This PR consolidates and normalizes select events. Much of the situation the bug describes was already addressed, I suspect through improvements to the focus manager. There were however still several classes of duplicative and confusing select events:

* When blocks were inserted from the flyout, they had the same ID as the block in the flyout. This is legal, because the main workspace and flyout workspace are separate, but resulted in select events being fired where the `oldElementId` and `newElementId` were the same, because the `oldElementId` was that of the block in the flyout, which was initially selected when a drag started, and the `newElementId` was that of the newly-created block in the main workspace, which was the same ID. Now, IDs are not preserved when inserting blocks from the flyout (this was already the case for subsequent insertions of the same block, because you can't have two blocks with the same ID on the same workspace).
* Select events are fired both when an element loses selection and when it gains it. This means that if block A was selected, then block B was clicked, block A would fire a select event from A to undefined (when it lost selection) and block B would fire a select event from A to B (when it gained selection). These are now consolidated in the event stream to one select event from A to B. Note that we can't just not fire events on selection loss, because you can e.g. click the workspace, which would cause a selected block to become unselected, but not cause anything else to gain selection. The workspace would gain focus, but selection events are for selection, which is a different concept.
* Moving elements in the DOM causes them to lose focus, which Blockly works around in several places by manually reassigning focus post-DOM move. If a selected block was e.g. brought to the front, this would cause it to fire a select event from itself to itself. These are now filtered out of the event stream.

I manually verified that the event stream for the actions described in the bug looks reasonable, and added unit tests to verify the consolidation/filtering logic described above, and ensured that they failed without these changes.