### PR TITLE
fix: transform svgPathSelected when using RTL and Zelos

### DIFF
--- a/packages/blockly/core/renderers/zelos/path_object.ts
+++ b/packages/blockly/core/renderers/zelos/path_object.ts
@@ -83,6 +83,10 @@ export class PathObject extends BasePathObject {
     for (const outline of this.outlines.values()) {
       outline.setAttribute('transform', 'scale(-1 1)');
     }
+    // Also transform svgPathSelected if it exists.
+    if (this.svgPathSelected) {
+      this.svgPathSelected.setAttribute('transform', 'scale(-1 1)');
+    }
   }
 
   override updateSelected(enable: boolean) {

--- a/packages/blockly/core/renderers/zelos/path_object.ts
+++ b/packages/blockly/core/renderers/zelos/path_object.ts
@@ -83,10 +83,7 @@ export class PathObject extends BasePathObject {
     for (const outline of this.outlines.values()) {
       outline.setAttribute('transform', 'scale(-1 1)');
     }
-    // Also transform svgPathSelected if it exists.
-    if (this.svgPathSelected) {
-      this.svgPathSelected.setAttribute('transform', 'scale(-1 1)');
-    }
+    this.svgPathSelected?.setAttribute('transform', 'scale(-1 1)');
   }
 
   override updateSelected(enable: boolean) {


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes https://github.com/RaspberryPiFoundation/blockly/issues/10151

### Proposed Changes

Update `flipRTL()` to also transform `svgPathSelected` when it exists. This is the same pattern Geras uses for its light/dark paths in `geras/path_object.ts`.
<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->

### Reason for Changes

From the issue:
> With Zelos in RTL mode, when one drops a block from the toolbox, the yellow border is mirrored in LTR.
<img width="296" height="159" alt="image" src="https://github.com/user-attachments/assets/41322a8e-e404-4d2a-a2df-34ac75205dd4" />


<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
