### PR TITLE
fix: Flyout toolbar changes block position

### DIFF
--- a/packages/blockly/core/toolbox/toolbox.ts
+++ b/packages/blockly/core/toolbox/toolbox.ts
@@ -722,13 +722,13 @@ export class Toolbox
       this.toolboxPosition === toolbox.Position.LEFT
         ? workspace.scrollX +
           rect.width +
-          (flyout?.isVisible() ? flyout.getWidth() : 0)
+          (flyout && !flyout.autoClose ? flyout.getWidth() : 0)
         : workspace.scrollX;
     const newY =
       this.toolboxPosition === toolbox.Position.TOP
         ? workspace.scrollY +
           rect.height +
-          (flyout?.isVisible() ? flyout.getHeight() : 0)
+          (flyout && !flyout.autoClose ? flyout.getHeight() : 0)
         : workspace.scrollY;
     workspace.translate(newX, newY);
 

--- a/packages/blockly/tests/mocha/toolbox_test.js
+++ b/packages/blockly/tests/mocha/toolbox_test.js
@@ -332,6 +332,23 @@ suite('Toolbox', function () {
         assert.isFalse(this.parentCategory.isExpanded());
         assert.isFalse(this.flyout.isVisible());
       });
+      test('resizing a toolbox item with an auto-closing flyout visible should not offset the workspace by the flyout size', function () {
+        clickCategory(this.parentCategory);
+        assert.isTrue(this.flyout.isVisible());
+        assert.isAbove(this.flyout.getWidth(), 0);
+
+        const workspace = this.toolbox.workspace_;
+        const translateSpy = sinon.spy(workspace, 'translate');
+        this.toolbox.handleToolboxItemResize();
+
+        const expectedX =
+          workspace.scrollX +
+          this.toolbox.HtmlDiv.getBoundingClientRect().width;
+        assert.deepEqual(translateSpy.firstCall.args, [
+          expectedX,
+          workspace.scrollY,
+        ]);
+      });
     });
   });
 


### PR DESCRIPTION
## The basics

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #9992

### Proposed Changes

Only add the flyout width/height to the workspace origin if the flyout is not autoClose.
