### PR TITLE
chore: add export and deprecation warnings to app engine demos

### DIFF
--- a/packages/blockly/appengine/app.yaml
+++ b/packages/blockly/appengine/app.yaml
@@ -66,6 +66,16 @@ handlers:
 - url: /static/demos/custom-fields/.*
   static_files: redirect.html
   upload: redirect.html
+# Playgrounds moved to GitHub Pages.
+- url: /static/tests/playgrounds/advanced_playground\.html
+  static_files: redirect.html
+  upload: redirect.html
+- url: /static/tests/multi_playground\.html
+  static_files: redirect.html
+  upload: redirect.html
+- url: /static/tests/playground\.html
+  static_files: redirect.html
+  upload: redirect.html
 
 # Blockly files.
 - url: /static

--- a/packages/blockly/appengine/redirect.html
+++ b/packages/blockly/appengine/redirect.html
@@ -100,6 +100,17 @@ if (loc.includes('/demos/fixed/')) {
   loc = 'https://google.github.io/blockly-samples/examples/pitch-field-demo/';
 }
 
+// Playgrounds moved to GitHub Pages in 2026.
+var ghPagesBase =
+    'https://raspberrypifoundation.github.io/blockly/packages/blockly/tests/';
+if (loc.includes('/tests/playgrounds/advanced_playground.html')) {
+  loc = ghPagesBase + 'playgrounds/advanced_playground.html';
+} else if (loc.includes('/tests/multi_playground.html')) {
+  loc = ghPagesBase + 'multi_playground.html';
+} else if (loc.includes('/tests/playground.html')) {
+  loc = ghPagesBase + 'playground.html';
+}
+
 location = loc;
 
     </script>

--- a/packages/blockly/demos/blockfactory/index.html
+++ b/packages/blockly/demos/blockfactory/index.html
@@ -54,7 +54,10 @@
     </button>
   </h1>
   <div id="legacyBanner">
-    This version of Developer Tools is only compatible with Blockly version 10 and earlier. Try the <a target="_blank" href="https://google.github.io/blockly-samples/examples/developer-tools/index.html">new Block Factory</a> and <a target="_blank" href="https://developers.google.com/blockly/guides/create-custom-blocks/blockly-developer-tools#import_from_legacy_block_factory">learn how to migrate your blocks</a>.
+    <strong>This service will be shut down on December 1, 2026.</strong>
+    Please export your block definitions before then, using the "Export Block Library" button, so you can import them into the new Block Factory.
+    <br>
+    This version of Developer Tools is only compatible with Blockly version 10 and earlier. Try the <a target="_blank" href="https://raspberrypifoundation.github.io/blockly-samples/examples/developer-tools/index.html">new Block Factory</a> and <a target="_blank" href="https://docs.blockly.com/guides/create-custom-blocks/blockly-developer-tools/#import-from-legacy-block-factory">learn how to migrate your blocks</a>.
   </div>
   <div id="tabContainer">
     <div id="blockFactory_tab" class="tab tabon">Block Factory</div>

--- a/packages/blockly/demos/code/code.js
+++ b/packages/blockly/demos/code/code.js
@@ -490,6 +490,7 @@ Code.init = function() {
 
   Code.bindClick('trashButton',
       function() {Code.discard(); Code.renderContent();});
+  Code.bindClick('exportButton', Code.exportWorkspace);
   Code.bindClick('runButton', Code.runJS);
   // Disable the link button if page isn't backed by App Engine storage.
   var linkButton = document.getElementById('linkButton');
@@ -602,6 +603,24 @@ Code.runJS = function(event) {
   } catch (e) {
     alert(MSG['badCode'].replace('%1', e));
   }
+};
+
+/**
+ * Download the current workspace as a JSON file that can be loaded into the
+ * Blockly Playground.
+ */
+Code.exportWorkspace = function() {
+  var state = Blockly.serialization.workspaces.save(Code.workspace);
+  var text = JSON.stringify(state, null, 2);
+  var blob = new Blob([text], {type: 'application/json'});
+  var url = URL.createObjectURL(blob);
+  var a = document.createElement('a');
+  a.href = url;
+  a.download = 'blockly-workspace.json';
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  URL.revokeObjectURL(url);
 };
 
 /**

--- a/packages/blockly/demos/code/index.html
+++ b/packages/blockly/demos/code/index.html
@@ -32,6 +32,17 @@
     </tr>
     <tr>
       <td colspan=2>
+        <div id="deprecationBanner">
+          <strong>This service will be shut down on December 1, 2026.</strong>
+          Saving and sharing via App Engine will no longer be available after
+          that date. Please use the "Export" button to download your work
+          before then. You can load the exported file into the
+          <a target="_blank" href="https://raspberrypifoundation.github.io/blockly/packages/blockly/tests/playground.html">Blockly Playground</a>.
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <td colspan=2>
         <table width="100%">
           <tr id="tabRow" height="1em">
             <td id="tab_blocks" class="tabon">...</td>
@@ -54,6 +65,7 @@
               <select id="code_menu"></select>
             </td>
             <td class="tabmax">
+              <button id="exportButton" title="Download your workspace as a JSON file.">Export</button>
               <button id="trashButton" class="notext" title="...">
                 <img src='../../media/1x1.gif' class="trash icon21">
               </button>

--- a/packages/blockly/demos/code/style.css
+++ b/packages/blockly/demos/code/style.css
@@ -57,6 +57,18 @@ button.disabled {
 button.notext {
   font-size: 10%;
 }
+#exportButton {
+  font-size: medium;
+  padding: 5px 10px;
+  vertical-align: middle;
+}
+#deprecationBanner {
+  border: #ccc 1px solid;
+  background-color: #FFCDD2;
+  margin: 5px;
+  padding: 8px;
+  font-size: medium;
+}
 
 h1 {
   font-weight: normal;

--- a/packages/blockly/demos/storage/index.html
+++ b/packages/blockly/demos/storage/index.html
@@ -26,11 +26,25 @@
       font-size: small;
       text-decoration: none;
     }
+    #deprecationBanner {
+      border: #ccc 1px solid;
+      background-color: #FFCDD2;
+      margin: 4px 0;
+      padding: 8px;
+    }
   </style>
 </head>
 <body>
   <h1><a href="https://developers.google.com/blockly/">Blockly</a> &gt;
     <a href="../index.html">Demos</a> &gt; Cloud Storage</h1>
+
+  <div id="deprecationBanner">
+    <strong>This service will be shut down on December 1, 2026.</strong>
+    Cloud storage will no longer be available after that date. Please use the
+    "Export" button to download your work before then. You can load the
+    exported file into the
+    <a target="_blank" href="https://raspberrypifoundation.github.io/blockly/packages/blockly/tests/playground.html">Blockly Playground</a>.
+  </div>
 
   <p>This is a simple demo of cloud storage using App Engine.</p>
 
@@ -50,6 +64,7 @@
 
   <p>
     <button onclick="BlocklyStorage.link()">Save Blocks</button>
+    <button onclick="exportWorkspace()" title="Download your workspace as a JSON file.">Export</button>
   </p>
 
   <div id="blocklyDiv" style="height: 480px; width: 600px;"></div>
@@ -94,6 +109,22 @@
     // An href with #key triggers an AJAX call to retrieve saved blocks.
     if ('BlocklyStorage' in window && window.location.hash.length > 1) {
       BlocklyStorage.retrieveXml(window.location.hash.substring(1));
+    }
+
+    // Download the current workspace as a JSON file that can be loaded into
+    // the Blockly Playground.
+    function exportWorkspace() {
+      var state = Blockly.serialization.workspaces.save(demoWorkspace);
+      var text = JSON.stringify(state, null, 2);
+      var blob = new Blob([text], {type: 'application/json'});
+      var url = URL.createObjectURL(blob);
+      var a = document.createElement('a');
+      a.href = url;
+      a.download = 'blockly-workspace.json';
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
+      URL.revokeObjectURL(url);
     }
   </script>
 


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->


### Proposed Changes

- Adds export buttons to code demo + cloud storage demo
- adds deprecation notices to the above + block factory
- adds redirect from app engine playground to github pages
- fixes the link to new block factory

### Reason for Changes

we do not have access to app engine anymore

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

cc @cpcallen and @BenHenning for one of you to approve the plan + you'll have to deploy app engine after this is merged
