### PR TITLE
chore: fix monorepo CI build for dev-tools

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,7 +52,10 @@ jobs:
         run: source ./tests/scripts/setup_linux_env.sh
         working-directory: ./packages/blockly
 
-      - name: Run
+      - name: Run Build
+        run: npm run build
+
+      - name: Run Test
         run: npm run test
 
         env:

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "packages/plugins/theme-highcontrast",
         "packages/plugins/theme-modern",
         "packages/plugins/theme-tritanopia",
-        "packages/dev-tools",
+        "packages/plugins/dev-tools",
         "packages/docs"
       ],
       "devDependencies": {
@@ -2194,7 +2194,6 @@
       "version": "13.1.0",
       "resolved": "https://registry.npmjs.org/@blockly/block-test/-/block-test-13.1.0.tgz",
       "integrity": "sha512-u59AFquSTta2yRQrp/W/dUk4wbaemKEMzKG+CMoBqwwToagxnSAsb+wLn4AuSt/wABmiAq0q9356rO9VwOuu+g==",
-      "dev": true,
       "license": "Apache 2.0",
       "peerDependencies": {
         "blockly": "^13.1.0"
@@ -2263,27 +2262,8 @@
       "license": "MIT"
     },
     "node_modules/@blockly/dev-tools": {
-      "version": "13.1.0",
-      "resolved": "https://registry.npmjs.org/@blockly/dev-tools/-/dev-tools-13.1.0.tgz",
-      "integrity": "sha512-jtQ1tIJGYgAXGA46mgCha+3UWCiL+lHHjpfyr09rce40hTedSSIeWlI4J58IeAnDkGBSQhkBRBpFV1b/37CA+A==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@blockly/block-test": "^13.1.0",
-        "@blockly/theme-dark": "^13.1.0",
-        "@blockly/theme-deuteranopia": "^13.1.0",
-        "@blockly/theme-highcontrast": "^13.1.0",
-        "@blockly/theme-tritanopia": "^13.1.0",
-        "chai": "^6.2.2",
-        "dat.gui": "^0.7.9",
-        "lodash.assign": "^4.2.0",
-        "lodash.merge": "^4.6.2",
-        "monaco-editor": "^0.55.1",
-        "sinon": "^22.0.0"
-      },
-      "peerDependencies": {
-        "blockly": "^13.1.0"
-      }
+      "resolved": "packages/plugins/dev-tools",
+      "link": true
     },
     "node_modules/@blockly/theme-dark": {
       "resolved": "packages/plugins/theme-dark",
@@ -7505,7 +7485,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.1.tgz",
       "integrity": "sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "type-detect": "4.0.8"
@@ -7515,7 +7494,6 @@
       "version": "15.4.0",
       "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-15.4.0.tgz",
       "integrity": "sha512-DsG+8/LscQIQg68J6Ef3dv10u6nVyetYn923s3/sus5eaGfTo1of5WMZSLf0UJc9KDuKPilPH0UDJCjvNbDNCA==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "@sinonjs/commons": "^3.0.1"
@@ -7525,7 +7503,6 @@
       "version": "10.0.2",
       "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-10.0.2.tgz",
       "integrity": "sha512-8lVwD1Df1BmzoaOLhMcGGcz/Jyr5QY2KSB75/YK1QgKzoabTeLdIVyhXNZK9ojfSKSdirbXqdbsXXqP9/Ve8+A==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "@sinonjs/commons": "^3.0.1",
@@ -7536,7 +7513,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.1.0.tgz",
       "integrity": "sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -8486,6 +8462,13 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/dat.gui": {
+      "version": "0.7.13",
+      "resolved": "https://registry.npmjs.org/@types/dat.gui/-/dat.gui-0.7.13.tgz",
+      "integrity": "sha512-LmG4Pr0mbsB/1WVttf8xaHx45BvSBDGY5D9+0/9AZCbI4vvOguwBHZdKyJMxt5Yst8+icRSHKmr7ClV2u5ZtDA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/debug": {
       "version": "4.1.13",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
@@ -8803,7 +8786,6 @@
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
       "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
-      "dev": true,
       "license": "MIT",
       "optional": true
     },
@@ -11013,7 +10995,6 @@
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
       "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -12659,7 +12640,6 @@
       "version": "0.7.9",
       "resolved": "https://registry.npmjs.org/dat.gui/-/dat.gui-0.7.9.tgz",
       "integrity": "sha512-sCNc1OHobc+Erc1HqiswYgHdVNpSJUlk/Hz8vzOCsER7rl+oF/4+v8GXFUyCgtXpoCX6+bnmg07DedLvBLwYKQ==",
-      "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/data-uri-to-buffer": {
@@ -13119,7 +13099,6 @@
       "version": "3.2.7",
       "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.7.tgz",
       "integrity": "sha512-WhL/YuveyGXJaerVlMYGWhvQswa7myDG17P7Vu65EWC05o8vfeNbvNf4d/BOvH99+ZW+LlQsc1GDKMa1vNK6dw==",
-      "dev": true,
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
@@ -18680,7 +18659,6 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
       "integrity": "sha512-hFuH8TY+Yji7Eja3mGiuAxBqLagejScbG8GbG0j6o9vzn0YL14My+ktnqtZgFTosKymC9/44wP6s7xyuLfnClw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.clonedeep": {
@@ -18706,7 +18684,6 @@
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.template": {
@@ -18897,7 +18874,6 @@
       "version": "14.0.0",
       "resolved": "https://registry.npmjs.org/marked/-/marked-14.0.0.tgz",
       "integrity": "sha512-uIj4+faQ+MgHgwUW1l2PsPglZLOLOT1uErt06dAPtx2kjteLAkbsd/0FiYg/MGS+i7ZKLb7w2WClxHkzOOuryQ==",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "marked": "bin/marked.js"
@@ -21635,7 +21611,6 @@
       "version": "0.55.1",
       "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.55.1.tgz",
       "integrity": "sha512-jz4x+TJNFHwHtwuV9vA9rMujcZRb0CEilTEwG2rRSpe/A7Jdkuj8xPKttCgOh+v/lkHy7HsZ64oj+q3xoAFl9A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "dompurify": "3.2.7",
@@ -26545,7 +26520,6 @@
       "version": "22.1.0",
       "resolved": "https://registry.npmjs.org/sinon/-/sinon-22.1.0.tgz",
       "integrity": "sha512-n1ajF2rBWMTtEwbKcw4UdFg4nCnDdq/U6RDoxtOd7oapOlRoJ5ynwFx60owROyhDpA9QhMZi0pCO/xtmwFjG7w==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "@sinonjs/commons": "^3.0.1",
@@ -26562,7 +26536,6 @@
       "version": "9.0.0",
       "resolved": "https://registry.npmjs.org/diff/-/diff-9.0.0.tgz",
       "integrity": "sha512-svtcdpS8CgJyqAjEQIXdb3OjhFVVYjzGAPO8WGCmRbrml64SPw/jJD4GoE98aR7r25A0XcgrK3F02yw9R/vhQw==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"
@@ -27930,7 +27903,6 @@
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
       "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -30409,6 +30381,31 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.mjs"
+      }
+    },
+    "packages/plugins/dev-tools": {
+      "name": "@blockly/dev-tools",
+      "version": "13.1.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@blockly/block-test": "^13.1.0",
+        "@blockly/theme-dark": "^13.1.0",
+        "@blockly/theme-deuteranopia": "^13.1.0",
+        "@blockly/theme-highcontrast": "^13.1.0",
+        "@blockly/theme-tritanopia": "^13.1.0",
+        "chai": "^6.2.2",
+        "dat.gui": "^0.7.9",
+        "lodash.assign": "^4.2.0",
+        "lodash.merge": "^4.6.2",
+        "monaco-editor": "^0.55.1",
+        "sinon": "^22.0.0"
+      },
+      "devDependencies": {
+        "@blockly/dev-scripts": "^13.1.0",
+        "@types/dat.gui": "^0.7.13"
+      },
+      "peerDependencies": {
+        "blockly": "^13.1.1"
       }
     },
     "packages/plugins/theme-dark": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "packages/plugins/theme-highcontrast",
     "packages/plugins/theme-modern",
     "packages/plugins/theme-tritanopia",
-    "packages/dev-tools",
+    "packages/plugins/dev-tools",
     "packages/docs"
   ],
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "test": "npm run test --ws --if-present",
     "lint": "npm run lint --ws --if-present",
     "lint:fix": "npm run lint:fix --ws --if-present",
-    "build": "npm run package --workspace=blockly && npm run build --ws --if-present",
+    "build": "npm run package --workspace=blockly && npm run docs --workspace=blockly && npm run build --ws --if-present",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "postinstall": "patch-package"


### PR DESCRIPTION
## The basics
- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

Fixes https://github.com/RaspberryPiFoundation/blockly/issues/7763, https://github.com/RaspberryPiFoundation/blockly/issues/10144

### Proposed Changes

- Fixes the workspace declaration for dev-tools so that it is correctly added to the monorepo workspaces
- Adds building all workspaces and running the docs script from blockly so that build can run properly on github actions.

### Reason for Changes

The dev-tools plugin was incorrectly specified in the package.json. Also, adding additional build steps ensures we no longer break docs when adding or updating dependencies.

### Test Coverage

No new tests were added. I validated this change locally by running the workflow steps (npm ci, npm run build, npm run test) locally after removing all the node modules, dist, build, and the docs reference directories.
