### PR TITLE
fix: Improve performance of variable name comparisons

### DIFF
--- a/packages/blockly/core/variables.ts
+++ b/packages/blockly/core/variables.ts
@@ -23,6 +23,10 @@ import * as utilsXml from './utils/xml.js';
 import type {Workspace} from './workspace.js';
 import type {WorkspaceSvg} from './workspace_svg.js';
 
+const nameComparisonCollator = new Intl.Collator(undefined, {
+  sensitivity: 'base',
+});
+
 /**
  * String for use in the "custom" attribute of a category in toolbox XML.
  * This string indicates that the category should be dynamically populated with
@@ -805,9 +809,7 @@ export function compareByName(
   var1: IVariableModel<IVariableState>,
   var2: IVariableModel<IVariableState>,
 ): number {
-  return var1
-    .getName()
-    .localeCompare(var2.getName(), undefined, {sensitivity: 'base'});
+  return nameComparisonCollator.compare(var1.getName(), var2.getName());
 }
 
 /**


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details

### Proposed Changes
This PR improves the performance of blocks and fields referencing variables. I forget where exactly this was turning up as a performance pitfall, but variable fields load and sort all the variables in the dropdown when the field is created using this method. `localeCompare()` winds up constructing one of these expensive collator objects behind the scenes, so just creating one once and then using it gives a significant performance improvement, while still allowing for fancy locale-aware sorting of variable names.