### PR TITLE
test: Fix the browser tests

### DIFF
--- a/packages/blockly/tests/browser/test/basic_block_test.mjs
+++ b/packages/blockly/tests/browser/test/basic_block_test.mjs
@@ -24,14 +24,12 @@ suite('Basic block tests', function (done) {
 
   // Setup Selenium for all of the tests
   suiteSetup(async function () {
-    this.browser = await testSetup(
-      testFileLocations.PLAYGROUND + '?toolbox=test-blocks',
-    );
+    this.browser = await testSetup(testFileLocations.PLAYGROUND);
   });
 
   test('Drag three blocks into the workspace', async function () {
     for (let i = 1; i <= 3; i++) {
-      await dragNthBlockFromFlyout(this.browser, 'Align', 0, 50, 50);
+      await dragNthBlockFromFlyout(this.browser, 'Logic', 0, 50, 50);
       chai.assert.equal((await getAllBlocks(this.browser)).length, i);
     }
   });

--- a/packages/blockly/tests/browser/test/toolbox_drag_test.mjs
+++ b/packages/blockly/tests/browser/test/toolbox_drag_test.mjs
@@ -194,14 +194,14 @@ suite('Open toolbox categories', function () {
     await openCategories(this.browser, basicCategories, screenDirection.RTL);
   });
 
-  test('opening every toolbox category in the test toolbox in LTR', async function () {
+  test.skip('opening every toolbox category in the test toolbox in LTR', async function () {
     this.browser = await testSetup(
       testFileLocations.PLAYGROUND + '?toolbox=test-blocks',
     );
     await openCategories(this.browser, testCategories, screenDirection.LTR);
   });
 
-  test('opening every toolbox category in the test toolbox in RTL', async function () {
+  test.skip('opening every toolbox category in the test toolbox in RTL', async function () {
     this.browser = await testSetup(
       testFileLocations.PLAYGROUND + '?toolbox=test-blocks&dir=rtl',
     );

--- a/packages/blockly/tests/browser/test/workspace_comment_test.mjs
+++ b/packages/blockly/tests/browser/test/workspace_comment_test.mjs
@@ -13,9 +13,7 @@ suite('Workspace comments', function () {
   this.timeout(0);
 
   suiteSetup(async function () {
-    this.browser = await testSetup(
-      testFileLocations.PLAYGROUND + '?toolbox=test-blocks',
-    );
+    this.browser = await testSetup(testFileLocations.PLAYGROUND);
   });
 
   teardown(async function () {


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
This PR fixes the browser tests now that the devtools have been removed from the playground. Two tests were using the test blocks version of the playground, which depends on the devtools, but for no actual reason; I modified them to use the normal toolbox. The other tests are those that drag out every block in the test block toolbox; I've skipped those for now, and we can either reenable them later or move them into a test suite that lives in devtools.
