### PR TITLE
chore: retitle translatewiki PRs

### DIFF
--- a/.github/workflows/conventional-label.yml
+++ b/.github/workflows/conventional-label.yml
@@ -7,6 +7,9 @@ name: commit lint & label
 jobs:
   commit-lint:
     runs-on: ubuntu-latest
+    # translatewiki PRs are retitled and labelled by translatewiki.yml, so
+    # skip them here to avoid a spurious commit-lint failure on their raw title.
+    if: ${{ !(github.event.pull_request.user.login == 'translatewiki' && github.event.pull_request.head.ref == 'translatewiki') }}
     env:
       PR_TITLE: ${{ github.event.pull_request.title }}
     permissions:
@@ -29,6 +32,8 @@ jobs:
 
   label:
     runs-on: ubuntu-latest
+    # translatewiki PRs are labelled by translatewiki.yml instead.
+    if: ${{ !(github.event.pull_request.user.login == 'translatewiki' && github.event.pull_request.head.ref == 'translatewiki') }}
     permissions:
       issues: write
       pull-requests: write

--- a/.github/workflows/translatewiki.yml
+++ b/.github/workflows/translatewiki.yml
@@ -1,0 +1,63 @@
+name: translatewiki automation
+
+# Automation for the localisation PRs opened by the translatewiki.net bot.
+#
+# The bot opens a PR from the `translatewiki` branch with a title like
+# "Localisation updates from https://translatewiki.net." That title has no
+# conventional-commit type prefix and a trailing full stop, so it fails
+# commit-lint. This workflow retitles the PR to a lint-clean
+# "chore: Localisation updates from https://translatewiki.net" and applies the
+# "PR: chore" label. conventional-label.yml deliberately skips these PRs so
+# they don't get a spurious commit-lint failure on their raw title.
+
+on:
+  pull_request_target:
+    types:
+      - opened
+
+jobs:
+  translatewiki:
+    runs-on: ubuntu-latest
+    # Only run for the translatewiki bot's PRs, matching on both the author and
+    # the source branch.
+    if: ${{ github.event.pull_request.user.login == 'translatewiki' && github.event.pull_request.head.ref == 'translatewiki' }}
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - name: Retitle and label translatewiki PR
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const {number: issue_number, title} = context.payload.pull_request;
+
+            // Conventional-commit types accepted by commitlint.config.mjs,
+            // optionally with a scope, e.g. "chore(deps):".
+            const typePrefix =
+              /^(build|chore|ci|docs|feat|fix|refactor|release|revert|test)(\([^)]*\))?!?:/;
+
+            // Strip trailing full stops / whitespace, then prepend "chore: "
+            // unless the title already starts with a conventional type.
+            let corrected = title.replace(/[.\s]+$/, '');
+            if (!typePrefix.test(corrected)) {
+              corrected = `chore: ${corrected}`;
+            }
+
+            if (corrected !== title) {
+              await github.rest.pulls.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: issue_number,
+                title: corrected,
+              });
+              core.info(`Retitled #${issue_number}: "${title}" -> "${corrected}"`);
+            } else {
+              core.info(`Title already clean for #${issue_number}: "${title}"`);
+            }
+
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number,
+              labels: ['PR: chore'],
+            });


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes translatewiki PRs requiring hand-editing the PR title

### Proposed Changes

adds workflow that retitles translatewiki prs to meet commit-lint and label appropriately

### Reason for Changes

i'm lazy

note that the reason the existing commit-lint jobs have to skip translatewiki PRs is that github won't re-run workflows that would be triggered by edits made by the default github access token, like we're doing in the new workflow. this is to avoid infinite loops of workflows rerunning. so in order to prevent a spurious lint failure, we just skip it and do the label ourselves

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

it has a generic automation title because i also want to add a check that yells if translatewiki tries to edit files outside of msg/
