### PR TITLE
chore: Add a docusaurus group for dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,7 +18,7 @@ updates:
     groups:
       docusaurus:
         patterns:
-          - "@docusaurus/*"
+          - '@docusaurus/*'
   - package-ecosystem: 'github-actions' # See documentation for possible values
     directory: '/'
     target-branch: 'main'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,6 +15,10 @@ updates:
     labels:
       - 'PR: chore'
       - 'PR: dependencies'
+    groups:
+      docusaurus:
+        patterns:
+          - "@docusaurus/*"
   - package-ecosystem: 'github-actions' # See documentation for possible values
     directory: '/'
     target-branch: 'main'


### PR DESCRIPTION
## The basics

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details

### Proposed Changes

Adds a group to the dependabot configuration for docusaurus packages so that they all get bumped together.

### Reason for Changes

Dependabot has been creating PRs that bump one docusaurus package but not others, which causes the docs `build` command to fail.