### PR TITLE
fix: Fix display of insertion markers and trashcan lid in RTL

### DIFF
--- a/packages/blockly/core/insertion_marker.ts
+++ b/packages/blockly/core/insertion_marker.ts
@@ -90,10 +90,9 @@ export class InsertionMarker {
     // Move the insertion marker to abut the static connection and render the
     // static block in case it needs to grow to accommodate the insertion
     // marker.
-    this.marker.setAttribute(
-      'transform',
-      `translate(${blockOffset.x + connectionOffset.x}, ${blockOffset.y + connectionOffset.y})`,
-    );
+    const translate = `translate(${blockOffset.x + connectionOffset.x}, ${blockOffset.y + connectionOffset.y})`;
+    const scale = connectingBlock.workspace.RTL ? 'scale(-1, 1)' : '';
+    this.marker.setAttribute('transform', `${translate} ${scale}`);
     staticConnection.getSourceBlock().queueRender();
     renderManagement.triggerQueuedRenders();
   }

--- a/packages/blockly/core/trashcan.ts
+++ b/packages/blockly/core/trashcan.ts
@@ -741,7 +741,7 @@ Css.register(`
     rotate: 45deg;
   }
 
-  .blocklyRTL .blocklyTrash.blocklyTrashFull.blocklyTrashOpen .blocklyTrashLid,
+  .blocklyRTL .blocklyTrash.blocklyTrashOpen .blocklyTrashLid,
   .blocklyRTL .blocklyTrash.blocklyTrashFull:hover .blocklyTrashLid,
   .blocklyRTL .blocklyTrash.blocklyTrashFull:focus .blocklyTrashLid {
     rotate: -45deg;


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #10204

### Proposed Changes
This PR fixes display of the new insertion markers in RTL by flipping them in that case. It also fixes an issue where the trashcan lid would rotate incorrectly in RTL – we changed the selector for the LTR case, but missed making the same change for RTL, so when the trashcan was empty in RTL it rotated the wrong way.
