### PR TITLE
fix: exclude toolbox separators from accessibility tree

### DIFF
--- a/packages/blockly/core/toolbox/separator.ts
+++ b/packages/blockly/core/toolbox/separator.ts
@@ -14,6 +14,7 @@
 import * as Css from '../css.js';
 import type {IToolbox} from '../interfaces/i_toolbox.js';
 import * as registry from '../registry.js';
+import * as aria from '../utils/aria.js';
 import * as dom from '../utils/dom.js';
 import type * as toolbox from '../utils/toolbox.js';
 import {ToolboxItem} from './toolbox_item.js';
@@ -54,14 +55,12 @@ export class ToolboxSeparator extends ToolboxItem {
    */
   protected createDom_(): HTMLDivElement {
     const container = document.createElement('div');
-    // Ensure that the separator has a tab index to ensure it receives focus
-    // when clicked (since clicking isn't managed by the toolbox).
-    container.tabIndex = -1;
     container.id = this.getId();
     const className = this.cssConfig_['container'];
     if (className) {
       dom.addClass(container, className);
     }
+    aria.setRole(container, aria.Role.NONE);
     this.htmlDiv = container;
     return container;
   }

--- a/packages/blockly/tests/mocha/toolbox_test.js
+++ b/packages/blockly/tests/mocha/toolbox_test.js
@@ -174,6 +174,16 @@ suite('Toolbox', function () {
     });
   });
 
+  suite('separator accessibility', function () {
+    test('Separator is presentational and not focusable via tabindex', function () {
+      const separator = getSeparator(this.toolbox);
+      const separatorDiv = separator.getDiv();
+      assert.equal(separatorDiv.getAttribute('role'), 'none');
+      assert.isFalse(separatorDiv.hasAttribute('tabindex'));
+      assert.isFalse(separator.canBeFocused());
+    });
+  });
+
   suite('focus management', function () {
     test('Losing focus hides autoclosing flyout', function () {
       // Focus the toolbox and select a category to open the flyout.


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes https://github.com/RaspberryPiFoundation/blockly/issues/10150

### Proposed Changes

- Mark toolbox separators with `role="none"`.
- Remove their `tabindex`.

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->



### Reason for Changes
Screen readers counted visual separators as tree rows, producing incorrect announcements such as "7 of 8." Excluding separators from the accessibility tree makes category positions accurate.
<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

Before:
<img width="543" height="287" alt="image" src="https://github.com/user-attachments/assets/704d533b-50f5-402f-95a7-41ab694a119c" />


After:
<img width="557" height="304" alt="image" src="https://github.com/user-attachments/assets/86409f70-0304-47b9-91b3-c2830a258a25" />
### Test Coverage

Added tests asserting separators have `role="none"`, no `tabindex`, and cannot receive focus.

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
