### PR TITLE
fix: Fix some memory leaks

### DIFF
--- a/packages/blockly/core/block.ts
+++ b/packages/blockly/core/block.ts
@@ -328,6 +328,7 @@ export class Block {
    */
   dispose(healStack = false) {
     this.disposing = true;
+    this.tooltip = '';
 
     // Dispose of this change listener before unplugging.
     // Technically not necessary due to the event firing delay.

--- a/packages/blockly/core/block_flyout_inflater.ts
+++ b/packages/blockly/core/block_flyout_inflater.ts
@@ -179,6 +179,7 @@ export class BlockFlyoutInflater implements IFlyoutInflater {
     const element = item.getElement();
     if (!(element instanceof BlockSvg)) return;
     this.removeListeners(element.id);
+    this.permanentlyDisabledBlocks.delete(element);
     element.dispose(false, false);
   }
 

--- a/packages/blockly/core/block_svg.ts
+++ b/packages/blockly/core/block_svg.ts
@@ -899,6 +899,8 @@ export class BlockSvg
   override dispose(healStack?: boolean, animate?: boolean) {
     this.disposing = true;
 
+    Tooltip.unbindMouseEvents(this.pathObject.svgPath);
+    delete (this.pathObject.svgPath as any).tooltip;
     Tooltip.dispose();
     ContextMenu.hide();
 

--- a/packages/blockly/core/field.ts
+++ b/packages/blockly/core/field.ts
@@ -661,6 +661,13 @@ export abstract class Field<T = any>
       dom.removeNode(this.fieldGroup_);
     }
 
+    const clickTarget = this.getClickTarget_();
+    if (clickTarget) {
+      Tooltip.unbindMouseEvents(clickTarget);
+      delete (clickTarget as any).tooltip;
+    }
+    this.tooltip = null;
+
     this.disposed = true;
   }
 

--- a/packages/blockly/core/icons/icon.ts
+++ b/packages/blockly/core/icons/icon.ts
@@ -81,8 +81,12 @@ export abstract class Icon implements IIcon, IContextMenu {
   }
 
   dispose(): void {
-    tooltip.unbindMouseEvents(this.svgRoot);
-    dom.removeNode(this.svgRoot);
+    if (this.svgRoot) {
+      tooltip.unbindMouseEvents(this.svgRoot);
+      delete (this.svgRoot as any).tooltip;
+      dom.removeNode(this.svgRoot);
+    }
+    this.tooltip = '';
   }
 
   getWeight(): number {


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details

### Proposed Changes
This PR fixes some memory leaks. These were largely related to (a) not unregistering tooltip listeners or clearing the `.tooltip` property on DOM elements, which various Blockly-related classes were stuffed into, sometimes creating cycles and (b) missing clearing an element in the block flyout inflater.

### Reason for Changes
RAM is expensive, and cleaning up your own mess is nice.