### PR TITLE
fix: Fix regression in trashcan lid behavior

### DIFF
--- a/packages/blockly/core/trashcan.ts
+++ b/packages/blockly/core/trashcan.ts
@@ -172,7 +172,12 @@ export class Trashcan
     );
 
     aria.setRole(this.svgGroup, aria.Role.BUTTON);
-    aria.setState(this.svgGroup, aria.State.LABEL, Msg['OPEN_TRASH']);
+    aria.setState(
+      this.svgGroup,
+      aria.State.LABEL,
+      Msg['ARIA_LABEL_TRASH_EMPTY'],
+    );
+    aria.setState(this.svgGroup, aria.State.DISABLED, true);
 
     let clip;
     const rnd = String(Math.random()).substring(2);
@@ -362,11 +367,17 @@ export class Trashcan
    * it will be closed.
    */
   emptyContents() {
-    if (!this.hasContents()) {
+    if (!this.hasContents() || !this.svgGroup) {
       return;
     }
     this.contents.length = 0;
-    this.svgGroup?.classList.remove(TRASH_FULL);
+    this.svgGroup.classList.remove(TRASH_FULL);
+    aria.setState(
+      this.svgGroup,
+      aria.State.LABEL,
+      Msg['ARIA_LABEL_TRASH_EMPTY'],
+    );
+    aria.setState(this.svgGroup, aria.State.DISABLED, true);
     this.closeFlyout();
   }
 
@@ -554,7 +565,8 @@ export class Trashcan
     if (
       this.workspace.options.maxTrashcanContents <= 0 ||
       !isBlockDelete(event) ||
-      event.wasShadow
+      event.wasShadow ||
+      !this.svgGroup
     ) {
       return;
     }
@@ -569,6 +581,8 @@ export class Trashcan
     }
 
     this.svgGroup?.classList.add(TRASH_FULL);
+    aria.setState(this.svgGroup, aria.State.LABEL, Msg['OPEN_TRASH']);
+    aria.clearState(this.svgGroup, aria.State.DISABLED);
   }
 
   /**
@@ -716,12 +730,12 @@ Css.register(`
   }
 
   .blocklyTrash.blocklyTrashOpen,
-  .blocklyTrash:hover,
-  .blocklyTrash:focus {
+  .blocklyTrash.blocklyTrashFull:hover,
+  .blocklyTrash.blocklyTrashFull:focus {
     opacity: 0.8;
   }
 
-  .blocklyTrash.blocklyTrashFull.blocklyTrashOpen .blocklyTrashLid,
+  .blocklyTrash.blocklyTrashOpen .blocklyTrashLid,
   .blocklyTrash.blocklyTrashFull:hover .blocklyTrashLid,
   .blocklyTrash.blocklyTrashFull:focus .blocklyTrashLid {
     rotate: 45deg;

--- a/packages/blockly/core/trashcan.ts
+++ b/packages/blockly/core/trashcan.ts
@@ -580,7 +580,7 @@ export class Trashcan
       this.contents.pop();
     }
 
-    this.svgGroup?.classList.add(TRASH_FULL);
+    this.svgGroup.classList.add(TRASH_FULL);
     aria.setState(this.svgGroup, aria.State.LABEL, Msg['OPEN_TRASH']);
     aria.clearState(this.svgGroup, aria.State.DISABLED);
   }

--- a/packages/blockly/msg/json/en.json
+++ b/packages/blockly/msg/json/en.json
@@ -648,5 +648,6 @@
 	"FIELD_MULTILINEINPUT_FINISH_EDITING": "Finish editing",
 	"FIELD_MULTILINEINPUT_NEW_LINE": "New line",
 	"ZOOM_TO_FIT_ARIA_LABEL": "Zoom to fit",
-	"MINIMAP_ARIA_LABEL": "Workspace minimap. Use the arrow keys to pan the workspace."
+	"MINIMAP_ARIA_LABEL": "Workspace minimap. Use the arrow keys to pan the workspace.",
+	"ARIA_LABEL_TRASH_EMPTY": "Trash, currently empty"
 }

--- a/packages/blockly/msg/json/qqq.json
+++ b/packages/blockly/msg/json/qqq.json
@@ -653,5 +653,6 @@
 	"FIELD_MULTILINEINPUT_FINISH_EDITING": "Label for the hint shown in the multiline input field editor indicating the key to finish editing. Keep this message brief.",
 	"FIELD_MULTILINEINPUT_NEW_LINE": "Label for the hint shown in the multiline input field editor indicating the key to insert a new line. Keep this message brief.",
 	"ZOOM_TO_FIT_ARIA_LABEL": "ARIA label for the zoom-to-fit button that zooms the workspace to fit all blocks.",
-	"MINIMAP_ARIA_LABEL": "ARIA label for the workspace minimap with instructions on keyboard use."
+	"MINIMAP_ARIA_LABEL": "ARIA label for the workspace minimap with instructions on keyboard use.",
+	"ARIA_LABEL_TRASH_EMPTY": "ARIA label for the trashcan when it contains no blocks and cannot be interacted with."
 }

--- a/packages/blockly/msg/messages.js
+++ b/packages/blockly/msg/messages.js
@@ -2461,3 +2461,6 @@ Blockly.Msg.ZOOM_TO_FIT_ARIA_LABEL = 'Zoom to fit';
 /** @type {string} */
 /// ARIA label for the workspace minimap with instructions on keyboard use.
 Blockly.Msg.MINIMAP_ARIA_LABEL = 'Workspace minimap. Use the arrow keys to pan the workspace.';
+/** @type {string} */
+/// ARIA label for the trashcan when it contains no blocks and cannot be interacted with.
+Blockly.Msg.ARIA_LABEL_TRASH_EMPTY = 'Trash, currently empty';


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #10112

### Proposed Changes
This PR fixes some regressions in the behavior of the trashcan. In v12, when a block was dragged over the trashcan, its lid would open to indicate that the block could be dropped there. In v13, this only happened if the trashcan already contained one or more items.

Additionally, in v12, hovering over an empty trashcan did not saturate its color, but in v13 it does.

This PR addresses both issues to align v13 with the v12 behavior: dragging a block over an empty (or full) trashcan will saturate it and animate the lid open, and merely hovering over an empty trashcan will not saturate it. Additionally, the keyboard/screenreader behavior was made more consistent with the mouse: when the trashcan is empty, it is marked as `aria-disabled`, since clicking/pressing enter on it has no effect, and it is not saturated when focused and empty. When empty, the trashcan's label indicates that, rather than saying "Open trash", which is impossible. When full, the label updates to "Open trash".