### PR TITLE
fix: Improve performance of large connection DB updates

### DIFF
--- a/packages/blockly/core/block_svg.ts
+++ b/packages/blockly/core/block_svg.ts
@@ -400,7 +400,9 @@ export class BlockSvg
     const currLoc = this.getRelativeToSurfaceXY();
     const newLoc = Coordinate.sum(currLoc, delta);
     this.translate(newLoc.x, newLoc.y);
+    this.workspace.connectionDBList.forEach((db) => db?.beginBulkUpdates());
     this.updateComponentLocations(newLoc);
+    this.workspace.connectionDBList.forEach((db) => db?.endBulkUpdates());
 
     if (eventsEnabled && event) {
       event!.recordNew();

--- a/packages/blockly/core/connection_db.ts
+++ b/packages/blockly/core/connection_db.ts
@@ -28,6 +28,12 @@ export class ConnectionDB {
   private readonly connections: RenderedConnection[] = [];
 
   /**
+   * Count of how many times bulk updates have been enabled. When reaching 0,
+   * the connection DB will be resorted.
+   */
+  private bulkCounter = 0;
+
+  /**
    * @param connectionChecker The workspace's connection type checker, used to
    *     decide if connections are valid during a drag.
    */
@@ -132,6 +138,23 @@ export class ConnectionDB {
       throw Error('Unable to find connection in connectionDB.');
     }
     this.connections.splice(index, 1);
+  }
+
+  /**
+   * Moves the given connection in the connection DB to reflect its new Y
+   * position. For performance, this will be deferred if the connection DB is in
+   * the middle of a bulk update.
+   *
+   * @param connection The connection that is moving. Should be provided before
+   *     its `Connection.y` field has been updated.
+   * @param newYPos The y coordinate (in workspace units) to which the
+   *     connection will move.
+   */
+  reorderConnection(connection: RenderedConnection, newYPos: number) {
+    if (this.bulkCounter !== 0) return;
+
+    this.removeConnection(connection, connection.y);
+    this.addConnection(connection, newYPos);
   }
 
   /**
@@ -276,6 +299,47 @@ export class ConnectionDB {
     conn.y = baseY;
     // If there were no valid connections, bestConnection will be null.
     return {connection: bestConnection, radius: bestRadius};
+  }
+
+  /**
+   * Notifies the connection DB that a series of connection moves is about to
+   * begin. May be called multiple times, and must be paired with a
+   * corresponding call to `endBulkUpdates()`.
+   *
+   * @internal
+   */
+  beginBulkUpdates() {
+    this.bulkCounter++;
+  }
+
+  /**
+   * Notifies the connection DB that the most recent bulk series of connection
+   * moves has ended. Must be called after the corresponding
+   * `beginBulkUpdates()`. If all in-flight bulk updates have ended, this method
+   * will reorder the connection DB to reflect the current state of the
+   * connections.
+   *
+   * @internal
+   */
+  endBulkUpdates() {
+    if (this.bulkCounter === 0) {
+      throw new Error('Bulk updates are already ended.');
+    }
+    this.bulkCounter--;
+    if (this.bulkCounter === 0) {
+      this.reorderConnections();
+    }
+  }
+
+  /**
+   * Sorts the connections in the connection DB to reflect the current
+   * coordinates of the connections to allow for quick and correct connection
+   * lookups. Run automatically when a bulk update finishes.
+   */
+  private reorderConnections() {
+    this.connections.sort((a, b) => {
+      return a.y - b.y;
+    });
   }
 
   /**

--- a/packages/blockly/core/render_management.ts
+++ b/packages/blockly/core/render_management.ts
@@ -133,10 +133,14 @@ function doRenders(workspace?: WorkspaceSvg) {
   }
   for (const workspace of workspaces) {
     workspace.resizeContents();
+    workspace.connectionDBList.forEach((db) => db?.beginBulkUpdates());
   }
   for (const block of blocks) {
     const blockOrigin = block.getRelativeToSurfaceXY();
     block.updateComponentLocations(blockOrigin);
+  }
+  for (const workspace of workspaces) {
+    workspace.connectionDBList.forEach((db) => db?.endBulkUpdates());
   }
   for (const block of blocks) {
     const oldGroup = eventUtils.getGroup();

--- a/packages/blockly/core/rendered_connection.ts
+++ b/packages/blockly/core/rendered_connection.ts
@@ -216,9 +216,7 @@ export class RenderedConnection
    *     was updated.
    */
   moveTo(x: number, y: number): boolean {
-    // TODO(#6922): Readd this optimization.
-    // const moved = this.x !== x || this.y !== y;
-    const moved = true;
+    const moved = this.x !== x || this.y !== y;
     let updated = false;
 
     if (this.trackedState === RenderedConnection.TrackedState.WILL_TRACK) {
@@ -229,8 +227,7 @@ export class RenderedConnection
       this.trackedState === RenderedConnection.TrackedState.TRACKED &&
       moved
     ) {
-      this.db.removeConnection(this, this.y);
-      this.db.addConnection(this, y);
+      this.db.reorderConnection(this, y);
       updated = true;
     }
 

--- a/packages/blockly/tests/mocha/render_management_test.js
+++ b/packages/blockly/tests/mocha/render_management_test.js
@@ -37,6 +37,7 @@ suite('Render Management', function () {
         initialized: true,
         workspace: {
           resizeContents: () => {},
+          connectionDBList: [],
         },
       };
     }
@@ -84,6 +85,7 @@ suite('Render Management', function () {
     function createMockWorkspace() {
       return {
         resizeContents: () => {},
+        connectionDBList: [],
       };
     }
 


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #6922

### Proposed Changes
This PR improves performance when making large changes to the connection DB, e.g. moving a stack of several thousand blocks. It also readds an optimization that skipped moving connections that hadn't moved; I couldn't repro the issue described in #6922/#6921 with that change.

### Reason for Changes
Previously, when a large stack of blocks was moved or rendered, each block would update the positions of all of its connections in the connection DB, as well as those of all of its children. When moving e.g. a stack of thousands of spaghetti blocks, this resulted in thousands of connections being moved in the connection DB. Each one of those connection moves would:

1. Do a binary search for the connection's current location in the DB
2. Splice the connection out of the underlying array of connections
3. Do a binary search for the connection's new location in the DB
4. Splice the connection into the underlying array of connections at that index

While binary search is of course fast, moving a stack of a few thousand blocks with a few connections each would result in perhaps 10,000 binary searches, and more concerningly, splicing into and out of an array is generally O(n), and that too was happening 10,000 times, with an n of several thousand.

The goal of all this is to maintain the connection DB as an array of connections sorted by Y coordinate, so that finding a given connection (and its nearest neighbours) can be done quickly. When a block stack is being moved or rendered, however, this can essentially be treated as an atomic operation, since we won't be e.g. looking up connections to find an insertion point mid-move/render. This enables a simple optimization: Go ahead an update the x/y coordinates on each connection, but rather than continuously mutating the connection DB to keep it 100% accurate at all times, wait until all connections have been updated and then sort the connection DB based on the connections' Y coordinates...once. This, naturally, yields a significant performance improvement.

Before, `ConnectionDB.addConnection()`, `ConnectionDB.removeConnection()`, and `ConnectionDB.calculateIndexForYPos()` added up to about 25% of total execution time when rapidly moving a block near the top of a spaghetti stack as demoed in #10156:
<img width="1562" height="1060" alt="Screenshot 2026-07-20 at 10 45 06 AM" src="https://github.com/user-attachments/assets/93df797b-2174-4dcc-9b38-e385639c1167" />


After, the most expensive bit of Blockly Javascript becomes `BlockSvg.updateComponentLocations()` (which triggers connection moves in the DB), at...1.5% of total execution time, with ~90% of overall execution time being in browser internals vs Blockly (and much of that is addressed in #10156):
<img width="1562" height="1060" alt="Screenshot 2026-07-20 at 10 43 49 AM" src="https://github.com/user-attachments/assets/1bdf3738-e860-47db-83b2-e4737506b633" />


### Test Coverage
All tests continue to pass. I also verified that moving large block stacks updated connection locations appropriately by attempting to connect blocks to them post-move and ensuring the appropriate connection was highlighted.