### PR TITLE
fix: throw on invalid XML connections

### DIFF
--- a/packages/blockly/core/xml.ts
+++ b/packages/blockly/core/xml.ts
@@ -1004,22 +1004,37 @@ function domToBlockHeadless(
 
   // Connect parent after processing mutation and before setting fields.
   if (parentConnection) {
+    let childConnection: Connection;
     if (connectedToParentNext) {
       if (block.previousConnection) {
-        parentConnection.connect(block.previousConnection);
+        childConnection = block.previousConnection;
       } else {
         throw TypeError('Next block does not have previous statement.');
       }
     } else {
       if (block.outputConnection) {
-        parentConnection.connect(block.outputConnection);
+        childConnection = block.outputConnection;
       } else if (block.previousConnection) {
-        parentConnection.connect(block.previousConnection);
+        childConnection = block.previousConnection;
       } else {
         throw TypeError(
           'Child block does not have output or previous statement.',
         );
       }
+    }
+    if (!parentConnection.connect(childConnection)) {
+      const checker = block.workspace.connectionChecker;
+      throw TypeError(
+        checker.getErrorMessage(
+          checker.canConnectWithReason(
+            childConnection,
+            parentConnection,
+            false,
+          ),
+          childConnection,
+          parentConnection,
+        ),
+      );
     }
   }
 

--- a/packages/blockly/tests/mocha/xml_test.js
+++ b/packages/blockly/tests/mocha/xml_test.js
@@ -726,6 +726,32 @@ suite('XML', function () {
             },
           ],
         },
+        {
+          'type': 'xml_parent_value_check_int',
+          'message0': '%1',
+          'args0': [
+            {
+              'type': 'input_value',
+              'name': 'VALUE',
+              'check': 'Int',
+            },
+          ],
+        },
+        {
+          'type': 'xml_child_output_check_long',
+          'message0': '',
+          'output': 'Long',
+        },
+        {
+          'type': 'xml_parent_next_check_int',
+          'message0': '',
+          'nextStatement': 'Int',
+        },
+        {
+          'type': 'xml_child_previous_check_long',
+          'message0': '',
+          'previousStatement': 'Long',
+        },
       ]);
     });
     teardown(function () {
@@ -805,6 +831,36 @@ suite('XML', function () {
       assert.throws(function () {
         Blockly.Xml.domToWorkspace(dom, this.workspace);
       });
+    });
+    test('Throws for incompatible value input connection', function () {
+      const dom = Blockly.utils.xml.textToDom(
+        '<xml xmlns="https://developers.google.com/blockly/xml">' +
+          '  <block type="xml_parent_value_check_int">' +
+          '    <value name="VALUE">' +
+          '      <block type="xml_child_output_check_long"></block>' +
+          '    </value>' +
+          '  </block>' +
+          '</xml>',
+      );
+      assert.throws(
+        () => Blockly.Xml.domToWorkspace(dom, this.workspace),
+        TypeError,
+      );
+    });
+    test('Throws for incompatible next connection', function () {
+      const dom = Blockly.utils.xml.textToDom(
+        '<xml xmlns="https://developers.google.com/blockly/xml">' +
+          '  <block type="xml_parent_next_check_int">' +
+          '    <next>' +
+          '      <block type="xml_child_previous_check_long"></block>' +
+          '    </next>' +
+          '  </block>' +
+          '</xml>',
+      );
+      assert.throws(
+        () => Blockly.Xml.domToWorkspace(dom, this.workspace),
+        TypeError,
+      );
     });
   });
   suite('appendDomToWorkspace', function () {


### PR DESCRIPTION
## The basics

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details

### Resolves

Fixes #9266

### Proposed changes

XML deserialization now checks whether connecting a child block to its serialized parent succeeds. If `Connection.connect()` returns `false`, deserialization throws a `TypeError` containing the developer-facing message from the workspace connection checker.

Regression tests cover failed connections for both value inputs and next statements.

### Reason for changes

Previously, `domToBlockHeadless` ignored the boolean result of `parentConnection.connect()`. When connection checks rejected serialized XML, the child block remained in the workspace without being connected to the root block. Because only descendants of the root block were initialized, this produced an uninitialized and potentially invisible "ghost" block.

This change follows the behavior agreed on in the issue discussion: invalid serialized state should fail during deserialization, matching the existing JSON deserialization behavior. It deliberately does not recover, disable, reposition, or otherwise correct invalid blocks, and it does not change JSON deserialization. This is the key difference from the approaches in #9715 and #9718, which were closed because they attempted to preserve invalid children as top-level blocks.

### Test coverage

- Added XML regression coverage for an incompatible value input connection.
- Added XML regression coverage for an incompatible next-statement connection.
- `gulp build --debug`
- Full browser Mocha suite: 0 failures
- Targeted browser Mocha regression tests: 0 failures
- ESLint on changed files
- Prettier check on changed files
- `git diff --check`

### Documentation

No documentation changes are required because this fixes error handling for invalid legacy XML and does not change a supported serialization format or public API.