### PR TITLE
fix: Fix bug that caused `getInitialCandidate()` to be called on every drag step

### DIFF
--- a/packages/blockly/core/dragging/block_drag_strategy.ts
+++ b/packages/blockly/core/dragging/block_drag_strategy.ts
@@ -358,9 +358,11 @@ export class BlockDragStrategy implements IDragStrategy {
     // use in constrained moved mode.
     if (e instanceof KeyboardEvent) {
       // Scooch the block to be offset from the connection preview indicator.
+      const initialCandidate = this.getInitialCandidate() ?? undefined;
       const neighbour = this.updateConnectionPreview(
         this.block,
         new Coordinate(0, 0),
+        initialCandidate,
       );
       if (neighbour) {
         this.block.moveDuringDrag(this.determineConnectionOffset());
@@ -645,16 +647,18 @@ export class BlockDragStrategy implements IDragStrategy {
    * @param draggingBlock The block being dragged.
    * @param delta How far the pointer has moved from the position
    *     at the start of the drag, in workspace units.
+   * @param initialCandidate If provided, a connection candidate that the
+   *     connection preview indicator will be attached to.
    * @returns The neighbouring connection to which the connection preview will
    *     be attached.
    */
   private updateConnectionPreview(
     draggingBlock: BlockSvg,
     delta: Coordinate,
+    initialCandidate?: ConnectionCandidate,
   ): RenderedConnection | undefined {
     const currCandidate = this.connectionCandidate;
-    const newCandidate =
-      this.getInitialCandidate() ?? this.getConnectionCandidate(delta);
+    const newCandidate = initialCandidate ?? this.getConnectionCandidate(delta);
 
     this.connectionPreviewer?.hidePreview();
     this.connectionCandidate = null;


### PR DESCRIPTION

<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details

### Proposed Changes
This PR fixes a bug that caused `BlockDragStrategy.getInitialCandidate()` to be called on every single drag step, including for mouse-driven drags. This method is intended to start keyboard drags at or close to an existing focused element on the workspace, and therefore only needs to be called from `startDrag` for keyboard moves. Instead, it was being called every time `drag()` was called, regardless of the modality. This method is relatively expensive, and in any case this was just wasted effort.