### PR TITLE
fix: Fix bug that caused some connections to refuse to connect when dragging from the toolbox

### DIFF
--- a/packages/blockly/core/dragging/block_drag_strategy.ts
+++ b/packages/blockly/core/dragging/block_drag_strategy.ts
@@ -242,6 +242,7 @@ export class BlockDragStrategy implements IDragStrategy {
           },
         ) as BlockSvg;
         eventUtils.setRecordUndo(false);
+        newBlock.render();
         this.positionNewBlock(this.block, newBlock);
         eventUtils.setRecordUndo(true);
 


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #10145

### Proposed Changes
This PR fixes a bug that caused only some connections to be connectable when dragging a block out of the toolbox. The new block wasn't being rendered before connections were cached, so all of its connections were cached as if they were located at (0, 0) on the block. Now, the block is immediately rendered, so connections get their correct offsets and the connection cache is correctly populated.