### PR TITLE
chore: add support for aria-pressed in aria utils

### DIFF
--- a/packages/blockly/core/utils/aria.ts
+++ b/packages/blockly/core/utils/aria.ts
@@ -194,6 +194,12 @@ export enum State {
    */
   LIVE = 'live',
   /**
+   * See https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-pressed.
+   *
+   * Value: one of {true, false, mixed, undefined}.
+   */
+  PRESSED = 'pressed',
+  /**
    * See https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-roledescription.
    *
    * Value: a string.


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes https://github.com/RaspberryPiFoundation/blockly/issues/10201

### Proposed Changes

Add support for `aria-pressed` to `utils.aria.STATE`.
<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->

