### PR TITLE
fix: Improve performance of `BlockSvg.getRelativeToSurfaceXY()`

### DIFF
--- a/packages/blockly/core/block.ts
+++ b/packages/blockly/core/block.ts
@@ -203,7 +203,7 @@ export class Block {
    */
   initialized = false;
 
-  private readonly xy: Coordinate;
+  protected readonly xy: Coordinate;
   isInFlyout: boolean;
   isInMutator: boolean;
   RTL: boolean;
@@ -2462,7 +2462,7 @@ export class Block {
    * @returns Object with .x and .y properties.
    */
   getRelativeToSurfaceXY(): Coordinate {
-    return this.xy;
+    return this.xy.clone();
   }
 
   /**

--- a/packages/blockly/core/block_svg.ts
+++ b/packages/blockly/core/block_svg.ts
@@ -347,38 +347,6 @@ export class BlockSvg
   }
 
   /**
-   * Return the coordinates of the top-left corner of this block relative to the
-   * drawing surface's origin (0,0), in workspace units.
-   * If the block is on the workspace, (0, 0) is the origin of the workspace
-   * coordinate system.
-   * This does not change with workspace scale.
-   *
-   * @returns Object with .x and .y properties in workspace coordinates.
-   */
-  override getRelativeToSurfaceXY(): Coordinate {
-    const layerManager = this.workspace.getLayerManager();
-    if (!layerManager) {
-      throw new Error(
-        'Cannot calculate position because the workspace has not been appended',
-      );
-    }
-    let x = 0;
-    let y = 0;
-
-    let element: SVGElement = this.getSvgRoot();
-    if (element) {
-      do {
-        // Loop through this block and every parent.
-        const xy = svgMath.getRelativeXY(element);
-        x += xy.x;
-        y += xy.y;
-        element = element.parentNode as SVGElement;
-      } while (element && !layerManager.hasLayer(element));
-    }
-    return new Coordinate(x, y);
-  }
-
-  /**
    * Move a block by a relative offset.
    *
    * @param dx Horizontal offset in workspace units.
@@ -736,6 +704,9 @@ export class BlockSvg
    * @internal
    */
   updateComponentLocations(blockOrigin: Coordinate) {
+    this.xy.x = blockOrigin.x;
+    this.xy.y = blockOrigin.y;
+
     if (!this.dragging) this.updateConnectionLocations(blockOrigin);
     this.updateIconLocations(blockOrigin);
     this.updateFieldLocations(blockOrigin);

--- a/packages/blockly/tests/mocha/event_test.js
+++ b/packages/blockly/tests/mocha/event_test.js
@@ -1465,7 +1465,7 @@ suite('Events', function () {
       const genUidStub = createGenUidStubWithReturns(TEST_GROUP_ID);
       const dom = Blockly.utils.xml.textToDom(
         '<xml xmlns="https://developers.google.com/blockly/xml">' +
-          '  <block type="field_variable_test_block" id="test_block_id">' +
+          '  <block type="field_variable_test_block" id="test_block_id" x="0" y="0">' +
           '    <field name="VAR" id="test_var_id">name1</field>' +
           '  </block>' +
           '</xml>',

--- a/packages/blockly/tests/mocha/test_helpers/events.js
+++ b/packages/blockly/tests/mocha/test_helpers/events.js
@@ -118,7 +118,7 @@ export function assertEventEquals(
     if (isXmlProperty_(key)) {
       assertXmlPropertyEqual_(value, expectedValue, prependMessage + key);
     } else {
-      assert.equal(value, expectedValue, prependMessage + key);
+      assert.deepEqual(value, expectedValue, prependMessage + key);
     }
   });
   if (isUiEvent) {

--- a/packages/blockly/tests/playground.html
+++ b/packages/blockly/tests/playground.html
@@ -283,23 +283,25 @@
         for (var i = 0, block; (block = blocks[i]); i++) {
           prototypes.push(block.getAttribute('type'));
         }
+
+        const scatteredBlocks = [];
+        const data = {
+          'blocks': {
+            blocks: scatteredBlocks,
+          },
+        };
+
         for (var i = 0; i < n; i++) {
           var prototype =
             prototypes[Math.floor(Math.random() * prototypes.length)];
-          var block = workspace.newBlock(prototype);
-          block.initSvg();
-          block
-            .getSvgRoot()
-            .setAttribute(
-              'transform',
-              'translate(' +
-                Math.round(Math.random() * 450 + 40) +
-                ', ' +
-                Math.round(Math.random() * 600 + 40) +
-                ')',
-            );
-          block.render();
+          scatteredBlocks.push({
+            type: prototype,
+            x: Math.round(Math.random() * 450 + 40),
+            y: Math.round(Math.random() * 600 + 40),
+          });
         }
+
+        Blockly.serialization.workspaces.load(data, workspace);
       }
 
       function spaghetti(n) {


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #4871

### Proposed Changes
This PR significantly improves performance when creating many blocks, and also separately improves the performance of the playground's Scatter (formerly airstrike) button.

### Reason for Changes
Previously, `BlockSvg.getRelativeToSurfaceXY()` would walk the DOM, getting the relative offset of each parent all the way to the root. When blocks are created, the `bumpIntoBoundsHandler` is run, to scooch them into the visible viewport. This winds up needing to know the bounds of the block, which in turn depends on `BlockSvg.getRelativeToSurfaceXY()`. This DOM access/measurement was expensive.

Now, blocks simply record their new coordinates when they are moved. `updateComponentLocations()` is already called with the block's absolute coordinate, which it used to cache the position of connections in the connection DB as well as icons. The block now caches this coordinate as well, and simply returns it from `BlockSvg.getRelativeToSurfaceXY()`. This change reduces the time needed to scatter 2000 blocks on the playground from about 10 seconds:
<img width="1562" height="1060" alt="Screenshot 2026-07-23 at 10 40 59 AM" src="https://github.com/user-attachments/assets/ec339abd-9373-4cb8-ac3e-a421ebcf3245" />

...to about 2 seconds:
<img width="1562" height="1060" alt="Screenshot 2026-07-23 at 10 41 19 AM" src="https://github.com/user-attachments/assets/8c653461-6671-4ef0-9892-add48c2a443f" />

But we can (and have!) improved on this further by making the `scatter()` method more efficient by constructing a serialized representation of the scattered blocks and loading it, rather than creating, positioning, and rendering each block one by one, which takes the time to scatter 2000 blocks down to about 250ms:
<img width="1562" height="1060" alt="Screenshot 2026-07-23 at 10 41 33 AM" src="https://github.com/user-attachments/assets/fea08b72-fdc9-4646-8651-950d16909102" />


### Test Coverage
All tests except for 2 continued to pass; these were relying on a side effect of `Block.getRelativeToSurfaceXY()` returning its xy coordinate object by reference. This was changed to return a clone so that callers don't accidentally mutate the internal state of blocks. This caused a strict equality check to fail. Additionally, the XML deserializer defaults to putting blocks that don't specify their coordinates at (10, 10). When it did so, the move event captured the block's coordinate by reference, so when it was later mutated, it appeared that the old and new coordinates were the same, causing the event to be filtered out of the event stream. This is no longer the case, so I updated the failing test to explicitly position the block at (0, 0) to fix the test by making the move a no-op.

I also verified that dragging blocks (via keyboard and mouse), moving stacks, and connecting blocks all continue to work as expected at varying zoom levels as well as in mutators.