### PR TITLE
feat: add setAriaTypeName method for Fields

### DIFF
--- a/packages/blockly/core/field.ts
+++ b/packages/blockly/core/field.ts
@@ -319,6 +319,18 @@ export abstract class Field<T = any>
   }
 
   /**
+   * Sets the ARIA-friendly label representation of this field's type.
+   *
+   * Implementations are responsible for, and encouraged to, set a localized
+   * version of the ARIA representation of the field's type.
+   *
+   * @param ariaTypeName An ARIA representation of the field's type.
+   */
+  setAriaTypeName(ariaTypeName: string) {
+    this.ariaTypeName = ariaTypeName;
+  }
+
+  /**
    * Gets an ARIA-friendly label representation of this field's value.
    *
    * Note that implementations should generally always override this value to

--- a/packages/blockly/tests/mocha/field_test.js
+++ b/packages/blockly/tests/mocha/field_test.js
@@ -896,6 +896,13 @@ suite('Abstract Fields', function () {
         assert.equal(field.computeAriaLabel(true), 'text: hello');
       });
 
+      test('Custom type and value when ariaTypeName is set', function () {
+        const field = new TestField();
+        field.setAriaTypeName('speed');
+        field.setValue('fast');
+        assert.equal(field.computeAriaLabel(), 'speed: fast');
+      });
+
       test('Type and placeholder when value is null', function () {
         const field = new TestField(null, {ariaTypeName: 'text'});
         assert.equal(


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes 

### Proposed Changes

This adds a setter for `Field.ariaTypeName`, which is protected.
<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->

### Reason for Changes

Previously, it was only possible to set `ariaTypeName` by passing a string for it as part of the `Field` constructor's `config` parameter.
<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage

Added a new test to confirm that the custom type name shows up in the computed aria label.
<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
