### PR TITLE
fix(field-bitmap): revert separate keys for revert and commit- #2760

### DIFF
--- a/packages/plugins/field-bitmap/package.json
+++ b/packages/plugins/field-bitmap/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@blockly/field-bitmap",
   "version": "13.1.0",
-  "private": true,
   "description": "A field that lets users input a pixel grid with their mouse.",
   "scripts": {
     "audit:fix": "blockly-scripts auditFix",

--- a/packages/plugins/field-bitmap/src/field-bitmap.ts
+++ b/packages/plugins/field-bitmap/src/field-bitmap.ts
@@ -338,7 +338,6 @@ export class FieldBitmap extends Blockly.Field<number[][]> {
     this.bindEvent(dropdownEditor, 'pointerleave', this.onPointerEnd);
     this.bindEvent(dropdownEditor, 'pointerdown', this.onPointerStart);
     this.bindEvent(dropdownEditor, 'pointercancel', this.onPointerEnd);
-    this.bindEvent(dropdownEditor, 'keydown', this.onEditorKeyDown);
     // Stop the browser from handling touch events and cancelling the event.
     this.bindEvent(dropdownEditor, 'touchmove', (e: Event) => {
       e.preventDefault();
@@ -422,26 +421,6 @@ export class FieldBitmap extends Blockly.Field<number[][]> {
       }
     }
     return grid;
-  }
-
-  /**
-   * Handles editor-level keyboard shortcuts.
-   * Ctrl/Cmd+Enter commits and closes; Escape reverts and closes.
-   *
-   * @param e The keydown event.
-   */
-  private onEditorKeyDown(e: KeyboardEvent) {
-    const isEscape = e.key === 'Escape';
-    const isCommit = e.key === 'Enter' && (e.ctrlKey || e.metaKey);
-    if (!isEscape && !isCommit) return;
-
-    if (isEscape && this.initialValue !== null) {
-      this.setValue(this.initialValue, false);
-    }
-    Blockly.DropDownDiv.hideIfOwner(this);
-    Blockly.getFocusManager().focusNode(this);
-    e.preventDefault();
-    e.stopPropagation();
   }
 
   /**
@@ -737,7 +716,6 @@ export class FieldBitmap extends Blockly.Field<number[][]> {
     this.focusedPixelIndex = -1;
     this.pointerIsDown = false;
     this.valToPaintWith = undefined;
-    // Set this.initialValue back to null.
     this.initialValue = null;
 
     Blockly.DropDownDiv.getContentDiv().classList.remove(
@@ -843,10 +821,11 @@ export class FieldBitmap extends Blockly.Field<number[][]> {
    * Resets pointer state (e.g. After either a pointerup event or if the
    * gesture is canceled).
    *
-   * @param e The pointer event that ended the gesture.
+   * @param e The pointer event that ended the gesture, when available.
    */
-  private onPointerEnd(e: PointerEvent) {
+  private onPointerEnd(e?: PointerEvent) {
     if (
+      e &&
       e.currentTarget instanceof HTMLElement &&
       e.currentTarget.hasPointerCapture?.(e.pointerId)
     ) {
@@ -938,10 +917,10 @@ export class FieldBitmap extends Blockly.Field<number[][]> {
    * @param eventName Name of the event to bind.
    * @param callback Function to be called on specified event.
    */
-  private bindEvent<E extends Event>(
+  private bindEvent(
     element: HTMLElement,
     eventName: string,
-    callback: (e: E) => void,
+    callback: (e: PointerEvent) => void,
   ) {
     this.boundEvents.push(
       Blockly.browserEvents.bind(element, eventName, this, callback),

--- a/packages/plugins/field-colour-hsv-sliders/package.json
+++ b/packages/plugins/field-colour-hsv-sliders/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@blockly/field-colour-hsv-sliders",
   "version": "13.1.0",
-  "private": true,
   "description": "A Blockly colour field using HSV sliders.",
   "scripts": {
     "audit:fix": "blockly-scripts auditFix",


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

This work is being duplicated in samples at https://github.com/RaspberryPiFoundation/blockly-samples/pull/2760 as plugins are not yet publishable from the monorepo.
<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://docs.blockly.com/guides/contribute/samples#making_and_verifying_a_change)

## The details
### Proposed Changes

Removes the recently added private `onEditorKeyDown` method from `FieldBitmap` which handled committing updated field values or reverting to the initial value.
<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->

This also unmarks `field-bitmap` and `field-colour-hsv-sliders` as private so that we can release 13.2.0 versions of each.

### Reason for Changes


Part of https://github.com/RaspberryPiFoundation/blockly-samples/pull/2754 included a behavior change where pressing escape would revert to the initial field value. This aligns to other fields, but it was deemed too risky as it's worse to suddenly lose a bunch of pixel changes than it is to have to hit undo if you didn't mean to commit them.

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
