### PR TITLE
test: Fix the browser tests

### DIFF
--- a/packages/blockly/core/gesture.ts
+++ b/packages/blockly/core/gesture.ts
@@ -975,9 +975,17 @@ export class Gesture {
    * @internal
    */
   setStartBlock(block: BlockSvg) {
-    // If the gesture already went through a block child, don't set the start
-    // block.
-    if (!this.startBlock && !this.startBubble && !this.startIcon) {
+    // If the gesture already went through a clickable block child, don't set
+    // the start block.
+    if (
+      !this.startBlock &&
+      !this.startBubble &&
+      (!this.startIcon ||
+        (block.isInFlyout &&
+          !this.startIcon.isClickableInFlyout?.(
+            !!block.workspace.getFlyout()?.autoClose,
+          )))
+    ) {
       this.startBlock = block;
       if (block.isInFlyout && block !== block.getRootBlock()) {
         this.setTargetBlock(block.getRootBlock());

--- a/packages/blockly/tests/browser/test/basic_playground_test.mjs
+++ b/packages/blockly/tests/browser/test/basic_playground_test.mjs
@@ -250,6 +250,7 @@ suite('Focused nodes are scrolled into bounds', function () {
     await this.browser.execute(() => {
       window.focusScrollTest = async (testcase) => {
         const workspace = Blockly.getMainWorkspace();
+        Blockly.getFocusManager().focusNode(workspace);
         const metrics = workspace.getMetricsManager();
         const initialViewport = metrics.getViewMetrics(true);
         const elementBounds = await testcase(workspace);

--- a/packages/blockly/tests/browser/test/test_setup.mjs
+++ b/packages/blockly/tests/browser/test/test_setup.mjs
@@ -179,11 +179,14 @@ export async function getSelectedBlockElement(browser) {
 /**
  * @param browser The active WebdriverIO Browser object.
  * @param id The ID of the Blockly block to search for.
+ * @param toolbox True if this block is in the toolbox (which must be open already).
  * @return A Promise that resolves to the root SVG element of the block with
  *     the given ID, as an interactable browser element.
  */
-export async function getBlockElementById(browser, id) {
-  const elem = await browser.$(`[data-id="${id}"]`);
+export async function getBlockElementById(browser, id, toolbox) {
+  const elem = await browser.$(
+    `${toolbox ? '' : '.blocklySvg'} [data-id="${id}"]`,
+  );
   elem['id'] = id;
   return elem;
 }
@@ -245,7 +248,7 @@ async function getTargetableBlockElement(browser, blockId, toolbox) {
     toolbox,
   );
 
-  return await getBlockElementById(browser, id);
+  return await getBlockElementById(browser, id, toolbox);
 }
 
 /**
@@ -584,9 +587,14 @@ export async function contextMenuSelect(browser, block, itemText) {
   await clickBlock(browser, block.id, {button: 2});
 
   await browser.pause(PAUSE_TIME);
-  const item = await browser.$(`div=${itemText}`);
-  await item.waitForExist();
-  await item.click();
+  const items = await browser.$$('.blocklyMenuItemContent');
+  for (const item of items) {
+    const text = await item.getText();
+    if (text.includes(itemText)) {
+      await item.click();
+      break;
+    }
+  }
 
   await browser.pause(PAUSE_TIME);
 }
@@ -599,7 +607,9 @@ export async function contextMenuSelect(browser, block, itemText) {
  * @return A Promise that resolves when the actions are complete.
  */
 export async function openMutatorForBlock(browser, block) {
-  const icon = await browser.$(`[data-id="${block.id}"] > g.blocklyIconGroup`);
+  const icon = await browser.$(
+    `.blocklySvg [data-id="${block.id}"] > g.blocklyIconGroup`,
+  );
   await icon.click();
 }
 

--- a/packages/blockly/tests/browser/test/workspace_comment_test.mjs
+++ b/packages/blockly/tests/browser/test/workspace_comment_test.mjs
@@ -179,7 +179,9 @@ suite('Workspace comments', function () {
       const textArea = await this.browser.$('.blocklyComment .blocklyTextarea');
       await textArea.addValue('test text');
       // Deselect text area to fire browser change event.
-      await this.browser.$('.blocklyWorkspace').click();
+      await this.browser.execute(() => {
+        Blockly.getFocusManager().focusNode(Blockly.getMainWorkspace());
+      });
 
       chai.assert.equal(
         await getCommentText(this.browser, commentId),


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details

### Proposed Changes
This PR fixes 6 failing tests in the browser test suite. One of these was caused by an actual bug, namely that blocks couldn't be dragged out of the flyout when the click occurred on a non-clickable icon. The rest were just a matter of fixing up selectors and focus.

### Reason for Changes
The browser tests were broken.

### Test Coverage
The browser tests now pass!