### PR TITLE
feat: Rewrite insertion markers to improve performance and fix memory leaks

### DIFF
--- a/packages/blockly/core/dragging/block_drag_strategy.ts
+++ b/packages/blockly/core/dragging/block_drag_strategy.ts
@@ -648,7 +648,6 @@ export class BlockDragStrategy implements IDragStrategy {
     const newCandidate =
       this.getInitialCandidate() ?? this.getConnectionCandidate(delta);
 
-    this.connectionPreviewer?.hidePreview();
     this.connectionCandidate = null;
     if (!newCandidate) {
       // Position above or below the first/last block.
@@ -657,13 +656,19 @@ export class BlockDragStrategy implements IDragStrategy {
           currCandidate?.neighbour.getSourceBlock() ?? null;
         let root = connectedBlock?.getRootBlock() ?? connectedBlock;
         if (root === draggingBlock) root = connectedBlock;
-        if (!root) return;
+        if (!root) {
+          this.connectionPreviewer?.hidePreview();
+          return;
+        }
 
         const blockRects = draggingBlock.workspace
           .getTopBlocks()
           .filter((block) => block !== draggingBlock.getRootBlock())
           .map((block) => block.getBoundingRectangle());
-        if (!blockRects.length) return;
+        if (!blockRects.length) {
+          this.connectionPreviewer?.hidePreview();
+          return;
+        }
 
         // If the block was previously connected, position the block near its previous connection.
         const destinationX =
@@ -694,6 +699,7 @@ export class BlockDragStrategy implements IDragStrategy {
           new Coordinate(destinationX, destinationY),
         );
       }
+      this.connectionPreviewer?.hidePreview();
       return;
     }
     const candidate =

--- a/packages/blockly/core/insertion_marker.ts
+++ b/packages/blockly/core/insertion_marker.ts
@@ -1,0 +1,165 @@
+/**
+ * @license
+ * Copyright 2026 Raspberry Pi Foundation
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type {BlockSvg} from './block_svg.js';
+import * as renderManagement from './render_management.js';
+import {RenderedConnection} from './rendered_connection.js';
+import {Coordinate} from './utils/coordinate.js';
+import * as dom from './utils/dom.js';
+import {Size} from './utils/size.js';
+import {Svg} from './utils/svg.js';
+
+/**
+ * Visual representation of a mid-drag block if it were to be connected.
+ */
+export class InsertionMarker {
+  /** The current size of the insertion marker, in workspace units. */
+  private size: Size = new Size(0, 0);
+
+  /** The DOM element representing the insertion marker. */
+  private marker?: SVGGElement;
+
+  /** The static connection to which the insertion marker is attached. */
+  private parentConnection?: RenderedConnection;
+
+  /**
+   * Returns the current size of the insertion marker in workspace units.
+   */
+  getHeightWidth() {
+    return this.size;
+  }
+
+  /**
+   * Displays an insertion marker representing the block structure if
+   * `draggingConnection` were to be connected to `staticConnection`.
+   *
+   * @param staticConnection The proposed connection on the stationary block.
+   * @param draggingConnection The proposed connection on a block being dragged.
+   */
+  show(
+    staticConnection: RenderedConnection,
+    draggingConnection: RenderedConnection,
+  ) {
+    this.parentConnection = staticConnection;
+    this.parentConnection.attachInsertionMarker(this);
+
+    const connectingBlock = draggingConnection.getSourceBlock();
+
+    // Save all the existing connections pairs on the dragged block.
+    const oldConnections = new Map<
+      RenderedConnection,
+      RenderedConnection | null
+    >();
+    for (const connection of connectingBlock.getConnections_(false)) {
+      oldConnections.set(connection, connection.targetConnection);
+      connection.targetConnection = null;
+    }
+
+    // Temporarily connect the dragging and static connections and render the
+    // dragging block to steal its size and path for use by the insertion
+    // marker. Importantly, this does *not* call connect(), which causes DOM
+    // manipulation, fires events, etc – it just swaps the target connection.
+    draggingConnection.targetConnection = staticConnection;
+    connectingBlock.workspace.getRenderer().render(connectingBlock);
+    this.partiallyTighten(connectingBlock, draggingConnection);
+
+    this.marker = this.makeMarker(connectingBlock);
+
+    const bounds = connectingBlock.getBoundingRectangleWithoutChildren();
+    this.size = new Size(bounds.getWidth(), bounds.getHeight());
+
+    const blockOffset = staticConnection
+      .getSourceBlock()
+      .getRelativeToSurfaceXY();
+
+    const connectionOffset = Coordinate.difference(
+      staticConnection.getOffsetInBlock(),
+      draggingConnection.getOffsetInBlock(),
+    );
+
+    // Restore the state of the dragging block and rerender it.
+    for (const [source, target] of oldConnections.entries()) {
+      source.targetConnection = target;
+    }
+    connectingBlock.workspace.getRenderer().render(connectingBlock);
+    this.partiallyTighten(connectingBlock, draggingConnection);
+
+    // Move the insertion marker to abut the static connection and render the
+    // static block in case it needs to grow to accommodate the insertion
+    // marker.
+    this.marker.setAttribute(
+      'transform',
+      `translate(${blockOffset.x + connectionOffset.x}, ${blockOffset.y + connectionOffset.y})`,
+    );
+    staticConnection.getSourceBlock().queueRender();
+    renderManagement.triggerQueuedRenders();
+  }
+
+  /**
+   * Hides the insertion marker.
+   */
+  hide() {
+    if (!this.parentConnection) return;
+
+    this.marker?.remove();
+    this.marker = undefined;
+    this.parentConnection.detachInsertionMarker();
+
+    this.parentConnection?.getSourceBlock().queueRender();
+    renderManagement.triggerQueuedRenders();
+    this.parentConnection = undefined;
+  }
+
+  /**
+   * Creates a new insertion marker corresponding to the given block.
+   *
+   * @param block The block whose path will be used for the insertion marker.
+   * @returns An SVG group representing an insertion marker.
+   */
+  private makeMarker(block: BlockSvg) {
+    const newMarker = dom.createSvgElement(Svg.G, {
+      'transform': `translate(${block.relativeCoords.x}, ${block.relativeCoords.y})`,
+      'class': 'blocklyInsertionMarker',
+    });
+
+    const path = block.pathObject.svgPath;
+    dom.createSvgElement(
+      Svg.PATH,
+      {
+        'd': path.getAttribute('d') ?? '',
+        'class': 'blocklyPath',
+      },
+      newMarker,
+    );
+
+    block.workspace.getCanvas().appendChild(newMarker);
+
+    return newMarker;
+  }
+
+  /**
+   * Moves all connections on the given block adjacent to one another, excepting
+   * a specified connection. Otherwise identical to
+   * `BlockSvg.tightenChildrenEfficiently()`.
+   *
+   * @param block The block whose connections should be tightened.
+   * @param skip A connection to avoid tightening; generally that to which the
+   *     insertion marker is being connected to, which may need to have a gap
+   *     between it and its partner connection which the insertion marker will
+   *     be spliced into.
+   */
+  private partiallyTighten(block: BlockSvg, skip: RenderedConnection) {
+    for (const input of block.inputList) {
+      if (input === skip.getParentInput()) {
+        continue;
+      }
+      const conn = input.connection as RenderedConnection;
+      if (conn) conn.tightenEfficiently();
+    }
+    if (block.nextConnection && block.nextConnection !== skip)
+      block.nextConnection.tightenEfficiently();
+  }
+}

--- a/packages/blockly/core/insertion_marker_previewer.ts
+++ b/packages/blockly/core/insertion_marker_previewer.ts
@@ -7,10 +7,13 @@
 import {BlockSvg} from './block_svg.js';
 import {ConnectionType} from './connection_type.js';
 import * as eventUtils from './events/utils.js';
+import {InsertionMarker} from './insertion_marker.js';
 import {IConnectionPreviewer} from './interfaces/i_connection_previewer.js';
 import * as registry from './registry.js';
 import * as renderManagement from './render_management.js';
 import {RenderedConnection} from './rendered_connection.js';
+import {Renderer as GerasRenderer} from './renderers/geras/renderer.js';
+import {Renderer as ThrasosRenderer} from './renderers/thrasos/renderer.js';
 import {Renderer as ZelosRenderer} from './renderers/zelos/renderer.js';
 import * as blocks from './serialization/blocks.js';
 import {WorkspaceSvg} from './workspace_svg.js';
@@ -26,8 +29,21 @@ export class InsertionMarkerPreviewer implements IConnectionPreviewer {
 
   private staticConn: RenderedConnection | null = null;
 
+  private insertionMarker: InsertionMarker;
+
+  /**
+   * If set to true, uses a faster method for rendering insertion markers which
+   * will become the default in v14. This rendering method is enabled for the
+   * built-in Thrasos, Geras and Zelos renderers regardless of the state of this
+   * flag. Custom renderers will use the old rendering behavior unless this is
+   * set to true. This field will be removed in v14.
+   */
+  static useFastInsertionMarkers = false;
+
   constructor(draggedBlock: BlockSvg) {
     this.workspace = draggedBlock.workspace;
+
+    this.insertionMarker = new InsertionMarker();
   }
 
   /**
@@ -62,7 +78,7 @@ export class InsertionMarkerPreviewer implements IConnectionPreviewer {
 
   /**
    * Display a connection preview where the draggedCon connects to the
-   * staticCon, and no block is being relaced.
+   * staticCon, and no block is being replaced.
    *
    * @param draggedConn The connection on the block stack being dragged.
    * @param staticConn The connection not being dragged that we are
@@ -85,7 +101,11 @@ export class InsertionMarkerPreviewer implements IConnectionPreviewer {
       //   static connection, so that it doesn't disconnect  unless that
       //   (+ a bit) has been exceeded.
       if (this.shouldUseMarkerPreview(draggedConn, staticConn)) {
-        this.markerConn = this.previewMarker(draggedConn, staticConn);
+        if (this.shouldUseFastInsertionMarkers()) {
+          this.insertionMarker.show(staticConn, draggedConn);
+        } else {
+          this.markerConn = this.previewMarker(draggedConn, staticConn);
+        }
       }
 
       if (this.workspace.getRenderer().shouldHighlightConnection(staticConn)) {
@@ -236,10 +256,14 @@ export class InsertionMarkerPreviewer implements IConnectionPreviewer {
         this.fadedBlock.fadeForReplacement(false);
         this.fadedBlock = null;
       }
-      if (this.markerConn) {
-        this.hideInsertionMarker(this.markerConn);
-        this.markerConn = null;
-        this.draggedConn = null;
+      if (this.shouldUseFastInsertionMarkers()) {
+        this.insertionMarker.hide();
+      } else {
+        if (this.markerConn) {
+          this.hideInsertionMarker(this.markerConn);
+          this.markerConn = null;
+          this.draggedConn = null;
+        }
       }
     } finally {
       eventUtils.enable();
@@ -266,6 +290,22 @@ export class InsertionMarkerPreviewer implements IConnectionPreviewer {
   /** Dispose of any references held by this connection previewer. */
   dispose() {
     this.hidePreview();
+  }
+
+  /**
+   * Returns whether or not new fast insertion marker rendering should be used.
+   * Defaults on for built-in renderers and off for custom renderers. Can be
+   * enabled for custom renderers by setting
+   * `InsertionMarkerPreviewer.useFastInsertionMarkers = true`.
+   */
+  private shouldUseFastInsertionMarkers() {
+    const renderer = this.workspace.getRenderer();
+    return (
+      renderer.constructor === ThrasosRenderer ||
+      renderer.constructor === GerasRenderer ||
+      renderer.constructor === ZelosRenderer ||
+      InsertionMarkerPreviewer.useFastInsertionMarkers
+    );
   }
 }
 

--- a/packages/blockly/core/rendered_connection.ts
+++ b/packages/blockly/core/rendered_connection.ts
@@ -20,6 +20,7 @@ import {ConnectionType} from './connection_type.js';
 import * as ContextMenu from './contextmenu.js';
 import {ContextMenuRegistry} from './contextmenu_registry.js';
 import * as eventUtils from './events/utils.js';
+import type {InsertionMarker} from './insertion_marker.js';
 import {IContextMenu} from './interfaces/i_contextmenu.js';
 import type {IFocusableNode} from './interfaces/i_focusable_node.js';
 import type {IFocusableTree} from './interfaces/i_focusable_tree.js';
@@ -49,6 +50,7 @@ export class RenderedConnection
   private readonly offsetInBlock: Coordinate;
   private trackedState: TrackedState;
   private highlighted: boolean = false;
+  private insertionMarker?: InsertionMarker;
 
   /** Connection this connection connects to.  Null if not connected. */
   override targetConnection: RenderedConnection | null = null;
@@ -302,6 +304,15 @@ export class RenderedConnection
       this.offsetInBlock,
       target.offsetInBlock,
     );
+
+    if (this.insertionMarker) {
+      if (this.type === ConnectionType.INPUT_VALUE) {
+        offset.x += this.insertionMarker.getHeightWidth().width;
+      } else {
+        offset.y += this.insertionMarker.getHeightWidth().height;
+      }
+    }
+
     block.translate(offset.x, offset.y);
   }
 
@@ -741,8 +752,33 @@ export class RenderedConnection
     // This cast is valid as TypeScript's definition is wrong. See:
     // https://github.com/microsoft/TypeScript/issues/60996.
     const root = this.getSourceBlock().getSvgRoot().getRootNode() as
-      ShadowRoot | HTMLDocument;
+      | ShadowRoot
+      | HTMLDocument;
     return root.getElementById(this.id) as SVGPathElement | null;
+  }
+
+  /**
+   * Associates the given insertion marker with this connection.
+   * @internal
+   */
+  attachInsertionMarker(marker: InsertionMarker) {
+    this.insertionMarker = marker;
+  }
+
+  /**
+   * Removes the insertion marker associated with this connection, if any.
+   * @internal
+   */
+  detachInsertionMarker() {
+    this.insertionMarker = undefined;
+  }
+
+  /**
+   * Returns the insertion marker associated with this connection, if any.
+   * @internal
+   */
+  getInsertionMarker() {
+    return this.insertionMarker;
   }
 }
 

--- a/packages/blockly/core/rendered_connection.ts
+++ b/packages/blockly/core/rendered_connection.ts
@@ -752,8 +752,7 @@ export class RenderedConnection
     // This cast is valid as TypeScript's definition is wrong. See:
     // https://github.com/microsoft/TypeScript/issues/60996.
     const root = this.getSourceBlock().getSvgRoot().getRootNode() as
-      | ShadowRoot
-      | HTMLDocument;
+      ShadowRoot | HTMLDocument;
     return root.getElementById(this.id) as SVGPathElement | null;
   }
 

--- a/packages/blockly/core/rendered_connection.ts
+++ b/packages/blockly/core/rendered_connection.ts
@@ -758,6 +758,7 @@ export class RenderedConnection
 
   /**
    * Associates the given insertion marker with this connection.
+   *
    * @internal
    */
   attachInsertionMarker(marker: InsertionMarker) {
@@ -766,6 +767,7 @@ export class RenderedConnection
 
   /**
    * Removes the insertion marker associated with this connection, if any.
+   *
    * @internal
    */
   detachInsertionMarker() {
@@ -774,6 +776,7 @@ export class RenderedConnection
 
   /**
    * Returns the insertion marker associated with this connection, if any.
+   *
    * @internal
    */
   getInsertionMarker() {

--- a/packages/blockly/core/renderers/measurables/external_value_input.ts
+++ b/packages/blockly/core/renderers/measurables/external_value_input.ts
@@ -29,9 +29,15 @@ export class ExternalValueInput extends InputConnection {
   constructor(constants: ConstantProvider, input: Input) {
     super(constants, input);
     this.type |= Types.EXTERNAL_VALUE_INPUT;
-    if (!this.connectedBlock) {
+
+    if (!this.connectedBlockHeight) {
       this.height = this.shape.height as number;
     } else {
+      const insertionMarker = this.connectionModel.getInsertionMarker();
+      if (insertionMarker) {
+        this.connectedBlockHeight = insertionMarker.getHeightWidth().height;
+      }
+
       this.height =
         this.connectedBlockHeight -
         this.constants_.TAB_OFFSET_FROM_TOP -

--- a/packages/blockly/core/renderers/measurables/inline_input.ts
+++ b/packages/blockly/core/renderers/measurables/inline_input.ts
@@ -27,7 +27,7 @@ export class InlineInput extends InputConnection {
     super(constants, input);
     this.type |= Types.INLINE_INPUT;
 
-    if (!this.connectedBlock) {
+    if (!this.connectedBlockWidth && !this.connectedBlockHeight) {
       this.height = this.constants_.EMPTY_INLINE_INPUT_HEIGHT;
       this.width = this.constants_.EMPTY_INLINE_INPUT_PADDING;
     } else {
@@ -44,7 +44,7 @@ export class InlineInput extends InputConnection {
     this.connectionWidth = !this.isDynamicShape
       ? (this.shape.width as number)
       : (this.shape.width as (p1: number) => number)(this.height);
-    if (!this.connectedBlock) {
+    if (!this.connectedBlockHeight) {
       this.width += this.connectionWidth * (this.isDynamicShape ? 2 : 1);
     }
 

--- a/packages/blockly/core/renderers/measurables/input_connection.ts
+++ b/packages/blockly/core/renderers/measurables/input_connection.ts
@@ -44,13 +44,23 @@ export class InputConnection extends Connection {
         ? (input.connection.targetBlock() as BlockSvg)
         : null;
 
+    const insertionMarker = (
+      input.connection as RenderedConnection
+    ).getInsertionMarker();
+
+    this.connectedBlockWidth = 0;
+    this.connectedBlockHeight = 0;
+
     if (this.connectedBlock) {
       const bBox = this.connectedBlock.getHeightWidth();
       this.connectedBlockWidth = bBox.width;
       this.connectedBlockHeight = bBox.height;
-    } else {
-      this.connectedBlockWidth = 0;
-      this.connectedBlockHeight = 0;
+    }
+
+    if (insertionMarker) {
+      const bBox = insertionMarker.getHeightWidth();
+      this.connectedBlockWidth += bBox.width;
+      this.connectedBlockHeight += bBox.height;
     }
   }
 }

--- a/packages/blockly/core/renderers/measurables/next_connection.ts
+++ b/packages/blockly/core/renderers/measurables/next_connection.ts
@@ -37,5 +37,10 @@ export class NextConnection extends Connection {
     this.type |= Types.NEXT_CONNECTION;
     this.height = this.shape.height as number;
     this.width = this.shape.width as number;
+
+    const insertionMarker = connectionModel.getInsertionMarker();
+    if (insertionMarker) {
+      this.height += insertionMarker.getHeightWidth().height;
+    }
   }
 }

--- a/packages/blockly/core/renderers/measurables/statement_input.ts
+++ b/packages/blockly/core/renderers/measurables/statement_input.ts
@@ -32,7 +32,7 @@ export class StatementInput extends InputConnection {
     super(constants, input);
     this.type |= Types.STATEMENT_INPUT;
 
-    if (!this.connectedBlock) {
+    if (!this.connectedBlockHeight) {
       this.height = this.constants_.EMPTY_STATEMENT_INPUT_HEIGHT;
     } else {
       // We allow the dark path to show on the parent block so that the child

--- a/packages/blockly/tests/mocha/keyboard_movement_test.js
+++ b/packages/blockly/tests/mocha/keyboard_movement_test.js
@@ -1226,6 +1226,7 @@ suite('Keyboard-driven movement', function () {
         this.workspace.clear();
         this.liveRegion = document.getElementById('blocklyAriaAnnounce');
         this.moveAndAssert = (moveFn, incPhrases, exclPhrases = []) => {
+          this.clock.tick(11);
           moveFn(this.workspace);
           this.clock.tick(11);
           let text = this.liveRegion.textContent;
@@ -1245,6 +1246,10 @@ suite('Keyboard-driven movement', function () {
         this.block1 = this.workspace.newBlock('draw_emoji');
         this.block1.initSvg();
         this.block1.render();
+      });
+
+      teardown(function () {
+        cancelMove(this.workspace);
       });
 
       test('announces simple block moving on workspace', function () {

--- a/packages/blockly/tests/mocha/shortcut_items_test.js
+++ b/packages/blockly/tests/mocha/shortcut_items_test.js
@@ -1539,8 +1539,8 @@ suite('Keyboard Shortcut Items', function () {
 
       const hasInsertionMarker = this.workspace
         .getTopBlocks()
-        .flatMap((b) => b.getChildren())
-        .some((b) => b.isInsertionMarker());
+        .flatMap((b) => b.getConnections_())
+        .some((c) => !!c.getInsertionMarker());
       assert.isTrue(hasInsertionMarker);
 
       Blockly.KeyboardMover.mover.abortMove();


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #5375 and #2249 once old behavior is removed.

### Proposed Changes
This PR rewrites Blockly's insertion markers to be SVG groups/paths on the workspace, and not actual blocks. This fixes a long-standing leaky abstraction, and more importantly significantly improves performance when attempting to connect blocks to large stacks. It also incidentally fixes an issue where all insertion marker blocks were being leaked, causing Blockly's memory usage to grow indefinitely every time an insertion marker was shown.

### Reason for Changes
Drawing insertion markers, particularly in large stacks of blocks, could be extremely slow. This is because, every time an insertion marker was shown (which was on every move), the dragging block would be cloned, the proposed connection point would be disconnected from its parent if any, and the cloned block would be connected to the proposed connection point. Connecting/disconnecting results in large DOM shuffles, because blocks are nested within each other in the DOM. This in turn caused a bunch of layout thrashing and redraw. Additionally, every insertion marker ever created was retained forever.

Now, when an insertion marker is rendered, the dragging block has its connections updated to the proposed connection (without using the connect() method, which shuffles the DOM/fires events/etc – the connection's `targetConnection` field is just set), is rerendered to extract its path, has the path used as the insertion marker, and is rerendered in its original state. This rendering involves only the block being dragged and the block it is being connected to, and doesn't involve any DOM modification outside of the blocks having their paths set and the insertion marker being added at the root of the workspace, which don't involve shifting and invalidating the layout of large DOM trees.

For users using the built-in renderers, this change will default on, and is not breaking. There are minor behavioral breaking changes possible for users with custom renderers, so this revised behavior defaults off for non-built-in renderers. Those users may opt in by setting `Blockly.InsertionMarkerPreviewer.useFastInsertionMarkers = true`. This will become the default behavior in v14.

This change significantly improves performance when e.g. dragging a new block into the top of the "spaghetti" block stack created in the playground in Safari, Firefox and Chrome.

Old:
https://github.com/user-attachments/assets/9c983a6c-ae7f-4e01-bcea-da9171e49242

New:
https://github.com/user-attachments/assets/f36e4fbd-1983-4ee8-951c-568f897894ce

Old profile (red flags indicate jank/dropped frames; note also continuously increasing node and listener counts):
<img width="1083" height="780" alt="Screenshot 2026-07-17 at 3 00 34 PM" src="https://github.com/user-attachments/assets/78889aec-0b80-462d-a313-e78a33bb26fb" />

New profile (note lack of jank, and stair-step node/listener count as GC runs):
<img width="1084" height="780" alt="Screenshot 2026-07-17 at 3 01 57 PM" src="https://github.com/user-attachments/assets/dd8245c0-4d15-4e8b-9757-ed52b20e7ff8" />

### Test Coverage
Existing tests continue to pass. I manually tested in Chrome, Safari and Firefox on Mac. I verified that insertion markers were correctly displayed when attaching blocks horizontally and vertically at the top/bottom/start/end of a stack/row, splicing them into the middle of a stack, and wrapping statement blocks around a stack, in Thrasos and Zelos, with mouse drags and keyboard-driven drags. 